### PR TITLE
Allow release scanning to upload SARIF file. 

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: read # to fetch code (actions/checkout)
+  # Require writing security events to upload SARIF file to security tab
+  security-events: write
 
 jobs:
   osv-scan:


### PR DESCRIPTION
Testing these fixes per merge, it runs correctly now, just need permission to upload the scan SARIF results. 