### PR TITLE
Fix go releaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,6 +36,6 @@ checksum:
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
   algorithm: sha256
 release:
-  draft: true
+  draft: false
 changelog:
   skip: true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,9 +26,7 @@ builds:
       # Further testing before supporting arm
       # - arm
       # - arm64
-    ignore:
-      - goos: linux
-        goarch: amd64
+    main: ./cmd/osv-scanner/main.go
     binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
   - format: binary

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,7 +22,8 @@ builds:
       - darwin
     goarch:
       - amd64
-      - '386'
+      # 32bit does not compile at the moment because of spdx dependency
+      # - '386'
       # Further testing before supporting arm
       # - arm
       # - arm64


### PR DESCRIPTION
Tested and working though the output is a bit rough: 
A release would look like this: https://github.com/another-rex/osv-scanner/releases/tag/v0.1.4