### PR TITLE
More specific cyclone dx parsing

### DIFF
--- a/cmd/osv-scanner/fixtures/locks-many/alpine.cdx.xml
+++ b/cmd/osv-scanner/fixtures/locks-many/alpine.cdx.xml
@@ -1,0 +1,604 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.4" serialNumber="urn:uuid:4243b783-229c-48e7-982b-febe2bb5bc2b" version="1">
+  <metadata>
+    <timestamp>2023-03-02T12:04:22+11:00</timestamp>
+    <tools>
+      <tool>
+        <vendor>anchore</vendor>
+        <name>syft</name>
+        <version>0.73.0</version>
+      </tool>
+    </tools>
+    <component bom-ref="5339058ca5e06f8a" type="container">
+      <name>alpine:latest</name>
+      <version>sha256:fd6275a37d2472b9d3be70c3261087b8d65e441c21342ae7313096312bcda2b3</version>
+    </component>
+  </metadata>
+  <components>
+    <component bom-ref="pkg:apk/alpine/alpine-baselayout@3.4.0-r0?arch=x86_64&amp;upstream=alpine-baselayout&amp;distro=alpine-3.17.2&amp;package-id=92b19c7750fb559d" type="library">
+      <publisher>Natanael Copa &lt;ncopa@alpinelinux.org&gt;</publisher>
+      <name>alpine-baselayout</name>
+      <version>3.4.0-r0</version>
+      <description>Alpine base dir structure and init scripts</description>
+      <licenses>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:alpine-baselayout:alpine-baselayout:3.4.0-r0:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:apk/alpine/alpine-baselayout@3.4.0-r0?arch=x86_64&amp;upstream=alpine-baselayout&amp;distro=alpine-3.17.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://git.alpinelinux.org/cgit/aports/tree/main/alpine-baselayout</url>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="syft:package:foundBy">apkdb-cataloger</property>
+        <property name="syft:package:metadataType">ApkMetadata</property>
+        <property name="syft:package:type">apk</property>
+        <property name="syft:cpe23">cpe:2.3:a:alpine-baselayout:alpine_baselayout:3.4.0-r0:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:alpine_baselayout:alpine-baselayout:3.4.0-r0:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:alpine_baselayout:alpine_baselayout:3.4.0-r0:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:alpine:alpine-baselayout:3.4.0-r0:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:alpine:alpine_baselayout:3.4.0-r0:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:7cd52847ad775a5ddc4b58326cf884beee34544296402c6292ed76474c686d39</property>
+        <property name="syft:location:0:path">/lib/apk/db/installed</property>
+        <property name="syft:metadata:gitCommitOfApkPort">bd965a7ebf7fd8f07d7a0cc0d7375bf3e4eb9b24</property>
+        <property name="syft:metadata:installedSize">331776</property>
+        <property name="syft:metadata:originPackage">alpine-baselayout</property>
+        <property name="syft:metadata:pullChecksum">Q1/eXfmbYT1WXenFSqKjroYyK84NE=</property>
+        <property name="syft:metadata:pullDependencies:0">alpine-baselayout-data=3.4.0-r0</property>
+        <property name="syft:metadata:pullDependencies:1">/bin/sh</property>
+        <property name="syft:metadata:size">8890</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:apk/alpine/alpine-baselayout-data@3.4.0-r0?arch=x86_64&amp;upstream=alpine-baselayout&amp;distro=alpine-3.17.2&amp;package-id=291d1267b40d636f" type="library">
+      <publisher>Natanael Copa &lt;ncopa@alpinelinux.org&gt;</publisher>
+      <name>alpine-baselayout-data</name>
+      <version>3.4.0-r0</version>
+      <description>Alpine base dir structure and init scripts</description>
+      <licenses>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:alpine-baselayout-data:alpine-baselayout-data:3.4.0-r0:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:apk/alpine/alpine-baselayout-data@3.4.0-r0?arch=x86_64&amp;upstream=alpine-baselayout&amp;distro=alpine-3.17.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://git.alpinelinux.org/cgit/aports/tree/main/alpine-baselayout</url>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="syft:package:foundBy">apkdb-cataloger</property>
+        <property name="syft:package:metadataType">ApkMetadata</property>
+        <property name="syft:package:type">apk</property>
+        <property name="syft:cpe23">cpe:2.3:a:alpine-baselayout-data:alpine_baselayout_data:3.4.0-r0:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:alpine_baselayout_data:alpine-baselayout-data:3.4.0-r0:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:alpine_baselayout_data:alpine_baselayout_data:3.4.0-r0:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:alpine-baselayout:alpine-baselayout-data:3.4.0-r0:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:alpine-baselayout:alpine_baselayout_data:3.4.0-r0:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:alpine_baselayout:alpine-baselayout-data:3.4.0-r0:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:alpine_baselayout:alpine_baselayout_data:3.4.0-r0:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:alpine:alpine-baselayout-data:3.4.0-r0:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:alpine:alpine_baselayout_data:3.4.0-r0:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:7cd52847ad775a5ddc4b58326cf884beee34544296402c6292ed76474c686d39</property>
+        <property name="syft:location:0:path">/lib/apk/db/installed</property>
+        <property name="syft:metadata:gitCommitOfApkPort">bd965a7ebf7fd8f07d7a0cc0d7375bf3e4eb9b24</property>
+        <property name="syft:metadata:installedSize">77824</property>
+        <property name="syft:metadata:originPackage">alpine-baselayout</property>
+        <property name="syft:metadata:pullChecksum">Q1/JgpM8J6DWI/541tUX+uHEzSjqo=</property>
+        <property name="syft:metadata:size">11664</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:apk/alpine/alpine-keys@2.4-r1?arch=x86_64&amp;upstream=alpine-keys&amp;distro=alpine-3.17.2&amp;package-id=2b5e23d349b556cf" type="library">
+      <publisher>Natanael Copa &lt;ncopa@alpinelinux.org&gt;</publisher>
+      <name>alpine-keys</name>
+      <version>2.4-r1</version>
+      <description>Public keys for Alpine Linux packages</description>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:alpine-keys:alpine-keys:2.4-r1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:apk/alpine/alpine-keys@2.4-r1?arch=x86_64&amp;upstream=alpine-keys&amp;distro=alpine-3.17.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://alpinelinux.org</url>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="syft:package:foundBy">apkdb-cataloger</property>
+        <property name="syft:package:metadataType">ApkMetadata</property>
+        <property name="syft:package:type">apk</property>
+        <property name="syft:cpe23">cpe:2.3:a:alpine-keys:alpine_keys:2.4-r1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:alpine_keys:alpine-keys:2.4-r1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:alpine_keys:alpine_keys:2.4-r1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:alpine:alpine-keys:2.4-r1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:alpine:alpine_keys:2.4-r1:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:7cd52847ad775a5ddc4b58326cf884beee34544296402c6292ed76474c686d39</property>
+        <property name="syft:location:0:path">/lib/apk/db/installed</property>
+        <property name="syft:metadata:gitCommitOfApkPort">aab68f8c9ab434a46710de8e12fb3206e2930a59</property>
+        <property name="syft:metadata:installedSize">159744</property>
+        <property name="syft:metadata:originPackage">alpine-keys</property>
+        <property name="syft:metadata:pullChecksum">Q1KM01lfKVp+gEZn23awujqjSkrN8=</property>
+        <property name="syft:metadata:size">13361</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:apk/alpine/apk-tools@2.12.10-r1?arch=x86_64&amp;upstream=apk-tools&amp;distro=alpine-3.17.2&amp;package-id=e5f757b0df1f62bc" type="library">
+      <publisher>Natanael Copa &lt;ncopa@alpinelinux.org&gt;</publisher>
+      <name>apk-tools</name>
+      <version>2.12.10-r1</version>
+      <description>Alpine Package Keeper - package manager for alpine</description>
+      <licenses>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:apk-tools:apk-tools:2.12.10-r1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:apk/alpine/apk-tools@2.12.10-r1?arch=x86_64&amp;upstream=apk-tools&amp;distro=alpine-3.17.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://gitlab.alpinelinux.org/alpine/apk-tools</url>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="syft:package:foundBy">apkdb-cataloger</property>
+        <property name="syft:package:metadataType">ApkMetadata</property>
+        <property name="syft:package:type">apk</property>
+        <property name="syft:cpe23">cpe:2.3:a:apk-tools:apk_tools:2.12.10-r1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:apk_tools:apk-tools:2.12.10-r1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:apk_tools:apk_tools:2.12.10-r1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:apk:apk-tools:2.12.10-r1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:apk:apk_tools:2.12.10-r1:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:7cd52847ad775a5ddc4b58326cf884beee34544296402c6292ed76474c686d39</property>
+        <property name="syft:location:0:path">/lib/apk/db/installed</property>
+        <property name="syft:metadata:gitCommitOfApkPort">0188f510baadbae393472103427b9c1875117136</property>
+        <property name="syft:metadata:installedSize">307200</property>
+        <property name="syft:metadata:originPackage">apk-tools</property>
+        <property name="syft:metadata:provides:0">so:libapk.so.3.12.0=3.12.0</property>
+        <property name="syft:metadata:provides:1">cmd:apk=2.12.10-r1</property>
+        <property name="syft:metadata:pullChecksum">Q1Ef3iwt+cMdGngEgaFr2URIJhKzQ=</property>
+        <property name="syft:metadata:pullDependencies:0">musl&gt;=1.2</property>
+        <property name="syft:metadata:pullDependencies:1">ca-certificates-bundle</property>
+        <property name="syft:metadata:pullDependencies:2">so:libc.musl-x86_64.so.1</property>
+        <property name="syft:metadata:pullDependencies:3">so:libcrypto.so.3</property>
+        <property name="syft:metadata:pullDependencies:4">so:libssl.so.3</property>
+        <property name="syft:metadata:pullDependencies:5">so:libz.so.1</property>
+        <property name="syft:metadata:size">120973</property>
+      </properties>
+    </component>
+    <component bom-ref="e93bc067bebd50a9" type="application">
+      <name>busybox</name>
+      <version>1.35.0</version>
+      <cpe>cpe:2.3:a:busybox:busybox:1.35.0:*:*:*:*:*:*:*</cpe>
+      <properties>
+        <property name="syft:package:foundBy">binary-cataloger</property>
+        <property name="syft:package:metadataType">BinaryMetadata</property>
+        <property name="syft:package:type">binary</property>
+        <property name="syft:cpe23">cpe:2.3:a:busybox:busybox:1.35.0:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:7cd52847ad775a5ddc4b58326cf884beee34544296402c6292ed76474c686d39</property>
+        <property name="syft:location:0:path">/bin/busybox</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:apk/alpine/busybox@1.35.0-r29?arch=x86_64&amp;upstream=busybox&amp;distro=alpine-3.17.2&amp;package-id=623d53216342d45e" type="library">
+      <publisher>Sören Tempel &lt;soeren+alpine@soeren-tempel.net&gt;</publisher>
+      <name>busybox</name>
+      <version>1.35.0-r29</version>
+      <description>Size optimized toolbox of many common UNIX utilities</description>
+      <licenses>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:busybox:busybox:1.35.0-r29:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:apk/alpine/busybox@1.35.0-r29?arch=x86_64&amp;upstream=busybox&amp;distro=alpine-3.17.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://busybox.net/</url>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="syft:package:foundBy">apkdb-cataloger</property>
+        <property name="syft:package:metadataType">ApkMetadata</property>
+        <property name="syft:package:type">apk</property>
+        <property name="syft:location:0:layerID">sha256:7cd52847ad775a5ddc4b58326cf884beee34544296402c6292ed76474c686d39</property>
+        <property name="syft:location:0:path">/lib/apk/db/installed</property>
+        <property name="syft:metadata:gitCommitOfApkPort">1dbf7a793afae640ea643a055b6dd4f430ac116b</property>
+        <property name="syft:metadata:installedSize">962560</property>
+        <property name="syft:metadata:originPackage">busybox</property>
+        <property name="syft:metadata:provides:0">cmd:busybox=1.35.0-r29</property>
+        <property name="syft:metadata:pullChecksum">Q1NN3sp0yr99btRysqty3nQUrWHaY=</property>
+        <property name="syft:metadata:pullDependencies:0">so:libc.musl-x86_64.so.1</property>
+        <property name="syft:metadata:size">509600</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:apk/alpine/busybox-binsh@1.35.0-r29?arch=x86_64&amp;upstream=busybox&amp;distro=alpine-3.17.2&amp;package-id=256fc96b4a8c4da8" type="library">
+      <publisher>Sören Tempel &lt;soeren+alpine@soeren-tempel.net&gt;</publisher>
+      <name>busybox-binsh</name>
+      <version>1.35.0-r29</version>
+      <description>busybox ash /bin/sh</description>
+      <licenses>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:busybox-binsh:busybox-binsh:1.35.0-r29:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:apk/alpine/busybox-binsh@1.35.0-r29?arch=x86_64&amp;upstream=busybox&amp;distro=alpine-3.17.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://busybox.net/</url>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="syft:package:foundBy">apkdb-cataloger</property>
+        <property name="syft:package:metadataType">ApkMetadata</property>
+        <property name="syft:package:type">apk</property>
+        <property name="syft:cpe23">cpe:2.3:a:busybox-binsh:busybox_binsh:1.35.0-r29:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:busybox_binsh:busybox-binsh:1.35.0-r29:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:busybox_binsh:busybox_binsh:1.35.0-r29:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:busybox:busybox-binsh:1.35.0-r29:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:busybox:busybox_binsh:1.35.0-r29:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:7cd52847ad775a5ddc4b58326cf884beee34544296402c6292ed76474c686d39</property>
+        <property name="syft:location:0:path">/lib/apk/db/installed</property>
+        <property name="syft:metadata:gitCommitOfApkPort">1dbf7a793afae640ea643a055b6dd4f430ac116b</property>
+        <property name="syft:metadata:installedSize">8192</property>
+        <property name="syft:metadata:originPackage">busybox</property>
+        <property name="syft:metadata:provides:0">/bin/sh</property>
+        <property name="syft:metadata:provides:1">cmd:sh=1.35.0-r29</property>
+        <property name="syft:metadata:pullChecksum">Q1miWwyhWKXVEiRYLhmArV1TKMs6A=</property>
+        <property name="syft:metadata:pullDependencies:0">busybox=1.35.0-r29</property>
+        <property name="syft:metadata:size">1547</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:apk/alpine/ca-certificates-bundle@20220614-r4?arch=x86_64&amp;upstream=ca-certificates&amp;distro=alpine-3.17.2&amp;package-id=b805d823ae624f04" type="library">
+      <publisher>Natanael Copa &lt;ncopa@alpinelinux.org&gt;</publisher>
+      <name>ca-certificates-bundle</name>
+      <version>20220614-r4</version>
+      <description>Pre generated bundle of Mozilla certificates</description>
+      <licenses>
+        <license>
+          <id>MPL-2.0</id>
+        </license>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:ca-certificates-bundle:ca-certificates-bundle:20220614-r4:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:apk/alpine/ca-certificates-bundle@20220614-r4?arch=x86_64&amp;upstream=ca-certificates&amp;distro=alpine-3.17.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://www.mozilla.org/en-US/about/governance/policies/security-group/certs/</url>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="syft:package:foundBy">apkdb-cataloger</property>
+        <property name="syft:package:metadataType">ApkMetadata</property>
+        <property name="syft:package:type">apk</property>
+        <property name="syft:cpe23">cpe:2.3:a:ca-certificates-bundle:ca_certificates_bundle:20220614-r4:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:ca_certificates_bundle:ca-certificates-bundle:20220614-r4:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:ca_certificates_bundle:ca_certificates_bundle:20220614-r4:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:ca-certificates:ca-certificates-bundle:20220614-r4:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:ca-certificates:ca_certificates_bundle:20220614-r4:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:ca_certificates:ca-certificates-bundle:20220614-r4:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:ca_certificates:ca_certificates_bundle:20220614-r4:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:ca:ca-certificates-bundle:20220614-r4:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:ca:ca_certificates_bundle:20220614-r4:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:7cd52847ad775a5ddc4b58326cf884beee34544296402c6292ed76474c686d39</property>
+        <property name="syft:location:0:path">/lib/apk/db/installed</property>
+        <property name="syft:metadata:gitCommitOfApkPort">e1839fd45a096c9e21ac24f8a61991d357d11628</property>
+        <property name="syft:metadata:installedSize">237568</property>
+        <property name="syft:metadata:originPackage">ca-certificates</property>
+        <property name="syft:metadata:provides:0">ca-certificates-cacert=20220614-r4</property>
+        <property name="syft:metadata:pullChecksum">Q14PFUzkDXTGDcHkiuEdFuzb+EvxQ=</property>
+        <property name="syft:metadata:size">126296</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:apk/alpine/libc-utils@0.7.2-r3?arch=x86_64&amp;upstream=libc-dev&amp;distro=alpine-3.17.2&amp;package-id=8126b232e2d3c608" type="library">
+      <publisher>Natanael Copa &lt;ncopa@alpinelinux.org&gt;</publisher>
+      <name>libc-utils</name>
+      <version>0.7.2-r3</version>
+      <description>Meta package to pull in correct libc</description>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+        </license>
+        <license>
+          <id>BSD-3-Clause</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libc-utils:libc-utils:0.7.2-r3:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:apk/alpine/libc-utils@0.7.2-r3?arch=x86_64&amp;upstream=libc-dev&amp;distro=alpine-3.17.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://alpinelinux.org</url>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="syft:package:foundBy">apkdb-cataloger</property>
+        <property name="syft:package:metadataType">ApkMetadata</property>
+        <property name="syft:package:type">apk</property>
+        <property name="syft:cpe23">cpe:2.3:a:libc-utils:libc_utils:0.7.2-r3:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libc_utils:libc-utils:0.7.2-r3:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libc_utils:libc_utils:0.7.2-r3:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libc:libc-utils:0.7.2-r3:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libc:libc_utils:0.7.2-r3:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:7cd52847ad775a5ddc4b58326cf884beee34544296402c6292ed76474c686d39</property>
+        <property name="syft:location:0:path">/lib/apk/db/installed</property>
+        <property name="syft:metadata:gitCommitOfApkPort">60424133be2e79bbfeff3d58147a22886f817ce2</property>
+        <property name="syft:metadata:installedSize">4096</property>
+        <property name="syft:metadata:originPackage">libc-dev</property>
+        <property name="syft:metadata:pullChecksum">Q19Gg06pBPiiG9UN94ql7qImsHSUQ=</property>
+        <property name="syft:metadata:pullDependencies:0">musl-utils</property>
+        <property name="syft:metadata:size">1485</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:apk/alpine/libcrypto3@3.0.8-r0?arch=x86_64&amp;upstream=openssl&amp;distro=alpine-3.17.2&amp;package-id=b0e92b2ef962ab6d" type="library">
+      <publisher>Ariadne Conill &lt;ariadne@dereferenced.org&gt;</publisher>
+      <name>libcrypto3</name>
+      <version>3.0.8-r0</version>
+      <description>Crypto library from openssl</description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libcrypto3:libcrypto3:3.0.8-r0:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:apk/alpine/libcrypto3@3.0.8-r0?arch=x86_64&amp;upstream=openssl&amp;distro=alpine-3.17.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://www.openssl.org/</url>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="syft:package:foundBy">apkdb-cataloger</property>
+        <property name="syft:package:metadataType">ApkMetadata</property>
+        <property name="syft:package:type">apk</property>
+        <property name="syft:location:0:layerID">sha256:7cd52847ad775a5ddc4b58326cf884beee34544296402c6292ed76474c686d39</property>
+        <property name="syft:location:0:path">/lib/apk/db/installed</property>
+        <property name="syft:metadata:gitCommitOfApkPort">524302e205a5b43c2bb48d041bcb10ccf2b480f9</property>
+        <property name="syft:metadata:installedSize">4206592</property>
+        <property name="syft:metadata:originPackage">openssl</property>
+        <property name="syft:metadata:provides:0">so:libcrypto.so.3=3</property>
+        <property name="syft:metadata:pullChecksum">Q1lyWpurYeMlLEt60ys+OlTABmzgs=</property>
+        <property name="syft:metadata:pullDependencies:0">so:libc.musl-x86_64.so.1</property>
+        <property name="syft:metadata:size">1710217</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:apk/alpine/libssl3@3.0.8-r0?arch=x86_64&amp;upstream=openssl&amp;distro=alpine-3.17.2&amp;package-id=9005623d3896bb87" type="library">
+      <publisher>Ariadne Conill &lt;ariadne@dereferenced.org&gt;</publisher>
+      <name>libssl3</name>
+      <version>3.0.8-r0</version>
+      <description>SSL shared libraries</description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libssl3:libssl3:3.0.8-r0:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:apk/alpine/libssl3@3.0.8-r0?arch=x86_64&amp;upstream=openssl&amp;distro=alpine-3.17.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://www.openssl.org/</url>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="syft:package:foundBy">apkdb-cataloger</property>
+        <property name="syft:package:metadataType">ApkMetadata</property>
+        <property name="syft:package:type">apk</property>
+        <property name="syft:location:0:layerID">sha256:7cd52847ad775a5ddc4b58326cf884beee34544296402c6292ed76474c686d39</property>
+        <property name="syft:location:0:path">/lib/apk/db/installed</property>
+        <property name="syft:metadata:gitCommitOfApkPort">524302e205a5b43c2bb48d041bcb10ccf2b480f9</property>
+        <property name="syft:metadata:installedSize">622592</property>
+        <property name="syft:metadata:originPackage">openssl</property>
+        <property name="syft:metadata:provides:0">so:libssl.so.3=3</property>
+        <property name="syft:metadata:pullChecksum">Q1Z6/d/FKYkPehWzNtOtYnJ74oIkY=</property>
+        <property name="syft:metadata:pullDependencies:0">so:libc.musl-x86_64.so.1</property>
+        <property name="syft:metadata:pullDependencies:1">so:libcrypto.so.3</property>
+        <property name="syft:metadata:size">246853</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:apk/alpine/musl@1.2.3-r4?arch=x86_64&amp;upstream=musl&amp;distro=alpine-3.17.2&amp;package-id=d9700f02cf26e8b8" type="library">
+      <publisher>Timo Teräs &lt;timo.teras@iki.fi&gt;</publisher>
+      <name>musl</name>
+      <version>1.2.3-r4</version>
+      <description>the musl c library (libc) implementation</description>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:musl:musl:1.2.3-r4:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:apk/alpine/musl@1.2.3-r4?arch=x86_64&amp;upstream=musl&amp;distro=alpine-3.17.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://musl.libc.org/</url>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="syft:package:foundBy">apkdb-cataloger</property>
+        <property name="syft:package:metadataType">ApkMetadata</property>
+        <property name="syft:package:type">apk</property>
+        <property name="syft:location:0:layerID">sha256:7cd52847ad775a5ddc4b58326cf884beee34544296402c6292ed76474c686d39</property>
+        <property name="syft:location:0:path">/lib/apk/db/installed</property>
+        <property name="syft:metadata:gitCommitOfApkPort">f93af038c3de7146121c2ea8124ba5ce29b4b058</property>
+        <property name="syft:metadata:installedSize">634880</property>
+        <property name="syft:metadata:originPackage">musl</property>
+        <property name="syft:metadata:provides:0">so:libc.musl-x86_64.so.1=1</property>
+        <property name="syft:metadata:pullChecksum">Q1Pk7x1woArbB1nzkMPJPq1TECwus=</property>
+        <property name="syft:metadata:size">388955</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:apk/alpine/musl-utils@1.2.3-r4?arch=x86_64&amp;upstream=musl&amp;distro=alpine-3.17.2&amp;package-id=f71ecf5267e6c37b" type="library">
+      <publisher>Timo Teräs &lt;timo.teras@iki.fi&gt;</publisher>
+      <name>musl-utils</name>
+      <version>1.2.3-r4</version>
+      <description>the musl c library (libc) implementation</description>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+        <license>
+          <id>BSD-2-Clause</id>
+        </license>
+        <license>
+          <id>GPL-2.0-or-later</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:musl-utils:musl-utils:1.2.3-r4:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:apk/alpine/musl-utils@1.2.3-r4?arch=x86_64&amp;upstream=musl&amp;distro=alpine-3.17.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://musl.libc.org/</url>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="syft:package:foundBy">apkdb-cataloger</property>
+        <property name="syft:package:metadataType">ApkMetadata</property>
+        <property name="syft:package:type">apk</property>
+        <property name="syft:cpe23">cpe:2.3:a:musl-utils:musl_utils:1.2.3-r4:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:musl_utils:musl-utils:1.2.3-r4:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:musl_utils:musl_utils:1.2.3-r4:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:musl:musl-utils:1.2.3-r4:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:musl:musl_utils:1.2.3-r4:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:7cd52847ad775a5ddc4b58326cf884beee34544296402c6292ed76474c686d39</property>
+        <property name="syft:location:0:path">/lib/apk/db/installed</property>
+        <property name="syft:metadata:gitCommitOfApkPort">f93af038c3de7146121c2ea8124ba5ce29b4b058</property>
+        <property name="syft:metadata:installedSize">135168</property>
+        <property name="syft:metadata:originPackage">musl</property>
+        <property name="syft:metadata:provides:0">cmd:getconf=1.2.3-r4</property>
+        <property name="syft:metadata:provides:1">cmd:getent=1.2.3-r4</property>
+        <property name="syft:metadata:provides:2">cmd:iconv=1.2.3-r4</property>
+        <property name="syft:metadata:provides:3">cmd:ldconfig=1.2.3-r4</property>
+        <property name="syft:metadata:provides:4">cmd:ldd=1.2.3-r4</property>
+        <property name="syft:metadata:pullChecksum">Q1ZWJL4eySx8nPSjF1FAJgQyvuNs4=</property>
+        <property name="syft:metadata:pullDependencies:0">scanelf</property>
+        <property name="syft:metadata:pullDependencies:1">so:libc.musl-x86_64.so.1</property>
+        <property name="syft:metadata:size">36697</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:apk/alpine/scanelf@1.3.5-r1?arch=x86_64&amp;upstream=pax-utils&amp;distro=alpine-3.17.2&amp;package-id=e903138d19e85b80" type="library">
+      <publisher>Natanael Copa &lt;ncopa@alpinelinux.org&gt;</publisher>
+      <name>scanelf</name>
+      <version>1.3.5-r1</version>
+      <description>Scan ELF binaries for stuff</description>
+      <licenses>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:scanelf:scanelf:1.3.5-r1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:apk/alpine/scanelf@1.3.5-r1?arch=x86_64&amp;upstream=pax-utils&amp;distro=alpine-3.17.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://wiki.gentoo.org/wiki/Hardened/PaX_Utilities</url>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="syft:package:foundBy">apkdb-cataloger</property>
+        <property name="syft:package:metadataType">ApkMetadata</property>
+        <property name="syft:package:type">apk</property>
+        <property name="syft:location:0:layerID">sha256:7cd52847ad775a5ddc4b58326cf884beee34544296402c6292ed76474c686d39</property>
+        <property name="syft:location:0:path">/lib/apk/db/installed</property>
+        <property name="syft:metadata:gitCommitOfApkPort">e52243dbb02069f10d48440ccc5fd41fa5fc2236</property>
+        <property name="syft:metadata:installedSize">98304</property>
+        <property name="syft:metadata:originPackage">pax-utils</property>
+        <property name="syft:metadata:provides:0">cmd:scanelf=1.3.5-r1</property>
+        <property name="syft:metadata:pullChecksum">Q11dxYFsHvBFAzzHGDo5gOTDNJDyQ=</property>
+        <property name="syft:metadata:pullDependencies:0">so:libc.musl-x86_64.so.1</property>
+        <property name="syft:metadata:size">37687</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:apk/alpine/ssl_client@1.35.0-r29?arch=x86_64&amp;upstream=busybox&amp;distro=alpine-3.17.2&amp;package-id=b15247aafcd4a647" type="library">
+      <publisher>Sören Tempel &lt;soeren+alpine@soeren-tempel.net&gt;</publisher>
+      <name>ssl_client</name>
+      <version>1.35.0-r29</version>
+      <description>EXternal ssl_client for busybox wget</description>
+      <licenses>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:ssl-client:ssl-client:1.35.0-r29:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:apk/alpine/ssl_client@1.35.0-r29?arch=x86_64&amp;upstream=busybox&amp;distro=alpine-3.17.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://busybox.net/</url>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="syft:package:foundBy">apkdb-cataloger</property>
+        <property name="syft:package:metadataType">ApkMetadata</property>
+        <property name="syft:package:type">apk</property>
+        <property name="syft:cpe23">cpe:2.3:a:ssl-client:ssl_client:1.35.0-r29:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:ssl_client:ssl-client:1.35.0-r29:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:ssl_client:ssl_client:1.35.0-r29:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:ssl:ssl-client:1.35.0-r29:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:ssl:ssl_client:1.35.0-r29:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:7cd52847ad775a5ddc4b58326cf884beee34544296402c6292ed76474c686d39</property>
+        <property name="syft:location:0:path">/lib/apk/db/installed</property>
+        <property name="syft:metadata:gitCommitOfApkPort">1dbf7a793afae640ea643a055b6dd4f430ac116b</property>
+        <property name="syft:metadata:installedSize">28672</property>
+        <property name="syft:metadata:originPackage">busybox</property>
+        <property name="syft:metadata:provides:0">cmd:ssl_client=1.35.0-r29</property>
+        <property name="syft:metadata:pullChecksum">Q1QuqZjeP6XG85I29tOiCWofL8Cj0=</property>
+        <property name="syft:metadata:pullDependencies:0">so:libc.musl-x86_64.so.1</property>
+        <property name="syft:metadata:pullDependencies:1">so:libcrypto.so.3</property>
+        <property name="syft:metadata:pullDependencies:2">so:libssl.so.3</property>
+        <property name="syft:metadata:size">4929</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:apk/alpine/zlib@1.2.13-r0?arch=x86_64&amp;upstream=zlib&amp;distro=alpine-3.17.2&amp;package-id=94014313cfcd2b71" type="library">
+      <publisher>Natanael Copa &lt;ncopa@alpinelinux.org&gt;</publisher>
+      <name>zlib</name>
+      <version>1.2.13-r0</version>
+      <description>A compression/decompression Library</description>
+      <licenses>
+        <license>
+          <id>Zlib</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:zlib:zlib:1.2.13-r0:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:apk/alpine/zlib@1.2.13-r0?arch=x86_64&amp;upstream=zlib&amp;distro=alpine-3.17.2</purl>
+      <externalReferences>
+        <reference type="distribution">
+          <url>https://zlib.net/</url>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="syft:package:foundBy">apkdb-cataloger</property>
+        <property name="syft:package:metadataType">ApkMetadata</property>
+        <property name="syft:package:type">apk</property>
+        <property name="syft:location:0:layerID">sha256:7cd52847ad775a5ddc4b58326cf884beee34544296402c6292ed76474c686d39</property>
+        <property name="syft:location:0:path">/lib/apk/db/installed</property>
+        <property name="syft:metadata:gitCommitOfApkPort">bb37266b06a72d21d1fd850ef4b86665cf9ef70f</property>
+        <property name="syft:metadata:installedSize">110592</property>
+        <property name="syft:metadata:originPackage">zlib</property>
+        <property name="syft:metadata:provides:0">so:libz.so.1=1.2.13</property>
+        <property name="syft:metadata:pullChecksum">Q1rjnXT01l1PAxXheUxe4Oldl5rFk=</property>
+        <property name="syft:metadata:pullDependencies:0">so:libc.musl-x86_64.so.1</property>
+        <property name="syft:metadata:size">54258</property>
+      </properties>
+    </component>
+    <component type="operating-system">
+      <name>alpine</name>
+      <version>3.17.2</version>
+      <description>Alpine Linux v3.17</description>
+      <swid tagId="alpine" name="alpine" version="3.17.2"></swid>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://gitlab.alpinelinux.org/alpine/aports/-/issues</url>
+        </reference>
+        <reference type="website">
+          <url>https://alpinelinux.org/</url>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="syft:distro:id">alpine</property>
+        <property name="syft:distro:prettyName">Alpine Linux v3.17</property>
+        <property name="syft:distro:versionID">3.17.2</property>
+      </properties>
+    </component>
+  </components>
+</bom>

