### PR TITLE
fix: include `replace` directives in `go.mod`

### DIFF
--- a/pkg/lockfile/fixtures/go/replace-different.mod
+++ b/pkg/lockfile/fixtures/go/replace-different.mod
@@ -1,5 +1,9 @@
+require (
+    golang.org/x/net v1.2.3
+    golang.org/x/net v0.5.6
+)
+
 replace (
-    golang.org/x/foo v1.2.3 => example.com/fork/foe v1.4.5
-    golang.org/x/foo v1.2.5 => example.com/fork/foe v1.4.2
-    golang.org/x/foe v1.2.3 => ./fork/far
+    golang.org/x/net v1.2.3 => example.com/fork/foe v1.4.5
+    golang.org/x/net v0.5.6 => example.com/fork/foe v1.4.2
 )

--- a/pkg/lockfile/fixtures/go/replace-different.mod
+++ b/pkg/lockfile/fixtures/go/replace-different.mod
@@ -1,0 +1,5 @@
+replace (
+    golang.org/x/foo v1.2.3 => example.com/fork/foe v1.4.5
+    golang.org/x/foo v1.2.5 => example.com/fork/foe v1.4.2
+    golang.org/x/foe v1.2.3 => ./fork/far
+)

--- a/pkg/lockfile/fixtures/go/replace-local.mod
+++ b/pkg/lockfile/fixtures/go/replace-local.mod
@@ -1,0 +1,8 @@
+require (
+    golang.org/x/net v1.2.3
+    github.com/BurntSushi/toml v1.0.0
+)
+
+replace (
+    golang.org/x/net v1.2.3 => ./fork/net
+)

--- a/pkg/lockfile/fixtures/go/replace-many.mod
+++ b/pkg/lockfile/fixtures/go/replace-many.mod
@@ -1,0 +1,6 @@
+replace (
+    golang.org/x/net v1.2.3 => example.com/fork/net v1.4.5
+    golang.org/x/net => example.com/fork/net v1.4.5
+    golang.org/x/net v1.2.3 => ./fork/net
+    golang.org/x/net => ./fork/net
+)

--- a/pkg/lockfile/fixtures/go/replace-many.mod
+++ b/pkg/lockfile/fixtures/go/replace-many.mod
@@ -1,6 +1,0 @@
-replace (
-    golang.org/x/net v1.2.3 => example.com/fork/net v1.4.5
-    golang.org/x/net => example.com/fork/net v1.4.5
-    golang.org/x/net v1.2.3 => ./fork/net
-    golang.org/x/net => ./fork/net
-)

--- a/pkg/lockfile/fixtures/go/replace-mixed.mod
+++ b/pkg/lockfile/fixtures/go/replace-mixed.mod
@@ -1,0 +1,10 @@
+require (
+    golang.org/x/net v1.2.3
+)
+
+replace (
+    golang.org/x/net v1.2.3 => example.com/fork/net v1.4.5
+    golang.org/x/net => example.com/fork/net v1.4.5
+    golang.org/x/net v1.2.3 => ./fork/net
+    golang.org/x/net => ./fork/net
+)

--- a/pkg/lockfile/fixtures/go/replace-no-version.mod
+++ b/pkg/lockfile/fixtures/go/replace-no-version.mod
@@ -4,5 +4,5 @@ require (
 )
 
 replace (
-    golang.org/x/net v1.2.3 => example.com/fork/net v1.4.5
+    golang.org/x/net => example.com/fork/net v1.4.5
 )

