### PR TITLE
fix: exit with generic non-zero code when there is a general error

### DIFF
--- a/cmd/osv-scanner/main.go
+++ b/cmd/osv-scanner/main.go
@@ -128,7 +128,11 @@ func run(args []string, stdout, stderr io.Writer) int {
 		}
 
 		r.PrintError(fmt.Sprintf("%v\n", err))
+	}
 
+	// if we've been told to print an error, and not already exited with
+	// a specific error code, then exit with a generic non-zero code
+	if r != nil && r.HasPrintedError() {
 		return 127
 	}
 

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -160,7 +160,7 @@ func TestRun(t *testing.T) {
 		{
 			name:         "",
 			args:         []string{"", "./fixtures/locks-many-with-invalid"},
-			wantExitCode: 0,
+			wantExitCode: 127,
 			wantStdout: `
 				Scanning dir ./fixtures/locks-many-with-invalid
 				Scanned %%/fixtures/locks-many-with-invalid/Gemfile.lock file and found 1 packages

--- a/internal/output/reporter.go
+++ b/internal/output/reporter.go
@@ -9,9 +9,10 @@ import (
 )
 
 type Reporter struct {
-	stdout io.Writer
-	stderr io.Writer
-	format string
+	stdout          io.Writer
+	stderr          io.Writer
+	format          string
+	hasPrintedError bool
 }
 
 func NewReporter(stdout io.Writer, stderr io.Writer, format string) *Reporter {
@@ -34,6 +35,11 @@ func NewVoidReporter() *Reporter {
 // is outputting as JSON or not
 func (r *Reporter) PrintError(msg string) {
 	fmt.Fprint(r.stderr, msg)
+	r.hasPrintedError = true
+}
+
+func (r *Reporter) HasPrintedError() bool {
+	return r.hasPrintedError
 }
 
 // PrintText writes the given message to stdout, _unless_ the reporter is set


### PR DESCRIPTION
Addresses something I noticed in #94 - I was expecting it to require more hoop jumping but realised this should be a pretty robust/correct solution.

Right now there is only one primary cases where an error is printed but the actual error does not result in the function bailing out, though this will be expanded a little by the changes in #94.

(this'll need rebasing when #158 is landed)