### PR TITLE
Fix gitignore matching for root directory

### DIFF
--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -184,7 +184,10 @@ func (m *gitIgnoreMatcher) match(absPath string, isDir bool) (bool, error) {
 		return false, err
 	}
 	// must prepend "." to paths because of how gitignore.ReadPatterns interprets paths
-	pathInGitSep := append([]string{"."}, strings.Split(pathInGit, string(filepath.Separator))...)
+	pathInGitSep := []string{"."}
+	if pathInGit != "." { // don't make the path "./."
+		pathInGitSep = append(pathInGitSep, strings.Split(pathInGit, string(filepath.Separator))...)
+	}
 
 	return m.matcher.Match(pathInGitSep, isDir), nil
 }


### PR DESCRIPTION
Was representing the relative root of the repo as `./.` which, if the .gitignore file matched `.*`, caused the whole directory to be ignored.