### PR TITLE
Reinstated Bash Formatting

### DIFF
--- a/docs/current/configuration.md
+++ b/docs/current/configuration.md
@@ -16,7 +16,7 @@ To ignore a vulnerability, enter the ID under the `IgnoreVulns` key. Optionally,
 
 #### Example
 
-~~~~~~~~~~~~~~~~~~~
+```toml
 [[IgnoredVulns]]
 id = "GO-2022-0968"
 # ignoreUntil = 2022-11-09 # Optional exception expiry date
@@ -26,4 +26,4 @@ reason = "No ssh servers are connected to or hosted in Go lang"
 id = "GO-2022-1059"
 # ignoreUntil = 2022-11-09 # Optional exception expiry date
 reason = "No external http servers are written in Go lang."
-~~~~~~~~~~~~~~~~~~~
+```

--- a/docs/current/installation.md
+++ b/docs/current/installation.md
@@ -15,28 +15,28 @@ You may download the [SLSA3](https://slsa.dev) compliant binaries for Linux, mac
 
 If you're a [**Windows Scoop**](https://scoop.sh) user, then you can install osv-scanner from the [official bucket](https://github.com/ScoopInstaller/Main/blob/master/bucket/osv-scanner.json):
 
-~~~~~~~~~~~~~~~~~~~
+```bash
 scoop install osv-scanner
-~~~~~~~~~~~~~~~~~~~
+```
 
 If you're a [Homebrew](https://brew.sh/) user, you can install [osv-scanner](https://formulae.brew.sh/formula/osv-scanner) via:
 
-~~~~~~~~~~~~~~~~~~~
+```bash
 brew install osv-scanner
-~~~~~~~~~~~~~~~~~~~
+```
 
 If you're a Arch Linux User, you can install osv-scanner from the official repo:
-~~~~~~~~~~~~~~~~~~~
+```bash
 pacman -S osv-scanner
-~~~~~~~~~~~~~~~~~~~
+```
 
 ### Install from source
 
 Alternatively, you can install this from source by running:
 
-~~~~~~~~~~~~~~~~~~~
+```bash
 go install github.com/google/osv-scanner/cmd/osv-scanner@v1
-~~~~~~~~~~~~~~~~~~~
+```
 
 This requires Go 1.18+ to be installed.
 

--- a/docs/current/output.md
+++ b/docs/current/output.md
@@ -11,7 +11,7 @@ When using the --json flag, only the JSON output will be printed to stdout, with
 
 ### Output Format
 
-~~~~~~~~~~~~~~~~~~~
+```json
 {
   "results": [
     {
@@ -98,4 +98,4 @@ When using the --json flag, only the JSON output will be printed to stdout, with
     }
   ]
 }
-~~~~~~~~~~~~~~~~~~~
+```

--- a/docs/current/usage.md
+++ b/docs/current/usage.md
@@ -24,9 +24,9 @@ as real git repositories.
 
 #### Example
 
-~~~~~~~~~~~~~~~~~~~
+```bash
 osv-scanner -r /path/to/your/dir
-~~~~~~~~~~~~~~~~~~~
+```
 
 ### Input an SBOM
 
@@ -39,9 +39,9 @@ auto-detected based on the input file contents.
 
 #### Example
 
-~~~~~~~~~~~~~~~~~~~
+```bash
 osv-scanner --sbom=/path/to/your/sbom.json
-~~~~~~~~~~~~~~~~~~~
+```
 
 ### Input a lockfile
 
@@ -67,9 +67,9 @@ A wide range of lockfiles are supported by utilizing this [lockfile package](htt
 
 #### Example
 
-~~~~~~~~~~~~~~~~~~~
+```bash
 osv-scanner --lockfile=/path/to/your/package-lock.json --lockfile=/path/to/another/Cargo.lock
-~~~~~~~~~~~~~~~~~~~
+```
 
 ### Scanning a Debian based docker image packages (preview)
 
@@ -83,27 +83,27 @@ This currently does not scan the filesystem of the Docker container, and has var
 
 #### Example
 
-~~~~~~~~~~~~~~~~~~~
+```bash
 osv-scanner --docker image_name:latest
-~~~~~~~~~~~~~~~~~~~
+```
 
 ### Running in a Docker Container
 
 The simplest way to get the osv-scanner docker image is to pull from GitHub Container Registry:
 
-~~~~~~~~~~~~~~~~~~~
+```bash
 docker pull ghcr.io/google/osv-scanner:latest
-~~~~~~~~~~~~~~~~~~~
+```
 
 Once you have the image, you can test that it works by running:
 
-~~~~~~~~~~~~~~~~~~~
+```bash
 docker run -it ghcr.io/google/osv-scanner -h
-~~~~~~~~~~~~~~~~~~~
+```
 
 Finally, to run it, mount the directory you want to scan to `/src` and pass the
 appropriate osv-scanner flags:
 
-~~~~~~~~~~~~~~~~~~~
+```bash
 docker run -it -v ${PWD}:/src ghcr.io/google/osv-scanner -L /src/go.mod
-~~~~~~~~~~~~~~~~~~~
+```

--- a/docs/working_docs/configuration.md
+++ b/docs/working_docs/configuration.md
@@ -20,7 +20,7 @@ To ignore a vulnerability, enter the ID under the `IgnoreVulns` key. Optionally,
 
 #### Example
 
-~~~~~~~~~~~~~~~~~~~
+```toml
 [[IgnoredVulns]]
 id = "GO-2022-0968"
 # ignoreUntil = 2022-11-09 # Optional exception expiry date
@@ -30,4 +30,4 @@ reason = "No ssh servers are connected to or hosted in Go lang"
 id = "GO-2022-1059"
 # ignoreUntil = 2022-11-09 # Optional exception expiry date
 reason = "No external http servers are written in Go lang."
-~~~~~~~~~~~~~~~~~~~
+```

--- a/docs/working_docs/installation.md
+++ b/docs/working_docs/installation.md
@@ -18,28 +18,28 @@ You may download the [SLSA3](https://slsa.dev) compliant binaries for Linux, mac
 
 If you're a [**Windows Scoop**](https://scoop.sh) user, then you can install osv-scanner from the [official bucket](https://github.com/ScoopInstaller/Main/blob/master/bucket/osv-scanner.json):
 
-~~~~~~~~~~~~~~~~~~~
+```bash
 scoop install osv-scanner
-~~~~~~~~~~~~~~~~~~~
+```
 
 If you're a [Homebrew](https://brew.sh/) user, you can install [osv-scanner](https://formulae.brew.sh/formula/osv-scanner) via:
 
-~~~~~~~~~~~~~~~~~~~
+```bash
 brew install osv-scanner
-~~~~~~~~~~~~~~~~~~~
+```
 
 If you're a Arch Linux User, you can install osv-scanner from the official repo:
-~~~~~~~~~~~~~~~~~~~
+```bash
 pacman -S osv-scanner
-~~~~~~~~~~~~~~~~~~~
+```
 
 ### Install from source
 
 Alternatively, you can install this from source by running:
 
-~~~~~~~~~~~~~~~~~~~
+```bash
 go install github.com/google/osv-scanner/cmd/osv-scanner@v1
-~~~~~~~~~~~~~~~~~~~
+```
 
 This requires Go 1.18+ to be installed.
 

--- a/docs/working_docs/output.md
+++ b/docs/working_docs/output.md
@@ -18,14 +18,14 @@ The default format, which outputs the results as a human-readable table.
 
 Sample output:
 
-~~~~~~~~~~~~~~~~~~~
+```bash
 ╭─────────────────────────────────────┬───────────┬──────────────────────────┬─────────┬────────────────────╮
 │ OSV URL (ID IN BOLD)                │ ECOSYSTEM │ PACKAGE                  │ VERSION │ SOURCE             │
 ├─────────────────────────────────────┼───────────┼──────────────────────────┼─────────┼────────────────────┤
 │ https://osv.dev/GHSA-c3h9-896r-86jm │ Go        │ github.com/gogo/protobuf │ 1.3.1   │ path/to/go.mod     │
 │ https://osv.dev/GHSA-m5pq-gvj9-9vr8 │ crates.io │ regex                    │ 1.3.1   │ path/to/Cargo.lock │
 ╰─────────────────────────────────────┴───────────┴──────────────────────────┴─────────┴────────────────────╯
-~~~~~~~~~~~~~~~~~~~
+```
 
 ### `json` format
 
@@ -33,7 +33,7 @@ Outputs the results as a JSON object to stdout, with all other output being dire
 
 Sample output:
 
-~~~~~~~~~~~~~~~~~~~
+```json
 {
   "results": [
     {
@@ -120,4 +120,4 @@ Sample output:
     }
   ]
 }
-~~~~~~~~~~~~~~~~~~~
+```

--- a/docs/working_docs/usage.md
+++ b/docs/working_docs/usage.md
@@ -14,9 +14,9 @@ OSV-Scanner parses lockfiles, SBOMs, and git directories to determine your proje
 
 ### General use case: scanning a directory
 
-~~~~~~~~~~~~~~~~~~~
+```bash
 osv-scanner -r /path/to/your/dir
-~~~~~~~~~~~~~~~~~~~
+```
 
 The preceding command will find lockfiles, SBOMs, and git directories in your target directory and use them to determine the dependencies to check against the OSV database for any known vulnerabilities.
 
@@ -36,9 +36,9 @@ The `--no-ignore` flag can be used to force the scanner to scan ignored files.
 
 If you want to check for known vulnerabilities only in dependencies in your SBOM, you can use the following command:
 
-~~~~~~~~~~~~~~~~~~~
+```bash
 osv-scanner --sbom=/path/to/your/sbom.json
-~~~~~~~~~~~~~~~~~~~
+```
 
 [SPDX] and [CycloneDX] SBOMs using [Package URLs] are supported. The format is
 auto-detected based on the input file contents.
@@ -50,15 +50,15 @@ auto-detected based on the input file contents.
 ### Specify Lockfile(s)
 If you want to check for known vulnerabilities in specific lockfiles, you can use the following command:
 
-~~~~~~~~~~~~~~~~~~~
+```bash
 osv-scanner --lockfile=/path/to/your/package-lock.json --lockfile=/path/to/another/Cargo.lock
-~~~~~~~~~~~~~~~~~~~
+```
 
 It is possible to specify more than one lockfile at a time; you can also specify how to parse an arbitrary file:
 
-~~~~~~~~~~~~~~~~~~~
+```bash
 osv-scanner --lockfile 'requirements.txt:/path/to/your/extra-requirements.txt'
-~~~~~~~~~~~~~~~~~~~
+```
 
 A wide range of lockfiles are supported by utilizing this [lockfile package](https://github.com/google/osv-scanner/tree/main/pkg/lockfile). This is the current list of supported lockfiles:
 
@@ -83,17 +83,17 @@ A wide range of lockfiles are supported by utilizing this [lockfile package](htt
 The scanner also supports `installed` files used by the Alpine Package Keeper (apk) that typically live at `/lib/apk/db/installed`,
 however you must specify this explicitly using the `--lockfile` flag:
 
-~~~~~~~~~~~~~~~~~~~
+```bash
 osv-scanner --lockfile 'apk-installed:/lib/apk/db/installed'
-~~~~~~~~~~~~~~~~~~~
+```
 
 If the file you are scanning is located in a directory that has a colon in its name,
 you can prefix the path to just a colon to explicitly signal to the scanner that
 it should infer the parser based on the filename:
 
-~~~~~~~~~~~~~~~~~~~
+```bash
 osv-scanner --lockfile ':/path/to/my:projects/package-lock.json'
-~~~~~~~~~~~~~~~~~~~
+```
 
 ### Scanning a Debian based docker image packages (preview)
 
@@ -107,27 +107,27 @@ This currently does not scan the filesystem of the Docker container, and has var
 
 #### Example
 
-~~~~~~~~~~~~~~~~~~~
+```bash
 osv-scanner --docker image_name:latest
-~~~~~~~~~~~~~~~~~~~
+```
 
 ### Running in a Docker Container
 
 The simplest way to get the osv-scanner docker image is to pull from GitHub Container Registry:
 
-~~~~~~~~~~~~~~~~~~~
+```bash
 docker pull ghcr.io/google/osv-scanner:latest
-~~~~~~~~~~~~~~~~~~~
+```
 
 Once you have the image, you can test that it works by running:
 
-~~~~~~~~~~~~~~~~~~~
+```bash
 docker run -it ghcr.io/google/osv-scanner -h
-~~~~~~~~~~~~~~~~~~~
+```
 
 Finally, to run it, mount the directory you want to scan to `/src` and pass the
 appropriate osv-scanner flags:
 
-~~~~~~~~~~~~~~~~~~~
+```bash
 docker run -it -v ${PWD}:/src ghcr.io/google/osv-scanner -L /src/go.mod
-~~~~~~~~~~~~~~~~~~~
+```


### PR DESCRIPTION
Hi Team, 

Based on post-merge feedback on #211 , styling has been updated to use bash formatting in most places, and json and toml where appropriate. 

Some of the text colors do not have good contrast. I will continue working on that as time permits, with the hope to roll it out to other projects too but this can be merged now. 

You can see what it looks like [here](https://hayleycd.github.io/osv-scanner/)