### PR TITLE
fix: trim leading zeros off when comparing numerical components in Maven versions (better)

### DIFF
--- a/internal/semantic/version-maven.go
+++ b/internal/semantic/version-maven.go
@@ -40,18 +40,7 @@ func (vt *mavenVersionToken) shouldTrim() bool {
 }
 
 func (vt *mavenVersionToken) equal(wt mavenVersionToken) bool {
-	if vt.prefix != wt.prefix {
-		return false
-	}
-
-	vv, vIsNumber := convertToBigInt(vt.value)
-	wv, wIsNumber := convertToBigInt(wt.value)
-
-	if vIsNumber && wIsNumber {
-		return vv.Cmp(wv) == 0
-	}
-
-	return vt.value == wt.value
+	return vt.prefix == wt.prefix && vt.value == wt.value
 }
 
 //nolint:gochecknoglobals // this is read-only and the nicest implementation
@@ -280,7 +269,7 @@ func newMavenVersion(str string) MavenVersion {
 			}
 
 			// remove any leading zeros
-			if d, isNumber := convertToBigInt(str); isNumber {
+			if d, isNumber := convertToBigInt(current); isNumber {
 				current = d.String()
 			}
 


### PR DESCRIPTION
While the fix I landed in https://github.com/google/osv-scanner/pull/279 was a fix, it wasn't the _best_ fix - really the bug was I'd used the wrong variable - @michaelkedar comment about [these tests](https://github.com/google/osv-scanner/pull/279#pullrequestreview-1334066731) catching this is the key (they pass because the whole string can be parsed as a number, meaning the incorrect condition is passing)