### PR TITLE
Update ldflags for reproducible builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,7 +13,7 @@ builds:
       - -trimpath
     ldflags:
       # prettier-ignore
-      - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.CommitDate}}'
+      - '-s -w'
     goos:
       # Further testing before supporting freebsd
       # - freebsd


### PR DESCRIPTION
This should make it possible to reproduce the GoReleaser builds (tested locally with --snapshot and compared with GH release).

See https://goreleaser.com/customization/build/#reproducible-builds