### PR TITLE
ci: ensure that `actions/checkout` is pinned

### DIFF
--- a/.github/workflows/link-check-on-push.yml
+++ b/.github/workflows/link-check-on-push.yml
@@ -7,7 +7,7 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
     - uses: gaurav-nelson/github-action-markdown-link-check@a996638015fbc9ef96beef1a41bbad7df8e06154
       with:
         use-quiet-mode: "yes"

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,6 +1,6 @@
 name: Check markdown links on schedule
 
-on: 
+on:
   schedule:
     - cron: '45 22 * * 1,4'
 permissions:  # added using https://github.com/step-security/secure-repo
@@ -9,7 +9,7 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
     - uses: gaurav-nelson/github-action-markdown-link-check@a996638015fbc9ef96beef1a41bbad7df8e06154
       with:
         use-quiet-mode: "yes"

--- a/.github/workflows/osv-scanner-reusable-pr.yml
+++ b/.github/workflows/osv-scanner-reusable-pr.yml
@@ -29,7 +29,7 @@ jobs:
   scan-pr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
         with:
           fetch-depth: 0
           # Do persist credentials, as we need it for the git checkout later
@@ -90,4 +90,3 @@ jobs:
         uses: github/codeql-action/upload-sarif@6a28655e3dcb49cb0840ea372fd6d17733edd8a4 # v2.21.8
         with:
           sarif_file: final-results.sarif
-


### PR DESCRIPTION
I'm surprised that renovate didn't flag these but oh well 🤷 