### PR TITLE
fix: ensure that files are closed when they're no longer needed

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -114,10 +114,12 @@ func normalizeConfigLoadPath(target string) (string, error) {
 // tryLoadConfig tries to load config in `target` (or it's containing directory)
 // `target` will be the key for the entry in configMap
 func tryLoadConfig(r *output.Reporter, configPath string) (Config, error) {
-	configFile, err := os.Open(configPath)
+	file, err := os.Open(configPath)
 	var config Config
 	if err == nil { // File exists, and we have permission to read
-		_, err := toml.NewDecoder(configFile).Decode(&config)
+		defer file.Close()
+
+		_, err := toml.NewDecoder(file).Decode(&config)
 		if err != nil {
 			return Config{}, fmt.Errorf("failed to parse config file: %w\n", err)
 		}

--- a/pkg/lockfile/csv.go
+++ b/pkg/lockfile/csv.go
@@ -97,13 +97,13 @@ func FromCSVRows(filePath string, parseAs string, rows []string) (Lockfile, erro
 }
 
 func FromCSVFile(pathToCSV string, parseAs string) (Lockfile, error) {
-	reader, err := os.Open(pathToCSV)
-
+	file, err := os.Open(pathToCSV)
 	if err != nil {
 		return Lockfile{}, fmt.Errorf("could not read %s: %w", pathToCSV, err)
 	}
+	defer file.Close()
 
-	packages, err := fromCSV(reader)
+	packages, err := fromCSV(file)
 
 	if err != nil {
 		err = fmt.Errorf("%s: %w", pathToCSV, err)

--- a/pkg/lockfile/parse-gradle-lock.go
+++ b/pkg/lockfile/parse-gradle-lock.go
@@ -37,15 +37,14 @@ func parseToGradlePackageDetail(line string) (PackageDetails, error) {
 }
 
 func ParseGradleLock(pathToLockfile string) ([]PackageDetails, error) {
-	lockFile, err := os.Open(pathToLockfile)
+	file, err := os.Open(pathToLockfile)
 	if err != nil {
 		return []PackageDetails{}, fmt.Errorf("could not open %s: %w", pathToLockfile, err)
 	}
-
-	defer lockFile.Close()
+	defer file.Close()
 
 	pkgs := make([]PackageDetails, 0, 0)
-	scanner := bufio.NewScanner(lockFile)
+	scanner := bufio.NewScanner(file)
 
 	for scanner.Scan() {
 		lockLine := strings.TrimSpace(scanner.Text())

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -109,6 +109,7 @@ func scanSBOMFile(r *output.Reporter, query *osv.BatchedQuery, path string) erro
 	if err != nil {
 		return err
 	}
+	defer file.Close()
 
 	for _, provider := range sbom.Providers {
 		if provider.Name() == "SPDX" &&


### PR DESCRIPTION
Noticed by @cmaritan on #105 - so far I've not been able to reproduce the error, but it's still good practice to be calling `file.Close` otherwise they won't get closed until GC next runs which could be a while.

I've also done a slight refactor of variable names for consistency.