### PR TITLE
fix(osv-query): omit SourceInfo from JSON marshaling

### DIFF
--- a/pkg/osv/osv.go
+++ b/pkg/osv/osv.go
@@ -36,7 +36,7 @@ type Query struct {
 	Commit  string            `json:"commit,omitempty"`
 	Package Package           `json:"package,omitempty"`
 	Version string            `json:"version,omitempty"`
-	Source  models.SourceInfo `json:"omit"`
+	Source  models.SourceInfo `json:"-"`
 }
 
 // BatchedQuery represents a batched query to OSV.


### PR DESCRIPTION
Resolve #184 (if `models.SourceInfo` is confirmed to be unneeded!)