### PR TITLE
Renovate bot ignore vulns package

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,5 +24,8 @@
   ],
   "ignorePaths": [
     "**/fixtures/**"
+  ],
+  "ignoreDeps": [
+    "golang.org/x/vuln" 
   ]
 }


### PR DESCRIPTION
Because govulncheckvulns has now been updated to remove the API vulncheck API, but haven't added a new API yet. Remove this once new API is ready.