### PR TITLE
fix: avoid infinite loops parsing Maven poms with syntax errors

### DIFF
--- a/pkg/lockfile/fixtures/maven/invalid-syntax.xml
+++ b/pkg/lockfile/fixtures/maven/invalid-syntax.xml
@@ -1,0 +1,13 @@
+<project>
+  <properties>
+    <${Id}.version>${project.version}</${Id}.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-all</artifactId>
+      <version>4.1.42.Final</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/pkg/lockfile/parse-maven-lock.go
+++ b/pkg/lockfile/parse-maven-lock.go
@@ -76,7 +76,10 @@ func (p *MavenLockProperties) UnmarshalXML(d *xml.Decoder, start xml.StartElemen
 	p.m = map[string]string{}
 
 	for {
-		t, _ := d.Token()
+		t, err := d.Token()
+		if err != nil {
+			return err
+		}
 
 		switch tt := t.(type) {
 		case xml.StartElement:

--- a/pkg/lockfile/parse-maven-lock_test.go
+++ b/pkg/lockfile/parse-maven-lock_test.go
@@ -23,6 +23,15 @@ func TestParseMavenLock_Invalid(t *testing.T) {
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 
+func TestParseMavenLock_InvalidSyntax(t *testing.T) {
+	t.Parallel()
+
+	packages, err := lockfile.ParseMavenLock("fixtures/maven/invalid-syntax.xml")
+
+	expectErrContaining(t, err, "XML syntax error")
+	expectPackages(t, packages, []lockfile.PackageDetails{})
+}
+
 func TestParseMavenLock_NoPackages(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Resolves #293 