### PR TITLE
test: remove nonsense case and correct names

### DIFF
--- a/pkg/lockfile/parse-cargo-lock_test.go
+++ b/pkg/lockfile/parse-cargo-lock_test.go
@@ -14,7 +14,7 @@ func TestParseCargoLock_FileDoesNotExist(t *testing.T) {
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 
-func TestParseCargoLock_InvalidJson(t *testing.T) {
+func TestParseCargoLock_InvalidToml(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseCargoLock("fixtures/cargo/not-toml.txt")

--- a/pkg/lockfile/parse-gemfile-lock_test.go
+++ b/pkg/lockfile/parse-gemfile-lock_test.go
@@ -14,18 +14,6 @@ func TestParseGemfileLock_FileDoesNotExist(t *testing.T) {
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 
-func TestParseGemfileLock_InvalidJson(t *testing.T) {
-	t.Parallel()
-
-	packages, err := lockfile.ParseGemfileLock("fixtures/bundler/not-json.txt")
-
-	if err == nil {
-		t.Errorf("Expected to get error, but did not")
-	}
-
-	expectPackages(t, packages, []lockfile.PackageDetails{})
-}
-
 func TestParseGemfileLock_NoSpecSection(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/lockfile/parse-poetry-lock_test.go
+++ b/pkg/lockfile/parse-poetry-lock_test.go
@@ -14,7 +14,7 @@ func TestParsePoetryLock_FileDoesNotExist(t *testing.T) {
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 
-func TestParsePoetryLock_InvalidJson(t *testing.T) {
+func TestParsePoetryLock_InvalidToml(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParsePoetryLock("fixtures/poetry/not-toml.txt")


### PR DESCRIPTION
`Gemfile.lock` is nothing close to JSON, so this test doesn't make sense - removing it does not decrease coverage either, so lets axe it.

My best guess is that it came from copying the standard set of tests from one of the other parsers, and then not realising it since it never failed 🤷 

I also noticed two test cases were incorrectly named "json" instead of "toml", so have corrected that too