### PR TITLE
Do not highlight borders of result table

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/BurntSushi/toml v1.2.1
 	github.com/CycloneDX/cyclonedx-go v0.7.0
 	github.com/google/go-cmp v0.5.9
-	github.com/jedib0t/go-pretty/v6 v6.4.3
+	github.com/jedib0t/go-pretty/v6 v6.4.4
 	github.com/package-url/packageurl-go v0.1.0
 	github.com/spdx/tools-golang v0.3.0
 	github.com/urfave/cli/v2 v2.23.7

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/jedib0t/go-pretty/v6 v6.4.3 h1:2n9BZ0YQiXGESUSR+6FLg0WWWE80u+mIz35f0uHWcIE=
-github.com/jedib0t/go-pretty/v6 v6.4.3/go.mod h1:MgmISkTWDSFu0xOqiZ0mKNntMQ2mDgOcwOkwBEkMDJI=
+github.com/jedib0t/go-pretty/v6 v6.4.4 h1:N+gz6UngBPF4M288kiMURPHELDMIhF/Em35aYuKrsSc=
+github.com/jedib0t/go-pretty/v6 v6.4.4/go.mod h1:MgmISkTWDSFu0xOqiZ0mKNntMQ2mDgOcwOkwBEkMDJI=
 github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/package-url/packageurl-go v0.1.0 h1:efWBc98O/dBZRg1pw2xiDzovnlMjCa9NPnfaiBduh8I=

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -26,6 +26,7 @@ func PrintTableResults(vulnResult *models.VulnerabilityResults, outputWriter io.
 		outputTable.SetStyle(table.StyleRounded)
 		outputTable.Style().Color.Row = text.Colors{text.Reset, text.BgHiBlack}
 		outputTable.Style().Color.RowAlternate = text.Colors{text.Reset, text.BgBlack}
+		outputTable.Style().Options.DoNotColorBordersAndSeparators = true
 		outputTable.SetAllowedRowLength(width)
 		isTerminal = true
 	} // Otherwise use default ascii (e.g. getting piped to a file)


### PR DESCRIPTION
When I ran osv-scanner in my repo, I got the following output:

<img width="797" alt="screenshot" src="https://user-images.githubusercontent.com/823277/211519090-c13ee192-7a34-460d-9f63-43370bbd8a33.png">

This looked weird for me since the entire lower half of table is highlighted including borders. I reported this at https://github.com/jedib0t/go-pretty/issues/248 and the maintainer kindly added an option for this.

This PR avoids highlighting borders of the table using the option. Now the output looks like below:

<img width="794" alt="スクリーンショット 2023-01-10 18 56 25" src="https://user-images.githubusercontent.com/823277/211519815-2a3180ab-b7f2-4039-b9db-06277ac80d45.png">

This looks better for me because it is clear that only the row is highlighted.

The `DoNotColorBordersAndSeparators` option requires the latest version of `go-pretty` so I updated the version in `go.mod` and `go.sum` (this was very small update from v6.4.3 to v6.4.4). I ran all tests with `run_tests.sh` and confirmed they passed successfully.