### PR TITLE
feat: Render output as a markdown table for use in github comments

### DIFF
--- a/cmd/osv-scanner/main.go
+++ b/cmd/osv-scanner/main.go
@@ -64,11 +64,11 @@ func run(args []string, stdout, stderr io.Writer) int {
 				Value:   "table",
 				Action: func(context *cli.Context, s string) error {
 					switch s {
-						case
-							"table",
-							"json",
-							"markdown":
-							return nil
+					case
+						"table",
+						"json",
+						"markdown":
+						return nil
 					}
 
 					return fmt.Errorf("unsupported output format \"%s\" - must be one of: \"table\", \"json\", \"markdown\"", s)

--- a/cmd/osv-scanner/main.go
+++ b/cmd/osv-scanner/main.go
@@ -63,11 +63,15 @@ func run(args []string, stdout, stderr io.Writer) int {
 				Usage:   "sets the output format",
 				Value:   "table",
 				Action: func(context *cli.Context, s string) error {
-					if s != "table" && s != "json" {
-						return fmt.Errorf("unsupported output format \"%s\" - must be either \"table\" or \"json\"", s)
+					switch s {
+						case
+							"table",
+							"json",
+							"markdown":
+							return nil
 					}
 
-					return nil
+					return fmt.Errorf("unsupported output format \"%s\" - must be one of: \"table\", \"json\", \"markdown\"", s)
 				},
 			},
 			&cli.BoolFlag{

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -222,6 +222,17 @@ func TestRun(t *testing.T) {
 				Scanned %%/fixtures/locks-many/composer.lock file and found 1 packages
 			`,
 		},
+		// output format: markdown table
+		{
+			name:         "",
+			args:         []string{"", "--format", "markdown", "./fixtures/locks-many/composer.lock"},
+			wantExitCode: 0,
+			wantStdout: `
+				Scanning dir ./fixtures/locks-many/composer.lock
+				Scanned %%/fixtures/locks-many/composer.lock file and found 1 packages
+			`,
+			wantStderr: "",
+		},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/internal/output/markdowntable.go
+++ b/internal/output/markdowntable.go
@@ -2,12 +2,8 @@ package output
 
 import (
 	"io"
-	"os"
-	"path/filepath"
-	"strings"
 
 	"github.com/google/osv-scanner/pkg/models"
-	"github.com/google/osv-scanner/pkg/osv"
 
 	"github.com/jedib0t/go-pretty/v6/table"
 )
@@ -18,43 +14,7 @@ func PrintMarkdownTableResults(vulnResult *models.VulnerabilityResults, outputWr
 	outputTable.SetOutputMirror(outputWriter)
 	outputTable.AppendHeader(table.Row{"OSV URL", "Ecosystem", "Package", "Version", "Source"})
 
-	for _, sourceRes := range vulnResult.Results {
-		for _, pkg := range sourceRes.Packages {
-			workingDir, err := os.Getwd()
-			source := sourceRes.Source
-			if err == nil {
-				sourcePath, err := filepath.Rel(workingDir, source.Path)
-				if err == nil { // Simplify the path if possible
-					source.Path = sourcePath
-				}
-			}
-
-			for _, group := range pkg.Groups {
-				outputRow := table.Row{}
-				shouldMerge := false
-
-				var ids []string
-				var links []string
-
-				for _, vuln := range group.IDs {
-					ids = append(ids, vuln)
-					links = append(links, osv.BaseVulnerabilityURL+vuln)
-				}
-
-				outputRow = append(outputRow, strings.Join(links, " <br>"))
-
-				if pkg.Package.Ecosystem == "GIT" {
-					outputRow = append(outputRow, "GIT", pkg.Package.Version, pkg.Package.Version)
-					shouldMerge = true
-				} else {
-					outputRow = append(outputRow, pkg.Package.Ecosystem, pkg.Package.Name, pkg.Package.Version)
-				}
-
-				outputRow = append(outputRow, source.Path)
-				outputTable.AppendRow(outputRow, table.RowConfig{AutoMerge: shouldMerge})
-			}
-		}
-	}
+	outputTable = tableBuilder(outputTable, vulnResult, false)
 
 	if outputTable.Length() == 0 {
 		return

--- a/internal/output/markdowntable.go
+++ b/internal/output/markdowntable.go
@@ -1,0 +1,63 @@
+package output
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/osv-scanner/internal/osv"
+	"github.com/google/osv-scanner/pkg/models"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+)
+
+// PrintTableResults prints the osv scan results into a human friendly table.
+func PrintMarkdownTableResults(vulnResult *models.VulnerabilityResults, outputWriter io.Writer) {
+	outputTable := table.NewWriter()
+	outputTable.SetOutputMirror(outputWriter)
+	outputTable.AppendHeader(table.Row{"OSV URL", "Ecosystem", "Package", "Version", "Source"})
+
+	for _, sourceRes := range vulnResult.Results {
+		for _, pkg := range sourceRes.Packages {
+			workingDir, err := os.Getwd()
+			source := sourceRes.Source
+			if err == nil {
+				sourcePath, err := filepath.Rel(workingDir, source.Path)
+				if err == nil { // Simplify the path if possible
+					source.Path = sourcePath
+				}
+			}
+
+			for _, group := range pkg.Groups {
+				outputRow := table.Row{}
+				shouldMerge := false
+
+				var ids []string
+				var links []string
+
+				for _, vuln := range group.IDs {
+					ids = append(ids, vuln)
+					links = append(links, osv.BaseVulnerabilityURL+vuln)
+				}
+
+				outputRow = append(outputRow, strings.Join(links, " <br>"))
+
+				if pkg.Package.Ecosystem == "GIT" {
+					outputRow = append(outputRow, "GIT", pkg.Package.Version, pkg.Package.Version)
+					shouldMerge = true
+				} else {
+					outputRow = append(outputRow, pkg.Package.Ecosystem, pkg.Package.Name, pkg.Package.Version)
+				}
+
+				outputRow = append(outputRow, source.Path)
+				outputTable.AppendRow(outputRow, table.RowConfig{AutoMerge: shouldMerge})
+			}
+		}
+	}
+
+	if outputTable.Length() == 0 {
+		return
+	}
+	outputTable.RenderMarkdown()
+}

--- a/internal/output/markdowntable.go
+++ b/internal/output/markdowntable.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/google/osv-scanner/internal/osv"
 	"github.com/google/osv-scanner/pkg/models"
+	"github.com/google/osv-scanner/pkg/osv"
 
 	"github.com/jedib0t/go-pretty/v6/table"
 )

--- a/internal/output/reporter.go
+++ b/internal/output/reporter.go
@@ -55,6 +55,8 @@ func (r *Reporter) PrintResult(vulnResult *models.VulnerabilityResults) error {
 	switch r.format {
 	case "json":
 		return PrintJSONResults(vulnResult, r.stdout)
+	case "markdown":
+		PrintMarkdownTableResults(vulnResult, r.stdout)
 	case "table":
 		PrintTableResults(vulnResult, r.stdout)
 	}


### PR DESCRIPTION
Add a `--markdown` command line switch that will render the output table as a markdown table for use when making comments to github and other places that use markdown.

Resolves #61

## Sample Output
Here's what the output looks like for `osv-scanner -D golang:1.18-rc-stretch --format markdown`:

### Raw
```
Scanned docker image with 189 packages
| OSV URL | Ecosystem | Package | Version | Source |
| --- | --- | --- | --- | --- |
| https://osv.dev/DLA-2948-1 | Debian | debian-archive-keyring | 2017.5+deb9u1 | golang:1.18-rc-stretch |
| https://osv.dev/DLA-3022-1 | Debian | dpkg | 1.18.25 | golang:1.18-rc-stretch |
| https://osv.dev/DLA-2952-1 | Debian | openssl | 1.1.0l-1~deb9u4 | golang:1.18-rc-stretch |
| https://osv.dev/DLA-3008-1 | Debian | openssl | 1.1.0l-1~deb9u4 | golang:1.18-rc-stretch |
| https://osv.dev/DLA-2963-1 | Debian | tzdata | 2021a-0+deb9u2 | golang:1.18-rc-stretch |
| https://osv.dev/DLA-3051-1 | Debian | tzdata | 2021a-0+deb9u2 | golang:1.18-rc-stretch |
```
### Rendered
Scanned docker image with 189 packages
| OSV URL | Ecosystem | Package | Version | Source |
| --- | --- | --- | --- | --- |
| https://osv.dev/DLA-2948-1 | Debian | debian-archive-keyring | 2017.5+deb9u1 | golang:1.18-rc-stretch |
| https://osv.dev/DLA-3022-1 | Debian | dpkg | 1.18.25 | golang:1.18-rc-stretch |
| https://osv.dev/DLA-2952-1 | Debian | openssl | 1.1.0l-1~deb9u4 | golang:1.18-rc-stretch |
| https://osv.dev/DLA-3008-1 | Debian | openssl | 1.1.0l-1~deb9u4 | golang:1.18-rc-stretch |
| https://osv.dev/DLA-2963-1 | Debian | tzdata | 2021a-0+deb9u2 | golang:1.18-rc-stretch |
| https://osv.dev/DLA-3051-1 | Debian | tzdata | 2021a-0+deb9u2 | golang:1.18-rc-stretch |
