### PR TITLE
PURLs on stdin

### DIFF
--- a/cmd/osv-scanner/main.go
+++ b/cmd/osv-scanner/main.go
@@ -142,8 +142,6 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 				}
 			}
 
-			// r.PrintText("\nScanning...\n")
-
 			vulnResult, err := osvscanner.DoScan(osvscanner.ScannerActions{
 				LockfilePaths:            context.StringSlice("lockfile"),
 				SBOMPaths:                context.StringSlice("sbom"),

--- a/cmd/osv-scanner/main.go
+++ b/cmd/osv-scanner/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/google/osv-scanner/pkg/osv"
 	"github.com/google/osv-scanner/pkg/osvscanner"
@@ -135,7 +136,11 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 				r.PrintText("Enter Package URLs, one per line, finishing with EOF:\n")
 				scanner := bufio.NewScanner(stdin)
 				for scanner.Scan() {
-					purls = append(purls, scanner.Text())
+					trimmedLine := strings.TrimSpace(scanner.Text())
+					if len(trimmedLine) == 0 {
+						continue
+					}
+					purls = append(purls, trimmedLine)
 				}
 
 				if err := scanner.Err(); err != nil {

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -115,15 +115,15 @@ func TestRun(t *testing.T) {
         No package sources found, --help for usage information.
 			`,
 		},
-
 		{
 			name:         "",
-			args:         []string{""},
-			wantExitCode: 128,
-			wantStdout:   "",
-			wantStderr: `
-        No package sources found, --help for usage information.
-			`,
+			args:         []string{"", "--version"},
+			wantExitCode: 0,
+			wantStdout: fmt.Sprintf(`
+				osv-scanner version: %s
+				commit: n/a
+				built at: n/a
+			`, version),
 		},
 		{
 			name:         "PURLs from stdin",

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -537,6 +537,8 @@ func DoScan(actions ScannerActions, r reporter.Reporter) (models.VulnerabilityRe
 		query.Queries = append(query.Queries, osv.MakePURLRequest(purl))
 	}
 
+	// r.PrintText(fmt.Sprintf("%v", query.Queries))
+
 	if len(query.Queries) == 0 {
 		return models.VulnerabilityResults{}, NoPackagesFoundErr
 	}

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -27,6 +27,7 @@ type ScannerActions struct {
 	SBOMPaths            []string
 	DirectoryPaths       []string
 	GitCommits           []string
+	Purls                []string
 	Recursive            bool
 	SkipGit              bool
 	NoIgnore             bool
@@ -530,6 +531,10 @@ func DoScan(actions ScannerActions, r reporter.Reporter) (models.VulnerabilityRe
 		if err != nil {
 			return models.VulnerabilityResults{}, err
 		}
+	}
+
+	for _, purl := range actions.Purls {
+		query.Queries = append(query.Queries, osv.MakePURLRequest(purl))
 	}
 
 	if len(query.Queries) == 0 {


### PR DESCRIPTION
Read package urls line by line on the Stdin, this allows the user flexibility to connect up their own parser (e.g. for formats we don't support) for their manifest files and pipe the results directly into osv-scanner. 