### PR TITLE
Make lint trigger same as codeql

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,7 +14,12 @@
 
 name: lint
 
-on: [pull_request]
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ main ]
 
 permissions: read-all
 


### PR DESCRIPTION
Which results in lint checks on the main branch after the PR has been merged.