### PR TITLE
Add go stdlib version support

### DIFF
--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -26,5 +26,5 @@ permissions:
   contents: read
 
 jobs:
-  scan-pr-attempt:
+  scan-scheduled:
     uses: "./.github/workflows/osv-scanner-reusable-scheduled.yml"

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -30,6 +30,7 @@ linters:
     - testpackage      # will re-add later (another-rex)
     - goerr113         # will re-add later (another-rex)
     - nonamedreturns   # disagree with, for now (another-rex)
+    - depguard         # not necessary at the moment (another-rex)
   presets:
     - bugs
     - comment

--- a/pkg/osvscanner/optional_enricher.go
+++ b/pkg/osvscanner/optional_enricher.go
@@ -27,7 +27,7 @@ func getGoVersion() (string, error) {
 }
 
 func postLockfileEnricher(r reporter.Reporter, parsedLockfile *lockfile.Lockfile) {
-	switch parsedLockfile.ParsedAs {
+	switch parsedLockfile.ParsedAs { //nolint:gocritic
 	case "go.mod":
 		goVer, err := getGoVersion()
 		if err != nil {

--- a/pkg/osvscanner/optional_enricher.go
+++ b/pkg/osvscanner/optional_enricher.go
@@ -1,0 +1,43 @@
+package osvscanner
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/google/osv-scanner/pkg/lockfile"
+	"github.com/google/osv-scanner/pkg/reporter"
+)
+
+// Get the go version of the default environment that osv-scanner is being ran on
+func getGoVersion() (string, error) {
+	// GOROOT will return either the custom go location specified by $GOROOT environment
+	// variable, or it will return the default go location used during the go build,
+	// which will match the default of the platform being ran on.
+	versionBytes, err := os.ReadFile(filepath.Join(runtime.GOROOT(), "VERSION"))
+	if err != nil {
+		return "", err
+	}
+	version := strings.TrimPrefix(string(versionBytes), "go")
+	version, _, _ = strings.Cut(version, " ")
+
+	return version, nil
+}
+
+func postLockfileEnricher(r reporter.Reporter, parsedLockfile *lockfile.Lockfile) {
+	switch parsedLockfile.ParsedAs {
+	case "go.mod":
+		goVer, err := getGoVersion()
+		if err != nil {
+			r.PrintError(fmt.Sprintf("cannot get go standard library version, go might not be installed: %s", err))
+		}
+		parsedLockfile.Packages = append(parsedLockfile.Packages, lockfile.PackageDetails{
+			Name:      "stdlib",
+			Version:   goVer,
+			Ecosystem: lockfile.GoEcosystem,
+			CompareAs: lockfile.GoEcosystem,
+		})
+	}
+}

--- a/pkg/osvscanner/optional_enricher.go
+++ b/pkg/osvscanner/optional_enricher.go
@@ -24,7 +24,7 @@ func getGoVersion() (string, error) {
 	return version, nil
 }
 
-func postLockfileEnricher(r reporter.Reporter, parsedLockfile *lockfile.Lockfile) {
+func addCompilerVersion(r reporter.Reporter, parsedLockfile *lockfile.Lockfile) {
 	switch parsedLockfile.ParsedAs { //nolint:gocritic
 	case "go.mod":
 		goVer, err := getGoVersion()

--- a/pkg/osvscanner/optional_enricher.go
+++ b/pkg/osvscanner/optional_enricher.go
@@ -2,9 +2,7 @@ package osvscanner
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
-	"runtime"
+	"os/exec"
 	"strings"
 
 	"github.com/google/osv-scanner/pkg/lockfile"
@@ -13,13 +11,13 @@ import (
 
 // Get the go version of the default environment that osv-scanner is being ran on
 func getGoVersion() (string, error) {
-	// GOROOT will return either the custom go location specified by $GOROOT environment
-	// variable, or it will return the default go location used during the go build,
-	// which will match the default of the platform being ran on.
-	versionBytes, err := os.ReadFile(filepath.Join(runtime.GOROOT(), "VERSION"))
+	versionBytes, err := exec.Command("go", "env", "GOVERSION").Output()
 	if err != nil {
 		return "", err
 	}
+	// version format can be:
+	// - go1.20.6
+	// - go1.22-20230729-RC00 cl/552016856 +457721cd52 X:fieldtrack,boringcrypto
 	version := strings.TrimPrefix(string(versionBytes), "go")
 	version, _, _ = strings.Cut(version, " ")
 

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -209,6 +209,9 @@ func scanLockfile(r reporter.Reporter, query *osv.BatchedQuery, path string, par
 	if err != nil {
 		return err
 	}
+
+	postLockfileEnricher(r, &parsedLockfile)
+
 	parsedAsComment := ""
 
 	if parseAs != "" {

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -210,7 +210,7 @@ func scanLockfile(r reporter.Reporter, query *osv.BatchedQuery, path string, par
 		return err
 	}
 
-	postLockfileEnricher(r, &parsedLockfile)
+	addCompilerVersion(r, &parsedLockfile)
 
 	parsedAsComment := ""
 


### PR DESCRIPTION
Fixes #453,

As discussed in #453, it does require go to be installed on the system that osv-scanner is being ran on. The go installation can be at a custom location as long as $GOROOT environment var is specified.

Also exclude the depguard check, which has been added in a newer version of golangci (which we haven't updated to, but will cause linting issues when we eventually do).
