### PR TITLE
Some minor post release fixes

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -140,3 +140,4 @@ jobs:
       base64-subjects: "${{ needs.goreleaser.outputs.hashes }}"
       upload-assets: true # upload to a new release
       draft-release: true # upload to a new draft release
+      upload-tag-name: "${{ inputs.version }}"

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -14,7 +14,7 @@ source "https://rubygems.org"
 gem "github-pages", "~> 228", group: :jekyll_plugins
 # If you have any plugins, put them here!
 group :jekyll_plugins do
-  gem "jekyll-feed", "~> 0.12"
+  gem "jekyll-feed", "~> 0.17"
 end
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -83,8 +83,8 @@ jobs:
     uses: "google/osv-scanner/.github/workflows/osv-scanner-reusable.yml"
     with:
       scan-args: |-
-        ./path/to/lockfile1
-        requirements.txt:./path/to/python-lockfile2.txt
+        --lockfile=./path/to/lockfile1
+        --lockfile=requirements.txt:./path/to/python-lockfile2.txt
 ```
 ##### Default arguments
 ```yml


### PR DESCRIPTION
- Fix github action documentation to have correct examples
- Update jekyll feed dependency, which renovate bot fails to do for some reason
- Set the upload-tag-name to actually upload the verification along with the release using the new pipeline. (This is because the new pipeline no longer runs "on" a commit, so cannot automatically pick up the tag. This actually causes bigger problems in that we can't verify the tag (see https://github.com/slsa-framework/slsa-github-generator/issues/1947))