### PR TITLE
Update release pipeline

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -80,7 +80,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: 'refs/tags/${{ inputs.version }}',
-              sha: ${{ inputs.commit }}
+              sha: '${{ inputs.commit }}'
             })
   goreleaser:
     outputs:

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -7,6 +7,10 @@ on:
         description: 'The version tag to release, (e.g. v1.2.3)'
         required: true
         type: string
+      commit:
+        description: 'The commit hash to release'
+        required: true
+        type: string
 
 permissions:
   contents: read # to fetch code (actions/checkout)
@@ -31,6 +35,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           persist-credentials: false
+          ref: ${{ inputs.commit }}
       - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
@@ -50,6 +55,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           persist-credentials: false
+          ref: ${{ inputs.commit }}
       - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
@@ -74,7 +80,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: 'refs/tags/${{ inputs.version }}',
-              sha: context.sha
+              sha: ${{ inputs.commit }}
             })
   goreleaser:
     outputs:
@@ -93,6 +99,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
+          ref: ${{ inputs.commit }}
       - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,4 +1,4 @@
-name: goreleaser
+name: Release new version
 
 on:
   workflow_dispatch:

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -67,7 +67,7 @@ jobs:
       contents: write  # to write a tag
     steps:
       - name: Create tag
-        uses: actions/github-script@v5
+        uses: actions/github-script@v6
         with:
           script: |
             github.rest.git.createRef({

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -84,9 +84,6 @@ jobs:
       packages: write # for goreleaser/goreleaser-action to publish docker images
     runs-on: ubuntu-latest
     needs:
-      - lint
-      - tests
-      - osv-scan
       - tag-release
     env:
       # Required for buildx on docker 19.x

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,9 +1,12 @@
 name: goreleaser
 
 on:
-  push:
-    tags:
-      - "*" # triggers only if push new tag version, like `0.8.4` or else
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'The version tag to release, (e.g. v1.2.3)'
+        required: true
+        type: string
 
 permissions:
   contents: read # to fetch code (actions/checkout)
@@ -54,6 +57,25 @@ jobs:
           check-latest: true
       - name: Run test action
         uses: ./.github/workflows/test-action
+  tag-release:
+    runs-on: ubuntu-latest
+    needs:
+      - lint
+      - tests
+      - osv-scan
+    permissions:
+      contents: write  # to write a tag
+    steps:
+      - name: Create tag
+        uses: actions/github-script@v5
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/${{ inputs.version }}',
+              sha: context.sha
+            })
   goreleaser:
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}
@@ -65,6 +87,7 @@ jobs:
       - lint
       - tests
       - osv-scan
+      - tag-release
     env:
       # Required for buildx on docker 19.x
       DOCKER_CLI_EXPERIMENTAL: "enabled"


### PR DESCRIPTION
Update the release pipeline to have it be manually triggered, and create a tag itself if checks and scans are successful.

It looks something like this:
![image](https://github.com/google/osv-scanner/assets/106129829/8258a7d3-3438-46f7-82cd-49c2b4056ecf)

The release doc has been updated to follow this new workflow. 