### PR TITLE
Go binary not found should not be an error

### DIFF
--- a/pkg/osvscanner/optional_enricher.go
+++ b/pkg/osvscanner/optional_enricher.go
@@ -29,7 +29,7 @@ func addCompilerVersion(r reporter.Reporter, parsedLockfile *lockfile.Lockfile) 
 	case "go.mod":
 		goVer, err := getGoVersion()
 		if err != nil {
-			r.PrintError(fmt.Sprintf("cannot get go standard library version, go might not be installed: %s\n", err))
+			r.PrintText(fmt.Sprintf("cannot get go standard library version, go might not be installed: %s\n", err))
 		} else {
 			parsedLockfile.Packages = append(parsedLockfile.Packages, lockfile.PackageDetails{
 				Name:      "stdlib",


### PR DESCRIPTION
as it's very likely to be found in a lot of circumstances (e.g. running in CI).

See #620 for more context. 