### PR TITLE
test: ensure case names match function under test

### DIFF
--- a/pkg/lockfile/apk-installed_test.go
+++ b/pkg/lockfile/apk-installed_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/google/osv-scanner/pkg/lockfile"
 )
 
-func TestApkInstalled_FileDoesNotExist(t *testing.T) {
+func TestParseApkInstalled_FileDoesNotExist(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseApkInstalled("fixtures/apk/does-not-exist")
@@ -15,7 +15,7 @@ func TestApkInstalled_FileDoesNotExist(t *testing.T) {
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 
-func TestApkInstalled_Empty(t *testing.T) {
+func TestParseApkInstalled_Empty(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseApkInstalled("fixtures/apk/empty_installed")
@@ -27,7 +27,7 @@ func TestApkInstalled_Empty(t *testing.T) {
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 
-func TestApkInstalled_NotAnInstalled(t *testing.T) {
+func TestParseApkInstalled_NotAnInstalled(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseApkInstalled("fixtures/apk/not_installed")
@@ -39,7 +39,7 @@ func TestApkInstalled_NotAnInstalled(t *testing.T) {
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 
-func TestApkInstalled_Malformed(t *testing.T) {
+func TestParseApkInstalled_Malformed(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseApkInstalled("fixtures/apk/malformed_installed")
@@ -59,7 +59,7 @@ func TestApkInstalled_Malformed(t *testing.T) {
 	})
 }
 
-func TestApkInstalled_Single(t *testing.T) {
+func TestParseApkInstalled_Single(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseApkInstalled("fixtures/apk/single_installed")
@@ -79,7 +79,7 @@ func TestApkInstalled_Single(t *testing.T) {
 	})
 }
 
-func TestApkInstalled_Shuffled(t *testing.T) {
+func TestParseApkInstalled_Shuffled(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseApkInstalled("fixtures/apk/shuffled_installed")
@@ -99,7 +99,7 @@ func TestApkInstalled_Shuffled(t *testing.T) {
 	})
 }
 
-func TestApkInstalled_Multiple(t *testing.T) {
+func TestParseApkInstalled_Multiple(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseApkInstalled("fixtures/apk/multiple_installed")

--- a/pkg/lockfile/dpkg-status_test.go
+++ b/pkg/lockfile/dpkg-status_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/google/osv-scanner/pkg/lockfile"
 )
 
-func TestDpkgStatus_FileDoesNotExist(t *testing.T) {
+func TestParseDpkgStatus_FileDoesNotExist(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseDpkgStatus("fixtures/dpkg/does-not-exist")
@@ -15,7 +15,7 @@ func TestDpkgStatus_FileDoesNotExist(t *testing.T) {
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 
-func TestDpkgStatus_Empty(t *testing.T) {
+func TestParseDpkgStatus_Empty(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseDpkgStatus("fixtures/dpkg/empty_status")
@@ -27,7 +27,7 @@ func TestDpkgStatus_Empty(t *testing.T) {
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 
-func TestDpkgStatus_NotAStatus(t *testing.T) {
+func TestParseDpkgStatus_NotAStatus(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseDpkgStatus("fixtures/dpkg/not_status")
@@ -39,7 +39,7 @@ func TestDpkgStatus_NotAStatus(t *testing.T) {
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 
-func TestDpkgStatus_Malformed(t *testing.T) {
+func TestParseDpkgStatus_Malformed(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseDpkgStatus("fixtures/dpkg/malformed_status")
@@ -64,7 +64,7 @@ func TestDpkgStatus_Malformed(t *testing.T) {
 	})
 }
 
-func TestDpkgStatus_Single(t *testing.T) {
+func TestParseDpkgStatus_Single(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseDpkgStatus("fixtures/dpkg/single_status")
@@ -83,7 +83,7 @@ func TestDpkgStatus_Single(t *testing.T) {
 	})
 }
 
-func TestDpkgStatus_Shuffled(t *testing.T) {
+func TestParseDpkgStatus_Shuffled(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseDpkgStatus("fixtures/dpkg/shuffled_status")
@@ -102,7 +102,7 @@ func TestDpkgStatus_Shuffled(t *testing.T) {
 	})
 }
 
-func TestDpkgStatus_Multiple(t *testing.T) {
+func TestParseDpkgStatus_Multiple(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseDpkgStatus("fixtures/dpkg/multiple_status")
@@ -133,7 +133,7 @@ func TestDpkgStatus_Multiple(t *testing.T) {
 	})
 }
 
-func TestDpkgStatus_Source_Ver_Override(t *testing.T) {
+func TestParseDpkgStatus_Source_Ver_Override(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseDpkgStatus("fixtures/dpkg/source_ver_override_status")


### PR DESCRIPTION
Typically test functions should start with the function under test (or at least that's the convention I've used for the rest of the tests in `lockfile`).