### PR TITLE
Added installation instructions for Scoop

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,9 @@ The above all results in fewer, more actionable vulnerability notifications, whi
 ### Installation Process
 You may download the [SLSA3](https://slsa.dev) compliant binaries for Linux, macOS, and Windows from our [releases page](https://github.com/google/osv-scanner/releases).
 
-#### Windows
+#### Package Managers
 
-On Windows, you can install this using the [Scoop](https://scoop.sh/) package manager by running:
-
+If you're a [**Windows Scoop**](https://scoop.sh) user, then you can install osv-scanner from the [official bucket](https://github.com/ScoopInstaller/Main/blob/master/bucket/osv-scanner.json):
 ```shell
 scoop install osv-scanner
 ```

--- a/README.md
+++ b/README.md
@@ -35,9 +35,18 @@ The above all results in fewer, more actionable vulnerability notifications, whi
 ### Installation Process
 You may download the [SLSA3](https://slsa.dev) compliant binaries for Linux, macOS, and Windows from our [releases page](https://github.com/google/osv-scanner/releases).
 
+#### Windows
+
+On Windows, you can install this using the [Scoop](https://scoop.sh/) package manager by running:
+
+```shell
+scoop install osv-scanner
+```
+
 #### Install from source
 
 Alternatively, you can install this from source by running:
+
 ```bash
 $ go install github.com/google/osv-scanner/cmd/osv-scanner@v1
 ```
@@ -45,6 +54,7 @@ $ go install github.com/google/osv-scanner/cmd/osv-scanner@v1
 This requires Go 1.18+ to be installed.
 
 ### SemVer Adherence
+
 All releases on the same Major version will be guaranteed to have backward compatible JSON output and CLI arguments.
 
 ## Usage


### PR DESCRIPTION
This PR adds installation instructions for using Scoop on Windows (https://github.com/ScoopInstaller/Main/pull/4231) which should make it nice and easy for anyone on a Windows machine to use this.