### PR TITLE
Fix sbom scanning code

### DIFF
--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -263,12 +263,14 @@ func scanSBOMFile(r reporter.Reporter, query *osv.BatchedQuery, path string, fro
 		if err == nil {
 			// Found the right format.
 			if count == 0 {
-				return sbom.InvalidFormatError{
+				errs = append(errs, sbom.InvalidFormatError{
 					Msg: "no Package URLs found",
 					Errs: []error{
 						fmt.Errorf("scanned %s as %s SBOM, but failed to find any package URLs, this is required to scan SBOMs", path, provider.Name()),
 					},
-				}
+				})
+
+				continue
 			}
 			r.PrintText(fmt.Sprintf("Scanned %s as %s SBOM and found %d packages\n", path, provider.Name(), count))
 			if ignoredCount > 0 {

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -261,8 +261,9 @@ func scanSBOMFile(r reporter.Reporter, query *osv.BatchedQuery, path string, fro
 			return nil
 		})
 		if err == nil {
-			// Found the right format.
+			// Found a parsable format.
 			if count == 0 {
+				// But no entries found, so maybe not the correct format
 				errs = append(errs, sbom.InvalidFormatError{
 					Msg: "no Package URLs found",
 					Errs: []error{


### PR DESCRIPTION
Bug in sbom scanning code to quit immediately after successfully parsing but not finding any packages, rather than trying all formats.