### PR TITLE
Fix minor bug when passing in unknown flags

### DIFF
--- a/cmd/osv-scanner/main.go
+++ b/cmd/osv-scanner/main.go
@@ -88,6 +88,9 @@ func run(args []string, stdout, stderr io.Writer) int {
 	}
 
 	if err := app.Run(args); err != nil {
+		if r == nil {
+			r = output.NewReporter(stdout, stderr, false)
+		}
 		if errors.Is(err, osvscanner.NoPackagesFoundErr) {
 			r.PrintError(fmt.Sprintf("No package sources found, --help for usage information.\n"))
 			return 128


### PR DESCRIPTION
Currently a nil pointer exception appears when passing in unknown flags. 