### PR TITLE
test: compare expected with actual rather than the other way around

### DIFF
--- a/internal/local/zip_test.go
+++ b/internal/local/zip_test.go
@@ -38,7 +38,7 @@ func expectDBToHaveOSVs(
 	db interface {
 		Vulnerabilities(includeWithdrawn bool) []models.Vulnerability
 	},
-	actual []models.Vulnerability,
+	expect []models.Vulnerability,
 ) {
 	t.Helper()
 
@@ -47,12 +47,12 @@ func expectDBToHaveOSVs(
 	sort.Slice(vulns, func(i, j int) bool {
 		return vulns[i].ID < vulns[j].ID
 	})
-	sort.Slice(actual, func(i, j int) bool {
-		return actual[i].ID < actual[j].ID
+	sort.Slice(expect, func(i, j int) bool {
+		return expect[i].ID < expect[j].ID
 	})
 
-	if !reflect.DeepEqual(vulns, actual) {
-		t.Errorf("db is missing some vulnerabilities: %v vs %v", vulns, actual)
+	if !reflect.DeepEqual(expect, vulns) {
+		t.Errorf("db is missing some vulnerabilities: %v vs %v", expect, vulns)
 	}
 }
 


### PR DESCRIPTION
This isn't hiding anything, but it's semantically incorrect