--- a/cmd/osv-scanner/fixtures/sbom-insecure/postgres-stretch.cdx.xml
+++ b/cmd/osv-scanner/fixtures/sbom-insecure/postgres-stretch.cdx.xml
@@ -1,0 +1,5110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.4" serialNumber="urn:uuid:7f5ffdc8-0965-4bce-9d01-6e0accc26c19" version="1">
+  <metadata>
+    <timestamp>2023-03-02T12:00:49+11:00</timestamp>
+    <tools>
+      <tool>
+        <vendor>anchore</vendor>
+        <name>syft</name>
+        <version>0.73.0</version>
+      </tool>
+    </tools>
+    <component bom-ref="a604e4369742aa31" type="container">
+      <name>postgres:11.15-stretch</name>
+      <version>sha256:84ac18036f93e18c3d8165e4fd9d9885924bb71beeab042dd50443d4f88fcdda</version>
+    </component>
+  </metadata>
+  <components>
+    <component bom-ref="pkg:deb/debian/adduser@3.115?arch=all&amp;distro=debian-9&amp;package-id=55b15606ad877995" type="library">
+      <publisher>Debian Adduser Developers &lt;adduser-devel@lists.alioth.debian.org&gt;</publisher>
+      <name>adduser</name>
+      <version>3.115</version>
+      <licenses>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:adduser:adduser:3.115:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/adduser@3.115?arch=all&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/adduser/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/adduser.conffiles</property>
+        <property name="syft:location:2:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/info/adduser.md5sums</property>
+        <property name="syft:location:3:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:3:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">849</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/apt@1.4.11?arch=amd64&amp;distro=debian-9&amp;package-id=6eb5e50bea2391d0" type="library">
+      <publisher>APT Development Team &lt;deity@lists.debian.org&gt;</publisher>
+      <name>apt</name>
+      <version>1.4.11</version>
+      <licenses>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <name>GPLv2+</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:apt:apt:1.4.11:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/apt@1.4.11?arch=amd64&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/apt/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/apt.conffiles</property>
+        <property name="syft:location:2:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/info/apt.md5sums</property>
+        <property name="syft:location:3:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:3:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">3539</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/base-files@9.9+deb9u13?arch=amd64&amp;distro=debian-9&amp;package-id=48785302322127f6" type="library">
+      <publisher>Santiago Vila &lt;sanvila@debian.org&gt;</publisher>
+      <name>base-files</name>
+      <version>9.9+deb9u13</version>
+      <licenses>
+        <license>
+          <name>GPL</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:base-files:base-files:9.9\+deb9u13:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/base-files@9.9+deb9u13?arch=amd64&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:base-files:base_files:9.9\+deb9u13:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:base_files:base-files:9.9\+deb9u13:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:base_files:base_files:9.9\+deb9u13:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:base:base-files:9.9\+deb9u13:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:base:base_files:9.9\+deb9u13:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/base-files/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/base-files.conffiles</property>
+        <property name="syft:location:2:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/info/base-files.md5sums</property>
+        <property name="syft:location:3:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:3:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">333</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/base-passwd@3.5.43?arch=amd64&amp;distro=debian-9&amp;package-id=73052e2f800e1136" type="library">
+      <publisher>Colin Watson &lt;cjwatson@debian.org&gt;</publisher>
+      <name>base-passwd</name>
+      <version>3.5.43</version>
+      <licenses>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <name>PD</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:base-passwd:base-passwd:3.5.43:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/base-passwd@3.5.43?arch=amd64&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:base-passwd:base_passwd:3.5.43:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:base_passwd:base-passwd:3.5.43:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:base_passwd:base_passwd:3.5.43:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:base:base-passwd:3.5.43:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:base:base_passwd:3.5.43:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/base-passwd/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/base-passwd.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">229</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/bash@4.4-5?arch=amd64&amp;distro=debian-9&amp;package-id=9c8152d11c29c7af" type="library">
+      <publisher>Matthias Klose &lt;doko@debian.org&gt;</publisher>
+      <name>bash</name>
+      <version>4.4-5</version>
+      <licenses>
+        <license>
+          <id>GPL-3.0-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:bash:bash:4.4-5:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/bash@4.4-5?arch=amd64&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/bash/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/bash.conffiles</property>
+        <property name="syft:location:2:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/info/bash.md5sums</property>
+        <property name="syft:location:3:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:3:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">5798</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/bsdutils@1:2.29.2-1+deb9u1?arch=amd64&amp;upstream=util-linux%402.29.2-1+deb9u1&amp;distro=debian-9&amp;package-id=30092af40321c6bc" type="library">
+      <publisher>Debian util-linux Maintainers &lt;ah-util-linux@debian.org&gt;</publisher>
+      <name>bsdutils</name>
+      <version>1:2.29.2-1+deb9u1</version>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+        </license>
+        <license>
+          <id>BSD-3-Clause</id>
+        </license>
+        <license>
+          <id>BSD-4-Clause</id>
+        </license>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>GPL-2.0-or-later</id>
+        </license>
+        <license>
+          <id>GPL-3.0-only</id>
+        </license>
+        <license>
+          <id>GPL-3.0-or-later</id>
+        </license>
+        <license>
+          <name>LGPL</name>
+        </license>
+        <license>
+          <id>LGPL-2.0-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.0-or-later</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-or-later</id>
+        </license>
+        <license>
+          <id>LGPL-3.0-only</id>
+        </license>
+        <license>
+          <id>LGPL-3.0-or-later</id>
+        </license>
+        <license>
+          <id>MIT</id>
+        </license>
+        <license>
+          <name>public-domain</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:bsdutils:bsdutils:1\:2.29.2-1\+deb9u1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/bsdutils@1:2.29.2-1+deb9u1?arch=amd64&amp;upstream=util-linux%402.29.2-1+deb9u1&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/bsdutils/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/bsdutils.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">238</property>
+        <property name="syft:metadata:source">util-linux</property>
+        <property name="syft:metadata:sourceVersion">2.29.2-1+deb9u1</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/coreutils@8.26-3?arch=amd64&amp;distro=debian-9&amp;package-id=9dc9eda0112d42ff" type="library">
+      <publisher>Michael Stone &lt;mstone@debian.org&gt;</publisher>
+      <name>coreutils</name>
+      <version>8.26-3</version>
+      <licenses>
+        <license>
+          <id>GPL-3.0-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:coreutils:coreutils:8.26-3:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/coreutils@8.26-3?arch=amd64&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/coreutils/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/coreutils.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">15103</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/dash@0.5.8-2.4?arch=amd64&amp;distro=debian-9&amp;package-id=e9cdd8c091939027" type="library">
+      <publisher>Gerrit Pape &lt;pape@smarden.org&gt;</publisher>
+      <name>dash</name>
+      <version>0.5.8-2.4</version>
+      <licenses>
+        <license>
+          <name>GPL</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:dash:dash:0.5.8-2.4:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/dash@0.5.8-2.4?arch=amd64&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/dash/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/dash.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">204</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/debconf@1.5.61?arch=all&amp;distro=debian-9&amp;package-id=5c25da680ba2ad9c" type="library">
+      <publisher>Debconf Developers &lt;debconf-devel@lists.alioth.debian.org&gt;</publisher>
+      <name>debconf</name>
+      <version>1.5.61</version>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:debconf:debconf:1.5.61:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/debconf@1.5.61?arch=all&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/debconf/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/debconf.conffiles</property>
+        <property name="syft:location:2:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/info/debconf.md5sums</property>
+        <property name="syft:location:3:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:3:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">558</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/debian-archive-keyring@2017.5+deb9u2?arch=all&amp;distro=debian-9&amp;package-id=b55ef5e3626ace0f" type="library">
+      <publisher>Debian Release Team &lt;packages@release.debian.org&gt;</publisher>
+      <name>debian-archive-keyring</name>
+      <version>2017.5+deb9u2</version>
+      <licenses>
+        <license>
+          <name>GPL</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:debian-archive-keyring:debian-archive-keyring:2017.5\+deb9u2:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/debian-archive-keyring@2017.5+deb9u2?arch=all&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:debian-archive-keyring:debian_archive_keyring:2017.5\+deb9u2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:debian_archive_keyring:debian-archive-keyring:2017.5\+deb9u2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:debian_archive_keyring:debian_archive_keyring:2017.5\+deb9u2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:debian-archive:debian-archive-keyring:2017.5\+deb9u2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:debian-archive:debian_archive_keyring:2017.5\+deb9u2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:debian_archive:debian-archive-keyring:2017.5\+deb9u2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:debian_archive:debian_archive_keyring:2017.5\+deb9u2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:debian:debian-archive-keyring:2017.5\+deb9u2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:debian:debian_archive_keyring:2017.5\+deb9u2:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/debian-archive-keyring/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/debian-archive-keyring.conffiles</property>
+        <property name="syft:location:2:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/info/debian-archive-keyring.md5sums</property>
+        <property name="syft:location:3:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:3:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">189</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/debianutils@4.8.1.1?arch=amd64&amp;distro=debian-9&amp;package-id=80920c1ec0d87897" type="library">
+      <publisher>Clint Adams &lt;clint@debian.org&gt;</publisher>
+      <name>debianutils</name>
+      <version>4.8.1.1</version>
+      <licenses>
+        <license>
+          <name>GPL</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:debianutils:debianutils:4.8.1.1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/debianutils@4.8.1.1?arch=amd64&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/debianutils/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/debianutils.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">213</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/diffutils@1:3.5-3?arch=amd64&amp;distro=debian-9&amp;package-id=7cb6d0a35e3ba648" type="library">
+      <publisher>Santiago Vila &lt;sanvila@debian.org&gt;</publisher>
+      <name>diffutils</name>
+      <version>1:3.5-3</version>
+      <licenses>
+        <license>
+          <name>GFDL</name>
+        </license>
+        <license>
+          <name>GPL</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:diffutils:diffutils:1\:3.5-3:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/diffutils@1:3.5-3?arch=amd64&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/diffutils/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/diffutils.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">1327</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/dirmngr@2.1.18-8~deb9u4?arch=amd64&amp;upstream=gnupg2&amp;distro=debian-9&amp;package-id=3f3d55404009c76a" type="library">
+      <publisher>Debian GnuPG Maintainers &lt;pkg-gnupg-maint@lists.alioth.debian.org&gt;</publisher>
+      <name>dirmngr</name>
+      <version>2.1.18-8~deb9u4</version>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+        </license>
+        <license>
+          <name>Expat</name>
+        </license>
+        <license>
+          <id>GPL-3.0-only</id>
+        </license>
+        <license>
+          <id>GPL-3.0-or-later</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-or-later</id>
+        </license>
+        <license>
+          <id>LGPL-3.0-only</id>
+        </license>
+        <license>
+          <id>LGPL-3.0-or-later</id>
+        </license>
+        <license>
+          <name>RFC-Reference</name>
+        </license>
+        <license>
+          <name>TinySCHEME</name>
+        </license>
+        <license>
+          <name>permissive</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:dirmngr:dirmngr:2.1.18-8\~deb9u4:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/dirmngr@2.1.18-8~deb9u4?arch=amd64&amp;upstream=gnupg2&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:0:path">/usr/share/doc/dirmngr/copyright</property>
+        <property name="syft:location:1:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/dirmngr.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">1088</property>
+        <property name="syft:metadata:source">gnupg2</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/dpkg@1.18.25?arch=amd64&amp;distro=debian-9&amp;package-id=61edba795c40f599" type="library">
+      <publisher>Dpkg Developers &lt;debian-dpkg@lists.debian.org&gt;</publisher>
+      <name>dpkg</name>
+      <version>1.18.25</version>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+        </license>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>GPL-2.0-or-later</id>
+        </license>
+        <license>
+          <name>public-domain-md5</name>
+        </license>
+        <license>
+          <name>public-domain-s-s-d</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:dpkg:dpkg:1.18.25:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/dpkg@1.18.25?arch=amd64&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/dpkg/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/dpkg.conffiles</property>
+        <property name="syft:location:2:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/info/dpkg.md5sums</property>
+        <property name="syft:location:3:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:3:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">6778</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/e2fslibs@1.43.4-2+deb9u2?arch=amd64&amp;upstream=e2fsprogs&amp;distro=debian-9&amp;package-id=e8a6fd1ef12a0d83" type="library">
+      <publisher>Theodore Y. Ts&#39;o &lt;tytso@mit.edu&gt;</publisher>
+      <name>e2fslibs</name>
+      <version>1.43.4-2+deb9u2</version>
+      <licenses>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.0-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:e2fslibs:e2fslibs:1.43.4-2\+deb9u2:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/e2fslibs@1.43.4-2+deb9u2?arch=amd64&amp;upstream=e2fsprogs&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/e2fslibs/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/e2fslibs:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">450</property>
+        <property name="syft:metadata:source">e2fsprogs</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/e2fsprogs@1.43.4-2+deb9u2?arch=amd64&amp;distro=debian-9&amp;package-id=adbbfefecacb6e15" type="library">
+      <publisher>Theodore Y. Ts&#39;o &lt;tytso@mit.edu&gt;</publisher>
+      <name>e2fsprogs</name>
+      <version>1.43.4-2+deb9u2</version>
+      <licenses>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.0-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:e2fsprogs:e2fsprogs:1.43.4-2\+deb9u2:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/e2fsprogs@1.43.4-2+deb9u2?arch=amd64&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/e2fsprogs/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/e2fsprogs.conffiles</property>
+        <property name="syft:location:2:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/info/e2fsprogs.md5sums</property>
+        <property name="syft:location:3:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:3:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">4027</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/findutils@4.6.0+git+20161106-2?arch=amd64&amp;distro=debian-9&amp;package-id=93713cc4aa8b2190" type="library">
+      <publisher>Andreas Metzler &lt;ametzler@debian.org&gt;</publisher>
+      <name>findutils</name>
+      <version>4.6.0+git+20161106-2</version>
+      <licenses>
+        <license>
+          <id>GFDL-1.3-only</id>
+        </license>
+        <license>
+          <id>GPL-3.0-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:findutils:findutils:4.6.0\+git\+20161106-2:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/findutils@4.6.0+git+20161106-2?arch=amd64&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/findutils/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/findutils.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">1854</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/gcc-6-base@6.3.0-18+deb9u1?arch=amd64&amp;upstream=gcc-6&amp;distro=debian-9&amp;package-id=a782e256f1d14ca3" type="library">
+      <publisher>Debian GCC Maintainers &lt;debian-gcc@lists.debian.org&gt;</publisher>
+      <name>gcc-6-base</name>
+      <version>6.3.0-18+deb9u1</version>
+      <licenses>
+        <license>
+          <name>Artistic</name>
+        </license>
+        <license>
+          <id>GFDL-1.2-only</id>
+        </license>
+        <license>
+          <name>GPL</name>
+        </license>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>GPL-3.0-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:gcc-6-base:gcc-6-base:6.3.0-18\+deb9u1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/gcc-6-base@6.3.0-18+deb9u1?arch=amd64&amp;upstream=gcc-6&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:gcc-6-base:gcc_6_base:6.3.0-18\+deb9u1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:gcc_6_base:gcc-6-base:6.3.0-18\+deb9u1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:gcc_6_base:gcc_6_base:6.3.0-18\+deb9u1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:gcc-6:gcc-6-base:6.3.0-18\+deb9u1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:gcc-6:gcc_6_base:6.3.0-18\+deb9u1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:gcc_6:gcc-6-base:6.3.0-18\+deb9u1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:gcc_6:gcc_6_base:6.3.0-18\+deb9u1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:gcc:gcc-6-base:6.3.0-18\+deb9u1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:gcc:gcc_6_base:6.3.0-18\+deb9u1:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/gcc-6-base/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/gcc-6-base:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">209</property>
+        <property name="syft:metadata:source">gcc-6</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:golang/github.com/opencontainers/runc@v1.0.1?package-id=7e09dde12880a55b" type="library">
+      <name>github.com/opencontainers/runc</name>
+      <version>v1.0.1</version>
+      <cpe>cpe:2.3:a:opencontainers:runc:v1.0.1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:golang/github.com/opencontainers/runc@v1.0.1</purl>
+      <properties>
+        <property name="syft:package:foundBy">go-module-binary-cataloger</property>
+        <property name="syft:package:language">go</property>
+        <property name="syft:package:metadataType">GolangBinMetadata</property>
+        <property name="syft:package:type">go-module</property>
+        <property name="syft:location:0:layerID">sha256:0305f2b14826a228defa3526b1fcd8af7291315d19e9e8dea531eb8725f1c369</property>
+        <property name="syft:location:0:path">/usr/local/bin/gosu</property>
+        <property name="syft:metadata:architecture">x86_64</property>
+        <property name="syft:metadata:goCompiledVersion">go1.16.7</property>
+        <property name="syft:metadata:h1Digest">h1:G18PGckGdAm3yVQRWDVQ1rLSLntiniKJ0cNRT2Tm5gs=</property>
+        <property name="syft:metadata:mainModule">github.com/tianon/gosu</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:golang/github.com/tianon/gosu@(devel)?package-id=656546dcfdff37ca" type="library">
+      <name>github.com/tianon/gosu</name>
+      <version>(devel)</version>
+      <cpe>cpe:2.3:a:tianon:gosu:\(devel\):*:*:*:*:*:*:*</cpe>
+      <purl>pkg:golang/github.com/tianon/gosu@(devel)</purl>
+      <properties>
+        <property name="syft:package:foundBy">go-module-binary-cataloger</property>
+        <property name="syft:package:language">go</property>
+        <property name="syft:package:metadataType">GolangBinMetadata</property>
+        <property name="syft:package:type">go-module</property>
+        <property name="syft:location:0:layerID">sha256:0305f2b14826a228defa3526b1fcd8af7291315d19e9e8dea531eb8725f1c369</property>
+        <property name="syft:location:0:path">/usr/local/bin/gosu</property>
+        <property name="syft:metadata:architecture">x86_64</property>
+        <property name="syft:metadata:goCompiledVersion">go1.16.7</property>
+        <property name="syft:metadata:mainModule">github.com/tianon/gosu</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/gnupg@2.1.18-8~deb9u4?arch=amd64&amp;upstream=gnupg2&amp;distro=debian-9&amp;package-id=4f5692070ff0fc8f" type="library">
+      <publisher>Debian GnuPG Maintainers &lt;pkg-gnupg-maint@lists.alioth.debian.org&gt;</publisher>
+      <name>gnupg</name>
+      <version>2.1.18-8~deb9u4</version>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+        </license>
+        <license>
+          <name>Expat</name>
+        </license>
+        <license>
+          <id>GPL-3.0-only</id>
+        </license>
+        <license>
+          <id>GPL-3.0-or-later</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-or-later</id>
+        </license>
+        <license>
+          <id>LGPL-3.0-only</id>
+        </license>
+        <license>
+          <id>LGPL-3.0-or-later</id>
+        </license>
+        <license>
+          <name>RFC-Reference</name>
+        </license>
+        <license>
+          <name>TinySCHEME</name>
+        </license>
+        <license>
+          <name>permissive</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:gnupg:gnupg:2.1.18-8\~deb9u4:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/gnupg@2.1.18-8~deb9u4?arch=amd64&amp;upstream=gnupg2&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:0:path">/usr/share/doc/gnupg/copyright</property>
+        <property name="syft:location:1:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/gnupg.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">2093</property>
+        <property name="syft:metadata:source">gnupg2</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/gnupg-agent@2.1.18-8~deb9u4?arch=amd64&amp;upstream=gnupg2&amp;distro=debian-9&amp;package-id=e5a02a979d1826fa" type="library">
+      <publisher>Debian GnuPG Maintainers &lt;pkg-gnupg-maint@lists.alioth.debian.org&gt;</publisher>
+      <name>gnupg-agent</name>
+      <version>2.1.18-8~deb9u4</version>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+        </license>
+        <license>
+          <name>Expat</name>
+        </license>
+        <license>
+          <id>GPL-3.0-only</id>
+        </license>
+        <license>
+          <id>GPL-3.0-or-later</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-or-later</id>
+        </license>
+        <license>
+          <id>LGPL-3.0-only</id>
+        </license>
+        <license>
+          <id>LGPL-3.0-or-later</id>
+        </license>
+        <license>
+          <name>RFC-Reference</name>
+        </license>
+        <license>
+          <name>TinySCHEME</name>
+        </license>
+        <license>
+          <name>permissive</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:gnupg-agent:gnupg-agent:2.1.18-8\~deb9u4:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/gnupg-agent@2.1.18-8~deb9u4?arch=amd64&amp;upstream=gnupg2&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:gnupg-agent:gnupg_agent:2.1.18-8\~deb9u4:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:gnupg_agent:gnupg-agent:2.1.18-8\~deb9u4:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:gnupg_agent:gnupg_agent:2.1.18-8\~deb9u4:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:gnupg:gnupg-agent:2.1.18-8\~deb9u4:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:gnupg:gnupg_agent:2.1.18-8\~deb9u4:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:0:path">/usr/share/doc/gnupg-agent/copyright</property>
+        <property name="syft:location:1:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/gnupg-agent.conffiles</property>
+        <property name="syft:location:2:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/info/gnupg-agent.md5sums</property>
+        <property name="syft:location:3:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:3:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">1362</property>
+        <property name="syft:metadata:source">gnupg2</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:golang/golang.org/x/sys@v0.0.0-20210817142637-7d9622a276b7?package-id=3c706254c24acc61" type="library">
+      <name>golang.org/x/sys</name>
+      <version>v0.0.0-20210817142637-7d9622a276b7</version>
+      <cpe>cpe:2.3:a:golang:x\/sys:v0.0.0-20210817142637-7d9622a276b7:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:golang/golang.org/x/sys@v0.0.0-20210817142637-7d9622a276b7</purl>
+      <properties>
+        <property name="syft:package:foundBy">go-module-binary-cataloger</property>
+        <property name="syft:package:language">go</property>
+        <property name="syft:package:metadataType">GolangBinMetadata</property>
+        <property name="syft:package:type">go-module</property>
+        <property name="syft:location:0:layerID">sha256:0305f2b14826a228defa3526b1fcd8af7291315d19e9e8dea531eb8725f1c369</property>
+        <property name="syft:location:0:path">/usr/local/bin/gosu</property>
+        <property name="syft:metadata:architecture">x86_64</property>
+        <property name="syft:metadata:goCompiledVersion">go1.16.7</property>
+        <property name="syft:metadata:h1Digest">h1:lQ8Btl/sJr2+f4ql7ffKUKfnV0BsgsICvm0oEeINAQY=</property>
+        <property name="syft:metadata:mainModule">github.com/tianon/gosu</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/gpgv@2.1.18-8~deb9u4?arch=amd64&amp;upstream=gnupg2&amp;distro=debian-9&amp;package-id=a580e485073b959c" type="library">
+      <publisher>Debian GnuPG Maintainers &lt;pkg-gnupg-maint@lists.alioth.debian.org&gt;</publisher>
+      <name>gpgv</name>
+      <version>2.1.18-8~deb9u4</version>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+        </license>
+        <license>
+          <name>Expat</name>
+        </license>
+        <license>
+          <id>GPL-3.0-only</id>
+        </license>
+        <license>
+          <id>GPL-3.0-or-later</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-or-later</id>
+        </license>
+        <license>
+          <id>LGPL-3.0-only</id>
+        </license>
+        <license>
+          <id>LGPL-3.0-or-later</id>
+        </license>
+        <license>
+          <name>RFC-Reference</name>
+        </license>
+        <license>
+          <name>TinySCHEME</name>
+        </license>
+        <license>
+          <name>permissive</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:gpgv:gpgv:2.1.18-8\~deb9u4:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/gpgv@2.1.18-8~deb9u4?arch=amd64&amp;upstream=gnupg2&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/gpgv/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/gpgv.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">721</property>
+        <property name="syft:metadata:source">gnupg2</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/grep@2.27-2?arch=amd64&amp;distro=debian-9&amp;package-id=ae037f98e812dc58" type="library">
+      <publisher>Anibal Monsalve Salazar &lt;anibal@debian.org&gt;</publisher>
+      <name>grep</name>
+      <version>2.27-2</version>
+      <licenses>
+        <license>
+          <id>GPL-3.0-only</id>
+        </license>
+        <license>
+          <id>GPL-3.0-or-later</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:grep:grep:2.27-2:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/grep@2.27-2?arch=amd64&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/grep/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/grep.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">1131</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/gzip@1.6-5+deb9u1?arch=amd64&amp;distro=debian-9&amp;package-id=eec157daae5643bd" type="library">
+      <publisher>Bdale Garbee &lt;bdale@gag.com&gt;</publisher>
+      <name>gzip</name>
+      <version>1.6-5+deb9u1</version>
+      <licenses>
+        <license>
+          <name>GPL</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:gzip:gzip:1.6-5\+deb9u1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/gzip@1.6-5+deb9u1?arch=amd64&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/gzip/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/gzip.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">230</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/hostname@3.18+b1?arch=amd64&amp;upstream=hostname%403.18&amp;distro=debian-9&amp;package-id=1b9e83fcd8ce7728" type="library">
+      <publisher>Debian Hostname Team &lt;hostname-devel@lists.alioth.debian.org&gt;</publisher>
+      <name>hostname</name>
+      <version>3.18+b1</version>
+      <licenses>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:hostname:hostname:3.18\+b1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/hostname@3.18+b1?arch=amd64&amp;upstream=hostname%403.18&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/hostname/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/hostname.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">47</property>
+        <property name="syft:metadata:source">hostname</property>
+        <property name="syft:metadata:sourceVersion">3.18</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/init-system-helpers@1.48?arch=all&amp;distro=debian-9&amp;package-id=1de4a3fbfe6e425a" type="library">
+      <publisher>Debian systemd Maintainers &lt;pkg-systemd-maintainers@lists.alioth.debian.org&gt;</publisher>
+      <name>init-system-helpers</name>
+      <version>1.48</version>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+        </license>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>GPL-2.0-or-later</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:init-system-helpers:init-system-helpers:1.48:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/init-system-helpers@1.48?arch=all&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:init-system-helpers:init_system_helpers:1.48:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:init_system_helpers:init-system-helpers:1.48:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:init_system_helpers:init_system_helpers:1.48:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:init-system:init-system-helpers:1.48:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:init-system:init_system_helpers:1.48:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:init_system:init-system-helpers:1.48:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:init_system:init_system_helpers:1.48:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:init:init-system-helpers:1.48:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:init:init_system_helpers:1.48:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/init-system-helpers/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/init-system-helpers.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">131</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libacl1@2.2.52-3+b1?arch=amd64&amp;upstream=acl%402.2.52-3&amp;distro=debian-9&amp;package-id=57350590fbc11016" type="library">
+      <publisher>Anibal Monsalve Salazar &lt;anibal@debian.org&gt;</publisher>
+      <name>libacl1</name>
+      <version>2.2.52-3+b1</version>
+      <licenses>
+        <license>
+          <name>GPL</name>
+        </license>
+        <license>
+          <id>LGPL-2.1-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libacl1:libacl1:2.2.52-3\+b1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libacl1@2.2.52-3+b1?arch=amd64&amp;upstream=acl%402.2.52-3&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/libacl1/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libacl1:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">62</property>
+        <property name="syft:metadata:source">acl</property>
+        <property name="syft:metadata:sourceVersion">2.2.52-3</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libapt-pkg5.0@1.4.11?arch=amd64&amp;upstream=apt&amp;distro=debian-9&amp;package-id=725c5c68b4aa6a6d" type="library">
+      <publisher>APT Development Team &lt;deity@lists.debian.org&gt;</publisher>
+      <name>libapt-pkg5.0</name>
+      <version>1.4.11</version>
+      <licenses>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <name>GPLv2+</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libapt-pkg5.0:libapt-pkg5.0:1.4.11:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libapt-pkg5.0@1.4.11?arch=amd64&amp;upstream=apt&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:libapt-pkg5.0:libapt_pkg5.0:1.4.11:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libapt_pkg5.0:libapt-pkg5.0:1.4.11:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libapt_pkg5.0:libapt_pkg5.0:1.4.11:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libapt:libapt-pkg5.0:1.4.11:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libapt:libapt_pkg5.0:1.4.11:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/libapt-pkg5.0/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libapt-pkg5.0:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">3056</property>
+        <property name="syft:metadata:source">apt</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libassuan0@2.4.3-2?arch=amd64&amp;upstream=libassuan&amp;distro=debian-9&amp;package-id=d221280433bd8960" type="library">
+      <publisher>Debian GnuPG-Maintainers &lt;pkg-gnupg-maint@lists.alioth.debian.org&gt;</publisher>
+      <name>libassuan0</name>
+      <version>2.4.3-2</version>
+      <licenses>
+        <license>
+          <name>GAP</name>
+        </license>
+        <license>
+          <name>GAP~FSF</name>
+        </license>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>GPL-2.0-or-later</id>
+        </license>
+        <license>
+          <id>GPL-3.0-only</id>
+        </license>
+        <license>
+          <id>GPL-3.0-or-later</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-or-later</id>
+        </license>
+        <license>
+          <id>LGPL-3.0-only</id>
+        </license>
+        <license>
+          <id>LGPL-3.0-or-later</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libassuan0:libassuan0:2.4.3-2:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libassuan0@2.4.3-2?arch=amd64&amp;upstream=libassuan&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:0:path">/usr/share/doc/libassuan0/copyright</property>
+        <property name="syft:location:1:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libassuan0:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">106</property>
+        <property name="syft:metadata:source">libassuan</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libattr1@1:2.4.47-2+b2?arch=amd64&amp;upstream=attr%401:2.4.47-2&amp;distro=debian-9&amp;package-id=bf188b6a509cc673" type="library">
+      <publisher>Anibal Monsalve Salazar &lt;anibal@debian.org&gt;</publisher>
+      <name>libattr1</name>
+      <version>1:2.4.47-2+b2</version>
+      <licenses>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libattr1:libattr1:1\:2.4.47-2\+b2:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libattr1@1:2.4.47-2+b2?arch=amd64&amp;upstream=attr%401:2.4.47-2&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/libattr1/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libattr1:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">42</property>
+        <property name="syft:metadata:source">attr</property>
+        <property name="syft:metadata:sourceVersion">1:2.4.47-2</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libaudit-common@1:2.6.7-2?arch=all&amp;upstream=audit&amp;distro=debian-9&amp;package-id=c7e028cca21d5664" type="library">
+      <publisher>Laurent Bigonville &lt;bigon@debian.org&gt;</publisher>
+      <name>libaudit-common</name>
+      <version>1:2.6.7-2</version>
+      <licenses>
+        <license>
+          <id>GPL-1.0-only</id>
+        </license>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libaudit-common:libaudit-common:1\:2.6.7-2:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libaudit-common@1:2.6.7-2?arch=all&amp;upstream=audit&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:libaudit-common:libaudit_common:1\:2.6.7-2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libaudit_common:libaudit-common:1\:2.6.7-2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libaudit_common:libaudit_common:1\:2.6.7-2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libaudit:libaudit-common:1\:2.6.7-2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libaudit:libaudit_common:1\:2.6.7-2:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/libaudit-common/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libaudit-common.conffiles</property>
+        <property name="syft:location:2:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/info/libaudit-common.md5sums</property>
+        <property name="syft:location:3:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:3:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">30</property>
+        <property name="syft:metadata:source">audit</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libaudit1@1:2.6.7-2?arch=amd64&amp;upstream=audit&amp;distro=debian-9&amp;package-id=4f96c4e72aa5726b" type="library">
+      <publisher>Laurent Bigonville &lt;bigon@debian.org&gt;</publisher>
+      <name>libaudit1</name>
+      <version>1:2.6.7-2</version>
+      <licenses>
+        <license>
+          <id>GPL-1.0-only</id>
+        </license>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libaudit1:libaudit1:1\:2.6.7-2:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libaudit1@1:2.6.7-2?arch=amd64&amp;upstream=audit&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/libaudit1/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libaudit1:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">150</property>
+        <property name="syft:metadata:source">audit</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libblkid1@2.29.2-1+deb9u1?arch=amd64&amp;upstream=util-linux&amp;distro=debian-9&amp;package-id=c3812f4aafaaaf14" type="library">
+      <publisher>Debian util-linux Maintainers &lt;ah-util-linux@debian.org&gt;</publisher>
+      <name>libblkid1</name>
+      <version>2.29.2-1+deb9u1</version>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+        </license>
+        <license>
+          <id>BSD-3-Clause</id>
+        </license>
+        <license>
+          <id>BSD-4-Clause</id>
+        </license>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>GPL-2.0-or-later</id>
+        </license>
+        <license>
+          <id>GPL-3.0-only</id>
+        </license>
+        <license>
+          <id>GPL-3.0-or-later</id>
+        </license>
+        <license>
+          <name>LGPL</name>
+        </license>
+        <license>
+          <id>LGPL-2.0-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.0-or-later</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-or-later</id>
+        </license>
+        <license>
+          <id>LGPL-3.0-only</id>
+        </license>
+        <license>
+          <id>LGPL-3.0-or-later</id>
+        </license>
+        <license>
+          <id>MIT</id>
+        </license>
+        <license>
+          <name>public-domain</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libblkid1:libblkid1:2.29.2-1\+deb9u1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libblkid1@2.29.2-1+deb9u1?arch=amd64&amp;upstream=util-linux&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/libblkid1/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libblkid1:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">367</property>
+        <property name="syft:metadata:source">util-linux</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libbsd0@0.8.3-1+deb9u1?arch=amd64&amp;upstream=libbsd&amp;distro=debian-9&amp;package-id=a224ab1b6c810692" type="library">
+      <publisher>Guillem Jover &lt;guillem@debian.org&gt;</publisher>
+      <name>libbsd0</name>
+      <version>0.8.3-1+deb9u1</version>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+        </license>
+        <license>
+          <id>BSD-2-Clause</id>
+        </license>
+        <license>
+          <name>BSD-2-clause-author</name>
+        </license>
+        <license>
+          <name>BSD-2-clause-verbatim</name>
+        </license>
+        <license>
+          <id>BSD-3-Clause</id>
+        </license>
+        <license>
+          <name>BSD-3-clause-Peter-Wemm</name>
+        </license>
+        <license>
+          <name>BSD-3-clause-Regents</name>
+        </license>
+        <license>
+          <name>BSD-4-clause-Christopher-G-Demetriou</name>
+        </license>
+        <license>
+          <name>BSD-4-clause-Niels-Provos</name>
+        </license>
+        <license>
+          <name>BSD-5-clause-Peter-Wemm</name>
+        </license>
+        <license>
+          <id>Beerware</id>
+        </license>
+        <license>
+          <name>Expat</name>
+        </license>
+        <license>
+          <id>ISC</id>
+        </license>
+        <license>
+          <name>ISC-Original</name>
+        </license>
+        <license>
+          <name>public-domain</name>
+        </license>
+        <license>
+          <name>public-domain-Colin-Plumb</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libbsd0:libbsd0:0.8.3-1\+deb9u1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libbsd0@0.8.3-1+deb9u1?arch=amd64&amp;upstream=libbsd&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:0:path">/usr/share/doc/libbsd0/copyright</property>
+        <property name="syft:location:1:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libbsd0:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">159</property>
+        <property name="syft:metadata:source">libbsd</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libbz2-1.0@1.0.6-8.1?arch=amd64&amp;upstream=bzip2&amp;distro=debian-9&amp;package-id=1abe9e67b40f4703" type="library">
+      <publisher>Anibal Monsalve Salazar &lt;anibal@debian.org&gt;</publisher>
+      <name>libbz2-1.0</name>
+      <version>1.0.6-8.1</version>
+      <licenses>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libbz2-1.0:libbz2-1.0:1.0.6-8.1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libbz2-1.0@1.0.6-8.1?arch=amd64&amp;upstream=bzip2&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:libbz2-1.0:libbz2_1.0:1.0.6-8.1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libbz2_1.0:libbz2-1.0:1.0.6-8.1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libbz2_1.0:libbz2_1.0:1.0.6-8.1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libbz2:libbz2-1.0:1.0.6-8.1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libbz2:libbz2_1.0:1.0.6-8.1:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/libbz2-1.0/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libbz2-1.0:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">96</property>
+        <property name="syft:metadata:source">bzip2</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libc-bin@2.24-11+deb9u4?arch=amd64&amp;upstream=glibc&amp;distro=debian-9&amp;package-id=1ae97f0985577a05" type="library">
+      <publisher>GNU Libc Maintainers &lt;debian-glibc@lists.debian.org&gt;</publisher>
+      <name>libc-bin</name>
+      <version>2.24-11+deb9u4</version>
+      <licenses>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libc-bin:libc-bin:2.24-11\+deb9u4:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libc-bin@2.24-11+deb9u4?arch=amd64&amp;upstream=glibc&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:libc-bin:libc_bin:2.24-11\+deb9u4:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libc_bin:libc-bin:2.24-11\+deb9u4:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libc_bin:libc_bin:2.24-11\+deb9u4:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libc:libc-bin:2.24-11\+deb9u4:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libc:libc_bin:2.24-11\+deb9u4:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/libc-bin/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libc-bin.conffiles</property>
+        <property name="syft:location:2:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/info/libc-bin.md5sums</property>
+        <property name="syft:location:3:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:3:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">3366</property>
+        <property name="syft:metadata:source">glibc</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libc-l10n@2.24-11+deb9u4?arch=all&amp;upstream=glibc&amp;distro=debian-9&amp;package-id=c2903426e3af5faf" type="library">
+      <publisher>GNU Libc Maintainers &lt;debian-glibc@lists.debian.org&gt;</publisher>
+      <name>libc-l10n</name>
+      <version>2.24-11+deb9u4</version>
+      <licenses>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libc-l10n:libc-l10n:2.24-11\+deb9u4:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libc-l10n@2.24-11+deb9u4?arch=all&amp;upstream=glibc&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:libc-l10n:libc_l10n:2.24-11\+deb9u4:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libc_l10n:libc-l10n:2.24-11\+deb9u4:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libc_l10n:libc_l10n:2.24-11\+deb9u4:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libc:libc-l10n:2.24-11\+deb9u4:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libc:libc_l10n:2.24-11\+deb9u4:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:5afa113a433cd32056370367d1a936a5e77cc30cca6590c0241acffa33d1ec56</property>
+        <property name="syft:location:0:path">/usr/share/doc/libc-l10n/copyright</property>
+        <property name="syft:location:1:layerID">sha256:5afa113a433cd32056370367d1a936a5e77cc30cca6590c0241acffa33d1ec56</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libc-l10n.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">4211</property>
+        <property name="syft:metadata:source">glibc</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libc6@2.24-11+deb9u4?arch=amd64&amp;upstream=glibc&amp;distro=debian-9&amp;package-id=bbf239efe9efd8a4" type="library">
+      <publisher>GNU Libc Maintainers &lt;debian-glibc@lists.debian.org&gt;</publisher>
+      <name>libc6</name>
+      <version>2.24-11+deb9u4</version>
+      <licenses>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libc6:libc6:2.24-11\+deb9u4:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libc6@2.24-11+deb9u4?arch=amd64&amp;upstream=glibc&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/libc6/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libc6:amd64.conffiles</property>
+        <property name="syft:location:2:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/info/libc6:amd64.md5sums</property>
+        <property name="syft:location:3:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:3:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">10686</property>
+        <property name="syft:metadata:source">glibc</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libcap-ng0@0.7.7-3+b1?arch=amd64&amp;upstream=libcap-ng%400.7.7-3&amp;distro=debian-9&amp;package-id=255846ac663b59de" type="library">
+      <publisher>Pierre Chifflier &lt;pollux@debian.org&gt;</publisher>
+      <name>libcap-ng0</name>
+      <version>0.7.7-3+b1</version>
+      <licenses>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>GPL-3.0-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libcap-ng0:libcap-ng0:0.7.7-3\+b1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libcap-ng0@0.7.7-3+b1?arch=amd64&amp;upstream=libcap-ng%400.7.7-3&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:libcap-ng0:libcap_ng0:0.7.7-3\+b1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libcap_ng0:libcap-ng0:0.7.7-3\+b1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libcap_ng0:libcap_ng0:0.7.7-3\+b1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libcap:libcap-ng0:0.7.7-3\+b1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libcap:libcap_ng0:0.7.7-3\+b1:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/libcap-ng0/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libcap-ng0:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">43</property>
+        <property name="syft:metadata:source">libcap-ng</property>
+        <property name="syft:metadata:sourceVersion">0.7.7-3</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libcomerr2@1.43.4-2+deb9u2?arch=amd64&amp;upstream=e2fsprogs&amp;distro=debian-9&amp;package-id=82b4125336fc8be9" type="library">
+      <publisher>Theodore Y. Ts&#39;o &lt;tytso@mit.edu&gt;</publisher>
+      <name>libcomerr2</name>
+      <version>1.43.4-2+deb9u2</version>
+      <cpe>cpe:2.3:a:libcomerr2:libcomerr2:1.43.4-2\+deb9u2:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libcomerr2@1.43.4-2+deb9u2?arch=amd64&amp;upstream=e2fsprogs&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/libcomerr2/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libcomerr2:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">84</property>
+        <property name="syft:metadata:source">e2fsprogs</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libdb5.3@5.3.28-12+deb9u1?arch=amd64&amp;upstream=db5.3&amp;distro=debian-9&amp;package-id=7e7fd9eee196f432" type="library">
+      <publisher>Debian Berkeley DB Group &lt;pkg-db-devel@lists.alioth.debian.org&gt;</publisher>
+      <name>libdb5.3</name>
+      <version>5.3.28-12+deb9u1</version>
+      <cpe>cpe:2.3:a:libdb5.3:libdb5.3:5.3.28-12\+deb9u1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libdb5.3@5.3.28-12+deb9u1?arch=amd64&amp;upstream=db5.3&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/libdb5.3/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libdb5.3:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">1814</property>
+        <property name="syft:metadata:source">db5.3</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libdebconfclient0@0.227?arch=amd64&amp;upstream=cdebconf&amp;distro=debian-9&amp;package-id=687d30de4f3848a2" type="library">
+      <publisher>Debian Install System Team &lt;debian-boot@lists.debian.org&gt;</publisher>
+      <name>libdebconfclient0</name>
+      <version>0.227</version>
+      <cpe>cpe:2.3:a:libdebconfclient0:libdebconfclient0:0.227:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libdebconfclient0@0.227?arch=amd64&amp;upstream=cdebconf&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/libdebconfclient0/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libdebconfclient0:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">67</property>
+        <property name="syft:metadata:source">cdebconf</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libedit2@3.1-20160903-3?arch=amd64&amp;upstream=libedit&amp;distro=debian-9&amp;package-id=731e0d6ce97a64ff" type="library">
+      <publisher>LLVM Packaging Team &lt;pkg-llvm-team@lists.alioth.debian.org&gt;</publisher>
+      <name>libedit2</name>
+      <version>3.1-20160903-3</version>
+      <cpe>cpe:2.3:a:libedit2:libedit2:3.1-20160903-3:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libedit2@3.1-20160903-3?arch=amd64&amp;upstream=libedit&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:0:path">/usr/share/doc/libedit2/copyright</property>
+        <property name="syft:location:1:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libedit2:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">241</property>
+        <property name="syft:metadata:source">libedit</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libfdisk1@2.29.2-1+deb9u1?arch=amd64&amp;upstream=util-linux&amp;distro=debian-9&amp;package-id=9768668a17d19311" type="library">
+      <publisher>Debian util-linux Maintainers &lt;ah-util-linux@debian.org&gt;</publisher>
+      <name>libfdisk1</name>
+      <version>2.29.2-1+deb9u1</version>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+        </license>
+        <license>
+          <id>BSD-3-Clause</id>
+        </license>
+        <license>
+          <id>BSD-4-Clause</id>
+        </license>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>GPL-2.0-or-later</id>
+        </license>
+        <license>
+          <id>GPL-3.0-only</id>
+        </license>
+        <license>
+          <id>GPL-3.0-or-later</id>
+        </license>
+        <license>
+          <name>LGPL</name>
+        </license>
+        <license>
+          <id>LGPL-2.0-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.0-or-later</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-or-later</id>
+        </license>
+        <license>
+          <id>LGPL-3.0-only</id>
+        </license>
+        <license>
+          <id>LGPL-3.0-or-later</id>
+        </license>
+        <license>
+          <id>MIT</id>
+        </license>
+        <license>
+          <name>public-domain</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libfdisk1:libfdisk1:2.29.2-1\+deb9u1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libfdisk1@2.29.2-1+deb9u1?arch=amd64&amp;upstream=util-linux&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/libfdisk1/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libfdisk1:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">469</property>
+        <property name="syft:metadata:source">util-linux</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libffi6@3.2.1-6?arch=amd64&amp;upstream=libffi&amp;distro=debian-9&amp;package-id=d4e68261585c2b2c" type="library">
+      <publisher>Debian GCC Maintainers &lt;debian-gcc@lists.debian.org&gt;</publisher>
+      <name>libffi6</name>
+      <version>3.2.1-6</version>
+      <licenses>
+        <license>
+          <name>GPL</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libffi6:libffi6:3.2.1-6:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libffi6@3.2.1-6?arch=amd64&amp;upstream=libffi&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:0:path">/usr/share/doc/libffi6/copyright</property>
+        <property name="syft:location:1:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libffi6:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">56</property>
+        <property name="syft:metadata:source">libffi</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libgcc1@1:6.3.0-18+deb9u1?arch=amd64&amp;upstream=gcc-6%406.3.0-18+deb9u1&amp;distro=debian-9&amp;package-id=af08b921c1b9b46b" type="library">
+      <publisher>Debian GCC Maintainers &lt;debian-gcc@lists.debian.org&gt;</publisher>
+      <name>libgcc1</name>
+      <version>1:6.3.0-18+deb9u1</version>
+      <licenses>
+        <license>
+          <name>Artistic</name>
+        </license>
+        <license>
+          <id>GFDL-1.2-only</id>
+        </license>
+        <license>
+          <name>GPL</name>
+        </license>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>GPL-3.0-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libgcc1:libgcc1:1\:6.3.0-18\+deb9u1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libgcc1@1:6.3.0-18+deb9u1?arch=amd64&amp;upstream=gcc-6%406.3.0-18+deb9u1&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/gcc-6-base/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libgcc1:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">108</property>
+        <property name="syft:metadata:source">gcc-6</property>
+        <property name="syft:metadata:sourceVersion">6.3.0-18+deb9u1</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libgcrypt20@1.7.6-2+deb9u4?arch=amd64&amp;distro=debian-9&amp;package-id=6e61bc4925d95288" type="library">
+      <publisher>Debian GnuTLS Maintainers &lt;pkg-gnutls-maint@lists.alioth.debian.org&gt;</publisher>
+      <name>libgcrypt20</name>
+      <version>1.7.6-2+deb9u4</version>
+      <licenses>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <name>LGPL</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libgcrypt20:libgcrypt20:1.7.6-2\+deb9u4:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libgcrypt20@1.7.6-2+deb9u4?arch=amd64&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/libgcrypt20/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libgcrypt20:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">1266</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libgdbm3@1.8.3-14?arch=amd64&amp;upstream=gdbm&amp;distro=debian-9&amp;package-id=58707622332fbd90" type="library">
+      <publisher>Debian QA Group &lt;packages@qa.debian.org&gt;</publisher>
+      <name>libgdbm3</name>
+      <version>1.8.3-14</version>
+      <licenses>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libgdbm3:libgdbm3:1.8.3-14:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libgdbm3@1.8.3-14?arch=amd64&amp;upstream=gdbm&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:0:path">/usr/share/doc/libgdbm3/copyright</property>
+        <property name="syft:location:1:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libgdbm3:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">68</property>
+        <property name="syft:metadata:source">gdbm</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libgmp10@2:6.1.2+dfsg-1+deb9u1?arch=amd64&amp;upstream=gmp&amp;distro=debian-9&amp;package-id=1875c366390dec22" type="library">
+      <publisher>Debian Science Team &lt;debian-science-maintainers@lists.alioth.debian.org&gt;</publisher>
+      <name>libgmp10</name>
+      <version>2:6.1.2+dfsg-1+deb9u1</version>
+      <licenses>
+        <license>
+          <name>GPL</name>
+        </license>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>GPL-3.0-only</id>
+        </license>
+        <license>
+          <id>LGPL-3.0-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libgmp10:libgmp10:2\:6.1.2\+dfsg-1\+deb9u1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libgmp10@2:6.1.2+dfsg-1+deb9u1?arch=amd64&amp;upstream=gmp&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:0:path">/usr/share/doc/libgmp10/copyright</property>
+        <property name="syft:location:1:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libgmp10:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">568</property>
+        <property name="syft:metadata:source">gmp</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libgnutls30@3.5.8-5+deb9u6?arch=amd64&amp;upstream=gnutls28&amp;distro=debian-9&amp;package-id=495267af1f16cf58" type="library">
+      <publisher>Debian GnuTLS Maintainers &lt;pkg-gnutls-maint@lists.alioth.debian.org&gt;</publisher>
+      <name>libgnutls30</name>
+      <version>3.5.8-5+deb9u6</version>
+      <licenses>
+        <license>
+          <name>CC0</name>
+        </license>
+        <license>
+          <id>GFDL-1.3-only</id>
+        </license>
+        <license>
+          <name>GPL</name>
+        </license>
+        <license>
+          <id>GPL-3.0-only</id>
+        </license>
+        <license>
+          <name>LGPL</name>
+        </license>
+        <license>
+          <id>LGPL-3.0-only</id>
+        </license>
+        <license>
+          <name>LGPL2.1</name>
+        </license>
+        <license>
+          <name>The</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libgnutls30:libgnutls30:3.5.8-5\+deb9u6:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libgnutls30@3.5.8-5+deb9u6?arch=amd64&amp;upstream=gnutls28&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:0:path">/usr/share/doc/libgnutls30/copyright</property>
+        <property name="syft:location:1:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libgnutls30:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">2429</property>
+        <property name="syft:metadata:source">gnutls28</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libgpg-error0@1.26-2?arch=amd64&amp;upstream=libgpg-error&amp;distro=debian-9&amp;package-id=a7c5e973df9e7778" type="library">
+      <publisher>Debian GnuPG Maintainers &lt;pkg-gnupg-maint@lists.alioth.debian.org&gt;</publisher>
+      <name>libgpg-error0</name>
+      <version>1.26-2</version>
+      <licenses>
+        <license>
+          <name>GPL-2.1+</name>
+        </license>
+        <license>
+          <id>LGPL-2.1-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libgpg-error0:libgpg-error0:1.26-2:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libgpg-error0@1.26-2?arch=amd64&amp;upstream=libgpg-error&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:libgpg-error0:libgpg_error0:1.26-2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libgpg_error0:libgpg-error0:1.26-2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libgpg_error0:libgpg_error0:1.26-2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libgpg:libgpg-error0:1.26-2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libgpg:libgpg_error0:1.26-2:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/libgpg-error0/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libgpg-error0:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">572</property>
+        <property name="syft:metadata:source">libgpg-error</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libgssapi-krb5-2@1.15-1+deb9u3?arch=amd64&amp;upstream=krb5&amp;distro=debian-9&amp;package-id=506553af6eef7c44" type="library">
+      <publisher>Sam Hartman &lt;hartmans@debian.org&gt;</publisher>
+      <name>libgssapi-krb5-2</name>
+      <version>1.15-1+deb9u3</version>
+      <licenses>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libgssapi-krb5-2:libgssapi-krb5-2:1.15-1\+deb9u3:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libgssapi-krb5-2@1.15-1+deb9u3?arch=amd64&amp;upstream=krb5&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:libgssapi-krb5-2:libgssapi_krb5_2:1.15-1\+deb9u3:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libgssapi_krb5_2:libgssapi-krb5-2:1.15-1\+deb9u3:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libgssapi_krb5_2:libgssapi_krb5_2:1.15-1\+deb9u3:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libgssapi-krb5:libgssapi-krb5-2:1.15-1\+deb9u3:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libgssapi-krb5:libgssapi_krb5_2:1.15-1\+deb9u3:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libgssapi_krb5:libgssapi-krb5-2:1.15-1\+deb9u3:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libgssapi_krb5:libgssapi_krb5_2:1.15-1\+deb9u3:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libgssapi:libgssapi-krb5-2:1.15-1\+deb9u3:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libgssapi:libgssapi_krb5_2:1.15-1\+deb9u3:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:0:path">/usr/share/doc/libgssapi-krb5-2/copyright</property>
+        <property name="syft:location:1:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libgssapi-krb5-2:amd64.conffiles</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/info/libgssapi-krb5-2:amd64.md5sums</property>
+        <property name="syft:location:3:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:3:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">423</property>
+        <property name="syft:metadata:source">krb5</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libhogweed4@3.3-1+deb9u1?arch=amd64&amp;upstream=nettle&amp;distro=debian-9&amp;package-id=581518934d60c07" type="library">
+      <publisher>Magnus Holmgren &lt;holmgren@debian.org&gt;</publisher>
+      <name>libhogweed4</name>
+      <version>3.3-1+deb9u1</version>
+      <licenses>
+        <license>
+          <name>GAP</name>
+        </license>
+        <license>
+          <name>GPL</name>
+        </license>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>GPL-2.0-or-later</id>
+        </license>
+        <license>
+          <name>LGPL</name>
+        </license>
+        <license>
+          <id>LGPL-2.0-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.0-or-later</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-or-later</id>
+        </license>
+        <license>
+          <name>other</name>
+        </license>
+        <license>
+          <name>public-domain</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libhogweed4:libhogweed4:3.3-1\+deb9u1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libhogweed4@3.3-1+deb9u1?arch=amd64&amp;upstream=nettle&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:0:path">/usr/share/doc/libnettle6/copyright</property>
+        <property name="syft:location:1:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libhogweed4:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">232</property>
+        <property name="syft:metadata:source">nettle</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libicu57@57.1-6+deb9u5?arch=amd64&amp;upstream=icu&amp;distro=debian-9&amp;package-id=cf82e7b9f44b93aa" type="library">
+      <publisher>Laszlo Boszormenyi (GCS) &lt;gcs@debian.org&gt;</publisher>
+      <name>libicu57</name>
+      <version>57.1-6+deb9u5</version>
+      <cpe>cpe:2.3:a:libicu57:libicu57:57.1-6\+deb9u5:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libicu57@57.1-6+deb9u5?arch=amd64&amp;upstream=icu&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:0:path">/usr/share/doc/libicu57/copyright</property>
+        <property name="syft:location:1:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libicu57:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">30043</property>
+        <property name="syft:metadata:source">icu</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libidn11@1.33-1+deb9u1?arch=amd64&amp;upstream=libidn&amp;distro=debian-9&amp;package-id=8ada063859882322" type="library">
+      <publisher>Debian Libidn Team &lt;help-libidn@gnu.org&gt;</publisher>
+      <name>libidn11</name>
+      <version>1.33-1+deb9u1</version>
+      <licenses>
+        <license>
+          <name>GAP</name>
+        </license>
+        <license>
+          <id>GFDL-1.3-only</id>
+        </license>
+        <license>
+          <name>GFDL-1.3+</name>
+        </license>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>GPL-3.0-only</id>
+        </license>
+        <license>
+          <id>GPL-3.0-or-later</id>
+        </license>
+        <license>
+          <id>LGPL-2.0-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-or-later</id>
+        </license>
+        <license>
+          <id>LGPL-3.0-only</id>
+        </license>
+        <license>
+          <id>LGPL-3.0-or-later</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libidn11:libidn11:1.33-1\+deb9u1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libidn11@1.33-1+deb9u1?arch=amd64&amp;upstream=libidn&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:0:path">/usr/share/doc/libidn11/copyright</property>
+        <property name="syft:location:1:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libidn11:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">307</property>
+        <property name="syft:metadata:source">libidn</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libjson-perl@2.90-1?arch=all&amp;distro=debian-9&amp;package-id=93315ef05928bcc6" type="library">
+      <publisher>Debian Perl Group &lt;pkg-perl-maintainers@lists.alioth.debian.org&gt;</publisher>
+      <name>libjson-perl</name>
+      <version>2.90-1</version>
+      <licenses>
+        <license>
+          <name>Artistic</name>
+        </license>
+        <license>
+          <id>GPL-1.0-only</id>
+        </license>
+        <license>
+          <id>GPL-1.0-or-later</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libjson-perl:libjson-perl:2.90-1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libjson-perl@2.90-1?arch=all&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:libjson-perl:libjson_perl:2.90-1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libjson_perl:libjson-perl:2.90-1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libjson_perl:libjson_perl:2.90-1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libjson:libjson-perl:2.90-1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libjson:libjson_perl:2.90-1:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:0:path">/usr/share/doc/libjson-perl/copyright</property>
+        <property name="syft:location:1:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libjson-perl.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">229</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libk5crypto3@1.15-1+deb9u3?arch=amd64&amp;upstream=krb5&amp;distro=debian-9&amp;package-id=49d4fc68379a095f" type="library">
+      <publisher>Sam Hartman &lt;hartmans@debian.org&gt;</publisher>
+      <name>libk5crypto3</name>
+      <version>1.15-1+deb9u3</version>
+      <licenses>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libk5crypto3:libk5crypto3:1.15-1\+deb9u3:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libk5crypto3@1.15-1+deb9u3?arch=amd64&amp;upstream=krb5&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:0:path">/usr/share/doc/libk5crypto3/copyright</property>
+        <property name="syft:location:1:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libk5crypto3:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">311</property>
+        <property name="syft:metadata:source">krb5</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libkeyutils1@1.5.9-9?arch=amd64&amp;upstream=keyutils&amp;distro=debian-9&amp;package-id=729608d1f3542600" type="library">
+      <publisher>Christian Kastner &lt;ckk@debian.org&gt;</publisher>
+      <name>libkeyutils1</name>
+      <version>1.5.9-9</version>
+      <licenses>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>GPL-2.0-or-later</id>
+        </license>
+        <license>
+          <id>LGPL-2.0-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.0-or-later</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libkeyutils1:libkeyutils1:1.5.9-9:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libkeyutils1@1.5.9-9?arch=amd64&amp;upstream=keyutils&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:0:path">/usr/share/doc/libkeyutils1/copyright</property>
+        <property name="syft:location:1:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libkeyutils1:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">36</property>
+        <property name="syft:metadata:source">keyutils</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libkrb5-3@1.15-1+deb9u3?arch=amd64&amp;upstream=krb5&amp;distro=debian-9&amp;package-id=bf7096f6308ec6f5" type="library">
+      <publisher>Sam Hartman &lt;hartmans@debian.org&gt;</publisher>
+      <name>libkrb5-3</name>
+      <version>1.15-1+deb9u3</version>
+      <licenses>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libkrb5-3:libkrb5-3:1.15-1\+deb9u3:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libkrb5-3@1.15-1+deb9u3?arch=amd64&amp;upstream=krb5&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:libkrb5-3:libkrb5_3:1.15-1\+deb9u3:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libkrb5_3:libkrb5-3:1.15-1\+deb9u3:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libkrb5_3:libkrb5_3:1.15-1\+deb9u3:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libkrb5:libkrb5-3:1.15-1\+deb9u3:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libkrb5:libkrb5_3:1.15-1\+deb9u3:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:0:path">/usr/share/doc/libkrb5-3/copyright</property>
+        <property name="syft:location:1:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libkrb5-3:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">1026</property>
+        <property name="syft:metadata:source">krb5</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libkrb5support0@1.15-1+deb9u3?arch=amd64&amp;upstream=krb5&amp;distro=debian-9&amp;package-id=ca1162c582d68c33" type="library">
+      <publisher>Sam Hartman &lt;hartmans@debian.org&gt;</publisher>
+      <name>libkrb5support0</name>
+      <version>1.15-1+deb9u3</version>
+      <licenses>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libkrb5support0:libkrb5support0:1.15-1\+deb9u3:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libkrb5support0@1.15-1+deb9u3?arch=amd64&amp;upstream=krb5&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:0:path">/usr/share/doc/libkrb5support0/copyright</property>
+        <property name="syft:location:1:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libkrb5support0:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">159</property>
+        <property name="syft:metadata:source">krb5</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libksba8@1.3.5-2?arch=amd64&amp;upstream=libksba&amp;distro=debian-9&amp;package-id=2c56917158bc561c" type="library">
+      <publisher>Debian GnuTLS Maintainers &lt;pkg-gnutls-maint@lists.alioth.debian.org&gt;</publisher>
+      <name>libksba8</name>
+      <version>1.3.5-2</version>
+      <licenses>
+        <license>
+          <id>GPL-3.0-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libksba8:libksba8:1.3.5-2:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libksba8@1.3.5-2?arch=amd64&amp;upstream=libksba&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:0:path">/usr/share/doc/libksba8/copyright</property>
+        <property name="syft:location:1:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libksba8:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">264</property>
+        <property name="syft:metadata:source">libksba</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libldap-2.4-2@2.4.44+dfsg-5+deb9u8?arch=amd64&amp;upstream=openldap&amp;distro=debian-9&amp;package-id=1b88ba6d65ec08b7" type="library">
+      <publisher>Debian OpenLDAP Maintainers &lt;pkg-openldap-devel@lists.alioth.debian.org&gt;</publisher>
+      <name>libldap-2.4-2</name>
+      <version>2.4.44+dfsg-5+deb9u8</version>
+      <cpe>cpe:2.3:a:libldap-2.4-2:libldap-2.4-2:2.4.44\+dfsg-5\+deb9u8:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libldap-2.4-2@2.4.44+dfsg-5+deb9u8?arch=amd64&amp;upstream=openldap&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:libldap-2.4-2:libldap_2.4_2:2.4.44\+dfsg-5\+deb9u8:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libldap_2.4_2:libldap-2.4-2:2.4.44\+dfsg-5\+deb9u8:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libldap_2.4_2:libldap_2.4_2:2.4.44\+dfsg-5\+deb9u8:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libldap-2.4:libldap-2.4-2:2.4.44\+dfsg-5\+deb9u8:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libldap-2.4:libldap_2.4_2:2.4.44\+dfsg-5\+deb9u8:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libldap_2.4:libldap-2.4-2:2.4.44\+dfsg-5\+deb9u8:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libldap_2.4:libldap_2.4_2:2.4.44\+dfsg-5\+deb9u8:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libldap:libldap-2.4-2:2.4.44\+dfsg-5\+deb9u8:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libldap:libldap_2.4_2:2.4.44\+dfsg-5\+deb9u8:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:0:path">/usr/share/doc/libldap-2.4-2/copyright</property>
+        <property name="syft:location:1:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libldap-2.4-2:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">510</property>
+        <property name="syft:metadata:source">openldap</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libldap-common@2.4.44+dfsg-5+deb9u8?arch=all&amp;upstream=openldap&amp;distro=debian-9&amp;package-id=57a65c0afc21e025" type="library">
+      <publisher>Debian OpenLDAP Maintainers &lt;pkg-openldap-devel@lists.alioth.debian.org&gt;</publisher>
+      <name>libldap-common</name>
+      <version>2.4.44+dfsg-5+deb9u8</version>
+      <cpe>cpe:2.3:a:libldap-common:libldap-common:2.4.44\+dfsg-5\+deb9u8:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libldap-common@2.4.44+dfsg-5+deb9u8?arch=all&amp;upstream=openldap&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:libldap-common:libldap_common:2.4.44\+dfsg-5\+deb9u8:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libldap_common:libldap-common:2.4.44\+dfsg-5\+deb9u8:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libldap_common:libldap_common:2.4.44\+dfsg-5\+deb9u8:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libldap:libldap-common:2.4.44\+dfsg-5\+deb9u8:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libldap:libldap_common:2.4.44\+dfsg-5\+deb9u8:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:0:path">/usr/share/doc/libldap-common/copyright</property>
+        <property name="syft:location:1:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libldap-common.conffiles</property>
+        <property name="syft:location:2:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/info/libldap-common.md5sums</property>
+        <property name="syft:location:3:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:3:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">109</property>
+        <property name="syft:metadata:source">openldap</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libllvm6.0@1:6.0-1~bpo9+1?arch=amd64&amp;upstream=llvm-toolchain-6.0&amp;distro=debian-9&amp;package-id=3375b7b47a4be969" type="library">
+      <publisher>LLVM Packaging Team &lt;pkg-llvm-team@lists.alioth.debian.org&gt;</publisher>
+      <name>libllvm6.0</name>
+      <version>1:6.0-1~bpo9+1</version>
+      <licenses>
+        <license>
+          <name>ARM</name>
+        </license>
+        <license>
+          <name>Apple</name>
+        </license>
+        <license>
+          <id>BSD-3-Clause</id>
+        </license>
+        <license>
+          <id>BSD-3-Clause</id>
+        </license>
+        <license>
+          <name>Expat</name>
+        </license>
+        <license>
+          <name>LLVM</name>
+        </license>
+        <license>
+          <id>MIT</id>
+        </license>
+        <license>
+          <id>NCSA</id>
+        </license>
+        <license>
+          <name>Polly</name>
+        </license>
+        <license>
+          <name>Python</name>
+        </license>
+        <license>
+          <name>U-OF-I-BSD-LIKE</name>
+        </license>
+        <license>
+          <name>public-domain</name>
+        </license>
+        <license>
+          <name>solar-public-domain</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libllvm6.0:libllvm6.0:1\:6.0-1\~bpo9\+1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libllvm6.0@1:6.0-1~bpo9+1?arch=amd64&amp;upstream=llvm-toolchain-6.0&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:0:path">/usr/share/doc/libllvm6.0/copyright</property>
+        <property name="syft:location:1:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libllvm6.0:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">59860</property>
+        <property name="syft:metadata:source">llvm-toolchain-6.0</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/liblz4-1@0.0~r131-2+deb9u1?arch=amd64&amp;upstream=lz4&amp;distro=debian-9&amp;package-id=c698fddfe7dd82d1" type="library">
+      <publisher>Nobuhiro Iwamatsu &lt;iwamatsu@debian.org&gt;</publisher>
+      <name>liblz4-1</name>
+      <version>0.0~r131-2+deb9u1</version>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+        </license>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>GPL-2.0-or-later</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:liblz4-1:liblz4-1:0.0\~r131-2\+deb9u1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/liblz4-1@0.0~r131-2+deb9u1?arch=amd64&amp;upstream=lz4&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:liblz4-1:liblz4_1:0.0\~r131-2\+deb9u1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:liblz4_1:liblz4-1:0.0\~r131-2\+deb9u1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:liblz4_1:liblz4_1:0.0\~r131-2\+deb9u1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:liblz4:liblz4-1:0.0\~r131-2\+deb9u1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:liblz4:liblz4_1:0.0\~r131-2\+deb9u1:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/liblz4-1/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/liblz4-1:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">92</property>
+        <property name="syft:metadata:source">lz4</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/liblzma5@5.2.2-1.2+deb9u1?arch=amd64&amp;upstream=xz-utils&amp;distro=debian-9&amp;package-id=7060505789001d5" type="library">
+      <publisher>Jonathan Nieder &lt;jrnieder@gmail.com&gt;</publisher>
+      <name>liblzma5</name>
+      <version>5.2.2-1.2+deb9u1</version>
+      <licenses>
+        <license>
+          <name>Autoconf</name>
+        </license>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>GPL-2.0-or-later</id>
+        </license>
+        <license>
+          <id>GPL-3.0-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.0-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-or-later</id>
+        </license>
+        <license>
+          <name>PD</name>
+        </license>
+        <license>
+          <name>PD-debian</name>
+        </license>
+        <license>
+          <name>config-h</name>
+        </license>
+        <license>
+          <name>noderivs</name>
+        </license>
+        <license>
+          <name>permissive-fsf</name>
+        </license>
+        <license>
+          <name>permissive-nowarranty</name>
+        </license>
+        <license>
+          <name>probably-PD</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:liblzma5:liblzma5:5.2.2-1.2\+deb9u1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/liblzma5@5.2.2-1.2+deb9u1?arch=amd64&amp;upstream=xz-utils&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/liblzma5/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/liblzma5:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">338</property>
+        <property name="syft:metadata:source">xz-utils</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libmount1@2.29.2-1+deb9u1?arch=amd64&amp;upstream=util-linux&amp;distro=debian-9&amp;package-id=bfe3b4a35000715a" type="library">
+      <publisher>Debian util-linux Maintainers &lt;ah-util-linux@debian.org&gt;</publisher>
+      <name>libmount1</name>
+      <version>2.29.2-1+deb9u1</version>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+        </license>
+        <license>
+          <id>BSD-3-Clause</id>
+        </license>
+        <license>
+          <id>BSD-4-Clause</id>
+        </license>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>GPL-2.0-or-later</id>
+        </license>
+        <license>
+          <id>GPL-3.0-only</id>
+        </license>
+        <license>
+          <id>GPL-3.0-or-later</id>
+        </license>
+        <license>
+          <name>LGPL</name>
+        </license>
+        <license>
+          <id>LGPL-2.0-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.0-or-later</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-or-later</id>
+        </license>
+        <license>
+          <id>LGPL-3.0-only</id>
+        </license>
+        <license>
+          <id>LGPL-3.0-or-later</id>
+        </license>
+        <license>
+          <id>MIT</id>
+        </license>
+        <license>
+          <name>public-domain</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libmount1:libmount1:2.29.2-1\+deb9u1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libmount1@2.29.2-1+deb9u1?arch=amd64&amp;upstream=util-linux&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/libmount1/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libmount1:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">403</property>
+        <property name="syft:metadata:source">util-linux</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libncurses5@6.0+20161126-1+deb9u2?arch=amd64&amp;upstream=ncurses&amp;distro=debian-9&amp;package-id=ffb963856267864a" type="library">
+      <publisher>Craig Small &lt;csmall@debian.org&gt;</publisher>
+      <name>libncurses5</name>
+      <version>6.0+20161126-1+deb9u2</version>
+      <cpe>cpe:2.3:a:libncurses5:libncurses5:6.0\+20161126-1\+deb9u2:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libncurses5@6.0+20161126-1+deb9u2?arch=amd64&amp;upstream=ncurses&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/libtinfo5/copyright</property>
+        <property name="syft:location:1:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libncurses5:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">287</property>
+        <property name="syft:metadata:source">ncurses</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libncursesw5@6.0+20161126-1+deb9u2?arch=amd64&amp;upstream=ncurses&amp;distro=debian-9&amp;package-id=79a8e20f8276327c" type="library">
+      <publisher>Craig Small &lt;csmall@debian.org&gt;</publisher>
+      <name>libncursesw5</name>
+      <version>6.0+20161126-1+deb9u2</version>
+      <cpe>cpe:2.3:a:libncursesw5:libncursesw5:6.0\+20161126-1\+deb9u2:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libncursesw5@6.0+20161126-1+deb9u2?arch=amd64&amp;upstream=ncurses&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/libtinfo5/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libncursesw5:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">347</property>
+        <property name="syft:metadata:source">ncurses</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libnettle6@3.3-1+deb9u1?arch=amd64&amp;upstream=nettle&amp;distro=debian-9&amp;package-id=16430935b5b8d923" type="library">
+      <publisher>Magnus Holmgren &lt;holmgren@debian.org&gt;</publisher>
+      <name>libnettle6</name>
+      <version>3.3-1+deb9u1</version>
+      <licenses>
+        <license>
+          <name>GAP</name>
+        </license>
+        <license>
+          <name>GPL</name>
+        </license>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>GPL-2.0-or-later</id>
+        </license>
+        <license>
+          <name>LGPL</name>
+        </license>
+        <license>
+          <id>LGPL-2.0-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.0-or-later</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-or-later</id>
+        </license>
+        <license>
+          <name>other</name>
+        </license>
+        <license>
+          <name>public-domain</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libnettle6:libnettle6:3.3-1\+deb9u1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libnettle6@3.3-1+deb9u1?arch=amd64&amp;upstream=nettle&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:0:path">/usr/share/doc/libnettle6/copyright</property>
+        <property name="syft:location:1:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libnettle6:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">357</property>
+        <property name="syft:metadata:source">nettle</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libnpth0@1.3-1?arch=amd64&amp;upstream=npth&amp;distro=debian-9&amp;package-id=e2452846216d7e45" type="library">
+      <publisher>Eric Dorland &lt;eric@debian.org&gt;</publisher>
+      <name>libnpth0</name>
+      <version>1.3-1</version>
+      <licenses>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>GPL-2.0-or-later</id>
+        </license>
+        <license>
+          <id>LGPL-3.0-only</id>
+        </license>
+        <license>
+          <id>LGPL-3.0-or-later</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libnpth0:libnpth0:1.3-1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libnpth0@1.3-1?arch=amd64&amp;upstream=npth&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:0:path">/usr/share/doc/libnpth0/copyright</property>
+        <property name="syft:location:1:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libnpth0:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">43</property>
+        <property name="syft:metadata:source">npth</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libnss-wrapper@1.1.3-1?arch=amd64&amp;upstream=nss-wrapper&amp;distro=debian-9&amp;package-id=e8bedd4756ee957b" type="library">
+      <publisher>Debian SSSD Team &lt;pkg-sssd-devel@lists.alioth.debian.org&gt;</publisher>
+      <name>libnss-wrapper</name>
+      <version>1.1.3-1</version>
+      <licenses>
+        <license>
+          <name>BSD-3-clauses</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libnss-wrapper:libnss-wrapper:1.1.3-1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libnss-wrapper@1.1.3-1?arch=amd64&amp;upstream=nss-wrapper&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:libnss-wrapper:libnss_wrapper:1.1.3-1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libnss_wrapper:libnss-wrapper:1.1.3-1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libnss_wrapper:libnss_wrapper:1.1.3-1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libnss:libnss-wrapper:1.1.3-1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libnss:libnss_wrapper:1.1.3-1:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:01d30ba422c5d9f4a346d59ee398d0ab9882cd9b962e972a68c9c5345c2e4767</property>
+        <property name="syft:location:0:path">/usr/share/doc/libnss-wrapper/copyright</property>
+        <property name="syft:location:1:layerID">sha256:01d30ba422c5d9f4a346d59ee398d0ab9882cd9b962e972a68c9c5345c2e4767</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libnss-wrapper.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">87</property>
+        <property name="syft:metadata:source">nss-wrapper</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libp11-kit0@0.23.3-2+deb9u1?arch=amd64&amp;upstream=p11-kit&amp;distro=debian-9&amp;package-id=a71d6a7c31de5ed4" type="library">
+      <publisher>Debian GnuTLS Maintainers &lt;pkg-gnutls-maint@lists.alioth.debian.org&gt;</publisher>
+      <name>libp11-kit0</name>
+      <version>0.23.3-2+deb9u1</version>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+        </license>
+        <license>
+          <id>ISC</id>
+        </license>
+        <license>
+          <name>ISC+IBM</name>
+        </license>
+        <license>
+          <name>permissive-like-automake-output</name>
+        </license>
+        <license>
+          <name>same-as-rest-of-p11kit</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libp11-kit0:libp11-kit0:0.23.3-2\+deb9u1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libp11-kit0@0.23.3-2+deb9u1?arch=amd64&amp;upstream=p11-kit&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:libp11-kit0:libp11_kit0:0.23.3-2\+deb9u1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libp11_kit0:libp11-kit0:0.23.3-2\+deb9u1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libp11_kit0:libp11_kit0:0.23.3-2\+deb9u1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libp11:libp11-kit0:0.23.3-2\+deb9u1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libp11:libp11_kit0:0.23.3-2\+deb9u1:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:0:path">/usr/share/doc/libp11-kit0/copyright</property>
+        <property name="syft:location:1:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libp11-kit0:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">439</property>
+        <property name="syft:metadata:source">p11-kit</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libpam-modules@1.1.8-3.6?arch=amd64&amp;upstream=pam&amp;distro=debian-9&amp;package-id=79683ef8f992497a" type="library">
+      <publisher>Steve Langasek &lt;vorlon@debian.org&gt;</publisher>
+      <name>libpam-modules</name>
+      <version>1.1.8-3.6</version>
+      <licenses>
+        <license>
+          <name>GPL</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libpam-modules:libpam-modules:1.1.8-3.6:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libpam-modules@1.1.8-3.6?arch=amd64&amp;upstream=pam&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:libpam-modules:libpam_modules:1.1.8-3.6:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libpam_modules:libpam-modules:1.1.8-3.6:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libpam_modules:libpam_modules:1.1.8-3.6:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libpam:libpam-modules:1.1.8-3.6:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libpam:libpam_modules:1.1.8-3.6:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/libpam-modules/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libpam-modules:amd64.conffiles</property>
+        <property name="syft:location:2:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/info/libpam-modules:amd64.md5sums</property>
+        <property name="syft:location:3:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:3:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">874</property>
+        <property name="syft:metadata:source">pam</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libpam-modules-bin@1.1.8-3.6?arch=amd64&amp;upstream=pam&amp;distro=debian-9&amp;package-id=aa7473cd04fa03e2" type="library">
+      <publisher>Steve Langasek &lt;vorlon@debian.org&gt;</publisher>
+      <name>libpam-modules-bin</name>
+      <version>1.1.8-3.6</version>
+      <licenses>
+        <license>
+          <name>GPL</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libpam-modules-bin:libpam-modules-bin:1.1.8-3.6:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libpam-modules-bin@1.1.8-3.6?arch=amd64&amp;upstream=pam&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:libpam-modules-bin:libpam_modules_bin:1.1.8-3.6:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libpam_modules_bin:libpam-modules-bin:1.1.8-3.6:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libpam_modules_bin:libpam_modules_bin:1.1.8-3.6:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libpam-modules:libpam-modules-bin:1.1.8-3.6:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libpam-modules:libpam_modules_bin:1.1.8-3.6:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libpam_modules:libpam-modules-bin:1.1.8-3.6:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libpam_modules:libpam_modules_bin:1.1.8-3.6:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libpam:libpam-modules-bin:1.1.8-3.6:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libpam:libpam_modules_bin:1.1.8-3.6:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/libpam-modules-bin/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libpam-modules-bin.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">220</property>
+        <property name="syft:metadata:source">pam</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libpam-runtime@1.1.8-3.6?arch=all&amp;upstream=pam&amp;distro=debian-9&amp;package-id=c568caf2e871076b" type="library">
+      <publisher>Steve Langasek &lt;vorlon@debian.org&gt;</publisher>
+      <name>libpam-runtime</name>
+      <version>1.1.8-3.6</version>
+      <licenses>
+        <license>
+          <name>GPL</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libpam-runtime:libpam-runtime:1.1.8-3.6:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libpam-runtime@1.1.8-3.6?arch=all&amp;upstream=pam&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:libpam-runtime:libpam_runtime:1.1.8-3.6:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libpam_runtime:libpam-runtime:1.1.8-3.6:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libpam_runtime:libpam_runtime:1.1.8-3.6:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libpam:libpam-runtime:1.1.8-3.6:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libpam:libpam_runtime:1.1.8-3.6:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/libpam-runtime/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libpam-runtime.conffiles</property>
+        <property name="syft:location:2:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/info/libpam-runtime.md5sums</property>
+        <property name="syft:location:3:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:3:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">1016</property>
+        <property name="syft:metadata:source">pam</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libpam0g@1.1.8-3.6?arch=amd64&amp;upstream=pam&amp;distro=debian-9&amp;package-id=2c16ea0da7f1b6de" type="library">
+      <publisher>Steve Langasek &lt;vorlon@debian.org&gt;</publisher>
+      <name>libpam0g</name>
+      <version>1.1.8-3.6</version>
+      <licenses>
+        <license>
+          <name>GPL</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libpam0g:libpam0g:1.1.8-3.6:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libpam0g@1.1.8-3.6?arch=amd64&amp;upstream=pam&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/libpam0g/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libpam0g:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">229</property>
+        <property name="syft:metadata:source">pam</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libpcre3@2:8.39-3?arch=amd64&amp;upstream=pcre3&amp;distro=debian-9&amp;package-id=a8ddcd78c8310c34" type="library">
+      <publisher>Matthew Vernon &lt;matthew@debian.org&gt;</publisher>
+      <name>libpcre3</name>
+      <version>2:8.39-3</version>
+      <cpe>cpe:2.3:a:libpcre3:libpcre3:2\:8.39-3:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libpcre3@2:8.39-3?arch=amd64&amp;upstream=pcre3&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/libpcre3/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libpcre3:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">668</property>
+        <property name="syft:metadata:source">pcre3</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libperl5.24@5.24.1-3+deb9u7?arch=amd64&amp;upstream=perl&amp;distro=debian-9&amp;package-id=3545e4218214cda1" type="library">
+      <publisher>Niko Tyni &lt;ntyni@debian.org&gt;</publisher>
+      <name>libperl5.24</name>
+      <version>5.24.1-3+deb9u7</version>
+      <licenses>
+        <license>
+          <name>Artistic</name>
+        </license>
+        <license>
+          <id>Artistic-2.0</id>
+        </license>
+        <license>
+          <id>BSD-3-Clause</id>
+        </license>
+        <license>
+          <name>BSD-3-clause-GENERIC</name>
+        </license>
+        <license>
+          <name>BSD-3-clause-with-weird-numbering</name>
+        </license>
+        <license>
+          <name>BSD-4-clause-POWERDOG</name>
+        </license>
+        <license>
+          <name>BZIP</name>
+        </license>
+        <license>
+          <name>DONT-CHANGE-THE-GPL</name>
+        </license>
+        <license>
+          <name>Expat</name>
+        </license>
+        <license>
+          <id>GPL-1.0-only</id>
+        </license>
+        <license>
+          <id>GPL-1.0-or-later</id>
+        </license>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>GPL-2.0-or-later</id>
+        </license>
+        <license>
+          <name>GPL-3+-WITH-BISON-EXCEPTION</name>
+        </license>
+        <license>
+          <name>HSIEH-BSD</name>
+        </license>
+        <license>
+          <name>HSIEH-DERIVATIVE</name>
+        </license>
+        <license>
+          <id>LGPL-2.1-only</id>
+        </license>
+        <license>
+          <name>REGCOMP</name>
+        </license>
+        <license>
+          <name>REGCOMP,</name>
+        </license>
+        <license>
+          <name>RRA-KEEP-THIS-NOTICE</name>
+        </license>
+        <license>
+          <name>S2P</name>
+        </license>
+        <license>
+          <name>SDBM-PUBLIC-DOMAIN</name>
+        </license>
+        <license>
+          <name>TEXT-TABS</name>
+        </license>
+        <license>
+          <name>Unicode</name>
+        </license>
+        <license>
+          <id>Zlib</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libperl5.24:libperl5.24:5.24.1-3\+deb9u7:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libperl5.24@5.24.1-3+deb9u7?arch=amd64&amp;upstream=perl&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:0:path">/usr/share/doc/libperl5.24/copyright</property>
+        <property name="syft:location:1:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libperl5.24:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">20936</property>
+        <property name="syft:metadata:source">perl</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libpq5@14.2-1.pgdg90+1?arch=amd64&amp;upstream=postgresql-14&amp;distro=debian-9&amp;package-id=c88b724ccdf4d6bd" type="library">
+      <publisher>Debian PostgreSQL Maintainers &lt;team+postgresql@tracker.debian.org&gt;</publisher>
+      <name>libpq5</name>
+      <version>14.2-1.pgdg90+1</version>
+      <licenses>
+        <license>
+          <name>Artistic</name>
+        </license>
+        <license>
+          <id>BSD-2-Clause</id>
+        </license>
+        <license>
+          <id>BSD-3-Clause</id>
+        </license>
+        <license>
+          <id>BSD-3-Clause</id>
+        </license>
+        <license>
+          <name>Custom-Unicode</name>
+        </license>
+        <license>
+          <name>Custom-pg_dump</name>
+        </license>
+        <license>
+          <name>Custom-regex</name>
+        </license>
+        <license>
+          <id>GPL-1.0-only</id>
+        </license>
+        <license>
+          <id>PostgreSQL</id>
+        </license>
+        <license>
+          <id>TCL</id>
+        </license>
+        <license>
+          <name>blf</name>
+        </license>
+        <license>
+          <name>double-metaphone</name>
+        </license>
+        <license>
+          <name>imath</name>
+        </license>
+        <license>
+          <name>nagaysau-ishii</name>
+        </license>
+        <license>
+          <name>rijndael</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libpq5:libpq5:14.2-1.pgdg90\+1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libpq5@14.2-1.pgdg90+1?arch=amd64&amp;upstream=postgresql-14&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:0:path">/usr/share/doc/libpq5/copyright</property>
+        <property name="syft:location:1:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libpq5:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">743</property>
+        <property name="syft:metadata:source">postgresql-14</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libreadline7@7.0-3?arch=amd64&amp;upstream=readline&amp;distro=debian-9&amp;package-id=5104134c69fba24b" type="library">
+      <publisher>Matthias Klose &lt;doko@debian.org&gt;</publisher>
+      <name>libreadline7</name>
+      <version>7.0-3</version>
+      <licenses>
+        <license>
+          <name>GFDL</name>
+        </license>
+        <license>
+          <id>GPL-3.0-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libreadline7:libreadline7:7.0-3:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libreadline7@7.0-3?arch=amd64&amp;upstream=readline&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:0:path">/usr/share/doc/libreadline7/copyright</property>
+        <property name="syft:location:1:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libreadline7:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">416</property>
+        <property name="syft:metadata:source">readline</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libsasl2-2@2.1.27~101-g0780600+dfsg-3+deb9u2?arch=amd64&amp;upstream=cyrus-sasl2&amp;distro=debian-9&amp;package-id=33f3c41d50c2e781" type="library">
+      <publisher>Debian Cyrus SASL Team &lt;pkg-cyrus-sasl2-debian-devel@lists.alioth.debian.org&gt;</publisher>
+      <name>libsasl2-2</name>
+      <version>2.1.27~101-g0780600+dfsg-3+deb9u2</version>
+      <licenses>
+        <license>
+          <id>BSD-4-Clause</id>
+        </license>
+        <license>
+          <id>GPL-3.0-only</id>
+        </license>
+        <license>
+          <id>GPL-3.0-or-later</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libsasl2-2:libsasl2-2:2.1.27\~101-g0780600\+dfsg-3\+deb9u2:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libsasl2-2@2.1.27~101-g0780600+dfsg-3+deb9u2?arch=amd64&amp;upstream=cyrus-sasl2&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:libsasl2-2:libsasl2_2:2.1.27\~101-g0780600\+dfsg-3\+deb9u2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libsasl2_2:libsasl2-2:2.1.27\~101-g0780600\+dfsg-3\+deb9u2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libsasl2_2:libsasl2_2:2.1.27\~101-g0780600\+dfsg-3\+deb9u2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libsasl2:libsasl2-2:2.1.27\~101-g0780600\+dfsg-3\+deb9u2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libsasl2:libsasl2_2:2.1.27\~101-g0780600\+dfsg-3\+deb9u2:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:0:path">/usr/share/doc/libsasl2-2/copyright</property>
+        <property name="syft:location:1:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libsasl2-2:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">184</property>
+        <property name="syft:metadata:source">cyrus-sasl2</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libsasl2-modules-db@2.1.27~101-g0780600+dfsg-3+deb9u2?arch=amd64&amp;upstream=cyrus-sasl2&amp;distro=debian-9&amp;package-id=702ffa2c313756b8" type="library">
+      <publisher>Debian Cyrus SASL Team &lt;pkg-cyrus-sasl2-debian-devel@lists.alioth.debian.org&gt;</publisher>
+      <name>libsasl2-modules-db</name>
+      <version>2.1.27~101-g0780600+dfsg-3+deb9u2</version>
+      <licenses>
+        <license>
+          <id>BSD-4-Clause</id>
+        </license>
+        <license>
+          <id>GPL-3.0-only</id>
+        </license>
+        <license>
+          <id>GPL-3.0-or-later</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libsasl2-modules-db:libsasl2-modules-db:2.1.27\~101-g0780600\+dfsg-3\+deb9u2:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libsasl2-modules-db@2.1.27~101-g0780600+dfsg-3+deb9u2?arch=amd64&amp;upstream=cyrus-sasl2&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:libsasl2-modules-db:libsasl2_modules_db:2.1.27\~101-g0780600\+dfsg-3\+deb9u2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libsasl2_modules_db:libsasl2-modules-db:2.1.27\~101-g0780600\+dfsg-3\+deb9u2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libsasl2_modules_db:libsasl2_modules_db:2.1.27\~101-g0780600\+dfsg-3\+deb9u2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libsasl2-modules:libsasl2-modules-db:2.1.27\~101-g0780600\+dfsg-3\+deb9u2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libsasl2-modules:libsasl2_modules_db:2.1.27\~101-g0780600\+dfsg-3\+deb9u2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libsasl2_modules:libsasl2-modules-db:2.1.27\~101-g0780600\+dfsg-3\+deb9u2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libsasl2_modules:libsasl2_modules_db:2.1.27\~101-g0780600\+dfsg-3\+deb9u2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libsasl2:libsasl2-modules-db:2.1.27\~101-g0780600\+dfsg-3\+deb9u2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libsasl2:libsasl2_modules_db:2.1.27\~101-g0780600\+dfsg-3\+deb9u2:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:0:path">/usr/share/doc/libsasl2-modules-db/copyright</property>
+        <property name="syft:location:1:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libsasl2-modules-db:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">97</property>
+        <property name="syft:metadata:source">cyrus-sasl2</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libselinux1@2.6-3+b3?arch=amd64&amp;upstream=libselinux%402.6-3&amp;distro=debian-9&amp;package-id=2c083958976aaa44" type="library">
+      <publisher>Debian SELinux maintainers &lt;selinux-devel@lists.alioth.debian.org&gt;</publisher>
+      <name>libselinux1</name>
+      <version>2.6-3+b3</version>
+      <licenses>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libselinux1:libselinux1:2.6-3\+b3:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libselinux1@2.6-3+b3?arch=amd64&amp;upstream=libselinux%402.6-3&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/libselinux1/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libselinux1:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">209</property>
+        <property name="syft:metadata:source">libselinux</property>
+        <property name="syft:metadata:sourceVersion">2.6-3</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libsemanage-common@2.6-2?arch=all&amp;upstream=libsemanage&amp;distro=debian-9&amp;package-id=692e2289e6c3028a" type="library">
+      <publisher>Debian SELinux maintainers &lt;selinux-devel@lists.alioth.debian.org&gt;</publisher>
+      <name>libsemanage-common</name>
+      <version>2.6-2</version>
+      <licenses>
+        <license>
+          <name>GPL</name>
+        </license>
+        <license>
+          <name>LGPL</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libsemanage-common:libsemanage-common:2.6-2:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libsemanage-common@2.6-2?arch=all&amp;upstream=libsemanage&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:libsemanage-common:libsemanage_common:2.6-2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libsemanage_common:libsemanage-common:2.6-2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libsemanage_common:libsemanage_common:2.6-2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libsemanage:libsemanage-common:2.6-2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libsemanage:libsemanage_common:2.6-2:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/libsemanage-common/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libsemanage-common.conffiles</property>
+        <property name="syft:location:2:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/info/libsemanage-common.md5sums</property>
+        <property name="syft:location:3:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:3:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">39</property>
+        <property name="syft:metadata:source">libsemanage</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libsemanage1@2.6-2?arch=amd64&amp;upstream=libsemanage&amp;distro=debian-9&amp;package-id=20c589d55de30ff7" type="library">
+      <publisher>Debian SELinux maintainers &lt;selinux-devel@lists.alioth.debian.org&gt;</publisher>
+      <name>libsemanage1</name>
+      <version>2.6-2</version>
+      <licenses>
+        <license>
+          <name>GPL</name>
+        </license>
+        <license>
+          <name>LGPL</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libsemanage1:libsemanage1:2.6-2:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libsemanage1@2.6-2?arch=amd64&amp;upstream=libsemanage&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/libsemanage1/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libsemanage1:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">291</property>
+        <property name="syft:metadata:source">libsemanage</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libsepol1@2.6-2?arch=amd64&amp;upstream=libsepol&amp;distro=debian-9&amp;package-id=50e2f3950e1f21de" type="library">
+      <publisher>Debian SELinux maintainers &lt;selinux-devel@lists.alioth.debian.org&gt;</publisher>
+      <name>libsepol1</name>
+      <version>2.6-2</version>
+      <licenses>
+        <license>
+          <name>GPL</name>
+        </license>
+        <license>
+          <name>LGPL</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libsepol1:libsepol1:2.6-2:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libsepol1@2.6-2?arch=amd64&amp;upstream=libsepol&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/libsepol1/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libsepol1:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">653</property>
+        <property name="syft:metadata:source">libsepol</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libsmartcols1@2.29.2-1+deb9u1?arch=amd64&amp;upstream=util-linux&amp;distro=debian-9&amp;package-id=197d7bad6178bf46" type="library">
+      <publisher>Debian util-linux Maintainers &lt;ah-util-linux@debian.org&gt;</publisher>
+      <name>libsmartcols1</name>
+      <version>2.29.2-1+deb9u1</version>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+        </license>
+        <license>
+          <id>BSD-3-Clause</id>
+        </license>
+        <license>
+          <id>BSD-4-Clause</id>
+        </license>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>GPL-2.0-or-later</id>
+        </license>
+        <license>
+          <id>GPL-3.0-only</id>
+        </license>
+        <license>
+          <id>GPL-3.0-or-later</id>
+        </license>
+        <license>
+          <name>LGPL</name>
+        </license>
+        <license>
+          <id>LGPL-2.0-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.0-or-later</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-or-later</id>
+        </license>
+        <license>
+          <id>LGPL-3.0-only</id>
+        </license>
+        <license>
+          <id>LGPL-3.0-or-later</id>
+        </license>
+        <license>
+          <id>MIT</id>
+        </license>
+        <license>
+          <name>public-domain</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libsmartcols1:libsmartcols1:2.29.2-1\+deb9u1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libsmartcols1@2.29.2-1+deb9u1?arch=amd64&amp;upstream=util-linux&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/libsmartcols1/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libsmartcols1:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">257</property>
+        <property name="syft:metadata:source">util-linux</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libsqlite3-0@3.16.2-5+deb9u3?arch=amd64&amp;upstream=sqlite3&amp;distro=debian-9&amp;package-id=abf30e67fe3e98a9" type="library">
+      <publisher>Laszlo Boszormenyi (GCS) &lt;gcs@debian.org&gt;</publisher>
+      <name>libsqlite3-0</name>
+      <version>3.16.2-5+deb9u3</version>
+      <licenses>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>GPL-2.0-or-later</id>
+        </license>
+        <license>
+          <name>public-domain</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libsqlite3-0:libsqlite3-0:3.16.2-5\+deb9u3:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libsqlite3-0@3.16.2-5+deb9u3?arch=amd64&amp;upstream=sqlite3&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:libsqlite3-0:libsqlite3_0:3.16.2-5\+deb9u3:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libsqlite3_0:libsqlite3-0:3.16.2-5\+deb9u3:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libsqlite3_0:libsqlite3_0:3.16.2-5\+deb9u3:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libsqlite3:libsqlite3-0:3.16.2-5\+deb9u3:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libsqlite3:libsqlite3_0:3.16.2-5\+deb9u3:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:0:path">/usr/share/doc/libsqlite3-0/copyright</property>
+        <property name="syft:location:1:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libsqlite3-0:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">1163</property>
+        <property name="syft:metadata:source">sqlite3</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libss2@1.43.4-2+deb9u2?arch=amd64&amp;upstream=e2fsprogs&amp;distro=debian-9&amp;package-id=79fa8520123f392e" type="library">
+      <publisher>Theodore Y. Ts&#39;o &lt;tytso@mit.edu&gt;</publisher>
+      <name>libss2</name>
+      <version>1.43.4-2+deb9u2</version>
+      <cpe>cpe:2.3:a:libss2:libss2:1.43.4-2\+deb9u2:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libss2@1.43.4-2+deb9u2?arch=amd64&amp;upstream=e2fsprogs&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/libss2/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libss2:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">96</property>
+        <property name="syft:metadata:source">e2fsprogs</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libssl1.1@1.1.0l-1~deb9u5?arch=amd64&amp;upstream=openssl&amp;distro=debian-9&amp;package-id=dbf41c74a3aaf60e" type="library">
+      <publisher>Debian OpenSSL Team &lt;pkg-openssl-devel@lists.alioth.debian.org&gt;</publisher>
+      <name>libssl1.1</name>
+      <version>1.1.0l-1~deb9u5</version>
+      <cpe>cpe:2.3:a:libssl1.1:libssl1.1:1.1.0l-1\~deb9u5:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libssl1.1@1.1.0l-1~deb9u5?arch=amd64&amp;upstream=openssl&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:0:path">/usr/share/doc/libssl1.1/copyright</property>
+        <property name="syft:location:1:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libssl1.1:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">3565</property>
+        <property name="syft:metadata:source">openssl</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libstdc++6@6.3.0-18+deb9u1?arch=amd64&amp;upstream=gcc-6&amp;distro=debian-9&amp;package-id=d2d8175c2ca39b9a" type="library">
+      <publisher>Debian GCC Maintainers &lt;debian-gcc@lists.debian.org&gt;</publisher>
+      <name>libstdc++6</name>
+      <version>6.3.0-18+deb9u1</version>
+      <licenses>
+        <license>
+          <name>Artistic</name>
+        </license>
+        <license>
+          <id>GFDL-1.2-only</id>
+        </license>
+        <license>
+          <name>GPL</name>
+        </license>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>GPL-3.0-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libstdc\+\+6:libstdc\+\+6:6.3.0-18\+deb9u1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libstdc++6@6.3.0-18+deb9u1?arch=amd64&amp;upstream=gcc-6&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/gcc-6-base/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libstdc++6:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">1998</property>
+        <property name="syft:metadata:source">gcc-6</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libsystemd0@232-25+deb9u13?arch=amd64&amp;upstream=systemd&amp;distro=debian-9&amp;package-id=1edf6012fe80dced" type="library">
+      <publisher>Debian systemd Maintainers &lt;pkg-systemd-maintainers@lists.alioth.debian.org&gt;</publisher>
+      <name>libsystemd0</name>
+      <version>232-25+deb9u13</version>
+      <licenses>
+        <license>
+          <name>CC0</name>
+        </license>
+        <license>
+          <name>Expat</name>
+        </license>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>GPL-2.0-or-later</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-or-later</id>
+        </license>
+        <license>
+          <name>public-domain</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libsystemd0:libsystemd0:232-25\+deb9u13:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libsystemd0@232-25+deb9u13?arch=amd64&amp;upstream=systemd&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/libsystemd0/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libsystemd0:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">654</property>
+        <property name="syft:metadata:source">systemd</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libtasn1-6@4.10-1.1+deb9u1?arch=amd64&amp;distro=debian-9&amp;package-id=3289449bc595d404" type="library">
+      <publisher>Debian GnuTLS Maintainers &lt;pkg-gnutls-maint@lists.alioth.debian.org&gt;</publisher>
+      <name>libtasn1-6</name>
+      <version>4.10-1.1+deb9u1</version>
+      <licenses>
+        <license>
+          <id>GFDL-1.3-only</id>
+        </license>
+        <license>
+          <id>GPL-3.0-only</id>
+        </license>
+        <license>
+          <name>LGPL</name>
+        </license>
+        <license>
+          <id>LGPL-2.1-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libtasn1-6:libtasn1-6:4.10-1.1\+deb9u1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libtasn1-6@4.10-1.1+deb9u1?arch=amd64&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:libtasn1-6:libtasn1_6:4.10-1.1\+deb9u1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libtasn1_6:libtasn1-6:4.10-1.1\+deb9u1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libtasn1_6:libtasn1_6:4.10-1.1\+deb9u1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libtasn1:libtasn1-6:4.10-1.1\+deb9u1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libtasn1:libtasn1_6:4.10-1.1\+deb9u1:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:0:path">/usr/share/doc/libtasn1-6/copyright</property>
+        <property name="syft:location:1:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libtasn1-6:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">112</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libtinfo5@6.0+20161126-1+deb9u2?arch=amd64&amp;upstream=ncurses&amp;distro=debian-9&amp;package-id=31d32056c3ca397a" type="library">
+      <publisher>Craig Small &lt;csmall@debian.org&gt;</publisher>
+      <name>libtinfo5</name>
+      <version>6.0+20161126-1+deb9u2</version>
+      <cpe>cpe:2.3:a:libtinfo5:libtinfo5:6.0\+20161126-1\+deb9u2:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libtinfo5@6.0+20161126-1+deb9u2?arch=amd64&amp;upstream=ncurses&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/libtinfo5/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libtinfo5:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">478</property>
+        <property name="syft:metadata:source">ncurses</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libudev1@232-25+deb9u13?arch=amd64&amp;upstream=systemd&amp;distro=debian-9&amp;package-id=3d988b644f391faa" type="library">
+      <publisher>Debian systemd Maintainers &lt;pkg-systemd-maintainers@lists.alioth.debian.org&gt;</publisher>
+      <name>libudev1</name>
+      <version>232-25+deb9u13</version>
+      <licenses>
+        <license>
+          <name>CC0</name>
+        </license>
+        <license>
+          <name>Expat</name>
+        </license>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>GPL-2.0-or-later</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-or-later</id>
+        </license>
+        <license>
+          <name>public-domain</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libudev1:libudev1:232-25\+deb9u13:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libudev1@232-25+deb9u13?arch=amd64&amp;upstream=systemd&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/libudev1/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libudev1:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">224</property>
+        <property name="syft:metadata:source">systemd</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libustr-1.0-1@1.0.4-6?arch=amd64&amp;upstream=ustr&amp;distro=debian-9&amp;package-id=3c141906671338d7" type="library">
+      <publisher>Vaclav Ovsik &lt;vaclav.ovsik@i.cz&gt;</publisher>
+      <name>libustr-1.0-1</name>
+      <version>1.0.4-6</version>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+        </license>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>GPL-2.0-or-later</id>
+        </license>
+        <license>
+          <id>LGPL-2.0-or-later</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-only</id>
+        </license>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libustr-1.0-1:libustr-1.0-1:1.0.4-6:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libustr-1.0-1@1.0.4-6?arch=amd64&amp;upstream=ustr&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:libustr-1.0-1:libustr_1.0_1:1.0.4-6:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libustr_1.0_1:libustr-1.0-1:1.0.4-6:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libustr_1.0_1:libustr_1.0_1:1.0.4-6:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libustr-1.0:libustr-1.0-1:1.0.4-6:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libustr-1.0:libustr_1.0_1:1.0.4-6:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libustr_1.0:libustr-1.0-1:1.0.4-6:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libustr_1.0:libustr_1.0_1:1.0.4-6:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libustr:libustr-1.0-1:1.0.4-6:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:libustr:libustr_1.0_1:1.0.4-6:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/libustr-1.0-1/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libustr-1.0-1:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">258</property>
+        <property name="syft:metadata:source">ustr</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libuuid1@2.29.2-1+deb9u1?arch=amd64&amp;upstream=util-linux&amp;distro=debian-9&amp;package-id=c53e0607c3a517cd" type="library">
+      <publisher>Debian util-linux Maintainers &lt;ah-util-linux@debian.org&gt;</publisher>
+      <name>libuuid1</name>
+      <version>2.29.2-1+deb9u1</version>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+        </license>
+        <license>
+          <id>BSD-3-Clause</id>
+        </license>
+        <license>
+          <id>BSD-4-Clause</id>
+        </license>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>GPL-2.0-or-later</id>
+        </license>
+        <license>
+          <id>GPL-3.0-only</id>
+        </license>
+        <license>
+          <id>GPL-3.0-or-later</id>
+        </license>
+        <license>
+          <name>LGPL</name>
+        </license>
+        <license>
+          <id>LGPL-2.0-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.0-or-later</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-or-later</id>
+        </license>
+        <license>
+          <id>LGPL-3.0-only</id>
+        </license>
+        <license>
+          <id>LGPL-3.0-or-later</id>
+        </license>
+        <license>
+          <id>MIT</id>
+        </license>
+        <license>
+          <name>public-domain</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libuuid1:libuuid1:2.29.2-1\+deb9u1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libuuid1@2.29.2-1+deb9u1?arch=amd64&amp;upstream=util-linux&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/libuuid1/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libuuid1:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">107</property>
+        <property name="syft:metadata:source">util-linux</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libxml2@2.9.4+dfsg1-2.2+deb9u6?arch=amd64&amp;distro=debian-9&amp;package-id=16b06b05ac7e6944" type="library">
+      <publisher>Debian XML/SGML Group &lt;debian-xml-sgml-pkgs@lists.alioth.debian.org&gt;</publisher>
+      <name>libxml2</name>
+      <version>2.9.4+dfsg1-2.2+deb9u6</version>
+      <cpe>cpe:2.3:a:libxml2:libxml2:2.9.4\+dfsg1-2.2\+deb9u6:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libxml2@2.9.4+dfsg1-2.2+deb9u6?arch=amd64&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:0:path">/usr/share/doc/libxml2/copyright</property>
+        <property name="syft:location:1:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libxml2:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">2131</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libxslt1.1@1.1.29-2.1+deb9u2?arch=amd64&amp;upstream=libxslt&amp;distro=debian-9&amp;package-id=e59cbc71250cb333" type="library">
+      <publisher>Debian XML/SGML Group &lt;debian-xml-sgml-pkgs@lists.alioth.debian.org&gt;</publisher>
+      <name>libxslt1.1</name>
+      <version>1.1.29-2.1+deb9u2</version>
+      <cpe>cpe:2.3:a:libxslt1.1:libxslt1.1:1.1.29-2.1\+deb9u2:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libxslt1.1@1.1.29-2.1+deb9u2?arch=amd64&amp;upstream=libxslt&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:0:path">/usr/share/doc/libxslt1.1/copyright</property>
+        <property name="syft:location:1:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libxslt1.1:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">481</property>
+        <property name="syft:metadata:source">libxslt</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/libzstd1@1.1.2-1+deb9u1?arch=amd64&amp;upstream=libzstd&amp;distro=debian-9&amp;package-id=6ea0f714af271317" type="library">
+      <publisher>Debian Med Packaging &lt;debian-med-packaging@lists.alioth.debian.org&gt;</publisher>
+      <name>libzstd1</name>
+      <version>1.1.2-1+deb9u1</version>
+      <licenses>
+        <license>
+          <name>BSD-3-clause-with-patent-grant</name>
+        </license>
+        <license>
+          <name>Expat</name>
+        </license>
+        <license>
+          <id>Zlib</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:libzstd1:libzstd1:1.1.2-1\+deb9u1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/libzstd1@1.1.2-1+deb9u1?arch=amd64&amp;upstream=libzstd&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:01d30ba422c5d9f4a346d59ee398d0ab9882cd9b962e972a68c9c5345c2e4767</property>
+        <property name="syft:location:0:path">/usr/share/doc/libzstd1/copyright</property>
+        <property name="syft:location:1:layerID">sha256:01d30ba422c5d9f4a346d59ee398d0ab9882cd9b962e972a68c9c5345c2e4767</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/libzstd1.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">550</property>
+        <property name="syft:metadata:source">libzstd</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/locales@2.24-11+deb9u4?arch=all&amp;upstream=glibc&amp;distro=debian-9&amp;package-id=f273d5a38c8c5241" type="library">
+      <publisher>GNU Libc Maintainers &lt;debian-glibc@lists.debian.org&gt;</publisher>
+      <name>locales</name>
+      <version>2.24-11+deb9u4</version>
+      <licenses>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:locales:locales:2.24-11\+deb9u4:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/locales@2.24-11+deb9u4?arch=all&amp;upstream=glibc&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:5afa113a433cd32056370367d1a936a5e77cc30cca6590c0241acffa33d1ec56</property>
+        <property name="syft:location:0:path">/usr/share/doc/locales/copyright</property>
+        <property name="syft:location:1:layerID">sha256:5afa113a433cd32056370367d1a936a5e77cc30cca6590c0241acffa33d1ec56</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/locales.conffiles</property>
+        <property name="syft:location:2:layerID">sha256:5afa113a433cd32056370367d1a936a5e77cc30cca6590c0241acffa33d1ec56</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/info/locales.md5sums</property>
+        <property name="syft:location:3:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:3:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">9246</property>
+        <property name="syft:metadata:source">glibc</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/login@1:4.4-4.1+deb9u1?arch=amd64&amp;upstream=shadow&amp;distro=debian-9&amp;package-id=3e8f147358fa80cc" type="library">
+      <publisher>Shadow package maintainers &lt;pkg-shadow-devel@lists.alioth.debian.org&gt;</publisher>
+      <name>login</name>
+      <version>1:4.4-4.1+deb9u1</version>
+      <licenses>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:login:login:1\:4.4-4.1\+deb9u1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/login@1:4.4-4.1+deb9u1?arch=amd64&amp;upstream=shadow&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/login/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/login.conffiles</property>
+        <property name="syft:location:2:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/info/login.md5sums</property>
+        <property name="syft:location:3:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:3:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">2747</property>
+        <property name="syft:metadata:source">shadow</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/lsb-base@9.20161125?arch=all&amp;upstream=lsb&amp;distro=debian-9&amp;package-id=f67a48477973c9cb" type="library">
+      <publisher>Debian LSB Team &lt;debian-lsb@lists.debian.org&gt;</publisher>
+      <name>lsb-base</name>
+      <version>9.20161125</version>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+        </license>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:lsb-base:lsb-base:9.20161125:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/lsb-base@9.20161125?arch=all&amp;upstream=lsb&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:lsb-base:lsb_base:9.20161125:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:lsb_base:lsb-base:9.20161125:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:lsb_base:lsb_base:9.20161125:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:lsb:lsb-base:9.20161125:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:lsb:lsb_base:9.20161125:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/lsb-base/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/lsb-base.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">49</property>
+        <property name="syft:metadata:source">lsb</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/mawk@1.3.3-17+b3?arch=amd64&amp;upstream=mawk%401.3.3-17&amp;distro=debian-9&amp;package-id=2aa71b5a2c22f638" type="library">
+      <publisher>Steve Langasek &lt;vorlon@debian.org&gt;</publisher>
+      <name>mawk</name>
+      <version>1.3.3-17+b3</version>
+      <licenses>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:mawk:mawk:1.3.3-17\+b3:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/mawk@1.3.3-17+b3?arch=amd64&amp;upstream=mawk%401.3.3-17&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/mawk/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/mawk.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">183</property>
+        <property name="syft:metadata:source">mawk</property>
+        <property name="syft:metadata:sourceVersion">1.3.3-17</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/mount@2.29.2-1+deb9u1?arch=amd64&amp;upstream=util-linux&amp;distro=debian-9&amp;package-id=a93f31d0994bf378" type="library">
+      <publisher>Debian util-linux Maintainers &lt;ah-util-linux@debian.org&gt;</publisher>
+      <name>mount</name>
+      <version>2.29.2-1+deb9u1</version>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+        </license>
+        <license>
+          <id>BSD-3-Clause</id>
+        </license>
+        <license>
+          <id>BSD-4-Clause</id>
+        </license>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>GPL-2.0-or-later</id>
+        </license>
+        <license>
+          <id>GPL-3.0-only</id>
+        </license>
+        <license>
+          <id>GPL-3.0-or-later</id>
+        </license>
+        <license>
+          <name>LGPL</name>
+        </license>
+        <license>
+          <id>LGPL-2.0-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.0-or-later</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-or-later</id>
+        </license>
+        <license>
+          <id>LGPL-3.0-only</id>
+        </license>
+        <license>
+          <id>LGPL-3.0-or-later</id>
+        </license>
+        <license>
+          <id>MIT</id>
+        </license>
+        <license>
+          <name>public-domain</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:mount:mount:2.29.2-1\+deb9u1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/mount@2.29.2-1+deb9u1?arch=amd64&amp;upstream=util-linux&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/mount/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/mount.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">444</property>
+        <property name="syft:metadata:source">util-linux</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/multiarch-support@2.24-11+deb9u4?arch=amd64&amp;upstream=glibc&amp;distro=debian-9&amp;package-id=1e7cd18f15ce27c" type="library">
+      <publisher>GNU Libc Maintainers &lt;debian-glibc@lists.debian.org&gt;</publisher>
+      <name>multiarch-support</name>
+      <version>2.24-11+deb9u4</version>
+      <licenses>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:multiarch-support:multiarch-support:2.24-11\+deb9u4:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/multiarch-support@2.24-11+deb9u4?arch=amd64&amp;upstream=glibc&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:multiarch-support:multiarch_support:2.24-11\+deb9u4:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:multiarch_support:multiarch-support:2.24-11\+deb9u4:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:multiarch_support:multiarch_support:2.24-11\+deb9u4:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:multiarch:multiarch-support:2.24-11\+deb9u4:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:multiarch:multiarch_support:2.24-11\+deb9u4:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/multiarch-support/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/multiarch-support.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">221</property>
+        <property name="syft:metadata:source">glibc</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/ncurses-base@6.0+20161126-1+deb9u2?arch=all&amp;upstream=ncurses&amp;distro=debian-9&amp;package-id=fedafddb586dd364" type="library">
+      <publisher>Craig Small &lt;csmall@debian.org&gt;</publisher>
+      <name>ncurses-base</name>
+      <version>6.0+20161126-1+deb9u2</version>
+      <cpe>cpe:2.3:a:ncurses-base:ncurses-base:6.0\+20161126-1\+deb9u2:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/ncurses-base@6.0+20161126-1+deb9u2?arch=all&amp;upstream=ncurses&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:ncurses-base:ncurses_base:6.0\+20161126-1\+deb9u2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:ncurses_base:ncurses-base:6.0\+20161126-1\+deb9u2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:ncurses_base:ncurses_base:6.0\+20161126-1\+deb9u2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:ncurses:ncurses-base:6.0\+20161126-1\+deb9u2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:ncurses:ncurses_base:6.0\+20161126-1\+deb9u2:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/ncurses-base/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/ncurses-base.conffiles</property>
+        <property name="syft:location:2:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/info/ncurses-base.md5sums</property>
+        <property name="syft:location:3:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:3:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">340</property>
+        <property name="syft:metadata:source">ncurses</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/ncurses-bin@6.0+20161126-1+deb9u2?arch=amd64&amp;upstream=ncurses&amp;distro=debian-9&amp;package-id=3dbd2e1c66d3c533" type="library">
+      <publisher>Craig Small &lt;csmall@debian.org&gt;</publisher>
+      <name>ncurses-bin</name>
+      <version>6.0+20161126-1+deb9u2</version>
+      <cpe>cpe:2.3:a:ncurses-bin:ncurses-bin:6.0\+20161126-1\+deb9u2:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/ncurses-bin@6.0+20161126-1+deb9u2?arch=amd64&amp;upstream=ncurses&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:ncurses-bin:ncurses_bin:6.0\+20161126-1\+deb9u2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:ncurses_bin:ncurses-bin:6.0\+20161126-1\+deb9u2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:ncurses_bin:ncurses_bin:6.0\+20161126-1\+deb9u2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:ncurses:ncurses-bin:6.0\+20161126-1\+deb9u2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:ncurses:ncurses_bin:6.0\+20161126-1\+deb9u2:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/ncurses-bin/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/ncurses-bin.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">536</property>
+        <property name="syft:metadata:source">ncurses</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/netbase@5.4?arch=all&amp;distro=debian-9&amp;package-id=e22ba6a7979fc866" type="library">
+      <publisher>Marco d&#39;Itri &lt;md@linux.it&gt;</publisher>
+      <name>netbase</name>
+      <version>5.4</version>
+      <licenses>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:netbase:netbase:5.4:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/netbase@5.4?arch=all&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:0:path">/usr/share/doc/netbase/copyright</property>
+        <property name="syft:location:1:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/netbase.conffiles</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/info/netbase.md5sums</property>
+        <property name="syft:location:3:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:3:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">44</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/openssl@1.1.0l-1~deb9u5?arch=amd64&amp;distro=debian-9&amp;package-id=a0fb71a0e8572229" type="library">
+      <publisher>Debian OpenSSL Team &lt;pkg-openssl-devel@lists.alioth.debian.org&gt;</publisher>
+      <name>openssl</name>
+      <version>1.1.0l-1~deb9u5</version>
+      <cpe>cpe:2.3:a:openssl:openssl:1.1.0l-1\~deb9u5:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/openssl@1.1.0l-1~deb9u5?arch=amd64&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:0:path">/usr/share/doc/openssl/copyright</property>
+        <property name="syft:location:1:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/openssl.conffiles</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/info/openssl.md5sums</property>
+        <property name="syft:location:3:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:3:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">1315</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/passwd@1:4.4-4.1+deb9u1?arch=amd64&amp;upstream=shadow&amp;distro=debian-9&amp;package-id=db5517681e1b8d5b" type="library">
+      <publisher>Shadow package maintainers &lt;pkg-shadow-devel@lists.alioth.debian.org&gt;</publisher>
+      <name>passwd</name>
+      <version>1:4.4-4.1+deb9u1</version>
+      <licenses>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:passwd:passwd:1\:4.4-4.1\+deb9u1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/passwd@1:4.4-4.1+deb9u1?arch=amd64&amp;upstream=shadow&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/passwd/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/passwd.conffiles</property>
+        <property name="syft:location:2:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/info/passwd.md5sums</property>
+        <property name="syft:location:3:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:3:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">2478</property>
+        <property name="syft:metadata:source">shadow</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/perl@5.24.1-3+deb9u7?arch=amd64&amp;distro=debian-9&amp;package-id=beabd7c3aae9abeb" type="library">
+      <publisher>Niko Tyni &lt;ntyni@debian.org&gt;</publisher>
+      <name>perl</name>
+      <version>5.24.1-3+deb9u7</version>
+      <licenses>
+        <license>
+          <name>Artistic</name>
+        </license>
+        <license>
+          <id>Artistic-2.0</id>
+        </license>
+        <license>
+          <id>BSD-3-Clause</id>
+        </license>
+        <license>
+          <name>BSD-3-clause-GENERIC</name>
+        </license>
+        <license>
+          <name>BSD-3-clause-with-weird-numbering</name>
+        </license>
+        <license>
+          <name>BSD-4-clause-POWERDOG</name>
+        </license>
+        <license>
+          <name>BZIP</name>
+        </license>
+        <license>
+          <name>DONT-CHANGE-THE-GPL</name>
+        </license>
+        <license>
+          <name>Expat</name>
+        </license>
+        <license>
+          <id>GPL-1.0-only</id>
+        </license>
+        <license>
+          <id>GPL-1.0-or-later</id>
+        </license>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>GPL-2.0-or-later</id>
+        </license>
+        <license>
+          <name>GPL-3+-WITH-BISON-EXCEPTION</name>
+        </license>
+        <license>
+          <name>HSIEH-BSD</name>
+        </license>
+        <license>
+          <name>HSIEH-DERIVATIVE</name>
+        </license>
+        <license>
+          <id>LGPL-2.1-only</id>
+        </license>
+        <license>
+          <name>REGCOMP</name>
+        </license>
+        <license>
+          <name>REGCOMP,</name>
+        </license>
+        <license>
+          <name>RRA-KEEP-THIS-NOTICE</name>
+        </license>
+        <license>
+          <name>S2P</name>
+        </license>
+        <license>
+          <name>SDBM-PUBLIC-DOMAIN</name>
+        </license>
+        <license>
+          <name>TEXT-TABS</name>
+        </license>
+        <license>
+          <name>Unicode</name>
+        </license>
+        <license>
+          <id>Zlib</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:perl:perl:5.24.1-3\+deb9u7:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/perl@5.24.1-3+deb9u7?arch=amd64&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/perl/copyright</property>
+        <property name="syft:location:1:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/perl.conffiles</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/info/perl.md5sums</property>
+        <property name="syft:location:3:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:3:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">651</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/perl-base@5.24.1-3+deb9u7?arch=amd64&amp;upstream=perl&amp;distro=debian-9&amp;package-id=a7f11228192df208" type="library">
+      <publisher>Niko Tyni &lt;ntyni@debian.org&gt;</publisher>
+      <name>perl-base</name>
+      <version>5.24.1-3+deb9u7</version>
+      <licenses>
+        <license>
+          <name>Artistic</name>
+        </license>
+        <license>
+          <id>Artistic-2.0</id>
+        </license>
+        <license>
+          <id>BSD-3-Clause</id>
+        </license>
+        <license>
+          <name>BSD-3-clause-GENERIC</name>
+        </license>
+        <license>
+          <name>BSD-3-clause-with-weird-numbering</name>
+        </license>
+        <license>
+          <name>BSD-4-clause-POWERDOG</name>
+        </license>
+        <license>
+          <name>BZIP</name>
+        </license>
+        <license>
+          <name>DONT-CHANGE-THE-GPL</name>
+        </license>
+        <license>
+          <name>Expat</name>
+        </license>
+        <license>
+          <id>GPL-1.0-only</id>
+        </license>
+        <license>
+          <id>GPL-1.0-or-later</id>
+        </license>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>GPL-2.0-or-later</id>
+        </license>
+        <license>
+          <name>GPL-3+-WITH-BISON-EXCEPTION</name>
+        </license>
+        <license>
+          <name>HSIEH-BSD</name>
+        </license>
+        <license>
+          <name>HSIEH-DERIVATIVE</name>
+        </license>
+        <license>
+          <id>LGPL-2.1-only</id>
+        </license>
+        <license>
+          <name>REGCOMP</name>
+        </license>
+        <license>
+          <name>REGCOMP,</name>
+        </license>
+        <license>
+          <name>RRA-KEEP-THIS-NOTICE</name>
+        </license>
+        <license>
+          <name>S2P</name>
+        </license>
+        <license>
+          <name>SDBM-PUBLIC-DOMAIN</name>
+        </license>
+        <license>
+          <name>TEXT-TABS</name>
+        </license>
+        <license>
+          <name>Unicode</name>
+        </license>
+        <license>
+          <id>Zlib</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:perl-base:perl-base:5.24.1-3\+deb9u7:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/perl-base@5.24.1-3+deb9u7?arch=amd64&amp;upstream=perl&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:perl-base:perl_base:5.24.1-3\+deb9u7:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:perl_base:perl-base:5.24.1-3\+deb9u7:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:perl_base:perl_base:5.24.1-3\+deb9u7:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:perl:perl-base:5.24.1-3\+deb9u7:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:perl:perl_base:5.24.1-3\+deb9u7:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/perl/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/perl-base.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">7551</property>
+        <property name="syft:metadata:source">perl</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/perl-modules-5.24@5.24.1-3+deb9u7?arch=all&amp;upstream=perl&amp;distro=debian-9&amp;package-id=3d7284049e6ccb36" type="library">
+      <publisher>Niko Tyni &lt;ntyni@debian.org&gt;</publisher>
+      <name>perl-modules-5.24</name>
+      <version>5.24.1-3+deb9u7</version>
+      <licenses>
+        <license>
+          <name>Artistic</name>
+        </license>
+        <license>
+          <id>Artistic-2.0</id>
+        </license>
+        <license>
+          <id>BSD-3-Clause</id>
+        </license>
+        <license>
+          <name>BSD-3-clause-GENERIC</name>
+        </license>
+        <license>
+          <name>BSD-3-clause-with-weird-numbering</name>
+        </license>
+        <license>
+          <name>BSD-4-clause-POWERDOG</name>
+        </license>
+        <license>
+          <name>BZIP</name>
+        </license>
+        <license>
+          <name>DONT-CHANGE-THE-GPL</name>
+        </license>
+        <license>
+          <name>Expat</name>
+        </license>
+        <license>
+          <id>GPL-1.0-only</id>
+        </license>
+        <license>
+          <id>GPL-1.0-or-later</id>
+        </license>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>GPL-2.0-or-later</id>
+        </license>
+        <license>
+          <name>GPL-3+-WITH-BISON-EXCEPTION</name>
+        </license>
+        <license>
+          <name>HSIEH-BSD</name>
+        </license>
+        <license>
+          <name>HSIEH-DERIVATIVE</name>
+        </license>
+        <license>
+          <id>LGPL-2.1-only</id>
+        </license>
+        <license>
+          <name>REGCOMP</name>
+        </license>
+        <license>
+          <name>REGCOMP,</name>
+        </license>
+        <license>
+          <name>RRA-KEEP-THIS-NOTICE</name>
+        </license>
+        <license>
+          <name>S2P</name>
+        </license>
+        <license>
+          <name>SDBM-PUBLIC-DOMAIN</name>
+        </license>
+        <license>
+          <name>TEXT-TABS</name>
+        </license>
+        <license>
+          <name>Unicode</name>
+        </license>
+        <license>
+          <id>Zlib</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:perl-modules-5.24:perl-modules-5.24:5.24.1-3\+deb9u7:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/perl-modules-5.24@5.24.1-3+deb9u7?arch=all&amp;upstream=perl&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:perl-modules-5.24:perl_modules_5.24:5.24.1-3\+deb9u7:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:perl_modules_5.24:perl-modules-5.24:5.24.1-3\+deb9u7:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:perl_modules_5.24:perl_modules_5.24:5.24.1-3\+deb9u7:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:perl-modules:perl-modules-5.24:5.24.1-3\+deb9u7:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:perl-modules:perl_modules_5.24:5.24.1-3\+deb9u7:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:perl_modules:perl-modules-5.24:5.24.1-3\+deb9u7:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:perl_modules:perl_modules_5.24:5.24.1-3\+deb9u7:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:perl:perl-modules-5.24:5.24.1-3\+deb9u7:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:perl:perl_modules_5.24:5.24.1-3\+deb9u7:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:0:path">/usr/share/doc/perl-modules-5.24/copyright</property>
+        <property name="syft:location:1:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/perl-modules-5.24.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">17631</property>
+        <property name="syft:metadata:source">perl</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/pgdg-keyring@2018.2?arch=all&amp;distro=debian-9&amp;package-id=2bd0ded31e16fd92" type="library">
+      <publisher>Debian PostgreSQL Maintainers &lt;pkg-postgresql-public@lists.alioth.debian.org&gt;</publisher>
+      <name>pgdg-keyring</name>
+      <version>2018.2</version>
+      <cpe>cpe:2.3:a:pgdg-keyring:pgdg-keyring:2018.2:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/pgdg-keyring@2018.2?arch=all&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:pgdg-keyring:pgdg_keyring:2018.2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:pgdg_keyring:pgdg-keyring:2018.2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:pgdg_keyring:pgdg_keyring:2018.2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:pgdg:pgdg-keyring:2018.2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:pgdg:pgdg_keyring:2018.2:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:0:path">/usr/share/doc/pgdg-keyring/copyright</property>
+        <property name="syft:location:1:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/pgdg-keyring.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">22</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/pinentry-curses@1.0.0-2?arch=amd64&amp;upstream=pinentry&amp;distro=debian-9&amp;package-id=d6a1df01970faf39" type="library">
+      <publisher>Debian GnuPG Maintainers &lt;pkg-gnupg-maint@lists.alioth.debian.org&gt;</publisher>
+      <name>pinentry-curses</name>
+      <version>1.0.0-2</version>
+      <licenses>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>GPL-2.0-or-later</id>
+        </license>
+        <license>
+          <id>LGPL-3.0-only</id>
+        </license>
+        <license>
+          <id>LGPL-3.0-or-later</id>
+        </license>
+        <license>
+          <id>X11</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:pinentry-curses:pinentry-curses:1.0.0-2:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/pinentry-curses@1.0.0-2?arch=amd64&amp;upstream=pinentry&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:pinentry-curses:pinentry_curses:1.0.0-2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:pinentry_curses:pinentry-curses:1.0.0-2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:pinentry_curses:pinentry_curses:1.0.0-2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:pinentry:pinentry-curses:1.0.0-2:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:pinentry:pinentry_curses:1.0.0-2:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:0:path">/usr/share/doc/pinentry-curses/copyright</property>
+        <property name="syft:location:1:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/pinentry-curses.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">99</property>
+        <property name="syft:metadata:source">pinentry</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:generic/postgresql@11.15?package-id=127784473033d1e8" type="application">
+      <name>postgresql</name>
+      <version>11.15</version>
+      <cpe>cpe:2.3:a:postgresql:postgresql:11.15:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:generic/postgresql@11.15</purl>
+      <properties>
+        <property name="syft:package:foundBy">binary-cataloger</property>
+        <property name="syft:package:metadataType">BinaryMetadata</property>
+        <property name="syft:package:type">binary</property>
+        <property name="syft:location:0:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:0:path">/usr/lib/postgresql/11/bin/postgres</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/postgresql-11@11.15-1.pgdg90+1?arch=amd64&amp;distro=debian-9&amp;package-id=e85cfa57fc519286" type="library">
+      <publisher>Debian PostgreSQL Maintainers &lt;team+postgresql@tracker.debian.org&gt;</publisher>
+      <name>postgresql-11</name>
+      <version>11.15-1.pgdg90+1</version>
+      <licenses>
+        <license>
+          <name>Artistic</name>
+        </license>
+        <license>
+          <id>BSD-2-Clause</id>
+        </license>
+        <license>
+          <id>BSD-3-Clause</id>
+        </license>
+        <license>
+          <name>Custom-Unicode</name>
+        </license>
+        <license>
+          <name>Custom-pg_dump</name>
+        </license>
+        <license>
+          <name>Custom-regex</name>
+        </license>
+        <license>
+          <id>GPL-1.0-only</id>
+        </license>
+        <license>
+          <id>PostgreSQL</id>
+        </license>
+        <license>
+          <name>Snowball</name>
+        </license>
+        <license>
+          <id>TCL</id>
+        </license>
+        <license>
+          <name>blf</name>
+        </license>
+        <license>
+          <name>double-metaphone</name>
+        </license>
+        <license>
+          <name>imath</name>
+        </license>
+        <license>
+          <name>nagaysau-ishii</name>
+        </license>
+        <license>
+          <name>rijndael</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:postgresql-11:postgresql-11:11.15-1.pgdg90\+1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/postgresql-11@11.15-1.pgdg90+1?arch=amd64&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:postgresql-11:postgresql_11:11.15-1.pgdg90\+1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:postgresql_11:postgresql-11:11.15-1.pgdg90\+1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:postgresql_11:postgresql_11:11.15-1.pgdg90\+1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:postgresql:postgresql-11:11.15-1.pgdg90\+1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:postgresql:postgresql_11:11.15-1.pgdg90\+1:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:0:path">/usr/share/doc/postgresql-11/copyright</property>
+        <property name="syft:location:1:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/postgresql-11.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">44373</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/postgresql-client-11@11.15-1.pgdg90+1?arch=amd64&amp;upstream=postgresql-11&amp;distro=debian-9&amp;package-id=bdc49c29b8778dd1" type="library">
+      <publisher>Debian PostgreSQL Maintainers &lt;team+postgresql@tracker.debian.org&gt;</publisher>
+      <name>postgresql-client-11</name>
+      <version>11.15-1.pgdg90+1</version>
+      <licenses>
+        <license>
+          <name>Artistic</name>
+        </license>
+        <license>
+          <id>BSD-2-Clause</id>
+        </license>
+        <license>
+          <id>BSD-3-Clause</id>
+        </license>
+        <license>
+          <name>Custom-Unicode</name>
+        </license>
+        <license>
+          <name>Custom-pg_dump</name>
+        </license>
+        <license>
+          <name>Custom-regex</name>
+        </license>
+        <license>
+          <id>GPL-1.0-only</id>
+        </license>
+        <license>
+          <id>PostgreSQL</id>
+        </license>
+        <license>
+          <name>Snowball</name>
+        </license>
+        <license>
+          <id>TCL</id>
+        </license>
+        <license>
+          <name>blf</name>
+        </license>
+        <license>
+          <name>double-metaphone</name>
+        </license>
+        <license>
+          <name>imath</name>
+        </license>
+        <license>
+          <name>nagaysau-ishii</name>
+        </license>
+        <license>
+          <name>rijndael</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:postgresql-client-11:postgresql-client-11:11.15-1.pgdg90\+1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/postgresql-client-11@11.15-1.pgdg90+1?arch=amd64&amp;upstream=postgresql-11&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:postgresql-client-11:postgresql_client_11:11.15-1.pgdg90\+1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:postgresql_client_11:postgresql-client-11:11.15-1.pgdg90\+1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:postgresql_client_11:postgresql_client_11:11.15-1.pgdg90\+1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:postgresql-client:postgresql-client-11:11.15-1.pgdg90\+1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:postgresql-client:postgresql_client_11:11.15-1.pgdg90\+1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:postgresql_client:postgresql-client-11:11.15-1.pgdg90\+1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:postgresql_client:postgresql_client_11:11.15-1.pgdg90\+1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:postgresql:postgresql-client-11:11.15-1.pgdg90\+1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:postgresql:postgresql_client_11:11.15-1.pgdg90\+1:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:0:path">/usr/share/doc/postgresql-client-11/copyright</property>
+        <property name="syft:location:1:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/postgresql-client-11.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">6465</property>
+        <property name="syft:metadata:source">postgresql-11</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/postgresql-client-common@238.pgdg90+1?arch=all&amp;upstream=postgresql-common&amp;distro=debian-9&amp;package-id=15d0e08bedb53e92" type="library">
+      <publisher>Debian PostgreSQL Maintainers &lt;team+postgresql@tracker.debian.org&gt;</publisher>
+      <name>postgresql-client-common</name>
+      <version>238.pgdg90+1</version>
+      <licenses>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>GPL-2.0-or-later</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:postgresql-client-common:postgresql-client-common:238.pgdg90\+1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/postgresql-client-common@238.pgdg90+1?arch=all&amp;upstream=postgresql-common&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:postgresql-client-common:postgresql_client_common:238.pgdg90\+1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:postgresql_client_common:postgresql-client-common:238.pgdg90\+1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:postgresql_client_common:postgresql_client_common:238.pgdg90\+1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:postgresql-client:postgresql-client-common:238.pgdg90\+1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:postgresql-client:postgresql_client_common:238.pgdg90\+1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:postgresql_client:postgresql-client-common:238.pgdg90\+1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:postgresql_client:postgresql_client_common:238.pgdg90\+1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:postgresql:postgresql-client-common:238.pgdg90\+1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:postgresql:postgresql_client_common:238.pgdg90\+1:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:0:path">/usr/share/doc/postgresql-client-common/copyright</property>
+        <property name="syft:location:1:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/postgresql-client-common.conffiles</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/info/postgresql-client-common.md5sums</property>
+        <property name="syft:location:3:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:3:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">188</property>
+        <property name="syft:metadata:source">postgresql-common</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/postgresql-common@238.pgdg90+1?arch=all&amp;distro=debian-9&amp;package-id=3593d9a60bbf8020" type="library">
+      <publisher>Debian PostgreSQL Maintainers &lt;team+postgresql@tracker.debian.org&gt;</publisher>
+      <name>postgresql-common</name>
+      <version>238.pgdg90+1</version>
+      <licenses>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>GPL-2.0-or-later</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:postgresql-common:postgresql-common:238.pgdg90\+1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/postgresql-common@238.pgdg90+1?arch=all&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:postgresql-common:postgresql_common:238.pgdg90\+1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:postgresql_common:postgresql-common:238.pgdg90\+1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:postgresql_common:postgresql_common:238.pgdg90\+1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:postgresql:postgresql-common:238.pgdg90\+1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:postgresql:postgresql_common:238.pgdg90\+1:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:0:path">/usr/share/doc/postgresql-common/copyright</property>
+        <property name="syft:location:1:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/postgresql-common.conffiles</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/info/postgresql-common.md5sums</property>
+        <property name="syft:location:3:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:3:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">691</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/readline-common@7.0-3?arch=all&amp;upstream=readline&amp;distro=debian-9&amp;package-id=86cb3e97f27101f3" type="library">
+      <publisher>Matthias Klose &lt;doko@debian.org&gt;</publisher>
+      <name>readline-common</name>
+      <version>7.0-3</version>
+      <licenses>
+        <license>
+          <name>GFDL</name>
+        </license>
+        <license>
+          <id>GPL-3.0-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:readline-common:readline-common:7.0-3:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/readline-common@7.0-3?arch=all&amp;upstream=readline&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:readline-common:readline_common:7.0-3:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:readline_common:readline-common:7.0-3:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:readline_common:readline_common:7.0-3:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:readline:readline-common:7.0-3:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:readline:readline_common:7.0-3:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:0:path">/usr/share/doc/readline-common/copyright</property>
+        <property name="syft:location:1:layerID">sha256:53da616d382b12a2259d87e48c0a266b2acdbbd42d6efb446b71ee2e1816be47</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/readline-common.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">89</property>
+        <property name="syft:metadata:source">readline</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/sed@4.4-1?arch=amd64&amp;distro=debian-9&amp;package-id=d982a15f8f640124" type="library">
+      <publisher>Clint Adams &lt;clint@debian.org&gt;</publisher>
+      <name>sed</name>
+      <version>4.4-1</version>
+      <licenses>
+        <license>
+          <id>GPL-3.0-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:sed:sed:4.4-1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/sed@4.4-1?arch=amd64&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/sed/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/sed.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">799</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/sensible-utils@0.0.9+deb9u1?arch=all&amp;distro=debian-9&amp;package-id=c271ea8239e99958" type="library">
+      <publisher>Anibal Monsalve Salazar &lt;anibal@debian.org&gt;</publisher>
+      <name>sensible-utils</name>
+      <version>0.0.9+deb9u1</version>
+      <licenses>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:sensible-utils:sensible-utils:0.0.9\+deb9u1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/sensible-utils@0.0.9+deb9u1?arch=all&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:sensible-utils:sensible_utils:0.0.9\+deb9u1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:sensible_utils:sensible-utils:0.0.9\+deb9u1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:sensible_utils:sensible_utils:0.0.9\+deb9u1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:sensible:sensible-utils:0.0.9\+deb9u1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:sensible:sensible_utils:0.0.9\+deb9u1:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/sensible-utils/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/sensible-utils.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">62</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/ssl-cert@1.0.39?arch=all&amp;distro=debian-9&amp;package-id=3aaf42ead5d2cb0b" type="library">
+      <publisher>Debian Apache Maintainers &lt;debian-apache@lists.debian.org&gt;</publisher>
+      <name>ssl-cert</name>
+      <version>1.0.39</version>
+      <licenses>
+        <license>
+          <id>BSD-3-Clause</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:ssl-cert:ssl-cert:1.0.39:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/ssl-cert@1.0.39?arch=all&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:ssl-cert:ssl_cert:1.0.39:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:ssl_cert:ssl-cert:1.0.39:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:ssl_cert:ssl_cert:1.0.39:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:ssl:ssl-cert:1.0.39:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:ssl:ssl_cert:1.0.39:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:0:path">/usr/share/doc/ssl-cert/copyright</property>
+        <property name="syft:location:1:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/ssl-cert.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">63</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/sysvinit-utils@2.88dsf-59.9?arch=amd64&amp;upstream=sysvinit&amp;distro=debian-9&amp;package-id=3e69d546ae40f210" type="library">
+      <publisher>Debian sysvinit maintainers &lt;pkg-sysvinit-devel@lists.alioth.debian.org&gt;</publisher>
+      <name>sysvinit-utils</name>
+      <version>2.88dsf-59.9</version>
+      <licenses>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:sysvinit-utils:sysvinit-utils:2.88dsf-59.9:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/sysvinit-utils@2.88dsf-59.9?arch=amd64&amp;upstream=sysvinit&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:sysvinit-utils:sysvinit_utils:2.88dsf-59.9:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:sysvinit_utils:sysvinit-utils:2.88dsf-59.9:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:sysvinit_utils:sysvinit_utils:2.88dsf-59.9:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:sysvinit:sysvinit-utils:2.88dsf-59.9:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:sysvinit:sysvinit_utils:2.88dsf-59.9:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/sysvinit-utils/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/sysvinit-utils.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">110</property>
+        <property name="syft:metadata:source">sysvinit</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/tar@1.29b-1.1+deb9u1?arch=amd64&amp;distro=debian-9&amp;package-id=66afa2819a37cd6a" type="library">
+      <publisher>Bdale Garbee &lt;bdale@gag.com&gt;</publisher>
+      <name>tar</name>
+      <version>1.29b-1.1+deb9u1</version>
+      <licenses>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>GPL-3.0-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:tar:tar:1.29b-1.1\+deb9u1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/tar@1.29b-1.1+deb9u1?arch=amd64&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/tar/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/tar.conffiles</property>
+        <property name="syft:location:2:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/info/tar.md5sums</property>
+        <property name="syft:location:3:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:3:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">2774</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/tzdata@2021a-0+deb9u3?arch=all&amp;distro=debian-9&amp;package-id=f4eed377a953bcf6" type="library">
+      <publisher>GNU Libc Maintainers &lt;debian-glibc@lists.debian.org&gt;</publisher>
+      <name>tzdata</name>
+      <version>2021a-0+deb9u3</version>
+      <cpe>cpe:2.3:a:tzdata:tzdata:2021a-0\+deb9u3:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/tzdata@2021a-0+deb9u3?arch=all&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/tzdata/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/tzdata.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">3036</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/ucf@3.0036?arch=all&amp;distro=debian-9&amp;package-id=d66a3785e67501fb" type="library">
+      <publisher>Manoj Srivastava &lt;srivasta@debian.org&gt;</publisher>
+      <name>ucf</name>
+      <version>3.0036</version>
+      <licenses>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:ucf:ucf:3.0036:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/ucf@3.0036?arch=all&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:0:path">/usr/share/doc/ucf/copyright</property>
+        <property name="syft:location:1:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/ucf.conffiles</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/info/ucf.md5sums</property>
+        <property name="syft:location:3:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:3:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">191</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/util-linux@2.29.2-1+deb9u1?arch=amd64&amp;distro=debian-9&amp;package-id=b350aa73096a3ea4" type="library">
+      <publisher>Debian util-linux Maintainers &lt;ah-util-linux@debian.org&gt;</publisher>
+      <name>util-linux</name>
+      <version>2.29.2-1+deb9u1</version>
+      <licenses>
+        <license>
+          <id>BSD-2-Clause</id>
+        </license>
+        <license>
+          <id>BSD-3-Clause</id>
+        </license>
+        <license>
+          <id>BSD-4-Clause</id>
+        </license>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>GPL-2.0-or-later</id>
+        </license>
+        <license>
+          <id>GPL-3.0-only</id>
+        </license>
+        <license>
+          <id>GPL-3.0-or-later</id>
+        </license>
+        <license>
+          <name>LGPL</name>
+        </license>
+        <license>
+          <id>LGPL-2.0-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.0-or-later</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-or-later</id>
+        </license>
+        <license>
+          <id>LGPL-3.0-only</id>
+        </license>
+        <license>
+          <id>LGPL-3.0-or-later</id>
+        </license>
+        <license>
+          <id>MIT</id>
+        </license>
+        <license>
+          <name>public-domain</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:util-linux:util-linux:2.29.2-1\+deb9u1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/util-linux@2.29.2-1+deb9u1?arch=amd64&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:util-linux:util_linux:2.29.2-1\+deb9u1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:util_linux:util-linux:2.29.2-1\+deb9u1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:util_linux:util_linux:2.29.2-1\+deb9u1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:util:util-linux:2.29.2-1\+deb9u1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:util:util_linux:2.29.2-1\+deb9u1:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/util-linux/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/util-linux.conffiles</property>
+        <property name="syft:location:2:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/info/util-linux.md5sums</property>
+        <property name="syft:location:3:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:3:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">3558</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/xz-utils@5.2.2-1.2+deb9u1?arch=amd64&amp;distro=debian-9&amp;package-id=52bf43563db7549d" type="library">
+      <publisher>Jonathan Nieder &lt;jrnieder@gmail.com&gt;</publisher>
+      <name>xz-utils</name>
+      <version>5.2.2-1.2+deb9u1</version>
+      <licenses>
+        <license>
+          <name>Autoconf</name>
+        </license>
+        <license>
+          <id>GPL-2.0-only</id>
+        </license>
+        <license>
+          <id>GPL-2.0-or-later</id>
+        </license>
+        <license>
+          <id>GPL-3.0-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.0-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-only</id>
+        </license>
+        <license>
+          <id>LGPL-2.1-or-later</id>
+        </license>
+        <license>
+          <name>PD</name>
+        </license>
+        <license>
+          <name>PD-debian</name>
+        </license>
+        <license>
+          <name>config-h</name>
+        </license>
+        <license>
+          <name>noderivs</name>
+        </license>
+        <license>
+          <name>permissive-fsf</name>
+        </license>
+        <license>
+          <name>permissive-nowarranty</name>
+        </license>
+        <license>
+          <name>probably-PD</name>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:xz-utils:xz-utils:5.2.2-1.2\+deb9u1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/xz-utils@5.2.2-1.2+deb9u1?arch=amd64&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:cpe23">cpe:2.3:a:xz-utils:xz_utils:5.2.2-1.2\+deb9u1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:xz_utils:xz-utils:5.2.2-1.2\+deb9u1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:xz_utils:xz_utils:5.2.2-1.2\+deb9u1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:xz:xz-utils:5.2.2-1.2\+deb9u1:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:xz:xz_utils:5.2.2-1.2\+deb9u1:*:*:*:*:*:*:*</property>
+        <property name="syft:location:0:layerID">sha256:01d30ba422c5d9f4a346d59ee398d0ab9882cd9b962e972a68c9c5345c2e4767</property>
+        <property name="syft:location:0:path">/usr/share/doc/xz-utils/copyright</property>
+        <property name="syft:location:1:layerID">sha256:01d30ba422c5d9f4a346d59ee398d0ab9882cd9b962e972a68c9c5345c2e4767</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/xz-utils.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">515</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/zlib1g@1:1.2.8.dfsg-5+deb9u1?arch=amd64&amp;upstream=zlib&amp;distro=debian-9&amp;package-id=f3515f1d22f72b1" type="library">
+      <publisher>Mark Brown &lt;broonie@debian.org&gt;</publisher>
+      <name>zlib1g</name>
+      <version>1:1.2.8.dfsg-5+deb9u1</version>
+      <cpe>cpe:2.3:a:zlib1g:zlib1g:1\:1.2.8.dfsg-5\+deb9u1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/zlib1g@1:1.2.8.dfsg-5+deb9u1?arch=amd64&amp;upstream=zlib&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:0:path">/usr/share/doc/zlib1g/copyright</property>
+        <property name="syft:location:1:layerID">sha256:20fa02db39e77a3327d6aabea63ca2b5ced645c33e08ada3aea745130d341e73</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/zlib1g:amd64.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">156</property>
+        <property name="syft:metadata:source">zlib</property>
+      </properties>
+    </component>
+    <component bom-ref="pkg:deb/debian/zstd@1.1.2-1+deb9u1?arch=amd64&amp;upstream=libzstd&amp;distro=debian-9&amp;package-id=dbbf5b55b260ff5e" type="library">
+      <publisher>Debian Med Packaging &lt;debian-med-packaging@lists.alioth.debian.org&gt;</publisher>
+      <name>zstd</name>
+      <version>1.1.2-1+deb9u1</version>
+      <licenses>
+        <license>
+          <name>BSD-3-clause-with-patent-grant</name>
+        </license>
+        <license>
+          <name>Expat</name>
+        </license>
+        <license>
+          <id>Zlib</id>
+        </license>
+      </licenses>
+      <cpe>cpe:2.3:a:zstd:zstd:1.1.2-1\+deb9u1:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:deb/debian/zstd@1.1.2-1+deb9u1?arch=amd64&amp;upstream=libzstd&amp;distro=debian-9</purl>
+      <properties>
+        <property name="syft:package:foundBy">dpkgdb-cataloger</property>
+        <property name="syft:package:metadataType">DpkgMetadata</property>
+        <property name="syft:package:type">deb</property>
+        <property name="syft:location:0:layerID">sha256:01d30ba422c5d9f4a346d59ee398d0ab9882cd9b962e972a68c9c5345c2e4767</property>
+        <property name="syft:location:0:path">/usr/share/doc/zstd/copyright</property>
+        <property name="syft:location:1:layerID">sha256:01d30ba422c5d9f4a346d59ee398d0ab9882cd9b962e972a68c9c5345c2e4767</property>
+        <property name="syft:location:1:path">/var/lib/dpkg/info/zstd.md5sums</property>
+        <property name="syft:location:2:layerID">sha256:28ad98e51293c2d01fd259354167ecd9f9ca0cd7aa8f025e068d7f372e5ccceb</property>
+        <property name="syft:location:2:path">/var/lib/dpkg/status</property>
+        <property name="syft:metadata:installedSize">1218</property>
+        <property name="syft:metadata:source">libzstd</property>
+      </properties>
+    </component>
+    <component type="operating-system">
+      <name>debian</name>
+      <version>9</version>
+      <description>Debian GNU/Linux 9 (stretch)</description>
+      <swid tagId="debian" name="debian" version="9"></swid>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://bugs.debian.org/</url>
+        </reference>
+        <reference type="website">
+          <url>https://www.debian.org/</url>
+        </reference>
+        <reference type="other">
+          <url>https://www.debian.org/support</url>
+          <comment>support</comment>
+        </reference>
+      </externalReferences>
+      <properties>
+        <property name="syft:distro:id">debian</property>
+        <property name="syft:distro:prettyName">Debian GNU/Linux 9 (stretch)</property>
+        <property name="syft:distro:versionCodename">stretch</property>
+        <property name="syft:distro:versionID">9</property>
+      </properties>
+    </component>
+  </components>
+</bom>

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -128,7 +128,27 @@ func TestRun(t *testing.T) {
 			wantExitCode: 0,
 			wantStdout: `
 				Scanning dir ./fixtures/locks-many/composer.lock
-        Scanned %%/fixtures/locks-many/composer.lock file and found 1 packages
+				Scanned %%/fixtures/locks-many/composer.lock file and found 1 packages
+			`,
+			wantStderr: "",
+		},
+		// one specific supported sbom with vulns
+		{
+			name:         "",
+			args:         []string{"", "./fixtures/sbom-insecure/postgres-stretch.cdx.xml"},
+			wantExitCode: 1,
+			wantStdout: `
+				Scanning dir ./fixtures/sbom-insecure/postgres-stretch.cdx.xml
+				Scanned /home/rexpan/Documents/Projects/osv-scanner/cmd/osv-scanner/fixtures/sbom-insecure/postgres-stretch.cdx.xml as CycloneDX SBOM and found 136 packages
+				+-------------------------------------+-----------+---------+------------------------------------+-------------------------------------------------+
+				| OSV URL (ID IN BOLD)                | ECOSYSTEM | PACKAGE | VERSION                            | SOURCE                                          |
+				+-------------------------------------+-----------+---------+------------------------------------+-------------------------------------------------+
+				| https://osv.dev/GHSA-v95c-p5hm-xq8f | Go        | runc    | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
+				| https://osv.dev/GO-2022-0274        |           |         |                                    |                                                 |
+				| https://osv.dev/GHSA-f3fp-gc8g-vw66 | Go        | runc    | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
+				| https://osv.dev/GHSA-p782-xgp4-8hr8 | Go        | sys     | v0.0.0-20210817142637-7d9622a276b7 | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
+				| https://osv.dev/GO-2022-0493        |           |         |                                    |                                                 |
+				+-------------------------------------+-----------+---------+------------------------------------+-------------------------------------------------+
 			`,
 			wantStderr: "",
 		},
