### PR TITLE
Move table columns so that the important column is displayed first

### DIFF
--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -18,7 +18,18 @@ import (
 func PrintTableResults(vulnResult *models.VulnerabilityResults, outputWriter io.Writer) {
 	outputTable := table.NewWriter()
 	outputTable.SetOutputMirror(outputWriter)
-	outputTable.AppendHeader(table.Row{"Source", "Ecosystem", "Affected Package", "Version", "OSV URL (ID In Bold)"})
+	outputTable.AppendHeader(table.Row{"OSV URL (ID In Bold)", "Ecosystem", "Affected Package", "Version", "Source"})
+
+	width, _, err := term.GetSize(int(os.Stdout.Fd()))
+	isTerminal := false
+	if err == nil { // If output is a terminal, set max length to width and add styling
+		outputTable.SetStyle(table.StyleRounded)
+		outputTable.Style().Color.Row = text.Colors{text.Reset, text.BgHiBlack}
+		outputTable.Style().Color.RowAlternate = text.Colors{text.Reset, text.BgBlack}
+		outputTable.SetAllowedRowLength(width)
+		isTerminal = true
+	} // Otherwise use default ascii (e.g. getting piped to a file)
+
 	for _, sourceRes := range vulnResult.Results {
 		for _, pkg := range sourceRes.Packages {
 			workingDir, err := os.Getwd()
@@ -31,8 +42,23 @@ func PrintTableResults(vulnResult *models.VulnerabilityResults, outputWriter io.
 			}
 
 			for _, group := range pkg.Groups {
-				outputRow := table.Row{source.Path}
+				outputRow := table.Row{}
 				shouldMerge := false
+
+				var ids []string
+				var links []string
+
+				for _, vuln := range group.IDs {
+					ids = append(ids, vuln)
+					if isTerminal {
+						links = append(links, osv.BaseVulnerabilityURL+text.Bold.EscapeSeq()+vuln+text.Reset.EscapeSeq())
+					} else {
+						links = append(links, osv.BaseVulnerabilityURL+vuln)
+					}
+				}
+
+				outputRow = append(outputRow, strings.Join(links, "\n"))
+
 				if pkg.Package.Ecosystem == "GIT" {
 					outputRow = append(outputRow, "GIT", pkg.Package.Version, pkg.Package.Version)
 					shouldMerge = true
@@ -40,28 +66,12 @@ func PrintTableResults(vulnResult *models.VulnerabilityResults, outputWriter io.
 					outputRow = append(outputRow, pkg.Package.Ecosystem, pkg.Package.Name, pkg.Package.Version)
 				}
 
-				var ids []string
-				var links []string
-
-				for _, vuln := range group.IDs {
-					ids = append(ids, vuln)
-					links = append(links, osv.BaseVulnerabilityURL+text.Bold.EscapeSeq()+vuln+text.Reset.EscapeSeq())
-				}
-
-				outputRow = append(outputRow, strings.Join(links, "\n"))
+				outputRow = append(outputRow, source.Path)
 				outputTable.AppendRow(outputRow, table.RowConfig{AutoMerge: shouldMerge})
 			}
 		}
 	}
 
-	outputTable.SetStyle(table.StyleRounded)
-	outputTable.Style().Color.Row = text.Colors{text.Reset, text.BgHiBlack}
-	outputTable.Style().Color.RowAlternate = text.Colors{text.Reset, text.BgBlack}
-
-	width, _, err := term.GetSize(int(os.Stdout.Fd()))
-	if err == nil { // If output is a terminal, set max length to width
-		outputTable.SetAllowedRowLength(width)
-	} // Otherwise don't set max width (e.g. getting piped to a file)
 	if outputTable.Length() == 0 {
 		return
 	}


### PR DESCRIPTION
(and last to get cropped

Also only do unicode output when printing to terminal, otherwise print default ascii when being piped to file or piped to a pager. 

Partially fixes #85 