### PR TITLE
Prettier lint md workflow

### DIFF
--- a/.github/workflows/lint-code.yaml
+++ b/.github/workflows/lint-code.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: lint
+name: Lint Code
 
 on:
   push:
@@ -25,7 +25,7 @@ permissions: read-all
 
 jobs:
   lint:
-    name: Lint and format
+    name: Lint and format Go code
     runs-on: ubuntu-latest
     steps:
       - name: Check out code

--- a/.github/workflows/lint-docs.yaml
+++ b/.github/workflows/lint-docs.yaml
@@ -25,3 +25,4 @@ jobs:
         with:
           commit_message: "Prettified markdown!"
           prettier_options: "--write --parser markdown --prose-wrap always --print-width 80 **/*.md"
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint-docs.yaml
+++ b/.github/workflows/lint-docs.yaml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
+        with:
+          ref: ${{ github.head_ref }}
 
       - name: Run Prettier action
         uses: creyD/prettier_action@6602189cf8bac1ce73ffe601925f6127ab7f21ac # 4.2.0

--- a/.github/workflows/lint-docs.yaml
+++ b/.github/workflows/lint-docs.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Run Prettier action

--- a/.github/workflows/lint-docs.yaml
+++ b/.github/workflows/lint-docs.yaml
@@ -1,0 +1,27 @@
+name: Lint Docs
+
+on:
+  pull_request:
+    paths:
+      # Only run this workflow when these paths have changed
+      - '**.md'
+      - '.github/workflows/lint-docs.yaml'
+
+permissions: read-all
+
+jobs:
+  lint-markdown-docs:
+    name: Lint Markdown
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Run Prettier action
+        uses: creyD/prettier_action@6602189cf8bac1ce73ffe601925f6127ab7f21ac # 4.2.0
+        with:
+          dry: True
+          commit_message: "Prettified markdown!"
+          prettier_options: "--check --parser Markdown --prose-wrap always --print-width 80 **/*.md"

--- a/.github/workflows/lint-docs.yaml
+++ b/.github/workflows/lint-docs.yaml
@@ -16,8 +16,6 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
-        with:
-          ref: ${{ github.head_ref }}
 
       - name: Run Prettier action
         uses: creyD/prettier_action@6602189cf8bac1ce73ffe601925f6127ab7f21ac # 4.2.0

--- a/.github/workflows/lint-docs.yaml
+++ b/.github/workflows/lint-docs.yaml
@@ -20,6 +20,5 @@ jobs:
       - name: Run Prettier action
         uses: creyD/prettier_action@6602189cf8bac1ce73ffe601925f6127ab7f21ac # 4.2.0
         with:
-          dry: True
           commit_message: "Prettified markdown!"
           prettier_options: "--write --parser markdown --prose-wrap always --print-width 80 **/*.md"

--- a/.github/workflows/lint-docs.yaml
+++ b/.github/workflows/lint-docs.yaml
@@ -17,6 +17,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
         with:
+          ref: ${{ github.head_ref }}
           fetch-depth: 0
 
       - name: Run Prettier action

--- a/.github/workflows/lint-docs.yaml
+++ b/.github/workflows/lint-docs.yaml
@@ -22,4 +22,4 @@ jobs:
         with:
           dry: True
           commit_message: "Prettified markdown!"
-          prettier_options: "--check --parser markdown --prose-wrap always --print-width 80 **/*.md"
+          prettier_options: "--write --parser markdown --prose-wrap always --print-width 80 **/*.md"

--- a/.github/workflows/lint-docs.yaml
+++ b/.github/workflows/lint-docs.yaml
@@ -17,7 +17,6 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
         with:
-          ref: ${{ github.head_ref }}
           fetch-depth: 0
 
       - name: Run Prettier action

--- a/.github/workflows/lint-docs.yaml
+++ b/.github/workflows/lint-docs.yaml
@@ -22,4 +22,4 @@ jobs:
         with:
           dry: True
           commit_message: "Prettified markdown!"
-          prettier_options: "--check --parser Markdown --prose-wrap always --print-width 80 **/*.md"
+          prettier_options: "--check --parser markdown --prose-wrap always --print-width 80 **/*.md"

--- a/.github/workflows/lint-docs.yaml
+++ b/.github/workflows/lint-docs.yaml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
         with:
           ref: ${{ github.head_ref }}
+          fetch-depth: 0
 
       - name: Run Prettier action
         uses: creyD/prettier_action@6602189cf8bac1ce73ffe601925f6127ab7f21ac # 4.2.0


### PR DESCRIPTION
Alternative to #129 that uses markdownlint-cli action, this PR instead uses a Prettier action.

Initially implemented with Prettier argument `--check` to not change files in place, so as to experiment with the configuration.
Intention to later switch from `--check` to `--write`.