### PR TITLE
fix: add missing toml tags to struct (and update linter)

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -39,5 +39,4 @@ jobs:
         uses: golangci/golangci-lint-action@v3.4.0
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.50.1
-
+          version: v1.51.1

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,8 +24,8 @@ type ConfigManager struct {
 }
 
 type Config struct {
-	IgnoredVulns []IgnoreEntry
-	LoadPath     string
+	IgnoredVulns []IgnoreEntry `toml:"IgnoredVulns"`
+	LoadPath     string        `toml:"LoadPath"`
 }
 
 type IgnoreEntry struct {

--- a/run_lints.sh
+++ b/run_lints.sh
@@ -2,4 +2,4 @@
 
 set -ex
 
-go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1 run ./... --max-same-issues 0
+go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.1 run ./... --max-same-issues 0


### PR DESCRIPTION
I was curious and ended up doing the work so might as well land it 🤷

This also removes one of the three "<linter> is disabled because generics" warnings.