### PR TITLE
refactor: move experimental flags into their own struct

### DIFF
--- a/cmd/osv-scanner/main.go
+++ b/cmd/osv-scanner/main.go
@@ -140,15 +140,17 @@ func run(args []string, stdout, stderr io.Writer) int {
 			}
 
 			vulnResult, err := osvscanner.DoScan(osvscanner.ScannerActions{
-				LockfilePaths:            context.StringSlice("lockfile"),
-				SBOMPaths:                context.StringSlice("sbom"),
-				DockerContainerNames:     context.StringSlice("docker"),
-				Recursive:                context.Bool("recursive"),
-				SkipGit:                  context.Bool("skip-git"),
-				NoIgnore:                 context.Bool("no-ignore"),
-				ConfigOverridePath:       context.String("config"),
-				DirectoryPaths:           context.Args().Slice(),
-				ExperimentalCallAnalysis: context.Bool("experimental-call-analysis"),
+				LockfilePaths:        context.StringSlice("lockfile"),
+				SBOMPaths:            context.StringSlice("sbom"),
+				DockerContainerNames: context.StringSlice("docker"),
+				Recursive:            context.Bool("recursive"),
+				SkipGit:              context.Bool("skip-git"),
+				NoIgnore:             context.Bool("no-ignore"),
+				ConfigOverridePath:   context.String("config"),
+				DirectoryPaths:       context.Args().Slice(),
+				ExperimentalScannerActions: osvscanner.ExperimentalScannerActions{
+					CallAnalysis: context.Bool("experimental-call-analysis"),
+				},
 			}, r)
 
 			if err != nil &&

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -33,7 +33,11 @@ type ScannerActions struct {
 	DockerContainerNames []string
 	ConfigOverridePath   string
 
-	ExperimentalCallAnalysis bool
+	ExperimentalScannerActions
+}
+
+type ExperimentalScannerActions struct {
+	CallAnalysis bool
 }
 
 // NoPackagesFoundErr for when no packages are found during a scan.
@@ -550,7 +554,7 @@ func DoScan(actions ScannerActions, r reporter.Reporter) (models.VulnerabilityRe
 		return models.VulnerabilityResults{}, fmt.Errorf("failed to hydrate OSV response: %w", err)
 	}
 
-	vulnerabilityResults := groupResponseBySource(r, query, hydratedResp, actions.ExperimentalCallAnalysis)
+	vulnerabilityResults := groupResponseBySource(r, query, hydratedResp, actions.CallAnalysis)
 
 	filtered := filterResults(r, &vulnerabilityResults, &configManager)
 	if filtered > 0 {


### PR DESCRIPTION
This pulls across the experimental struct from #183 which I'm assuming folks are happy with given that PR is approved - I think it is good to land this in its own PR as its technically an allowed breaking change (or "experimental change" if you will), and that way it can be explicitly linked to in changelogs etc without having to understand #183 as much.