--- a/pkg/lockfile/fixtures/go/replace-not-required.mod
+++ b/pkg/lockfile/fixtures/go/replace-not-required.mod
@@ -1,6 +1,6 @@
 require (
-    golang.org/x/net v1.2.3
     golang.org/x/net v0.5.6
+    github.com/BurntSushi/toml v1.0.0
 )
 
 replace (

--- a/pkg/lockfile/fixtures/go/replace-one.mod
+++ b/pkg/lockfile/fixtures/go/replace-one.mod
@@ -1,0 +1,1 @@
+replace golang.org/x/net v1.2.3 => example.com/fork/net v1.4.5

--- a/pkg/lockfile/fixtures/go/replace-one.mod
+++ b/pkg/lockfile/fixtures/go/replace-one.mod
@@ -1,1 +1,5 @@
+require (
+  golang.org/x/net v1.2.3
+)
+
 replace golang.org/x/net v1.2.3 => example.com/fork/net v1.4.5

--- a/pkg/lockfile/parse-go-lock.go
+++ b/pkg/lockfile/parse-go-lock.go
@@ -9,6 +9,16 @@ import (
 
 const GoEcosystem Ecosystem = "Go"
 
+func deduplicatePackages(packages map[string]PackageDetails) map[string]PackageDetails {
+	details := map[string]PackageDetails{}
+
+	for _, detail := range packages {
+		details[detail.Name+"@"+detail.Version] = detail
+	}
+
+	return details
+}
+
 func ParseGoLock(pathToLockfile string) ([]PackageDetails, error) {
 	lockfileContents, err := os.ReadFile(pathToLockfile)
 
@@ -34,7 +44,7 @@ func ParseGoLock(pathToLockfile string) ([]PackageDetails, error) {
 	}
 
 	for _, replace := range parsedLockfile.Replace {
-		packages[replace.New.Path+"@"+replace.New.Version] = PackageDetails{
+		packages[replace.Old.Path+"@"+replace.Old.Version] = PackageDetails{
 			Name:      replace.New.Path,
 			Version:   strings.TrimPrefix(replace.New.Version, "v"),
 			Ecosystem: GoEcosystem,
@@ -42,5 +52,5 @@ func ParseGoLock(pathToLockfile string) ([]PackageDetails, error) {
 		}
 	}
 
-	return pkgDetailsMapToSlice(packages), nil
+	return pkgDetailsMapToSlice(deduplicatePackages(packages)), nil
 }

--- a/pkg/lockfile/parse-go-lock.go
+++ b/pkg/lockfile/parse-go-lock.go
@@ -22,16 +22,25 @@ func ParseGoLock(pathToLockfile string) ([]PackageDetails, error) {
 		return []PackageDetails{}, fmt.Errorf("could not parse %s: %w", pathToLockfile, err)
 	}
 
-	packages := make([]PackageDetails, 0, len(parsedLockfile.Require))
+	packages := map[string]PackageDetails{}
 
 	for _, require := range parsedLockfile.Require {
-		packages = append(packages, PackageDetails{
+		packages[require.Mod.Path+"@"+require.Mod.Version] = PackageDetails{
 			Name:      require.Mod.Path,
 			Version:   strings.TrimPrefix(require.Mod.Version, "v"),
 			Ecosystem: GoEcosystem,
 			CompareAs: GoEcosystem,
-		})
+		}
 	}
 
-	return packages, nil
+	for _, replace := range parsedLockfile.Replace {
+		packages[replace.New.Path+"@"+replace.New.Version] = PackageDetails{
+			Name:      replace.New.Path,
+			Version:   strings.TrimPrefix(replace.New.Version, "v"),
+			Ecosystem: GoEcosystem,
+			CompareAs: GoEcosystem,
+		}
+	}
+
+	return pkgDetailsMapToSlice(packages), nil
 }

--- a/pkg/lockfile/parse-go-lock_test.go
+++ b/pkg/lockfile/parse-go-lock_test.go
@@ -141,10 +141,35 @@ func TestParseGoLock_Replacements_One(t *testing.T) {
 	})
 }
 
-func TestParseGoLock_Replacements_Many(t *testing.T) {
+func TestParseGoLock_Replacements_Mixed(t *testing.T) {
 	t.Parallel()
 
-	packages, err := lockfile.ParseGoLock("fixtures/go/replace-many.mod")
+	packages, err := lockfile.ParseGoLock("fixtures/go/replace-mixed.mod")
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	expectPackages(t, packages, []lockfile.PackageDetails{
+		{
+			Name:      "example.com/fork/net",
+			Version:   "1.4.5",
+			Ecosystem: lockfile.GoEcosystem,
+			CompareAs: lockfile.GoEcosystem,
+		},
+		{
+			Name:      "golang.org/x/net",
+			Version:   "0.5.6",
+			Ecosystem: lockfile.GoEcosystem,
+			CompareAs: lockfile.GoEcosystem,
+		},
+	})
+}
+
+func TestParseGoLock_Replacements_Local(t *testing.T) {
+	t.Parallel()
+
+	packages, err := lockfile.ParseGoLock("fixtures/go/replace-local.mod")
 
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
@@ -157,22 +182,9 @@ func TestParseGoLock_Replacements_Many(t *testing.T) {
 			Ecosystem: lockfile.GoEcosystem,
 			CompareAs: lockfile.GoEcosystem,
 		},
-	})
-}
-
-func TestParseGoLock_Replacements_Mixed(t *testing.T) {
-	t.Parallel()
-
-	packages, err := lockfile.ParseGoLock("fixtures/go/replace-mixed.mod")
-
-	if err != nil {
-		t.Errorf("Got unexpected error: %v", err)
-	}
-
-	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
-			Name:      "./fork/net",
-			Version:   "",
+			Name:      "github.com/BurntSushi/toml",
+			Version:   "1.0.0",
 			Ecosystem: lockfile.GoEcosystem,
 			CompareAs: lockfile.GoEcosystem,
 		},
@@ -201,9 +213,48 @@ func TestParseGoLock_Replacements_Different(t *testing.T) {
 			Ecosystem: lockfile.GoEcosystem,
 			CompareAs: lockfile.GoEcosystem,
 		},
