### PR TITLE
Add withdrawn and fix time serialization to conform to the schema.

### DIFF
--- a/pkg/models/vulnerability.go
+++ b/pkg/models/vulnerability.go
@@ -148,7 +148,7 @@ func (v Vulnerability) MarshalJSON() ([]byte, error) {
 	return json.Marshal(raw)
 }
 
-// MarshalJSON implements the json.Marshaler interface.
+// MarshalYAML implements the yaml.Marshaler interface.
 //
 // This method ensures times all times are formated correctly.
 func (v Vulnerability) MarshalYAML() (interface{}, error) {

--- a/pkg/models/vulnerability.go
+++ b/pkg/models/vulnerability.go
@@ -145,6 +145,7 @@ func (v Vulnerability) MarshalJSON() ([]byte, error) {
 	if !v.Withdrawn.IsZero() {
 		raw.Withdrawn = v.Withdrawn.UTC().Format(time.RFC3339)
 	}
+
 	return json.Marshal(raw)
 }
 
@@ -163,5 +164,6 @@ func (v Vulnerability) MarshalYAML() (interface{}, error) {
 	if !v.Withdrawn.IsZero() {
 		raw.Withdrawn = v.Withdrawn.UTC()
 	}
+
 	return raw, nil
 }

--- a/pkg/models/vulnerability.go
+++ b/pkg/models/vulnerability.go
@@ -73,7 +73,7 @@ type Affected struct {
 func (a Affected) MarshalJSON() ([]byte, error) {
 	type rawAffected Affected // alias Affected to avoid recursion during Marshal
 	type wrapper struct {
-		Package *Package `json:"package,omitempty" yaml:"package,omitempty"`
+		Package *Package `json:"package,omitempty"`
 		rawAffected
 	}
 	raw := wrapper{rawAffected: rawAffected(a)}
@@ -114,6 +114,7 @@ type Vulnerability struct {
 	ID               string                 `json:"id" yaml:"id"`
 	Modified         time.Time              `json:"modified" yaml:"modified"`
 	Published        time.Time              `json:"published,omitempty" yaml:"published,omitempty"`
+	Withdrawn        time.Time              `json:"withdrawn,omitempty" yaml:"withdrawn,omitempty"`
 	Aliases          []string               `json:"aliases,omitempty" yaml:"aliases,omitempty"`
 	Related          []string               `json:"related,omitempty" yaml:"related,omitempty"`
 	Summary          string                 `json:"summary,omitempty" yaml:"summary,omitempty"`
@@ -123,4 +124,44 @@ type Vulnerability struct {
 	References       []Reference            `json:"references,omitempty" yaml:"references,omitempty"`
 	Credits          []Credit               `json:"credits,omitempty" yaml:"credits,omitempty"`
 	DatabaseSpecific map[string]interface{} `json:"database_specific,omitempty" yaml:"database_specific,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+//
+// This method ensures times all times are formated correctly according to the schema.
+func (v Vulnerability) MarshalJSON() ([]byte, error) {
+	type rawVulnerability Vulnerability // alias Vulnerability to avoid recursion during Marshal
+	type wrapper struct {
+		Modified  string `json:"modified"`
+		Published string `json:"published,omitempty"`
+		Withdrawn string `json:"withdrawn,omitempty"`
+		rawVulnerability
+	}
+	raw := wrapper{rawVulnerability: rawVulnerability(v)}
+	raw.Modified = v.Modified.UTC().Format(time.RFC3339)
+	if !v.Published.IsZero() {
+		raw.Published = v.Published.UTC().Format(time.RFC3339)
+	}
+	if !v.Withdrawn.IsZero() {
+		raw.Withdrawn = v.Withdrawn.UTC().Format(time.RFC3339)
+	}
+	return json.Marshal(raw)
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+//
+// This method ensures times all times are formated correctly.
+func (v Vulnerability) MarshalYAML() (interface{}, error) {
+	type rawVulnerability Vulnerability // alias Vulnerability to avoid recursion during Marshal
+	raw := rawVulnerability(v)
+	if !v.Modified.IsZero() {
+		raw.Modified = v.Modified.UTC()
+	}
+	if !v.Published.IsZero() {
+		raw.Published = v.Published.UTC()
+	}
+	if !v.Withdrawn.IsZero() {
+		raw.Withdrawn = v.Withdrawn.UTC()
+	}
+	return raw, nil
 }

--- a/pkg/models/vulnerability_test.go
+++ b/pkg/models/vulnerability_test.go
@@ -113,19 +113,19 @@ func TestVulnerability_MarshalJSONTimes(t *testing.T) {
 
 	tests := []struct {
 		name string
-		vuln Vulnerability
+		vuln models.Vulnerability
 		want string
 	}{
 		{
 			name: "empty",
-			vuln: Vulnerability{
+			vuln: models.Vulnerability{
 				ID: "TEST-0000",
 			},
 			want: `{"modified":"0001-01-01T00:00:00Z","id":"TEST-0000"}`,
 		},
 		{
 			name: "no withdraw",
-			vuln: Vulnerability{
+			vuln: models.Vulnerability{
 				ID:        "TEST-0000",
 				Modified:  time.Date(2023, 12, 1, 12, 30, 30, 0, time.UTC),
 				Published: time.Date(2021, 6, 30, 1, 0, 0, 0, time.UTC),
@@ -134,7 +134,7 @@ func TestVulnerability_MarshalJSONTimes(t *testing.T) {
 		},
 		{
 			name: "all UTC",
-			vuln: Vulnerability{
+			vuln: models.Vulnerability{
 				ID:        "TEST-0000",
 				Modified:  time.Date(2023, 12, 1, 12, 30, 30, 0, time.UTC),
 				Published: time.Date(2021, 6, 30, 1, 0, 0, 0, time.UTC),
@@ -144,7 +144,7 @@ func TestVulnerability_MarshalJSONTimes(t *testing.T) {
 		},
 		{
 			name: "all Los Angeles",
-			vuln: Vulnerability{
+			vuln: models.Vulnerability{
 				ID:        "TEST-0000",
 				Modified:  time.Date(2023, 12, 1, 12, 30, 30, 0, losAngeles),
 				Published: time.Date(2021, 6, 30, 1, 0, 0, 0, losAngeles),
@@ -177,19 +177,19 @@ func TestVulnerability_MarshalYAMLTimes(t *testing.T) {
 
 	tests := []struct {
 		name string
-		vuln Vulnerability
+		vuln models.Vulnerability
 		want string
 	}{
 		{
 			name: "empty",
-			vuln: Vulnerability{
+			vuln: models.Vulnerability{
 				ID: "TEST-0000",
 			},
 			want: "id: TEST-0000\nmodified: 0001-01-01T00:00:00Z\n",
 		},
 		{
 			name: "no withdraw",
-			vuln: Vulnerability{
+			vuln: models.Vulnerability{
 				ID:        "TEST-0000",
 				Modified:  time.Date(2023, 12, 1, 12, 30, 30, 0, time.UTC),
 				Published: time.Date(2021, 6, 30, 1, 0, 0, 0, time.UTC),
@@ -198,7 +198,7 @@ func TestVulnerability_MarshalYAMLTimes(t *testing.T) {
 		},
 		{
 			name: "all UTC",
-			vuln: Vulnerability{
+			vuln: models.Vulnerability{
 				ID:        "TEST-0000",
 				Modified:  time.Date(2023, 12, 1, 12, 30, 30, 0, time.UTC),
 				Published: time.Date(2021, 6, 30, 1, 0, 0, 0, time.UTC),
@@ -208,7 +208,7 @@ func TestVulnerability_MarshalYAMLTimes(t *testing.T) {
 		},
 		{
 			name: "all Los Angeles",
-			vuln: Vulnerability{
+			vuln: models.Vulnerability{
 				ID:        "TEST-0000",
 				Modified:  time.Date(2023, 12, 1, 12, 30, 30, 0, losAngeles),
 				Published: time.Date(2021, 6, 30, 1, 0, 0, 0, losAngeles),

--- a/pkg/models/vulnerability_test.go
+++ b/pkg/models/vulnerability_test.go
@@ -154,6 +154,7 @@ func TestVulnerability_MarshalJSONTimes(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := json.Marshal(test.vuln)
 			if err != nil {
 				t.Fatalf("Marshal() = %v; want no error", err)

--- a/pkg/models/vulnerability_test.go
+++ b/pkg/models/vulnerability_test.go
@@ -153,14 +153,15 @@ func TestVulnerability_MarshalJSONTimes(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+		innerTest := test
+		t.Run(innerTest.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := json.Marshal(test.vuln)
+			got, err := json.Marshal(innerTest.vuln)
 			if err != nil {
 				t.Fatalf("Marshal() = %v; want no error", err)
 			}
-			if string(got) != test.want {
-				t.Errorf("Marshal() = %v; want %v", string(got), test.want)
+			if string(got) != innerTest.want {
+				t.Errorf("Marshal() = %v; want %v", string(got), innerTest.want)
 			}
 		})
 	}

--- a/pkg/models/vulnerability_test.go
+++ b/pkg/models/vulnerability_test.go
@@ -224,7 +224,7 @@ func TestVulnerability_MarshalYAMLTimes(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Marshal() = %v; want no error", err)
 			}
-			if string(got) != test.want {
+			if string(got) != innerTest.want {
 				t.Errorf("Marshal() = %v; want %v", string(got), innerTest.want)
 			}
 		})

--- a/pkg/models/vulnerability_test.go
+++ b/pkg/models/vulnerability_test.go
@@ -217,13 +217,15 @@ func TestVulnerability_MarshalYAMLTimes(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			got, err := yaml.Marshal(test.vuln)
+		innerTest := test
+		t.Run(innerTest.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := yaml.Marshal(innerTest.vuln)
 			if err != nil {
 				t.Fatalf("Marshal() = %v; want no error", err)
 			}
 			if string(got) != test.want {
-				t.Errorf("Marshal() = %v; want %v", string(got), test.want)
+				t.Errorf("Marshal() = %v; want %v", string(got), innerTest.want)
 			}
 		})
 	}

--- a/pkg/models/vulnerability_test.go
+++ b/pkg/models/vulnerability_test.go
@@ -3,6 +3,7 @@ package models
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -22,7 +23,7 @@ func TestAffected_MarshalJSONWithPackage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Marshal() = %v; want no error", err)
 	}
-	want := `{"id":"TEST-0000","modified":"0001-01-01T00:00:00Z","published":"0001-01-01T00:00:00Z","affected":[{"package":{"ecosystem":"PyPI","name":"requests"},"versions":["1.0.0"]}]}`
+	want := `{"modified":"0001-01-01T00:00:00Z","id":"TEST-0000","affected":[{"package":{"ecosystem":"PyPI","name":"requests"},"versions":["1.0.0"]}]}`
 	if string(got) != want {
 		t.Errorf("Marshal() = %v; want %v", string(got), want)
 	}
@@ -42,7 +43,7 @@ func TestAffected_MarshalJSONWithoutPackage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Marshal() = %v; want no error", err)
 	}
-	want := `{"id":"TEST-0000","modified":"0001-01-01T00:00:00Z","published":"0001-01-01T00:00:00Z","affected":[{"versions":["1.0.0"]}]}`
+	want := `{"modified":"0001-01-01T00:00:00Z","id":"TEST-0000","affected":[{"versions":["1.0.0"]}]}`
 	if string(got) != want {
 		t.Errorf("Marshal() = %v; want %v", string(got), want)
 	}
@@ -99,5 +100,129 @@ affected:
 `
 	if string(got) != want {
 		t.Errorf("Marshal() = %v; want %v", string(got), want)
+	}
+}
+
+func TestVulnerability_MarshalJSONTimes(t *testing.T) {
+	t.Parallel()
+	losAngeles, err := time.LoadLocation("America/Los_Angeles")
+	if err != nil {
+		panic(err)
+	}
+
+	tests := []struct {
+		name string
+		vuln Vulnerability
+		want string
+	}{
+		{
+			name: "empty",
+			vuln: Vulnerability{
+				ID: "TEST-0000",
+			},
+			want: `{"modified":"0001-01-01T00:00:00Z","id":"TEST-0000"}`,
+		},
+		{
+			name: "no withdraw",
+			vuln: Vulnerability{
+				ID:        "TEST-0000",
+				Modified:  time.Date(2023, 12, 1, 12, 30, 30, 0, time.UTC),
+				Published: time.Date(2021, 6, 30, 1, 0, 0, 0, time.UTC),
+			},
+			want: `{"modified":"2023-12-01T12:30:30Z","published":"2021-06-30T01:00:00Z","id":"TEST-0000"}`,
+		},
+		{
+			name: "all UTC",
+			vuln: Vulnerability{
+				ID:        "TEST-0000",
+				Modified:  time.Date(2023, 12, 1, 12, 30, 30, 0, time.UTC),
+				Published: time.Date(2021, 6, 30, 1, 0, 0, 0, time.UTC),
+				Withdrawn: time.Date(2022, 1, 15, 23, 59, 59, 0, time.UTC),
+			},
+			want: `{"modified":"2023-12-01T12:30:30Z","published":"2021-06-30T01:00:00Z","withdrawn":"2022-01-15T23:59:59Z","id":"TEST-0000"}`,
+		},
+		{
+			name: "all Los Angeles",
+			vuln: Vulnerability{
+				ID:        "TEST-0000",
+				Modified:  time.Date(2023, 12, 1, 12, 30, 30, 0, losAngeles),
+				Published: time.Date(2021, 6, 30, 1, 0, 0, 0, losAngeles),
+				Withdrawn: time.Date(2022, 1, 15, 23, 59, 59, 0, losAngeles),
+			},
+			want: `{"modified":"2023-12-01T20:30:30Z","published":"2021-06-30T08:00:00Z","withdrawn":"2022-01-16T07:59:59Z","id":"TEST-0000"}`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := json.Marshal(test.vuln)
+			if err != nil {
+				t.Fatalf("Marshal() = %v; want no error", err)
+			}
+			if string(got) != test.want {
+				t.Errorf("Marshal() = %v; want %v", string(got), test.want)
+			}
+		})
+	}
+}
+
+func TestVulnerability_MarshalYAMLTimes(t *testing.T) {
+	t.Parallel()
+	losAngeles, err := time.LoadLocation("America/Los_Angeles")
+	if err != nil {
+		panic(err)
+	}
+
+	tests := []struct {
+		name string
+		vuln Vulnerability
+		want string
+	}{
+		{
+			name: "empty",
+			vuln: Vulnerability{
+				ID: "TEST-0000",
+			},
+			want: "id: TEST-0000\nmodified: 0001-01-01T00:00:00Z\n",
+		},
+		{
+			name: "no withdraw",
+			vuln: Vulnerability{
+				ID:        "TEST-0000",
+				Modified:  time.Date(2023, 12, 1, 12, 30, 30, 0, time.UTC),
+				Published: time.Date(2021, 6, 30, 1, 0, 0, 0, time.UTC),
+			},
+			want: "id: TEST-0000\nmodified: 2023-12-01T12:30:30Z\npublished: 2021-06-30T01:00:00Z\n",
+		},
+		{
+			name: "all UTC",
+			vuln: Vulnerability{
+				ID:        "TEST-0000",
+				Modified:  time.Date(2023, 12, 1, 12, 30, 30, 0, time.UTC),
+				Published: time.Date(2021, 6, 30, 1, 0, 0, 0, time.UTC),
+				Withdrawn: time.Date(2022, 1, 15, 23, 59, 59, 0, time.UTC),
+			},
+			want: "id: TEST-0000\nmodified: 2023-12-01T12:30:30Z\npublished: 2021-06-30T01:00:00Z\nwithdrawn: 2022-01-15T23:59:59Z\n",
+		},
+		{
+			name: "all Los Angeles",
+			vuln: Vulnerability{
+				ID:        "TEST-0000",
+				Modified:  time.Date(2023, 12, 1, 12, 30, 30, 0, losAngeles),
+				Published: time.Date(2021, 6, 30, 1, 0, 0, 0, losAngeles),
+				Withdrawn: time.Date(2022, 1, 15, 23, 59, 59, 0, losAngeles),
+			},
+			want: "id: TEST-0000\nmodified: 2023-12-01T20:30:30Z\npublished: 2021-06-30T08:00:00Z\nwithdrawn: 2022-01-16T07:59:59Z\n",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := yaml.Marshal(test.vuln)
+			if err != nil {
+				t.Fatalf("Marshal() = %v; want no error", err)
+			}
+			if string(got) != test.want {
+				t.Errorf("Marshal() = %v; want %v", string(got), test.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
- withdrawn timestamp does not exist in the model - add it to the model.
- fix the timestamp serialization to ensure published and withdrawn are *only* present when the value is not zero
- fix timestamp serialization to use RFC3339 for JSON (it uses RFC3339Nano by default)
- fix the timestamps to be normalized to UTC as per the schema