### PR TITLE
chore: don't trim trailing whitespace on fixture snapshots

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,3 +14,6 @@ indent_size = 2
 
 [*.go]
 indent_style = tab
+
+[internal/output/fixtures/*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
This makes it easier to work with for IDEs