### PR TITLE
Set version in source code

### DIFF
--- a/cmd/osv-scanner/main.go
+++ b/cmd/osv-scanner/main.go
@@ -13,7 +13,8 @@ import (
 )
 
 var (
-	version = "dev"
+	// Update this variable when doing a release
+	version = "1.2.0"
 	commit  = "n/a"
 	date    = "n/a"
 )

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -115,7 +115,7 @@ func TestRun(t *testing.T) {
 			args:         []string{"", "--version"},
 			wantExitCode: 0,
 			wantStdout: `
-				osv-scanner version: dev
+				osv-scanner version: 1.2.0
 				commit: n/a
 				built at: n/a
 			`,


### PR DESCRIPTION
Set the release version in the source code. 

An alternative to setting the version directly in source code is to get package repositories to build their osv-scanner with goreleaser instead of go directly. While goreleaser is often already in most repositories, it is not as straightforward:

- Package repositories sometimes have their own guidelines for how to build go, e.g. Arch Linux go binaries must be built with hardened options which we currently do not do with goreleaser.
- goreleaser also expects to be in a git repository (to get version tags), but most build systems prefers downloading the source code in a tarball instead of checking out the repository. 