### PR TITLE
Prevent `.gitignore` files from interfering with tests

### DIFF
--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -4,10 +4,13 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/go-git/go-git/v5"
 )
 
 func dedent(t *testing.T, str string) string {
@@ -488,4 +491,15 @@ func TestRun_LockfileWithExplicitParseAs(t *testing.T) {
 			testCli(t, tt)
 		})
 	}
+}
+
+func TestMain(m *testing.M) {
+	// Temporarily make the fixtures folder a git repository to prevent gitignore files messing with tests.
+	_, err := git.PlainInit("./fixtures", false)
+	if err != nil {
+		panic(err)
+	}
+	code := m.Run()
+	os.RemoveAll("./fixtures/.git")
+	os.Exit(code)
 }


### PR DESCRIPTION
Should fix #286.
The issue was that the tests were expecting osv-scanner to be a git repository, and the downloading the GitHub release source files does not include the `.git` directory.

Fixed by initializing the `fixtures` directory as a git repository when running the tests, which both prevents git from walking past the folder, and parses the `.gitignore` files for the related test.