+	})
+}
+
+func TestParseGoLock_Replacements_NotRequired(t *testing.T) {
+	t.Parallel()
+
+	packages, err := lockfile.ParseGoLock("fixtures/go/replace-not-required.mod")
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
-			Name:      "./fork/far",
-			Version:   "",
+			Name:      "golang.org/x/net",
+			Version:   "0.5.6",
+			Ecosystem: lockfile.GoEcosystem,
+			CompareAs: lockfile.GoEcosystem,
+		},
+		{
+			Name:      "github.com/BurntSushi/toml",
+			Version:   "1.0.0",
+			Ecosystem: lockfile.GoEcosystem,
+			CompareAs: lockfile.GoEcosystem,
+		},
+	})
+}
+
+
+func TestParseGoLock_Replacements_NoVersion(t *testing.T) {
+	t.Parallel()
+
+	packages, err := lockfile.ParseGoLock("fixtures/go/replace-no-version.mod")
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	expectPackages(t, packages, []lockfile.PackageDetails{
+		{
+			Name:      "example.com/fork/net",
+			Version:   "1.4.5",
 			Ecosystem: lockfile.GoEcosystem,
 			CompareAs: lockfile.GoEcosystem,
 		},

--- a/pkg/lockfile/parse-go-lock_test.go
+++ b/pkg/lockfile/parse-go-lock_test.go
@@ -121,3 +121,47 @@ func TestParseGoLock_IndirectPackages(t *testing.T) {
 		},
 	})
 }
+
+func TestParseGoLock_Replacements_One(t *testing.T) {
+	t.Parallel()
+
+	packages, err := lockfile.ParseGoLock("fixtures/go/replace-one.mod")
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	expectPackages(t, packages, []lockfile.PackageDetails{
+		{
+			Name:      "example.com/fork/net",
+			Version:   "1.4.5",
+			Ecosystem: lockfile.GoEcosystem,
+			CompareAs: lockfile.GoEcosystem,
+		},
+	})
+}
+
+func TestParseGoLock_Replacements_Many(t *testing.T) {
+	t.Parallel()
+
+	packages, err := lockfile.ParseGoLock("fixtures/go/replace-many.mod")
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	expectPackages(t, packages, []lockfile.PackageDetails{
+		{
+			Name:      "./fork/net",
+			Version:   "",
+			Ecosystem: lockfile.GoEcosystem,
+			CompareAs: lockfile.GoEcosystem,
+		},
+		{
+			Name:      "example.com/fork/net",
+			Version:   "1.4.5",
+			Ecosystem: lockfile.GoEcosystem,
+			CompareAs: lockfile.GoEcosystem,
+		},
+	})
+}

--- a/pkg/lockfile/parse-go-lock_test.go
+++ b/pkg/lockfile/parse-go-lock_test.go
@@ -157,9 +157,53 @@ func TestParseGoLock_Replacements_Many(t *testing.T) {
 			Ecosystem: lockfile.GoEcosystem,
 			CompareAs: lockfile.GoEcosystem,
 		},
+	})
+}
+
+func TestParseGoLock_Replacements_Mixed(t *testing.T) {
+	t.Parallel()
+
+	packages, err := lockfile.ParseGoLock("fixtures/go/replace-mixed.mod")
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
-			Name:      "example.com/fork/net",
+			Name:      "./fork/net",
+			Version:   "",
+			Ecosystem: lockfile.GoEcosystem,
+			CompareAs: lockfile.GoEcosystem,
+		},
+	})
+}
+
+func TestParseGoLock_Replacements_Different(t *testing.T) {
+	t.Parallel()
+
+	packages, err := lockfile.ParseGoLock("fixtures/go/replace-different.mod")
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	expectPackages(t, packages, []lockfile.PackageDetails{
+		{
+			Name:      "example.com/fork/foe",
 			Version:   "1.4.5",
+			Ecosystem: lockfile.GoEcosystem,
+			CompareAs: lockfile.GoEcosystem,
+		},
+		{
+			Name:      "example.com/fork/foe",
+			Version:   "1.4.2",
+			Ecosystem: lockfile.GoEcosystem,
+			CompareAs: lockfile.GoEcosystem,
+		},
+		{
+			Name:      "./fork/far",
+			Version:   "",
 			Ecosystem: lockfile.GoEcosystem,
 			CompareAs: lockfile.GoEcosystem,
 		},


### PR DESCRIPTION
Resolves #30

In theory this adds support for `replace`, though in practice it's only going to be useful when the replacement package is remote because there's no way to resolve the local package to the corresponding remote package name that'll be in OSVs - it's tempting to try and infer that from the target (e.g. if you're replacing `golang.org/x/net` with `./fork/net`, then it could be reasonable to assume its a fork of `golang.org/x/net`) but in practice there's no way to know when that shouldn't be applied either.

Likewise for the version, if there isn't one set as part of the replacement then there's not really anything that can be done because there's no requirement from Go that a version be specified for the replacement package anywhere on disk - the best that could be done would be to try and look for a git commit, but I think that is out of scope for this section of code + PR.