### PR TITLE
fix: support Pipenv develop packages without versions.

### DIFF
--- a/pkg/lockfile/fixtures/pipenv/no-version.json
+++ b/pkg/lockfile/fixtures/pipenv/no-version.json
@@ -22,5 +22,11 @@
             "ref": "b36054111bc1e8bbadb5d0d60158feb72926f467"
         }
     },
-    "develop": {}
+    "develop": {
+        "itsdangerous": {
+            "editable": true,
+            "git": "https://github.com/pallets/itsdangerous",
+            "ref": "de09cad488a4d7c7bbcbcdb8e1c2dfde64325f48"
+        }
+    }
 }

--- a/pkg/lockfile/parse-pipenv-lock.go
+++ b/pkg/lockfile/parse-pipenv-lock.go
@@ -32,33 +32,27 @@ func ParsePipenvLock(pathToLockfile string) ([]PackageDetails, error) {
 		return []PackageDetails{}, fmt.Errorf("could not parse %s: %w", pathToLockfile, err)
 	}
 
-	packages := make(map[string]PackageDetails)
+	details := make(map[string]PackageDetails)
 
-	for name, pipenvPackage := range parsedLockfile.Packages {
+	addPkgDetails(details, parsedLockfile.Packages)
+	addPkgDetails(details, parsedLockfile.PackagesDev)
+
+	return pkgDetailsMapToSlice(details), nil
+}
+
+func addPkgDetails(details map[string]PackageDetails, packages map[string]PipenvPackage) {
+	for name, pipenvPackage := range packages {
 		if pipenvPackage.Version == "" {
 			continue
 		}
 
 		version := pipenvPackage.Version[2:]
 
-		packages[name+"@"+version] = PackageDetails{
+		details[name+"@"+version] = PackageDetails{
 			Name:      name,
 			Version:   version,
 			Ecosystem: PipenvEcosystem,
 			CompareAs: PipenvEcosystem,
 		}
 	}
-
-	for name, pipenvPackage := range parsedLockfile.PackagesDev {
-		version := pipenvPackage.Version[2:]
-
-		packages[name+"@"+version] = PackageDetails{
-			Name:      name,
-			Version:   version,
-			Ecosystem: PipenvEcosystem,
-			CompareAs: PipenvEcosystem,
-		}
-	}
-
-	return pkgDetailsMapToSlice(packages), nil
 }


### PR DESCRIPTION
This extracts the shared detail parsing between default and develop packages.

Resolves #296 