### PR TITLE
Enable arm64 build target

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,7 +26,7 @@ builds:
       # - '386'
       # Further testing before supporting arm
       # - arm
-      # - arm64
+      - arm64
     main: ./cmd/osv-scanner/main.go
     binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:


### PR DESCRIPTION
Tested locally emulating aarch64 and it ran successfully. Scorecard also supports aarch64. Fixes #49