### PR TITLE
chore: capture coverage and upload it to codecov

### DIFF
--- a/.github/workflows/test-action/action.yml
+++ b/.github/workflows/test-action/action.yml
@@ -21,3 +21,5 @@ runs:
     - name: Run go test
       shell: bash
       run: ./run_tests.sh
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3

--- a/.github/workflows/test-action/action.yml
+++ b/.github/workflows/test-action/action.yml
@@ -22,4 +22,4 @@ runs:
       shell: bash
       run: ./run_tests.sh
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .idea/
 /dist/
 /osv-scanner
+/coverage.out
+/coverage.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ This project follows
 [Google's Open Source Community Guidelines](https://opensource.google.com/conduct/).
 
 ## Contributing documentation
-Please review the documentation [README](docs/README.md) for more information about contributing to documentation. 
+Please review the documentation [README](docs/README.md) for more information about contributing to documentation.
 
 ## Contributing code
 
@@ -67,6 +67,12 @@ To run tests:
 ./run_tests.sh
 ```
 
+You can generate an HTML coverage report afterward by running:
+
+```
+go tool cover -html=coverage.out -o coverage.html
+```
+
 ### Linting
 To lint your code, run
 
@@ -76,11 +82,11 @@ To lint your code, run
 
 ## Contributing documentation
 
-Please follow these steps to successfully contribute documentation. 
+Please follow these steps to successfully contribute documentation.
 
-1. Fork the repository. 
-2. Make desired documentation changes. 
-3. Preview the changes by spinning up a GitHub page for your fork, building from your working branch. 
+1. Fork the repository.
+2. Make desired documentation changes.
+3. Preview the changes by spinning up a GitHub page for your fork, building from your working branch.
     - On your fork, go to the settings tab and then the GitHub page settings. Sample URL: https://github.com/{your-github-profile}/osv-scanner/settings/pages
     - Under "Build and deployment" select "Build from branch"
     - Set the branch to your working branch

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 set -e
-go test ./...
+go test ./... -coverprofile coverage.out


### PR DESCRIPTION
This is a real basic starter for 10 - I considered doing something more fancy with `run_tests.sh` but realised it would just be better to discuss the general approach to scripts for the scanner as its own thing (i.e. we could use `make`, we could move things into `scripts`, we could just have multiple scripts for things...) so for now have just made coverage collection always enabled and documented how to generate the HTML report.

~I have also included uploading the results to codecov but ultimately that's for Google folks to decide what they want to do - if folks are happy to use codecov I think this can be merged as is and it'll just automatically create the project etc and you should be able to access that via logging in with GitHub.~ Whoops I didn't think about the actions running for the PR would trigger it so I guess that happened 😅 

Also this is the coverage currently:

```
❯ ./run_tests.sh
?       github.com/google/osv-scanner/cmd/osv-reporter  [no test files]
ok      github.com/google/osv-scanner/cmd/osv-scanner   9.997s  coverage: 73.9% of statements
?       github.com/google/osv-scanner/internal/cachedregexp     [no test files]
ok      github.com/google/osv-scanner/internal/ci       0.006s  coverage: 81.5% of statements
ok      github.com/google/osv-scanner/internal/local    0.014s  coverage: 46.2% of statements
ok      github.com/google/osv-scanner/internal/output   0.003s  coverage: 9.0% of statements
ok      github.com/google/osv-scanner/internal/sbom     0.003s  coverage: 35.0% of statements
ok      github.com/google/osv-scanner/internal/semantic 0.172s  coverage: 96.7% of statements
ok      github.com/google/osv-scanner/internal/sourceanalysis   1.240s  coverage: 46.1% of statements
?       github.com/google/osv-scanner/internal/sourceanalysis/govulncheck       [no test files]
?       github.com/google/osv-scanner/internal/testutility      [no test files]
?       github.com/google/osv-scanner/internal/thirdparty/ar    [no test files]
ok      github.com/google/osv-scanner/internal/utility/vulns    0.004s  coverage: 88.6% of statements
ok      github.com/google/osv-scanner/pkg/config        0.004s  coverage: 35.4% of statements
ok      github.com/google/osv-scanner/pkg/grouper       0.002s  coverage: 83.3% of statements
ok      github.com/google/osv-scanner/pkg/lockfile      0.017s  coverage: 94.0% of statements
ok      github.com/google/osv-scanner/pkg/models        0.003s  coverage: 71.6% of statements
?       github.com/google/osv-scanner/pkg/osv   [no test files]
ok      github.com/google/osv-scanner/pkg/osvscanner    0.016s  coverage: 11.9% of statements
ok      github.com/google/osv-scanner/pkg/reporter      0.002s  coverage: 26.8% of statements
```