### PR TITLE
Fix git commit result reporting

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -71,7 +71,7 @@ func (c *ConfigManager) Get(r *output.Reporter, targetPath string) Config {
 
 	configPath, err := normalizeConfigLoadPath(targetPath)
 	if err != nil {
-		r.PrintError(fmt.Sprintf("Can't find config path: %s", err))
+		r.PrintError(fmt.Sprintf("Can't find config path: %s\n", err))
 		return Config{}
 	}
 

--- a/pkg/osvscanner/vulnerability_result.go
+++ b/pkg/osvscanner/vulnerability_result.go
@@ -25,6 +25,7 @@ func groupResponse(r *output.Reporter, query osv.BatchedQuery, resp *osv.Hydrate
 		if query.Commit != "" {
 			pkg.Package.Version = query.Commit
 			pkg.Package.Ecosystem = "GIT"
+			pkg.Vulnerabilities = response.Vulns
 		} else if query.Package.PURL != "" {
 			var err error
 			pkg.Package, err = PURLToPackage(query.Package.PURL)

--- a/pkg/osvscanner/vulnerability_result.go
+++ b/pkg/osvscanner/vulnerability_result.go
@@ -25,7 +25,6 @@ func groupResponse(r *output.Reporter, query osv.BatchedQuery, resp *osv.Hydrate
 		if query.Commit != "" {
 			pkg.Package.Version = query.Commit
 			pkg.Package.Ecosystem = "GIT"
-			pkg.Vulnerabilities = response.Vulns
 		} else if query.Package.PURL != "" {
 			var err error
 			pkg.Package, err = PURLToPackage(query.Package.PURL)
@@ -34,7 +33,6 @@ func groupResponse(r *output.Reporter, query osv.BatchedQuery, resp *osv.Hydrate
 					query.Package.PURL, err))
 				continue
 			}
-			pkg.Vulnerabilities = response.Vulns
 		} else {
 			pkg = models.PackageVulns{
 				Package: models.PackageInfo{
@@ -42,10 +40,10 @@ func groupResponse(r *output.Reporter, query osv.BatchedQuery, resp *osv.Hydrate
 					Version:   query.Version,
 					Ecosystem: query.Package.Ecosystem,
 				},
-				Vulnerabilities: response.Vulns,
 			}
 		}
 
+		pkg.Vulnerabilities = response.Vulns
 		groupedBySource[query.Source] = append(groupedBySource[query.Source], pkg)
 	}
 


### PR DESCRIPTION
Missing a line in the result grouping code that caused the git vulnerabilities to not actually be reported. 