### PR TITLE
Fix lockfile command example flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ A wide range of lockfiles are supported by utilizing this [lockfile package](htt
 #### Example
 
 ```bash
-$ osv-scanner --lockfile=/path/to/your/package-lock.json -L /path/to/another/Cargo.lock
+$ osv-scanner --lockfile=/path/to/your/package-lock.json --lockfile=/path/to/another/Cargo.lock
 ```
 
 ### Scanning a Debian based docker image packages (preview)


### PR DESCRIPTION
## What does this do?

Corrects the osv-scanner command example for scanning lockfiles to use consistent command line flags.

## Why?

Using mixed `--lockfile` and `-L` options in the same command (as shown in example) results in a `Can't use two forms of same flag: L lockfile` error.