### PR TITLE
fix: trim leading zeros off when comparing numerical components in Maven versions

### DIFF
--- a/internal/semantic/fixtures/maven-versions.txt
+++ b/internal/semantic/fixtures/maven-versions.txt
@@ -33,6 +33,9 @@
 1 = 1-0
 1 = 1.0-0
 1.0 = 1.0-0
+
+1.1 = 1.01
+
 // no separator between number and character
 1a = 1-a
 1a = 1.0-a

--- a/internal/semantic/version-maven.go
+++ b/internal/semantic/version-maven.go
@@ -40,7 +40,18 @@ func (vt *mavenVersionToken) shouldTrim() bool {
 }
 
 func (vt *mavenVersionToken) equal(wt mavenVersionToken) bool {
-	return vt.prefix == wt.prefix && vt.value == wt.value
+	if vt.prefix != wt.prefix {
+		return false
+	}
+
+	vv, vIsNumber := convertToBigInt(vt.value)
+	wv, wIsNumber := convertToBigInt(wt.value)
+
+	if vIsNumber && wIsNumber {
+		return vv.Cmp(wv) == 0
+	}
+
+	return vt.value == wt.value
 }
 
 //nolint:gochecknoglobals // this is read-only and the nicest implementation


### PR DESCRIPTION
This was found in the latest version of the generated maven versions fixture - I'm pretty sure this also is present in the API version too as it's also missing kind of function, but I've not tested that for sure.

I've not updated the generated fixture because I'm going to be following this up with a new generator workflow that will involve that, but this needs to be landed first otherwise _that_ PR will fail CI 😅 