### PR TITLE
fix: set error codes differently based on if there are vulnerabilities present

### DIFF
--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -103,7 +103,7 @@ func TestRun(t *testing.T) {
 		{
 			name:         "",
 			args:         []string{""},
-			wantExitCode: 1,
+			wantExitCode: 127,
 			wantStdout: `
 				NAME:
 					 osv-scanner - scans various mediums for dependencies and matches it against the OSV database
@@ -141,7 +141,7 @@ func TestRun(t *testing.T) {
 		{
 			name:         "",
 			args:         []string{"", "./fixtures/locks-many/not-a-lockfile.toml"},
-			wantExitCode: 1,
+			wantExitCode: 127,
 			wantStdout: `
 				Scanning dir ./fixtures/locks-many/not-a-lockfile.toml
 				NAME:


### PR DESCRIPTION
I've not yet added any test cases for the exit code when vulnerabilities are present because that requires having a lockfile with a vulnerability (which'll annoy dependabot) and interacting with the production API (which'll be relatively slow, the OSV could change, etc) - I plan to address that by adding a flag to set the API URL which'll allow leveraging [`httptest`](https://pkg.go.dev/net/http/httptest) like what I do in `osv-detector` [for testing the API-based databases](https://github.com/G-Rath/osv-detector/blob/main/pkg/database/api-check_test.go#L139-L153).

As for the error codes themselves, I've effectively split the 0-255 range in half (rounded down) with the upper half (starting at 127, as "general error") being reserved for "non-results related errors" such as files not found, errors with the API, etc; and the lower half being reserved for errors about vulnerabilities i.e. some tools set the exit code based on the severity of the vulnerabilities found (something that I'm not convinced is useful enough to land right away, but this way we can do so with minimal impact).

Currently the only other exit code the detector is using that I think will eventually make its way into the scanner is 128, meaning "lockfile not found", because that's the only error so far that I've identified as being useful to differentiate for automatic tools because that could be expected (and essentially enables differing figuring out if the detector/scanner can do anything with a file or directory to the tool itself, which is a very good thing)

Resolves #7