### PR TITLE
ci: run tests on macos and in parallel when releasing

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -43,9 +43,13 @@ jobs:
           check-latest: true
       - name: Run lint action
         uses: ./.github/workflows/lint-action
-  test:
+  tests:
     name: Run unit tests
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Check out code
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -9,6 +9,26 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 
 jobs:
+  tests:
+    name: Run unit tests
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        with:
+          go-version: '1.19'
+          check-latest: true
+      - name: Run test action
+        uses: ./.github/workflows/test-action
   goreleaser:
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}
@@ -16,6 +36,8 @@ jobs:
       contents: write  # for goreleaser/goreleaser-action to create a GitHub release
       packages: write # for goreleaser/goreleaser-action to publish docker images
     runs-on: ubuntu-latest
+    needs:
+      - tests
     env:
       # Required for buildx on docker 19.x
       DOCKER_CLI_EXPERIMENTAL: "enabled"
@@ -29,8 +51,6 @@ jobs:
         with:
           go-version: 1.19
           check-latest: true
-      - name: Run Tests
-        uses: ./.github/workflows/test-action
       - name: Run Lints
         uses: ./.github/workflows/lint-action
       - uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -9,6 +9,22 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 
 jobs:
+  lint:
+    name: golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        with:
+          go-version: '1.19'
+          check-latest: true
+      - name: Run lint action
+        uses: ./.github/workflows/lint-action
   tests:
     name: Run unit tests
     strategy:
@@ -37,6 +53,7 @@ jobs:
       packages: write # for goreleaser/goreleaser-action to publish docker images
     runs-on: ubuntu-latest
     needs:
+      - lint
       - tests
     env:
       # Required for buildx on docker 19.x
@@ -51,8 +68,6 @@ jobs:
         with:
           go-version: 1.19
           check-latest: true
-      - name: Run Lints
-        uses: ./.github/workflows/lint-action
       - uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3
       - uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3
       - name: ghcr-login


### PR DESCRIPTION
The test suite needs to be adjusted to handle OS-based differences before it can be run on Windows, but in the meantime we can start running on macOS; this also moves the linting step to be in parallel when releasing too.