### PR TITLE
Have renovate-bot label its PRs as it does with osv.dev

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
   ],
   "timezone": "Australia/Sydney",
   "schedule": ["before 6am on monday"],
+  "labels": ["dependencies"],
   "packageRules": [
     {
       "matchUpdateTypes": ["major"],


### PR DESCRIPTION
Use the same PR labelling strategy we're using the osv.dev repo.