@@ -152,6 +172,7 @@ func TestRun(t *testing.T) {
 			wantStdout: `
 				Scanning dir ./fixtures/locks-many
 				Scanned %%/fixtures/locks-many/Gemfile.lock file and found 1 packages
+				Scanned /home/rexpan/Documents/Projects/osv-scanner/cmd/osv-scanner/fixtures/locks-many/alpine.cdx.xml as CycloneDX SBOM and found 15 packages
 				Scanned %%/fixtures/locks-many/composer.lock file and found 1 packages
 				Scanned %%/fixtures/locks-many/yarn.lock file and found 1 packages
 			`,

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -139,7 +139,7 @@ func TestRun(t *testing.T) {
 			wantExitCode: 1,
 			wantStdout: `
 				Scanning dir ./fixtures/sbom-insecure/postgres-stretch.cdx.xml
-				Scanned /home/rexpan/Documents/Projects/osv-scanner/cmd/osv-scanner/fixtures/sbom-insecure/postgres-stretch.cdx.xml as CycloneDX SBOM and found 136 packages
+				Scanned %%/fixtures/sbom-insecure/postgres-stretch.cdx.xml as CycloneDX SBOM and found 136 packages
 				+-------------------------------------+-----------+---------+------------------------------------+-------------------------------------------------+
 				| OSV URL (ID IN BOLD)                | ECOSYSTEM | PACKAGE | VERSION                            | SOURCE                                          |
 				+-------------------------------------+-----------+---------+------------------------------------+-------------------------------------------------+
@@ -172,7 +172,7 @@ func TestRun(t *testing.T) {
 			wantStdout: `
 				Scanning dir ./fixtures/locks-many
 				Scanned %%/fixtures/locks-many/Gemfile.lock file and found 1 packages
-				Scanned /home/rexpan/Documents/Projects/osv-scanner/cmd/osv-scanner/fixtures/locks-many/alpine.cdx.xml as CycloneDX SBOM and found 15 packages
+				Scanned %%/fixtures/locks-many/alpine.cdx.xml as CycloneDX SBOM and found 15 packages
 				Scanned %%/fixtures/locks-many/composer.lock file and found 1 packages
 				Scanned %%/fixtures/locks-many/yarn.lock file and found 1 packages
 			`,

--- a/internal/sbom/cyclonedx.go
+++ b/internal/sbom/cyclonedx.go
@@ -22,8 +22,8 @@ func (c *CycloneDX) Name() string {
 	return "CycloneDX"
 }
 
-func (s *CycloneDX) StandardFileName(path string) bool {
-	// From https://cyclonedx.org/specification/overview/#recognized-file-patterns
+func (c *CycloneDX) MatchesRecognizedFileNames(path string) bool {
+	// See https://cyclonedx.org/specification/overview/#recognized-file-patterns
 	expectedGlobs := []string{
 		"bom.xml",
 		"bom.json",

--- a/internal/sbom/cyclonedx.go
+++ b/internal/sbom/cyclonedx.go
@@ -3,6 +3,7 @@ package sbom
 import (
 	"fmt"
 	"io"
+	"path/filepath"
 	"strings"
 
 	"github.com/CycloneDX/cyclonedx-go"
@@ -19,6 +20,29 @@ var (
 
 func (c *CycloneDX) Name() string {
 	return "CycloneDX"
+}
+
+func (s *CycloneDX) StandardFileName(path string) bool {
+	expectedGlobs := []string{
+		"bom.xml",
+		"bom.json",
+		"*.cdx.json",
+		"*.cdx.xml",
+	}
+	filename := filepath.Base(path)
+	for _, v := range expectedGlobs {
+		matched, err := filepath.Match(v, filename)
+		if err != nil {
+			// Just panic since the only error is invalid glob pattern
+			panic("Glob pattern is invalid: " + err.Error())
+		}
+
+		if matched {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (c *CycloneDX) enumerateComponents(components []cyclonedx.Component, callback func(Identifier) error) error {

--- a/internal/sbom/cyclonedx.go
+++ b/internal/sbom/cyclonedx.go
@@ -23,6 +23,7 @@ func (c *CycloneDX) Name() string {
 }
 
 func (s *CycloneDX) StandardFileName(path string) bool {
+	// From https://cyclonedx.org/specification/overview/#recognized-file-patterns
 	expectedGlobs := []string{
 		"bom.xml",
 		"bom.json",

--- a/internal/sbom/sbom.go
+++ b/internal/sbom/sbom.go
@@ -14,7 +14,7 @@ type Identifier struct {
 type SBOMReader interface {
 	Name() string
 	// Checks if the file path is a standard recognized file name
-	StandardFileName(string) bool
+	MatchesRecognizedFileNames(string) bool
 	GetPackages(io.ReadSeeker, func(Identifier) error) error
 }
 

--- a/internal/sbom/sbom.go
+++ b/internal/sbom/sbom.go
@@ -13,6 +13,8 @@ type Identifier struct {
 // SBOMReader is an interface for all SBOM providers.
 type SBOMReader interface {
 	Name() string
+	// Checks if the file path is a standard recognized file name
+	StandardFileName(string) bool
 	GetPackages(io.ReadSeeker, func(Identifier) error) error
 }
 

--- a/internal/sbom/spdx.go
+++ b/internal/sbom/spdx.go
@@ -4,8 +4,10 @@ package sbom
 import (
 	"fmt"
 	"io"
+	"path/filepath"
+	"strings"
 
-	"github.com/spdx/tools-golang/json"
+	spdx_json "github.com/spdx/tools-golang/json"
 	"github.com/spdx/tools-golang/rdfloader"
 	"github.com/spdx/tools-golang/spdx/v2_3"
 	"github.com/spdx/tools-golang/tvloader"
@@ -24,6 +26,12 @@ var (
 
 func (s *SPDX) Name() string {
 	return "SPDX"
+}
+
+func (s *SPDX) StandardFileName(path string) bool {
+	// All spdx files should have the .spdx in the filename, even if
+	// it's not the extension:  https://spdx.github.io/spdx-spec/v2.3/conformance/
+	return strings.Contains(strings.ToLower(filepath.Base(path)), ".spdx")
 }
 
 func (s *SPDX) enumeratePackages(doc *v2_3.Document, callback func(Identifier) error) error {

--- a/internal/sbom/spdx.go
+++ b/internal/sbom/spdx.go
@@ -28,7 +28,7 @@ func (s *SPDX) Name() string {
 	return "SPDX"
 }
 
-func (s *SPDX) StandardFileName(path string) bool {
+func (s *SPDX) MatchesRecognizedFileNames(path string) bool {
 	// All spdx files should have the .spdx in the filename, even if
 	// it's not the extension:  https://spdx.github.io/spdx-spec/v2.3/conformance/
 	return strings.Contains(strings.ToLower(filepath.Base(path)), ".spdx")

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -222,22 +222,22 @@ func scanLockfile(r *output.Reporter, query *osv.BatchedQuery, path string, pars
 // scanSBOMFile will load, identify, and parse the SBOM path passed in, and add the dependencies specified
 // within to `query`
 func scanSBOMFile(r *output.Reporter, query *osv.BatchedQuery, path string) error {
-	file, err := os.Open(path)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
 	for _, provider := range sbom.Providers {
-		if provider.Name() == "SPDX" &&
-			!strings.Contains(strings.ToLower(filepath.Base(path)), ".spdx") {
-			// All spdx files should have the .spdx in the filename, even if
-			// it's not the extension:  https://spdx.github.io/spdx-spec/v2.3/conformance/
-			// Skip if this isn't the case to avoid panics
+		if !provider.StandardFileName(path) {
+			// Skip if filename is not usually a sbom file of this format
 			continue
 		}
+
+		// Opening file inside loop is OK, since providers is not very long,
+		// and it is unlikely that multiple providers accept the same file name
+		file, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+
 		count := 0
-		err := provider.GetPackages(file, func(id sbom.Identifier) error {
+		err = provider.GetPackages(file, func(id sbom.Identifier) error {
 			purlQuery := osv.MakePURLRequest(id.PURL)
 			purlQuery.Source = models.SourceInfo{
 				Path: path,

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -223,7 +223,7 @@ func scanLockfile(r *output.Reporter, query *osv.BatchedQuery, path string, pars
 // within to `query`
 func scanSBOMFile(r *output.Reporter, query *osv.BatchedQuery, path string) error {
 	for _, provider := range sbom.Providers {
-		if !provider.StandardFileName(path) {
+		if !provider.MatchesRecognizedFileNames(path) {
 			// Skip if filename is not usually a sbom file of this format
 			continue
 		}

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -250,7 +250,7 @@ func scanSBOMFile(r *output.Reporter, query *osv.BatchedQuery, path string) erro
 		})
 		if err == nil {
 			// Found the right format.
-			r.PrintText(fmt.Sprintf("Scanned %s SBOM and found %d packages\n", provider.Name(), count))
+			r.PrintText(fmt.Sprintf("Scanned %s as %s SBOM and found %d packages\n", path, provider.Name(), count))
 			return nil
 		}
 


### PR DESCRIPTION
Make sure the file name follows the recognized file names here: https://cyclonedx.org/specification/overview/#recognized-file-patterns

Resolves #257 

Also 
- adds tests for sboms,
- makes SBOM scan logging output consistent with lockfile scan logging output
- Minor refactor of SBOMs

I believe we will also want something similar to parse-as in lockfiles for SBOMs as well in the future to allow file names that doesn't conform to the standard to be scanned. 