### PR TITLE
Set `skip-pkg-cache: true` for golangci-lint

### DIFF
--- a/.github/workflows/lint-action/action.yml
+++ b/.github/workflows/lint-action/action.yml
@@ -23,3 +23,5 @@ runs:
       with:
         # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
         version: v1.51.1
+        # https://github.com/golangci/golangci-lint-action/issues/135
+        skip-pkg-cache: true


### PR DESCRIPTION
This occassionally causes issues for our linter like: https://github.com/google/osv-scanner/actions/runs/4675534898

See https://github.com/golangci/golangci-lint-action/issues/135.