### PR TITLE
Make scheduled and PR scanning only scan the relevant files and ignore fixtures

### DIFF
--- a/.github/workflows/osv-scanner-pr.yml
+++ b/.github/workflows/osv-scanner-pr.yml
@@ -23,6 +23,12 @@ on:
 jobs:
   scan-pr:
     uses: "./.github/workflows/osv-scanner-reusable-pr.yml"
+    with:
+      # Just scan the root directory and docs, since everything else is fixtures
+      scan-args: |-
+          --skip-git
+          ./
+          ./docs/
     permissions:
       security-events: write
       contents: read

--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -23,6 +23,12 @@ on:
 jobs:
   scan-scheduled:
     uses: "./.github/workflows/osv-scanner-reusable.yml"
+    with:
+      # Just scan the root directory and docs, since everything else is fixtures
+      scan-args: |-
+          --skip-git
+          ./
+          ./docs/
     permissions:
       # Require writing security events to upload SARIF file to security tab
       security-events: write


### PR DESCRIPTION
Make scheduled and PR scanning only scan the relevant files and ignore fixtures. This prevents us from constantly having to add ignores for new vulnerabilities, and it polluting the output.

We still need to add new vulns to the tests though.