### PR TITLE
Check if PURL is valid before adding it to queries

### DIFF
--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -237,7 +237,13 @@ func scanSBOMFile(r *output.Reporter, query *osv.BatchedQuery, path string) erro
 		defer file.Close()
 
 		count := 0
+		ignoredCount := 0
 		err = provider.GetPackages(file, func(id sbom.Identifier) error {
+			_, err := PURLToPackage(id.PURL)
+			if err != nil {
+				ignoredCount++
+				return nil
+			}
 			purlQuery := osv.MakePURLRequest(id.PURL)
 			purlQuery.Source = models.SourceInfo{
 				Path: path,
@@ -250,7 +256,7 @@ func scanSBOMFile(r *output.Reporter, query *osv.BatchedQuery, path string) erro
 		})
 		if err == nil {
 			// Found the right format.
-			r.PrintText(fmt.Sprintf("Scanned %s as %s SBOM and found %d packages\n", path, provider.Name(), count))
+			r.PrintText(fmt.Sprintf("Scanned %s as %s SBOM and found %d packages, ignored %d invalid PURLs \n", path, provider.Name(), count, ignoredCount))
 			return nil
 		}
 

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -242,6 +242,7 @@ func scanSBOMFile(r *output.Reporter, query *osv.BatchedQuery, path string) erro
 			_, err := PURLToPackage(id.PURL)
 			if err != nil {
 				ignoredCount++
+				//nolint:nilerr
 				return nil
 			}
 			purlQuery := osv.MakePURLRequest(id.PURL)
@@ -256,7 +257,11 @@ func scanSBOMFile(r *output.Reporter, query *osv.BatchedQuery, path string) erro
 		})
 		if err == nil {
 			// Found the right format.
-			r.PrintText(fmt.Sprintf("Scanned %s as %s SBOM and found %d packages, ignored %d invalid PURLs \n", path, provider.Name(), count, ignoredCount))
+			r.PrintText(fmt.Sprintf("Scanned %s as %s SBOM and found %d packages\n", path, provider.Name(), count))
+			if ignoredCount > 0 {
+				r.PrintText(fmt.Sprintf("Ignored %d packages with invalid PURLs\n", ignoredCount))
+			}
+
 			return nil
 		}
 


### PR DESCRIPTION
This is also probably where having a verbosity level when reporting could be useful. By default we probably would not want to print out every invalid PURL, but this could be helpful if someone wants to find what invalid PURLs they have in their SBOM.