### PR TITLE
Nits  - APK installed optimizations

### DIFF
--- a/pkg/lockfile/apk-installed.go
+++ b/pkg/lockfile/apk-installed.go
@@ -17,15 +17,14 @@ func groupApkPackageLines(scanner *bufio.Scanner) [][]string {
 	for scanner.Scan() {
 		line := scanner.Text()
 
-		if line == "" {
-			if len(group) > 0 {
-				groups = append(groups, group)
-			}
-			group = make([]string, 0)
-
+		if line != "" {
+			group = append(group, line)
 			continue
 		}
-		group = append(group, line)
+		if len(group) > 0 {
+			groups = append(groups, group)
+		}
+		group = make([]string, 0)
 	}
 
 	if len(group) > 0 {
@@ -56,7 +55,7 @@ func parseApkPackageGroup(group []string, pathToLockfile string) PackageDetails 
 	if pkg.Version == "" {
 		pkgPrintName := pkg.Name
 		if pkgPrintName == "" {
-			pkgPrintName = "<unknown>"
+			pkgPrintName = unknownPkgName
 		}
 
 		_, _ = fmt.Fprintf(


### PR DESCRIPTION
Hello,

ported to APK installed parser common optimizations already merged for DPKG in #168.
Additionally, a couple of staticcheck linter errors have been corrected (I think!).
I saw the comments here: https://github.com/google/osv-scanner/blob/fb4d2c4d8e4e59961db70121e31870593e045a4e/pkg/osvscanner/osvscanner.go#L39-L43 but after my change both lints and tests are ok so it's not clear to me if comments are now out of date or if I'm missing something!

Comments have been introduced in #149.

Thank you,
Regards.
 