### PR TITLE
Wrap source column when it exceeds 40 characters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/CycloneDX/cyclonedx-go v0.7.0
 	github.com/google/go-cmp v0.5.9
 	github.com/jedib0t/go-pretty/v6 v6.4.3
+	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/package-url/packageurl-go v0.1.0
 	github.com/spdx/tools-golang v0.3.0
 	github.com/urfave/cli/v2 v2.23.7

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/jedib0t/go-pretty/v6 v6.4.3 h1:2n9BZ0YQiXGESUSR+6FLg0WWWE80u+mIz35f0u
 github.com/jedib0t/go-pretty/v6 v6.4.3/go.mod h1:MgmISkTWDSFu0xOqiZ0mKNntMQ2mDgOcwOkwBEkMDJI=
 github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
+github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
+github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
 github.com/package-url/packageurl-go v0.1.0 h1:efWBc98O/dBZRg1pw2xiDzovnlMjCa9NPnfaiBduh8I=
 github.com/package-url/packageurl-go v0.1.0/go.mod h1:C/ApiuWpmbpni4DIOECf6WCjFUZV7O1Fx7VAzrZHgBw=
 github.com/pkg/profile v1.6.0/go.mod h1:qBsxPvzyUincmltOk6iyRVxHYg4adc0OFOv72ZdLa18=

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -16,13 +16,12 @@ import (
 )
 
 const sourceLength = 40
-const headerRow = table.Row{"OSV URL (ID In Bold)", "Ecosystem", "Package", "Version", "Source"}
 
 // PrintTableResults prints the osv scan results into a human friendly table.
 func PrintTableResults(vulnResult *models.VulnerabilityResults, outputWriter io.Writer) {
 	outputTable := table.NewWriter()
 	outputTable.SetOutputMirror(outputWriter)
-	outputTable.AppendHeader(headerRow)
+	outputTable.AppendHeader(table.Row{"OSV URL (ID In Bold)", "Ecosystem", "Package", "Version", "Source"})
 
 	width, _, err := term.GetSize(int(os.Stdout.Fd()))
 	isTerminal := false

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -16,12 +16,13 @@ import (
 )
 
 const sourceLength = 40
+const headerRow = table.Row{"OSV URL (ID In Bold)", "Ecosystem", "Package", "Version", "Source"}
 
 // PrintTableResults prints the osv scan results into a human friendly table.
 func PrintTableResults(vulnResult *models.VulnerabilityResults, outputWriter io.Writer) {
 	outputTable := table.NewWriter()
 	outputTable.SetOutputMirror(outputWriter)
-	outputTable.AppendHeader(table.Row{"OSV URL (ID In Bold)", "Ecosystem", "Affected Package", "Version", "Source"})
+	outputTable.AppendHeader(headerRow)
 
 	width, _, err := term.GetSize(int(os.Stdout.Fd()))
 	isTerminal := false

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -8,11 +8,14 @@ import (
 
 	"github.com/google/osv-scanner/internal/osv"
 	"github.com/google/osv-scanner/pkg/models"
+	"github.com/mitchellh/go-wordwrap"
 
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/jedib0t/go-pretty/v6/text"
 	"golang.org/x/term"
 )
+
+const sourceLength = 40
 
 // PrintTableResults prints the osv scan results into a human friendly table.
 func PrintTableResults(vulnResult *models.VulnerabilityResults, outputWriter io.Writer) {
@@ -66,7 +69,7 @@ func PrintTableResults(vulnResult *models.VulnerabilityResults, outputWriter io.
 					outputRow = append(outputRow, pkg.Package.Ecosystem, pkg.Package.Name, pkg.Package.Version)
 				}
 
-				outputRow = append(outputRow, source.Path)
+				outputRow = append(outputRow, wrapPath(source.Path))
 				outputTable.AppendRow(outputRow, table.RowConfig{AutoMerge: shouldMerge})
 			}
 		}
@@ -75,5 +78,14 @@ func PrintTableResults(vulnResult *models.VulnerabilityResults, outputWriter io.
 	if outputTable.Length() == 0 {
 		return
 	}
+
 	outputTable.Render()
+}
+
+func wrapPath(path string) string {
+	slashPath := filepath.ToSlash(path)
+	moddedPath := strings.ReplaceAll(slashPath, "/", "/ ")
+	wrappedPath := wordwrap.WrapString(moddedPath, sourceLength)
+	unmoddedWrappedPath := strings.ReplaceAll(wrappedPath, "/ ", "/")
+	return filepath.FromSlash(unmoddedWrappedPath)
 }

--- a/internal/output/table_test.go
+++ b/internal/output/table_test.go
@@ -1,0 +1,36 @@
+package output
+
+import "testing"
+
+func Test_wrapPath(t *testing.T) {
+	type args struct {
+		path string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "No wrap",
+			args: args{
+				path: "some/short/path",
+			},
+			want: "some/short/path",
+		},
+		{
+			name: "Wrapping",
+			args: args{
+				path: "a/much/much/longer/path/here12345678901234567",
+			},
+			want: "a/much/much/longer/path/\nhere12345678901234567",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := wrapPath(tt.args.path); got != tt.want {
+				t.Errorf("wrapPath() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Wrap source column when it exceeds 40 characters. An improvement to this is to calculate the max width of the table and only wrap to that. 