### PR TITLE
chore: adjust comment to match type name

### DIFF
--- a/pkg/lockfile/parse-nuget-lock.go
+++ b/pkg/lockfile/parse-nuget-lock.go
@@ -10,7 +10,7 @@ type NuGetLockPackage struct {
 	Resolved string `json:"resolved"`
 }
 
-// NuGetLockFile contains the required dependency information as defined in
+// NuGetLockfile contains the required dependency information as defined in
 // https://github.com/NuGet/NuGet.Client/blob/6.5.0.136/src/NuGet.Core/NuGet.ProjectModel/ProjectLockFile/PackagesLockFileFormat.cs
 type NuGetLockfile struct {
 	Version      int                                    `json:"version"`


### PR DESCRIPTION
There's a Go convention with comments to start them with the name of the type/func/etc which GoLand checks for by default - afaik this isn't strictly a rule being followed in this repo, but this particular comment is only off by a single char so might as well make GoLand happy 😅 