### PR TITLE
Fix PURLToPackage function and move it

### DIFF
--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -147,7 +147,7 @@ func TestRun(t *testing.T) {
 				+-------------------------------------+------+-----------+--------------------------------+------------------------------------+-------------------------------------------------+
 				| OSV URL                             | CVSS | ECOSYSTEM | PACKAGE                        | VERSION                            | SOURCE                                          |
 				+-------------------------------------+------+-----------+--------------------------------+------------------------------------+-------------------------------------------------+
-				| https://osv.dev/DLA-3022-1          |      | Debian    | debian/dpkg                    | 1.18.25                            | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
+				| https://osv.dev/DLA-3022-1          |      | Debian    | dpkg                           | 1.18.25                            | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 				| https://osv.dev/GHSA-v95c-p5hm-xq8f | 6    | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 				| https://osv.dev/GO-2022-0274        |      |           |                                |                                    |                                                 |
 				| https://osv.dev/GHSA-f3fp-gc8g-vw66 | 5.9  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
@@ -156,9 +156,9 @@ func TestRun(t *testing.T) {
 				| https://osv.dev/GHSA-vpvm-3wq2-2wvm | 7    | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 				| https://osv.dev/GHSA-p782-xgp4-8hr8 | 5.3  | Go        | golang.org/x/sys               | v0.0.0-20210817142637-7d9622a276b7 | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 				| https://osv.dev/GO-2022-0493        |      |           |                                |                                    |                                                 |
-				| https://osv.dev/DLA-3012-1          |      | Debian    | debian/libxml2                 | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-				| https://osv.dev/DLA-3008-1          |      | Debian    | debian/openssl                 | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-				| https://osv.dev/DLA-3051-1          |      | Debian    | debian/tzdata                  | 2021a-0+deb9u3                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
+				| https://osv.dev/DLA-3012-1          |      | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
+				| https://osv.dev/DLA-3008-1          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
+				| https://osv.dev/DLA-3051-1          |      | Debian    | tzdata                         | 2021a-0+deb9u3                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 				+-------------------------------------+------+-----------+--------------------------------+------------------------------------+-------------------------------------------------+
 			`,
 			wantStderr: "",

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -144,22 +144,22 @@ func TestRun(t *testing.T) {
 			wantStdout: `
 				Scanning dir ./fixtures/sbom-insecure/postgres-stretch.cdx.xml
 				Scanned %%/fixtures/sbom-insecure/postgres-stretch.cdx.xml as CycloneDX SBOM and found 136 packages
-				+-------------------------------------+------+-----------+---------+------------------------------------+-------------------------------------------------+
-				| OSV URL                             | CVSS | ECOSYSTEM | PACKAGE | VERSION                            | SOURCE                                          |
-				+-------------------------------------+------+-----------+---------+------------------------------------+-------------------------------------------------+
-				| https://osv.dev/DLA-3022-1          |      | Debian    | dpkg    | 1.18.25                            | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-				| https://osv.dev/GHSA-v95c-p5hm-xq8f | 6    | Go        | runc    | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-				| https://osv.dev/GO-2022-0274        |      |           |         |                                    |                                                 |
-				| https://osv.dev/GHSA-f3fp-gc8g-vw66 | 5.9  | Go        | runc    | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-				| https://osv.dev/GHSA-g2j6-57v7-gm8c | 6.1  | Go        | runc    | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-				| https://osv.dev/GHSA-m8cg-xc2p-r3fc | 2.5  | Go        | runc    | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-				| https://osv.dev/GHSA-vpvm-3wq2-2wvm | 7    | Go        | runc    | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-				| https://osv.dev/GHSA-p782-xgp4-8hr8 | 5.3  | Go        | sys     | v0.0.0-20210817142637-7d9622a276b7 | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-				| https://osv.dev/GO-2022-0493        |      |           |         |                                    |                                                 |
-				| https://osv.dev/DLA-3012-1          |      | Debian    | libxml2 | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-				| https://osv.dev/DLA-3008-1          |      | Debian    | openssl | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-				| https://osv.dev/DLA-3051-1          |      | Debian    | tzdata  | 2021a-0+deb9u3                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-				+-------------------------------------+------+-----------+---------+------------------------------------+-------------------------------------------------+
+				+-------------------------------------+------+-----------+--------------------------------+------------------------------------+-------------------------------------------------+
+				| OSV URL                             | CVSS | ECOSYSTEM | PACKAGE                        | VERSION                            | SOURCE                                          |
+				+-------------------------------------+------+-----------+--------------------------------+------------------------------------+-------------------------------------------------+
+				| https://osv.dev/DLA-3022-1          |      | Debian    | debian/dpkg                    | 1.18.25                            | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
+				| https://osv.dev/GHSA-v95c-p5hm-xq8f | 6    | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
+				| https://osv.dev/GO-2022-0274        |      |           |                                |                                    |                                                 |
+				| https://osv.dev/GHSA-f3fp-gc8g-vw66 | 5.9  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
+				| https://osv.dev/GHSA-g2j6-57v7-gm8c | 6.1  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
+				| https://osv.dev/GHSA-m8cg-xc2p-r3fc | 2.5  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
+				| https://osv.dev/GHSA-vpvm-3wq2-2wvm | 7    | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
+				| https://osv.dev/GHSA-p782-xgp4-8hr8 | 5.3  | Go        | golang.org/x/sys               | v0.0.0-20210817142637-7d9622a276b7 | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
+				| https://osv.dev/GO-2022-0493        |      |           |                                |                                    |                                                 |
+				| https://osv.dev/DLA-3012-1          |      | Debian    | debian/libxml2                 | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
+				| https://osv.dev/DLA-3008-1          |      | Debian    | debian/openssl                 | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
+				| https://osv.dev/DLA-3051-1          |      | Debian    | debian/tzdata                  | 2021a-0+deb9u3                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
+				+-------------------------------------+------+-----------+--------------------------------+------------------------------------+-------------------------------------------------+
 			`,
 			wantStderr: "",
 		},

--- a/pkg/models/purl_to_package.go
+++ b/pkg/models/purl_to_package.go
@@ -32,7 +32,14 @@ func PURLToPackage(purl string) (PackageInfo, error) {
 	// PackageInfo expects the full namespace in the name for ecosystems that specify it.
 	name := parsedPURL.Name
 	if parsedPURL.Namespace != "" {
-		name = parsedPURL.Namespace + "/" + parsedPURL.Name
+		if ecosystem == string(EcosystemMaven) { // Maven uses : to separate namespace and package
+			name = parsedPURL.Namespace + ":" + parsedPURL.Name
+		} else if ecosystem == string(EcosystemDebian) || ecosystem == string(EcosystemAlpine) {
+			// Debian and Alpine repeats their namespace in PURL, so don't add it to the name
+			name = parsedPURL.Name
+		} else {
+			name = parsedPURL.Namespace + "/" + parsedPURL.Name
+		}
 	}
 
 	return PackageInfo{

--- a/pkg/models/purl_to_package.go
+++ b/pkg/models/purl_to_package.go
@@ -1,0 +1,43 @@
+package models
+
+import (
+	"github.com/package-url/packageurl-go"
+)
+
+var purlEcosystems = map[string]string{
+	"cargo":    "crates.io",
+	"deb":      "Debian",
+	"hex":      "Hex",
+	"golang":   "Go",
+	"maven":    "Maven",
+	"nuget":    "NuGet",
+	"npm":      "npm",
+	"composer": "Packagist",
+	"generic":  "OSS-Fuzz",
+	"pypi":     "PyPI",
+	"gem":      "RubyGems",
+}
+
+// PURLToPackage converts a Package URL string to models.PackageInfo
+func PURLToPackage(purl string) (PackageInfo, error) {
+	parsedPURL, err := packageurl.FromString(purl)
+	if err != nil {
+		return PackageInfo{}, err
+	}
+	ecosystem := purlEcosystems[parsedPURL.Type]
+	if ecosystem == "" {
+		ecosystem = parsedPURL.Type
+	}
+
+	// PackageInfo expects the full namespace in the name for ecosystems that specify it.
+	name := parsedPURL.Name
+	if parsedPURL.Namespace != "" {
+		name = parsedPURL.Namespace + "/" + parsedPURL.Name
+	}
+
+	return PackageInfo{
+		Name:      name,
+		Ecosystem: ecosystem,
+		Version:   parsedPURL.Version,
+	}, nil
+}

--- a/pkg/models/purl_to_package_test.go
+++ b/pkg/models/purl_to_package_test.go
@@ -1,0 +1,61 @@
+package models
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestPURLToPackage(t *testing.T) {
+	type args struct {
+		purl string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    PackageInfo
+		wantErr bool
+	}{
+		{
+			name: "valid PURL",
+			args: args{
+				purl: "pkg:cargo/memoffset@0.6.1",
+			},
+			want: PackageInfo{
+				Name:      "memoffset",
+				Version:   "0.6.1",
+				Ecosystem: string(EcosystemCratesIO),
+			},
+		},
+		{
+			name: "valid PURL golang",
+			args: args{
+				purl: "pkg:golang/github.com/gogo/protobuf@5.6.0",
+			},
+			want: PackageInfo{
+				Name:      "github.com/gogo/protobuf",
+				Version:   "5.6.0",
+				Ecosystem: string(EcosystemGo),
+			},
+		},
+		{
+			name: "invalid PURL",
+			args: args{
+				purl: "pkg-golang/github.com/gogo/protobuf.0",
+			},
+			want:    PackageInfo{},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := PURLToPackage(tt.args.purl)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("PURLToPackage() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("PURLToPackage() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/models/purl_to_package_test.go
+++ b/pkg/models/purl_to_package_test.go
@@ -38,6 +38,28 @@ func TestPURLToPackage(t *testing.T) {
 			},
 		},
 		{
+			name: "valid PURL maven",
+			args: args{
+				purl: "pkg:maven/org.hdrhistogram/HdrHistogram@2.1.12",
+			},
+			want: PackageInfo{
+				Name:      "org.hdrhistogram:HdrHistogram",
+				Version:   "2.1.12",
+				Ecosystem: string(EcosystemMaven),
+			},
+		},
+		{
+			name: "valid Debian maven",
+			args: args{
+				purl: "pkg:deb/debian/nginx@2.36.1-8+deb11u1",
+			},
+			want: PackageInfo{
+				Name:      "nginx",
+				Version:   "2.36.1-8+deb11u1",
+				Ecosystem: string(EcosystemDebian),
+			},
+		},
+		{
 			name: "invalid PURL",
 			args: args{
 				purl: "pkg-golang/github.com/gogo/protobuf.0",

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -244,7 +244,7 @@ func scanSBOMFile(r reporter.Reporter, query *osv.BatchedQuery, path string, fro
 		count := 0
 		ignoredCount := 0
 		err = provider.GetPackages(file, func(id sbom.Identifier) error {
-			_, err := PURLToPackage(id.PURL)
+			_, err := models.PURLToPackage(id.PURL)
 			if err != nil {
 				ignoredCount++
 				//nolint:nilerr

--- a/pkg/osvscanner/purl_to_package.go
+++ b/pkg/osvscanner/purl_to_package.go
@@ -2,36 +2,11 @@ package osvscanner
 
 import (
 	"github.com/google/osv-scanner/pkg/models"
-	"github.com/package-url/packageurl-go"
 )
 
-var purlEcosystems = map[string]string{
-	"cargo":    "crates.io",
-	"deb":      "Debian",
-	"hex":      "Hex",
-	"golang":   "Go",
-	"maven":    "Maven",
-	"nuget":    "NuGet",
-	"npm":      "npm",
-	"composer": "Packagist",
-	"generic":  "OSS-Fuzz",
-	"pypi":     "PyPI",
-	"gem":      "RubyGems",
-}
-
+// PURLToPackage converts a Package URL string to models.PackageInfo
+//
+// Deprecated: Use the PURLToPackage in the models package instead.
 func PURLToPackage(purl string) (models.PackageInfo, error) {
-	parsedPURL, err := packageurl.FromString(purl)
-	if err != nil {
-		return models.PackageInfo{}, err
-	}
-	ecosystem := purlEcosystems[parsedPURL.Type]
-	if ecosystem == "" {
-		ecosystem = parsedPURL.Type
-	}
-
-	return models.PackageInfo{
-		Name:      parsedPURL.Name,
-		Ecosystem: ecosystem,
-		Version:   parsedPURL.Version,
-	}, nil
+	return models.PURLToPackage(purl)
 }

--- a/pkg/osvscanner/vulnerability_result.go
+++ b/pkg/osvscanner/vulnerability_result.go
@@ -30,7 +30,7 @@ func groupResponseBySource(r reporter.Reporter, query osv.BatchedQuery, resp *os
 			pkg.Package.Ecosystem = "GIT"
 		} else if query.Package.PURL != "" {
 			var err error
-			pkg.Package, err = PURLToPackage(query.Package.PURL)
+			pkg.Package, err = models.PURLToPackage(query.Package.PURL)
 			if err != nil {
 				r.PrintError(fmt.Sprintf("Failed to parse purl: %s, with error: %s",
 					query.Package.PURL, err))


### PR DESCRIPTION
Turns out our `PURLToPackage` function was returning incorrect results for ecosystems that contain a namespace like golang, the returned result was simply missing the full namespace (github.com/author/...). When adding the namespace, there's also some exceptions with some ecosystems (e.g. Maven uses `:`, debian and alpine repeats their name in their namespace, etc).

This also moves the `PURLToPackage` to the `models` package instead of `osvscanner`, deprecating the existing one in `osvscanner` because:
- Makes more sense, it actually has nothing to do with the scanner itself, but is converting between PURLs and a structure under `model`.
- Prevents cyclic imports when being used elsewhere (in the offline scanning PR, and in the upcoming PURL parsing PR that I'm currently working on) 

Also added additional tests to clarify behavior and prevent regressions in the future.