### PR TITLE
Improve gitignore parsing

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -30,6 +30,13 @@ The recursive flag `-r` or `--recursive` will tell the scanner to search all sub
 
 Git directories are searched for the latest commit hash. Searching for git commit hash is intended to work with projects that use git submodules or a similar mechanism where dependencies are checked out as real git repositories. 
 
+### Ignored files
+
+By default, OSV-Scanner will not scan files that are ignored by `.gitignore` files. If the specified file is not part of a git repository, `.gitignore` files are parsed recursively starting from the target directory,
+otherwise they are parsed from the root of the git repository as typical.
+
+The `--no-ignore` flag can be used force the scanner to scan ignored files.
+
 ### Specify SBOM
 
 If you want to check for known vulnerabilities only in dependencies in your SBOM, you can use the following command:

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/osv-scanner/pkg/models"
 	"github.com/google/osv-scanner/pkg/osv"
 
+	"github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-billy/v5/osfs"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
@@ -52,7 +53,7 @@ func scanDir(r *output.Reporter, query *osv.BatchedQuery, dir string, skipGit bo
 		var err error
 		ignoreMatcher, err = parseGitIgnores(dir)
 		if err != nil {
-			r.PrintError(fmt.Sprintf("Unable to parse git ignores: %v", err))
+			r.PrintError(fmt.Sprintf("Unable to parse git ignores: %v\n", err))
 			useGitIgnore = false
 		}
 	}
@@ -74,9 +75,12 @@ func scanDir(r *output.Reporter, query *osv.BatchedQuery, dir string, skipGit bo
 		if useGitIgnore {
 			match, err := ignoreMatcher.match(path, info.IsDir())
 			if err != nil {
-				r.PrintText(fmt.Sprintf("Failed to resolve gitignore for %s: %v", path, err))
+				r.PrintText(fmt.Sprintf("Failed to resolve gitignore for %s: %v\n", path, err))
 				// Don't skip if we can't parse now - potentially noisy for directories with lots of items
 			} else if match {
+				if root { // Don't silently skip if the argument file was ignored.
+					r.PrintError(fmt.Sprintf("%s was not scanned because it is excluded by a .gitignore file. Use --no-ignore to scan it.\n", path))
+				}
 				if info.IsDir() {
 					return filepath.SkipDir
 				}
@@ -124,9 +128,23 @@ type gitIgnoreMatcher struct {
 
 func parseGitIgnores(dir string) (*gitIgnoreMatcher, error) {
 	// We need to parse .gitignore files from the root of the git repo to correctly identify ignored files
-	// Defaults to current directory if dir is not in a repo or some other error
-	// TODO: Won't parse ignores if dir is not in a git repo, and is not under the current directory (e.g ../path/to)
-	fs := osfs.New(".")
+	var fs billy.Filesystem
+
+	// Default to dir (or directory containing dir if it's a file) is not in a repo or some other error
+	f, err := os.Open(dir)
+	if err != nil {
+		return nil, err
+	}
+	s, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if s.IsDir() {
+		fs = osfs.New(dir)
+	} else {
+		fs = osfs.New(filepath.Dir(dir))
+	}
+
 	if repo, err := git.PlainOpenWithOptions(dir, &git.PlainOpenOptions{DetectDotGit: true}); err == nil {
 		if tree, err := repo.Worktree(); err == nil {
 			fs = tree.Filesystem

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -131,15 +131,11 @@ func parseGitIgnores(dir string) (*gitIgnoreMatcher, error) {
 	var fs billy.Filesystem
 
 	// Default to dir (or directory containing dir if it's a file) is not in a repo or some other error
-	f, err := os.Open(dir)
+	finfo, err := os.Stat(dir)
 	if err != nil {
 		return nil, err
 	}
-	s, err := f.Stat()
-	if err != nil {
-		return nil, err
-	}
-	if s.IsDir() {
+	if finfo.IsDir() {
 		fs = osfs.New(dir)
 	} else {
 		fs = osfs.New(filepath.Dir(dir))


### PR DESCRIPTION
I had thought of some minor improvements for the gitignore parsing I had implemented:
- Parse gitignores for non-git files from their respective directories, instead of the current working directory.
  - Should fix #202, and I think also a potential issue on Windows scanning across drive letters.
- Fix some error messages not having newlines.
- Add a error message warning if the root file is ignored, instead of skipping silently.
- Add some notes in USAGE.md about gitignore behaviour.