### PR TITLE
SBOM parsing improvements.

### DIFF
--- a/.github/workflows/lint-action/action.yml
+++ b/.github/workflows/lint-action/action.yml
@@ -23,3 +23,5 @@ runs:
       with:
         # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
         version: v1.51.1
+        # https://github.com/golangci/golangci-lint-action/issues/135
+        skip-pkg-cache: true

--- a/.github/workflows/lint-action/action.yml
+++ b/.github/workflows/lint-action/action.yml
@@ -23,5 +23,3 @@ runs:
       with:
         # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
         version: v1.51.1
-        # https://github.com/golangci/golangci-lint-action/issues/135
-        skip-pkg-cache: true

--- a/internal/sbom/cyclonedx.go
+++ b/internal/sbom/cyclonedx.go
@@ -19,11 +19,11 @@ type cyclonedxType struct {
 
 var (
 	cycloneDXTypes = []cyclonedxType{
-		cyclonedxType{
+		{
 			name:    "json",
 			bomType: cyclonedx.BOMFileFormatJSON,
 		},
-		cyclonedxType{
+		{
 			name:    "xml",
 			bomType: cyclonedx.BOMFileFormatXML,
 		},
@@ -89,6 +89,7 @@ func (c *CycloneDX) enumeratePackages(bom *cyclonedx.BOM, callback func(Identifi
 }
 
 func (c *CycloneDX) GetPackages(r io.ReadSeeker, callback func(Identifier) error) error {
+	//nolint:prealloc // Not sure how many there will be in advance.
 	var errs []error
 	var bom cyclonedx.BOM
 
@@ -107,10 +108,10 @@ func (c *CycloneDX) GetPackages(r io.ReadSeeker, callback func(Identifier) error
 			}
 		}
 
-		errs = append(errs, fmt.Errorf("failed trying %s: %v", formatType.name, err))
+		errs = append(errs, fmt.Errorf("failed trying %s: %w", formatType.name, err))
 	}
 
-	return &ErrInvalidFormat{
+	return &InvalidFormatError{
 		msg:  "failed to parse CycloneDX",
 		errs: errs,
 	}

--- a/internal/sbom/cyclonedx.go
+++ b/internal/sbom/cyclonedx.go
@@ -111,7 +111,7 @@ func (c *CycloneDX) GetPackages(r io.ReadSeeker, callback func(Identifier) error
 		errs = append(errs, fmt.Errorf("failed trying %s: %w", formatType.name, err))
 	}
 
-	return &InvalidFormatError{
+	return InvalidFormatError{
 		msg:  "failed to parse CycloneDX",
 		errs: errs,
 	}

--- a/internal/sbom/cyclonedx.go
+++ b/internal/sbom/cyclonedx.go
@@ -1,6 +1,7 @@
 package sbom
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -11,10 +12,21 @@ import (
 
 type CycloneDX struct{}
 
+type cyclonedxType struct {
+	name    string
+	bomType cyclonedx.BOMFileFormat
+}
+
 var (
-	cycloneDXTypes = []cyclonedx.BOMFileFormat{
-		cyclonedx.BOMFileFormatJSON,
-		cyclonedx.BOMFileFormatXML,
+	cycloneDXTypes = []cyclonedxType{
+		cyclonedxType{
+			name:    "json",
+			bomType: cyclonedx.BOMFileFormatJSON,
+		},
+		cyclonedxType{
+			name:    "xml",
+			bomType: cyclonedx.BOMFileFormatXML,
+		},
 	}
 )
 
@@ -77,6 +89,7 @@ func (c *CycloneDX) enumeratePackages(bom *cyclonedx.BOM, callback func(Identifi
 }
 
 func (c *CycloneDX) GetPackages(r io.ReadSeeker, callback func(Identifier) error) error {
+	var errs []error
 	var bom cyclonedx.BOM
 
 	for _, formatType := range cycloneDXTypes {
@@ -84,12 +97,21 @@ func (c *CycloneDX) GetPackages(r io.ReadSeeker, callback func(Identifier) error
 		if err != nil {
 			return fmt.Errorf("failed to seek to start of file: %w", err)
 		}
-		decoder := cyclonedx.NewBOMDecoder(r, formatType)
+		decoder := cyclonedx.NewBOMDecoder(r, formatType.bomType)
 		err = decoder.Decode(&bom)
-		if err == nil && (bom.BOMFormat == "CycloneDX" || strings.HasPrefix(bom.XMLNS, "http://cyclonedx.org/schema/bom")) {
-			return c.enumeratePackages(&bom, callback)
+		if err == nil {
+			if bom.BOMFormat == "CycloneDX" || strings.HasPrefix(bom.XMLNS, "http://cyclonedx.org/schema/bom") {
+				return c.enumeratePackages(&bom, callback)
+			} else {
+				err = errors.New("invalid BOMFormat")
+			}
 		}
+
+		errs = append(errs, fmt.Errorf("failed trying %s: %v", formatType.name, err))
 	}
 
-	return ErrInvalidFormat
+	return &ErrInvalidFormat{
+		msg:  "failed to parse CycloneDX",
+		errs: errs,
+	}
 }

--- a/internal/sbom/sbom.go
+++ b/internal/sbom/sbom.go
@@ -31,7 +31,7 @@ type InvalidFormatError struct {
 	errs []error
 }
 
-func (e *InvalidFormatError) Error() string {
+func (e InvalidFormatError) Error() string {
 	errStrings := make([]string, 0, len(e.errs))
 	for _, e := range e.errs {
 		errStrings = append(errStrings, "\t"+e.Error())

--- a/internal/sbom/sbom.go
+++ b/internal/sbom/sbom.go
@@ -26,13 +26,13 @@ var (
 	}
 )
 
-type ErrInvalidFormat struct {
+type InvalidFormatError struct {
 	msg  string
 	errs []error
 }
 
-func (e *ErrInvalidFormat) Error() string {
-	var errStrings []string
+func (e *InvalidFormatError) Error() string {
+	errStrings := make([]string, 0, len(e.errs))
 	for _, e := range e.errs {
 		errStrings = append(errStrings, "\t"+e.Error())
 	}

--- a/internal/sbom/sbom.go
+++ b/internal/sbom/sbom.go
@@ -1,8 +1,9 @@
 package sbom
 
 import (
-	"errors"
+	"fmt"
 	"io"
+	"strings"
 )
 
 // Identifier is the identifier extracted from the SBOM.
@@ -19,12 +20,22 @@ type SBOMReader interface {
 }
 
 var (
-	ErrInvalidFormat = errors.New("invalid format")
-)
-
-var (
 	Providers = []SBOMReader{
 		&SPDX{},
 		&CycloneDX{},
 	}
 )
+
+type ErrInvalidFormat struct {
+	msg  string
+	errs []error
+}
+
+func (e *ErrInvalidFormat) Error() string {
+	var errStrings []string
+	for _, e := range e.errs {
+		errStrings = append(errStrings, "\t"+e.Error())
+	}
+
+	return fmt.Sprintf("%s:\n%s", e.msg, strings.Join(errStrings, "\n"))
+}

--- a/internal/sbom/spdx.go
+++ b/internal/sbom/spdx.go
@@ -23,15 +23,15 @@ type loader struct {
 
 var (
 	spdxLoaders = []loader{
-		loader{
+		{
 			name:   "json",
 			loader: spdx_json.Load2_3,
 		},
-		loader{
+		{
 			name:   "rdf",
 			loader: rdfloader.Load2_3,
 		},
-		loader{
+		{
 			name:   "tv",
 			loader: tvloader.Load2_3,
 		},
@@ -66,6 +66,7 @@ func (s *SPDX) enumeratePackages(doc *v2_3.Document, callback func(Identifier) e
 }
 
 func (s *SPDX) GetPackages(r io.ReadSeeker, callback func(Identifier) error) error {
+	//nolint:prealloc // Not sure how many there will be in advance.
 	var errs []error
 	for _, loader := range spdxLoaders {
 		_, err := r.Seek(0, io.SeekStart)
@@ -76,10 +77,10 @@ func (s *SPDX) GetPackages(r io.ReadSeeker, callback func(Identifier) error) err
 		if err == nil {
 			return s.enumeratePackages(doc, callback)
 		}
-		errs = append(errs, fmt.Errorf("failed trying %s: %v", loader.name, err))
+		errs = append(errs, fmt.Errorf("failed trying %s: %w", loader.name, err))
 	}
 
-	return &ErrInvalidFormat{
+	return &InvalidFormatError{
 		msg:  "failed to parse SPDX",
 		errs: errs,
 	}

--- a/internal/sbom/spdx.go
+++ b/internal/sbom/spdx.go
@@ -16,11 +16,25 @@ import (
 type SPDX struct{}
 type spdxLoader func(io.Reader) (*v2_3.Document, error)
 
+type loader struct {
+	name   string
+	loader spdxLoader
+}
+
 var (
-	spdxLoaders = []spdxLoader{
-		spdx_json.Load2_3,
-		rdfloader.Load2_3,
-		tvloader.Load2_3,
+	spdxLoaders = []loader{
+		loader{
+			name:   "json",
+			loader: spdx_json.Load2_3,
+		},
+		loader{
+			name:   "rdf",
+			loader: rdfloader.Load2_3,
+		},
+		loader{
+			name:   "tv",
+			loader: tvloader.Load2_3,
+		},
 	}
 )
 
@@ -52,16 +66,21 @@ func (s *SPDX) enumeratePackages(doc *v2_3.Document, callback func(Identifier) e
 }
 
 func (s *SPDX) GetPackages(r io.ReadSeeker, callback func(Identifier) error) error {
+	var errs []error
 	for _, loader := range spdxLoaders {
 		_, err := r.Seek(0, io.SeekStart)
 		if err != nil {
 			return fmt.Errorf("failed to seek to start of file: %w", err)
 		}
-		doc, err := loader(r)
+		doc, err := loader.loader(r)
 		if err == nil {
 			return s.enumeratePackages(doc, callback)
 		}
+		errs = append(errs, fmt.Errorf("failed trying %s: %v", loader.name, err))
 	}
 
-	return ErrInvalidFormat
+	return &ErrInvalidFormat{
+		msg:  "failed to parse SPDX",
+		errs: errs,
+	}
 }

--- a/internal/sbom/spdx.go
+++ b/internal/sbom/spdx.go
@@ -80,7 +80,7 @@ func (s *SPDX) GetPackages(r io.ReadSeeker, callback func(Identifier) error) err
 		errs = append(errs, fmt.Errorf("failed trying %s: %w", loader.name, err))
 	}
 
-	return &InvalidFormatError{
+	return InvalidFormatError{
 		msg:  "failed to parse SPDX",
 		errs: errs,
 	}

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -286,6 +286,7 @@ func scanSBOMFile(r *output.Reporter, query *osv.BatchedQuery, path string, from
 			r.PrintText(err.Error() + "\n")
 		}
 	}
+
 	return nil
 }
 

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -270,7 +270,7 @@ func scanSBOMFile(r *output.Reporter, query *osv.BatchedQuery, path string, from
 			return nil
 		}
 
-		if _, ok := err.(*sbom.ErrInvalidFormat); ok {
+		if _, ok := err.(*sbom.InvalidFormatError); ok {
 			errs = append(errs, err)
 			continue
 		}

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -270,7 +270,8 @@ func scanSBOMFile(r *output.Reporter, query *osv.BatchedQuery, path string, from
 			return nil
 		}
 
-		if _, ok := err.(*sbom.InvalidFormatError); ok {
+		var formatErr sbom.InvalidFormatError
+		if errors.As(err, &formatErr) {
 			errs = append(errs, err)
 			continue
 		}

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -498,8 +498,6 @@ func DoScan(actions ScannerActions, r *output.Reporter) (models.VulnerabilityRes
 		if err != nil {
 			return models.VulnerabilityResults{}, fmt.Errorf("failed to resolved path with error %w", err)
 		}
-		// If this is passed as an explicit SBOM, don't validate the filename since it's common
-		// for filenames to not conform to the spec and cause user confusion.
 		err = scanSBOMFile(r, &query, sbomElem, false)
 		if err != nil {
 			return models.VulnerabilityResults{}, err


### PR DESCRIPTION
Addresses part of #335

1. Be more relaxed about filename matching the spec when the SBOM is explicitly passed via --sbom since we've seen multiple complaints from different users about this.
2. Surface all parse errors when SBOM parsing fails (and we're explicitly scanning via --sbom).

This will look something like:

```
Failed to parse SBOM using all supported formats:
failed to parse SPDX:
        failed trying json: failed to parse Supplier 'Google LLC'
        failed trying rdf: found extra chars before tag start
        failed trying tv: no colon found in '{'
failed to parse CycloneDX:
        failed trying json: invalid BOMFormat
        failed trying xml: XML syntax error on line 74: expected attribute name in element
No package sources found, --help for usage information.
exit status 128
```