### PR TITLE
fix: change error strings to golang convention

### DIFF
--- a/cmd/osv-scanner/main.go
+++ b/cmd/osv-scanner/main.go
@@ -80,7 +80,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 			}
 
 			if err := r.PrintResult(&vulnResult); err != nil {
-				return fmt.Errorf("Failed to write output: %v", err)
+				return fmt.Errorf("failed to write output: %v", err)
 			}
 
 			return nil

--- a/internal/osv/osv.go
+++ b/internal/osv/osv.go
@@ -113,10 +113,10 @@ func checkResponseError(resp *http.Response) error {
 
 	respBuf, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return fmt.Errorf("Failed to read error response from server: %w", err)
+		return fmt.Errorf("failed to read error response from server: %w", err)
 	}
 
-	return fmt.Errorf("Server response error: %s", string(respBuf))
+	return fmt.Errorf("server response error: %s", string(respBuf))
 }
 
 func MakeRequest(request BatchedQuery) (*BatchedResponse, error) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -96,7 +96,7 @@ func (c *ConfigManager) Get(r *output.Reporter, targetPath string) Config {
 func normalizeConfigLoadPath(target string) (string, error) {
 	stat, err := os.Stat(target)
 	if err != nil {
-		return "", fmt.Errorf("Failed to stat target: %w", err)
+		return "", fmt.Errorf("failed to stat target: %w", err)
 	}
 
 	var containingFolder string
@@ -117,11 +117,11 @@ func tryLoadConfig(r *output.Reporter, configPath string) (Config, error) {
 	if err == nil { // File exists, and we have permission to read
 		_, err := toml.NewDecoder(configFile).Decode(&config)
 		if err != nil {
-			return Config{}, fmt.Errorf("Failed to parse config file: %w\n", err)
+			return Config{}, fmt.Errorf("failed to parse config file: %w\n", err)
 		}
 		config.LoadPath = configPath
 		return config, nil
 	}
 
-	return Config{}, fmt.Errorf("No config file found on this path: %s", configPath)
+	return Config{}, fmt.Errorf("no config file found on this path: %s", configPath)
 }

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -30,7 +30,7 @@ type ScannerActions struct {
 }
 
 // Error for when no packages is found during a scan.
-var NoPackagesFoundErr = errors.New("No packages found in scan.")
+var NoPackagesFoundErr = errors.New("no packages found in scan")
 
 // scanDir walks through the given directory to try to find any relevant files
 // These include:
@@ -153,7 +153,7 @@ func getCommitSHA(repoDir string) (string, error) {
 		if exiterr, ok := err.(*exec.ExitError); ok && exiterr.ExitCode() == 128 {
 			return "", fmt.Errorf("Failed to get commit hash, no commits exist? %w", exiterr)
 		} else {
-			return "", fmt.Errorf("Failed to get commit hash: %w", err)
+			return "", fmt.Errorf("failed to get commit hash: %w", err)
 		}
 	}
 
@@ -210,7 +210,7 @@ func scanDebianDocker(r *output.Reporter, query *osv.BatchedQuery, dockerImageNa
 		splitText := strings.Split(text, "###")
 		if len(splitText) != 2 {
 			r.PrintError(fmt.Sprintf("Unexpected output from Debian container: \n\n%s\n", text))
-			return fmt.Errorf("Unexpected output from Debian container: \n\n%s", text)
+			return fmt.Errorf("unexpected output from Debian container: \n\n%s", text)
 		}
 		pkgDetailsQuery := osv.MakePkgRequest(lockfile.PackageDetails{
 			Name:    splitText[0],
@@ -299,7 +299,7 @@ func DoScan(actions ScannerActions, r *output.Reporter) (models.VulnerabilityRes
 	for _, sbomElem := range actions.SBOMPaths {
 		sbomElem, err := filepath.Abs(sbomElem)
 		if err != nil {
-			return models.VulnerabilityResults{}, fmt.Errorf("Failed to resolved path with error %s\n", err)
+			return models.VulnerabilityResults{}, fmt.Errorf("failed to resolved path with error %s\n", err)
 		}
 		err = scanSBOMFile(r, &query, sbomElem)
 		if err != nil {
@@ -328,7 +328,7 @@ func DoScan(actions ScannerActions, r *output.Reporter) (models.VulnerabilityRes
 
 	resp, err := osv.MakeRequest(query)
 	if err != nil {
-		return models.VulnerabilityResults{}, fmt.Errorf("Scan failed %v", err)
+		return models.VulnerabilityResults{}, fmt.Errorf("scan failed %v", err)
 	}
 
 	filtered := filterResponse(r, query, resp, &configManager)
@@ -338,7 +338,7 @@ func DoScan(actions ScannerActions, r *output.Reporter) (models.VulnerabilityRes
 
 	hydratedResp, err := osv.Hydrate(resp)
 	if err != nil {
-		return models.VulnerabilityResults{}, fmt.Errorf("Failed to hydrate OSV response: %v", err)
+		return models.VulnerabilityResults{}, fmt.Errorf("failed to hydrate OSV response: %v", err)
 	}
 
 	return groupResponse(r, query, hydratedResp, &configManager), nil


### PR DESCRIPTION
The error messages were not following the convention established for Go: [Convention](https://github.com/golang/go/wiki/CodeReviewComments#error-strings)