### PR TITLE
[cli output] added new column "Fixed versions" in cli table output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 .vscode/
 /dist/
 /osv-scanner
+osv
+Makefile
+requirements.txt


### PR DESCRIPTION

Added new column in cli table output

![image](https://user-images.githubusercontent.com/4498415/231729865-da6f87f7-bcd0-4d77-aa6e-2cc179493388.png)

Dev can quickly know what versions in ecosystem the vulnerabilities are fixed
