### PR TITLE
fixed broken link

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -58,7 +58,7 @@ nav_external_links:
     url: https://osv.dev
     hide_icon: false # set to true to hide the external link icon - defaults to false
   - title: API docs
-    url: https://osv.dev/docs
+    url: https://osv.dev/docs/
     hide_icon: false # set to true to hide the external link icon - defaults to false
   - title: OSV Schema
     url: https://ossf.github.io/osv-schema/


### PR DESCRIPTION
The Link to the osv.dev docs was broken. ([osv.dev/docs](https://osv.dev/docs) gets a 404 but [osv.dev/docs/](https://osv.dev/docs/) works ok. Thanks to Kara for the catch.