### PR TITLE
Block release on vuln scan

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -9,6 +9,12 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 
 jobs:
+  osv-scan:
+    name: OSV-Scanner vulnerability scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Scan
+        uses: ./.github/workflows/osv-scanner-reusable.yml
   lint:
     name: golangci-lint
     runs-on: ubuntu-latest
@@ -55,6 +61,7 @@ jobs:
     needs:
       - lint
       - tests
+      - osv-scan
     env:
       # Required for buildx on docker 19.x
       DOCKER_CLI_EXPERIMENTAL: "enabled"

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -15,6 +15,13 @@ jobs:
     steps:
       - name: Scan
         uses: ./.github/workflows/osv-scanner-reusable.yml
+        with:
+          # Only scan the top level go.mod file without recursively scanning directories since
+          # this is pipeline is about releasing the go module and binary
+          scan-args: |-
+            --skip-git
+            ./
+
   lint:
     name: golangci-lint
     runs-on: ubuntu-latest

--- a/.github/workflows/osv-scanner-reusable.yml
+++ b/.github/workflows/osv-scanner-reusable.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: OSV-Scanner scheduled scan reusable
+name: OSV-Scanner scanning reusable
 
 on:
   workflow_call:
@@ -24,6 +24,10 @@ on:
           -r
           --skip-git
           ./
+      results-file-name:
+        description: "File name of the result SARIF file"
+        type: string
+        default: results.sarif
 
 jobs:
   scan-scheduled:
@@ -34,7 +38,7 @@ jobs:
         uses: google/osv-scanner/actions/scanner@main
         with:
           scan-args: |-
-            --output=results.sarif
+            --output=${{ inputs.results-file-name }}
             --format=sarif
             ${{ inputs.scan-args }}
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
@@ -44,12 +48,12 @@ jobs:
         uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: SARIF file
-          path: results.sarif
+          path: ${{ inputs.results-file-name }}
           retention-days: 5
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
         if: '!cancelled()'
         uses: github/codeql-action/upload-sarif@6a28655e3dcb49cb0840ea372fd6d17733edd8a4 # v2.21.8
         with:
-          sarif_file: results.sarif
+          sarif_file: ${{ inputs.results-file-name }}
 

--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -20,7 +20,7 @@ on:
   push:
     branches: [ "main" ]
 
-permissions: 
+permissions:
   # Require writing security events to upload SARIF file to security tab
   security-events: write
   # Only need to read contents
@@ -28,4 +28,4 @@ permissions:
 
 jobs:
   scan-scheduled:
-    uses: "./.github/workflows/osv-scanner-reusable-scheduled.yml"
+    uses: "./.github/workflows/osv-scanner-reusable.yml"

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -11,16 +11,16 @@ nav_order: 6
 
 OSV-Scanner is offered as a GitHub Action. We currently have two different GitHub Actions:
 
-1. An action that performs a vulnerability scan on a [regular schedule](./github-action.md#scheduled-scans). 
-2. An action that triggers a scan with each [pull request](./github-action.md#scans-on-prs) and will only check for new vulnerabilities introduced through the pull request. 
+1. An action that performs a vulnerability scan on a [regular schedule](./github-action.md#scheduled-scans).
+2. An action that triggers a scan with each [pull request](./github-action.md#scans-on-prs) and will only check for new vulnerabilities introduced through the pull request.
 
 ## Scheduled scans
 
-Regularly scanning your project for vulnerabilities can alert you to new vulnerabilities in your dependency tree. This GitHub Action will scan your project on a set schedule and report all known vulnerabilities. 
+Regularly scanning your project for vulnerabilities can alert you to new vulnerabilities in your dependency tree. This GitHub Action will scan your project on a set schedule and report all known vulnerabilities.
 
 ### Instructions
 
-In your project repository, create a new file `.github/workflows/osv-scanner-scheduled.yml`. 
+In your project repository, create a new file `.github/workflows/osv-scanner-scheduled.yml`.
 
 Include the following in the [`osv-scanner-scheduled.yml`](https://github.com/google/osv-scanner/blob/main/.github/workflows/osv-scanner-scheduled.yml) file:
 
@@ -34,7 +34,7 @@ on:
   push:
     branches: [ main ]
 
-permissions: 
+permissions:
   # Require writing security events to upload SARIF file to security tab
   security-events: write
   # Only need to read contents
@@ -42,10 +42,10 @@ permissions:
 
 jobs:
   scan-scheduled:
-    uses: "google/osv-scanner/.github/workflows/osv-scanner-reusable-scheduled.yml@main"
+    uses: "google/osv-scanner/.github/workflows/osv-scanner-reusable.yml@main"
 ```
 
-As written, the scanner will run on 12:12 pm UTC every Monday. You can change the schedule by following the instructions [here](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule). 
+As written, the scanner will run on 12:12 pm UTC every Monday. You can change the schedule by following the instructions [here](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule).
 
 ### View results
 
@@ -57,7 +57,7 @@ Scanning your project on each pull request can help you keep vulnerabilities out
 
 ### Instructions
 
-In your project repository, create a new file `.github/workflows/osv-scanner-pr.yml`. 
+In your project repository, create a new file `.github/workflows/osv-scanner-pr.yml`.
 
 Include the following in the [`osv-scanner-pr.yml`](https://github.com/google/osv-scanner/blob/main/.github/workflows/osv-scanner-pr.yml) file:
 
@@ -81,6 +81,6 @@ jobs:
 
 ### View results
 
-Results may be viewed by clicking on the details of the failed action, either from your project's actions tab or directly on the PR. Results are also included in GitHub annotations on the "Files changed" tab for the PR. 
+Results may be viewed by clicking on the details of the failed action, either from your project's actions tab or directly on the PR. Results are also included in GitHub annotations on the "Files changed" tab for the PR.
 
 Results are also available to maintainers by navigating to their project's security > code scanning tab.


### PR DESCRIPTION
`osv-scanner-reusable-scheduled` actually doesn't have anything to do with having a schedule, so just removed the scheduled part from the name. 

This reusable workflow is now also used in the release pipeline to block releases if there are vulnerabilities.

