### PR TITLE
Use short url in scanner output

### DIFF
--- a/internal/osv/osv.go
+++ b/internal/osv/osv.go
@@ -17,7 +17,7 @@ const (
 	// GetEndpoint is the URL for getting vulenrabilities from OSV.
 	GetEndpoint = "https://api.osv.dev/v1/vulns"
 	// BaseVulnerabilityURL is the base URL for detailed vulnerability views.
-	BaseVulnerabilityURL = "https://osv.dev/vulnerability/"
+	BaseVulnerabilityURL = "https://osv.dev/"
 	// MaxQueriesPerRequest splits up querybatch into multiple requests if
 	// number of queries exceed this number
 	MaxQueriesPerRequest = 1000


### PR DESCRIPTION
Use short url in scanner output.

```
╭─────────────────────────────────────┬───────────┬──────────────────────────────┬─────────────────────────────────────┬──────────────────────────────────────────────────────────────────────────────────────╮
│ OSV URL (ID IN BOLD)                │ ECOSYSTEM │ PACKAGE                      │ VERSION                             │ SOURCE                                                                               │
├─────────────────────────────────────┼───────────┼──────────────────────────────┼─────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────┤
│ https://osv.dev/RUSTSEC-2021-0145   │ crates.io │ atty                         │ 0.2.14                              │ ..       │
│ https://osv.dev/GHSA-3wx7-46ch-7rq2 │ crates.io │ openssl-src                  │ 111.18.0+1.1.1n                     │ ...       │
```