### PR TITLE
Workflow for linting markdown files

### DIFF
--- a/.github/workflows/lint-code.yaml
+++ b/.github/workflows/lint-code.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: lint
+name: Lint Code
 
 on:
   push:
@@ -24,8 +24,8 @@ on:
 permissions: read-all
 
 jobs:
-  lint:
-    name: Lint and format
+  lint-go-code:
+    name: Lint and format Go code
     runs-on: ubuntu-latest
     steps:
       - name: Check out code

--- a/.github/workflows/lint-docs.yaml
+++ b/.github/workflows/lint-docs.yaml
@@ -1,20 +1,24 @@
 name: Lint Docs
 
-on: [pull_request]
+on:
+  pull_request:
+    paths:
+      # Only run this workflow when these paths have changes
+      - '**.md'
+      - '.github/workflows/lint-docs.yaml'
 
 permissions: read-all
 
 jobs:
-  lint:
+  lint-markdown-docs:
     name: Lint Markdown
     runs-on: ubuntu-latest
     steps:
-      - name: Check out code
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
-      - name: Set up Go
-        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+      - name: Checkout code
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+
+      - name: Run markdownlint action
+        uses: DavidAnson/markdownlint-cli2-action@5b7c9f74fec47e6b15667b2cc23c63dff11e449e
         with:
-          go-version: '1.19'
-          check-latest: true
-      - name: Run go vet
-        run: ./run_lints.sh
+          globs: |
+            "**/*.md"

--- a/.github/workflows/lint-docs.yaml
+++ b/.github/workflows/lint-docs.yaml
@@ -1,0 +1,20 @@
+name: Lint Docs
+
+on: [pull_request]
+
+permissions: read-all
+
+jobs:
+  lint:
+    name: Lint Markdown
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
+      - name: Set up Go
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+        with:
+          go-version: '1.19'
+          check-latest: true
+      - name: Run go vet
+        run: ./run_lints.sh

--- a/.github/workflows/lint-docs.yaml
+++ b/.github/workflows/lint-docs.yaml
@@ -20,5 +20,4 @@ jobs:
       - name: Run markdownlint action
         uses: DavidAnson/markdownlint-cli2-action@5b7c9f74fec47e6b15667b2cc23c63dff11e449e
         with:
-          globs: |
-            "**/*.md"
+          globs: "**/*.md"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-v1.1.0:
-===
+# Changelog
+
+## v1.1.0
 
 This update adds support for NuGet ecosystem and various bug fixes by the community.
 
@@ -10,17 +11,14 @@ This update adds support for NuGet ecosystem and various bug fixes by the commun
 - [Bug #131](https://github.com/google/osv-scanner/pull/131): Fix table highlighting overflow.
 - [Bug #101](https://github.com/google/osv-scanner/issues/101): Now supports 32 bit systems.
 
-
-v1.0.2
-===
+## v1.0.2
 
 This is a minor patch release to mitigate human readable output issues on narrow terminals (#85).
 
 - [Bug #85](https://github.com/google/osv-scanner/issues/85): Better support for narrow terminals.
 
+## v1.0.1
 
-v1.0.1
-===
 Various bug fixes and improvements. Many thanks to the amazing contributions and suggestions from the community!
 
 - Feature: ARM64 builds are now also available!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,9 @@ This project follows
 ## Contributing code
 
 ### Prerequisites
+
 Install:
+
 1. [Go](https://go.dev/) 1.18+, use `go version` to check.
 2. [GoReleaser](https://goreleaser.com/) (Optional, only if you want reproducible builds).
 
@@ -39,16 +41,19 @@ Install:
 #### Build using only `go`
 
 Run the following in the project directory:
-```shell
-$ go build ./cmd/osv-scanner/
+
+```console
+go build ./cmd/osv-scanner/
 ```
+
 Produces `osv-scanner` binary in the project directory.
 
 #### Build using `goreleaser`
 
 Run the following in the project directory:
-```shell
-$ goreleaser build --rm-dist --single-target --snapshot
+
+```console
+goreleaser build --rm-dist --single-target --snapshot
 ```
 
 See GoReleaser [documentation](https://goreleaser.com/cmd/goreleaser_build/) for build options.
@@ -59,13 +64,15 @@ using the same Go version as the one used during the actual release (see gorelea
 ### Running tests
 
 To run tests:
-```shell
+
+```console
 ./run_tests.sh
 ```
 
 ### Linting
+
 To lint your code, run
 
-```shell
+```console
 ./run_lints.sh
 ```

--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ brew install osv-scanner
 ```
 
 If you're a Arch Linux User, you can install osv-scanner from the official repo:
-```
+
+```console
 pacman -S osv-scanner
 ```
 
@@ -147,7 +148,7 @@ A wide range of lockfiles are supported by utilizing this [lockfile package](htt
 #### Example
 
 ```console
-$ osv-scanner --lockfile=/path/to/your/package-lock.json --lockfile=/path/to/another/Cargo.lock
+osv-scanner --lockfile=/path/to/your/package-lock.json --lockfile=/path/to/another/Cargo.lock
 ```
 
 ### Scanning a Debian based docker image packages (preview)
@@ -212,6 +213,7 @@ reason = "No external http servers are written in Go lang."
 ```
 
 ## JSON output
+
 By default osv-scanner outputs a human readable table. To have osv-scanner output JSON instead, pass the `--json` flag when calling osv-scanner.
 
 When using the --json flag, only the JSON output will be printed to stdout, with all other outputs being directed to stderr. So to save only the json output to file, you can redirect the output with `osv-scanner --json ... > /path/to/file.json`
@@ -310,12 +312,12 @@ When using the --json flag, only the JSON output will be printed to stdout, with
 ## Contribute
 
 ### Report Problems
+
 If you have what looks like a bug, please use the [Github issue tracking system](https://github.com/google/osv-scanner/issues). Before you file an issue, please search existing issues to see if your issue is already covered.
 
 ### Contributing code to `osv-scanner`
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for documentation on how to contribute code.
-
 
 ## Stargazers over time
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ The above all results in fewer, more actionable vulnerability notifications, whi
 [announcement blog post]: https://security.googleblog.com/2022/12/announcing-osv-scanner-vulnerability.html
 
 ## Table of Contents
-
 - [OSV-Scanner](#osv-scanner)
   - [Table of Contents](#table-of-contents)
   - [Installing](#installing)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The above all results in fewer, more actionable vulnerability notifications, whi
 [announcement blog post]: https://security.googleblog.com/2022/12/announcing-osv-scanner-vulnerability.html
 
 ## Table of Contents
+
 - [OSV-Scanner](#osv-scanner)
   - [Table of Contents](#table-of-contents)
   - [Installing](#installing)


### PR DESCRIPTION
Following from #100 this PR adds a workflow to lint any markdown files within the repository.

On #100 it was suggested to use Prettier for this. Instead I have used [David Anson's markdownlint-cli2 action](https://github.com/marketplace/actions/markdownlint-cli2-action). There are a couple reasons not to use Prettier.

- Prettier does not support Go, so would be adding a very broad tool for one simple part of functionality
- Actions are simpler to use in GitHub workflows
- I'm not too familiar with Prettier 😄 

Developers still have the ability to run this check from a development environment using [markdownlint-cli2 itself](https://github.com/DavidAnson/markdownlint-cli2) or any intergration in their IDE, such as [this one for vscode](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint).

That said, if there is a strong preference for Prettier I would be happy to look into using that instead 🙂 .