### PR TITLE
test: ensure fixtures directory isn't already a git repository

### DIFF
--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -506,6 +506,10 @@ func TestRun_LockfileWithExplicitParseAs(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
+	// ensure a git repository doesn't already exist in the fixtures directory,
+	// in case we didn't get a chance to clean-up properly in the last run
+	os.RemoveAll("./fixtures/.git")
+
 	// Temporarily make the fixtures folder a git repository to prevent gitignore files messing with tests.
 	_, err := git.PlainInit("./fixtures", false)
 	if err != nil {


### PR DESCRIPTION
Currently if the test suite is exited prematurely by a ctrl+c or if it runs badly such as due to invalid flags being passed, it'll not properly do its cleanup - this'll then cause the suite to fail with a panic until the `.git` directory is manually removed from `.cmd/osv-scanner/fixtures`.