### PR TITLE
fix: reuse app-level writer and err writers in `VersionPrinter`

### DIFF
--- a/cmd/osv-scanner/main.go
+++ b/cmd/osv-scanner/main.go
@@ -22,7 +22,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 	var r *output.Reporter
 
 	cli.VersionPrinter = func(ctx *cli.Context) {
-		r = output.NewReporter(stdout, stderr, "")
+		r = output.NewReporter(ctx.App.Writer, ctx.App.ErrWriter, "")
 		r.PrintText(fmt.Sprintf("osv-scanner version: %s\ncommit: %s\nbuilt at: %s\n", ctx.App.Version, commit, date))
 	}
 


### PR DESCRIPTION
Because `VersionPrinter` is a global, everytime `run` is called that function is set to use whatever
 the latest call to `run` was passed for `stdout` and `stderr`; while this shouldn't ever be a
 problem when running the scanner from the commandline (because that'll only call `run` once), the
 test suite calls `run` many times in parallel with different `stdout` and `stderr` writes each time
  so there's a very small chance that by the time the `--version` test actually ends up calling the
  `VersionPrinter` it's been set to a new function using the `stdout` and `stderr` of a _different_
  test causing it to fail.

We can fix this by having the `VersionPrinter` use the `Writer` and `ErrWriter` writers that have been passed to the `App`, which will always be the right `stdout` and `stderr` writers for the test

-----

Example of what happens without this change:

```
--- FAIL: TestRun (0.00s)
    --- FAIL: TestRun/#01 (0.00s)
        main_test.go:231: stdout
             got:


             want:
            osv-scanner version: dev
            commit: n/a
            built at: n/a
    --- FAIL: TestRun/#03 (0.00s)
        main_test.go:231: stdout
             got:
            osv-scanner version: dev
            commit: n/a
            built at: n/a
            Scanning dir ./fixtures/locks-many/not-a-lockfile.toml

             want:
            Scanning dir ./fixtures/locks-many/not-a-lockfile.toml
FAIL
FAIL    github.com/google/osv-scanner/cmd/osv-scanner   0.705s
FAIL
```

It's not super rare, but go caching tests makes it harder to hit unless you're actively working on these tests.