### PR TITLE
Adding call graph info back in

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -71,3 +71,4 @@ slsa-verifier verify-artifact ./osv-scanner_1.2.0_linux_amd64 --provenance-path 
 ## SemVer Adherence
 
 All releases on the same Major version will be guaranteed to have backward compatible JSON output and CLI arguments.
+However, features prefixed with `experimental` (e.g. `--experimental-call-analysis`) might be changed or removed with only a Minor version change.

--- a/docs/output.md
+++ b/docs/output.md
@@ -114,7 +114,15 @@ osv-scanner --format json -L path/to/lockfile > /path/to/file.json
               "ids": [
                 "GHSA-c3h9-896r-86jm",
                 "GO-2021-0053"
-              ]
+              ],
+              // Call stack analysis is done using the `--experimental-call-analysis` flag
+              // and result is matched against data provided by the advisory to check if
+              // affected code is actually being executed.
+              "experimentalAnalysis": {
+                "GO-2021-0053": {
+                  "called": false
+                }
+              }
             }
           ]
         }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -95,6 +95,26 @@ it should infer the parser based on the filename:
 osv-scanner --lockfile ':/path/to/my:projects/package-lock.json'
 ```
 
+### Scanning with call analysis
+{: .note }
+Features and flags with the `experimental` prefix might change or be removed with only a minor version update.
+
+Call stack analysis can be performed on some languages to check if the 
+vulnerable code is actually being executed by your project. If the code
+is not being executed, these vulnerabilities will be marked as unexecuted.
+
+To enable call analysis, call OSV-Scanner with the `--experimental-call-analysis` flag.
+
+#### Supported languages
+- `go`
+  - Additional dependencies:
+    - `go` compiler needs to be installed and available on PATH
+
+#### Example
+```bash
+osv-scanner --experimental-call-analysis ./my/project/path
+```
+
 ### Scanning a Debian based docker image packages
 Preview
 {: .label } 


### PR DESCRIPTION
Adding call graph stuff back in now the current docs are on the docs branch. 