### PR TITLE
Create draft release first in goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -83,6 +83,6 @@ checksum:
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
   algorithm: sha256
 release:
-  draft: false
+  draft: true
 changelog:
-  skip: true
+  skip: false


### PR DESCRIPTION
Create draft release first for future releases instead of a full release so release details can be edited before the email is sent out to watchers. 