### PR TITLE
feat: add version command

### DIFF
--- a/cmd/osv-scanner/main.go
+++ b/cmd/osv-scanner/main.go
@@ -12,11 +12,23 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+var (
+	version = "dev"
+	commit  = "n/a"
+	date    = "n/a"
+)
+
 func run(args []string, stdout, stderr io.Writer) int {
 	var r *output.Reporter
 
+	cli.VersionPrinter = func(ctx *cli.Context) {
+		r = output.NewReporter(stdout, stderr, false)
+		r.PrintText(fmt.Sprintf("osv-scanner version: %s\ncommit: %s\nbuilt at: %s\n", ctx.App.Version, commit, date))
+	}
+
 	app := &cli.App{
 		Name:      "osv-scanner",
+		Version:   version,
 		Usage:     "scans various mediums for dependencies and matches it against the OSV database",
 		Suggest:   true,
 		Writer:    stdout,


### PR DESCRIPTION
The version command was missing, as mentioned in this [issue](https://github.com/google/osv-scanner/issues/42).

The goreleaser already setting build information here: https://github.com/google/osv-scanner/blob/e5f1dc67baff39c840963a5966219f81e2c7fe76/.goreleaser.yml#L14-L16, to take advantage of this I implemented this feature based on this information.

The "urfave/cli" already has a clean way to implement this feature, as mentioned here: https://cli.urfave.org/v2/examples/version-flag/

