### PR TITLE
Fix action naming and scheduled scan parameters

### DIFF
--- a/.github/workflows/osv-scanner-pr.yml
+++ b/.github/workflows/osv-scanner-pr.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: osv-scanner
+name: OSV-Scanner PR Scan
 
 on:
   pull_request:

--- a/.github/workflows/osv-scanner-pr.yml
+++ b/.github/workflows/osv-scanner-pr.yml
@@ -16,7 +16,6 @@ name: OSV-Scanner PR Scan
 
 on:
   pull_request:
-    # The branches below must be a subset of the branches above
     branches: [ main ]
   merge_group:
     branches: [ main ]
@@ -25,5 +24,5 @@ on:
 permissions: read-all
 
 jobs:
-  scan-pr-attempt:
+  scan-pr:
     uses: "./.github/workflows/osv-scanner-reusable-pr.yml"

--- a/.github/workflows/osv-scanner-reusable-pr.yml
+++ b/.github/workflows/osv-scanner-reusable-pr.yml
@@ -56,7 +56,7 @@ jobs:
             --output=final-results.sarif
             --old=old-results.json
             --new=new-results.json
-            --gh-annoatations=true
+            --gh-annotations=true
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"

--- a/.github/workflows/osv-scanner-reusable-pr.yml
+++ b/.github/workflows/osv-scanner-reusable-pr.yml
@@ -56,7 +56,7 @@ jobs:
             --output=final-results.sarif
             --old=old-results.json
             --new=new-results.json
-            --gh-annoatations: true
+            --gh-annoatations=true
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"

--- a/.github/workflows/osv-scanner-reusable-pr.yml
+++ b/.github/workflows/osv-scanner-reusable-pr.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: OSV-Scanner PR scanning
+name: OSV-Scanner PR scanning reusable
 
 on:
   workflow_call:

--- a/.github/workflows/osv-scanner-reusable-scheduled.yml
+++ b/.github/workflows/osv-scanner-reusable-scheduled.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: OSV-Scanner Scheduled scanning
+name: OSV-Scanner scheduled scan reusable
 
 on:
   workflow_call:
@@ -30,6 +30,7 @@ jobs:
             --format=sarif
             -r
             --skip-git
+            ./
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"

--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: osv-scanner
+name: OSV-Scanner Scheduled Scan
 
 on:
   schedule:

--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -20,9 +20,10 @@ on:
   push:
     branches: [ "main" ]
 
-# Declare default permissions as read only.
 permissions: 
+  # Require writing security events to upload SARIF file to security tab
   security-events: write
+  # Only need to read contents
   contents: read
 
 jobs:


### PR DESCRIPTION
- Fix missing the ./ in the scheduled scan. 
- Fix passing gh-annotations correctly
- Update naming of the actions to be more clear