### PR TITLE
Revert breaking change in `osv.go`

### DIFF
--- a/internal/local/check.go
+++ b/internal/local/check.go
@@ -38,8 +38,8 @@ func toPackageDetails(query *osv.Query) (lockfile.PackageDetails, error) {
 		Name:      query.Package.Name,
 		Version:   query.Version,
 		Commit:    query.Commit,
-		Ecosystem: query.Package.Ecosystem,
-		CompareAs: query.Package.Ecosystem,
+		Ecosystem: lockfile.Ecosystem(query.Package.Ecosystem),
+		CompareAs: lockfile.Ecosystem(query.Package.Ecosystem),
 	}, nil
 }
 

--- a/pkg/lockfile/extractor.go
+++ b/pkg/lockfile/extractor.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 )
 
-var ErrNotSupported = errors.New("this file does not support opening files")
+var ErrOpenNotSupported = errors.New("this file does not support opening files")
 
 // DepFile is an abstraction for a file that has been opened for extraction,
 // and that knows how to open other DepFiles relative to itself.

--- a/pkg/osv/osv.go
+++ b/pkg/osv/osv.go
@@ -32,9 +32,9 @@ var RequestUserAgent = ""
 
 // Package represents a package identifier for OSV.
 type Package struct {
-	PURL      string             `json:"purl,omitempty"`
-	Name      string             `json:"name,omitempty"`
-	Ecosystem lockfile.Ecosystem `json:"ecosystem,omitempty"`
+	PURL      string `json:"purl,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Ecosystem string `json:"ecosystem,omitempty"`
 }
 
 // Query represents a query to OSV.
@@ -57,7 +57,7 @@ type MinimalVulnerability struct {
 
 // Response represents a full response from OSV.
 type Response struct {
-	Vulns models.Vulnerabilities `json:"vulns"`
+	Vulns []models.Vulnerability `json:"vulns"`
 }
 
 // MinimalResponse represents an unhydrated response from OSV.
@@ -98,7 +98,7 @@ func MakePkgRequest(pkgDetails lockfile.PackageDetails) *Query {
 		// Commit:  pkgDetails.Commit,
 		Package: Package{
 			Name:      pkgDetails.Name,
-			Ecosystem: pkgDetails.Ecosystem,
+			Ecosystem: string(pkgDetails.Ecosystem),
 		},
 	}
 }

--- a/pkg/osvscanner/vulnerability_result.go
+++ b/pkg/osvscanner/vulnerability_result.go
@@ -42,7 +42,7 @@ func groupResponseBySource(r reporter.Reporter, query osv.BatchedQuery, resp *os
 				Package: models.PackageInfo{
 					Name:      query.Package.Name,
 					Version:   query.Version,
-					Ecosystem: string(query.Package.Ecosystem),
+					Ecosystem: query.Package.Ecosystem,
 				},
 			}
 		}


### PR DESCRIPTION
Changing the type of Package.Ecosystem would be a breaking change, so revert that back to string. Doesn't affect too much so looks fine to me, let's add this to #442 for V2.

Also changed `Response.Vulns` back to type `[]models.Vulnerability`. I don't think this changes anything since go coerces the types to each other when setting the value.

And made the not supported error a bit more specific