### PR TITLE
test: check against error type rather than message

### DIFF
--- a/pkg/lockfile/apk-installed_test.go
+++ b/pkg/lockfile/apk-installed_test.go
@@ -1,6 +1,7 @@
 package lockfile_test
 
 import (
+	"io/fs"
 	"testing"
 
 	"github.com/google/osv-scanner/pkg/lockfile"
@@ -11,7 +12,7 @@ func TestParseApkInstalled_FileDoesNotExist(t *testing.T) {
 
 	packages, err := lockfile.ParseApkInstalled("fixtures/apk/does-not-exist")
 
-	expectErrContaining(t, err, "no such file or directory")
+	expectErrIs(t, err, fs.ErrNotExist)
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 

--- a/pkg/lockfile/dpkg-status_test.go
+++ b/pkg/lockfile/dpkg-status_test.go
@@ -1,6 +1,7 @@
 package lockfile_test
 
 import (
+	"io/fs"
 	"testing"
 
 	"github.com/google/osv-scanner/pkg/lockfile"
@@ -11,7 +12,7 @@ func TestParseDpkgStatus_FileDoesNotExist(t *testing.T) {
 
 	packages, err := lockfile.ParseDpkgStatus("fixtures/dpkg/does-not-exist")
 
-	expectErrContaining(t, err, "no such file or directory")
+	expectErrIs(t, err, fs.ErrNotExist)
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 

--- a/pkg/lockfile/helpers_test.go
+++ b/pkg/lockfile/helpers_test.go
@@ -1,6 +1,7 @@
 package lockfile_test
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -18,6 +19,18 @@ func expectErrContaining(t *testing.T, err error, str string) {
 
 	if !strings.Contains(err.Error(), str) {
 		t.Errorf("Expected to get \"%s\" error, but got \"%v\"", str, err)
+	}
+}
+
+func expectErrIs(t *testing.T, err error, expected error) {
+	t.Helper()
+
+	if err == nil {
+		t.Errorf("Expected to get error, but did not")
+	}
+
+	if !errors.Is(err, expected) {
+		t.Errorf("Expected to get \"%v\" error but got \"%v\" instead", expected, err)
 	}
 }
 

--- a/pkg/lockfile/osv-vuln-result_test.go
+++ b/pkg/lockfile/osv-vuln-result_test.go
@@ -1,6 +1,7 @@
 package lockfile_test
 
 import (
+	"io/fs"
 	"testing"
 
 	"github.com/google/osv-scanner/pkg/lockfile"
@@ -11,7 +12,7 @@ func TestParseOSVScannerResults_FileDoesNotExist(t *testing.T) {
 
 	packages, err := lockfile.ParseOSVScannerResults("fixtures/osvscannerresults/does-not-exist")
 
-	expectErrContaining(t, err, "no such file or directory")
+	expectErrIs(t, err, fs.ErrNotExist)
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 

--- a/pkg/lockfile/parse-cargo-lock_test.go
+++ b/pkg/lockfile/parse-cargo-lock_test.go
@@ -1,6 +1,7 @@
 package lockfile_test
 
 import (
+	"io/fs"
 	"testing"
 
 	"github.com/google/osv-scanner/pkg/lockfile"
@@ -63,7 +64,7 @@ func TestParseCargoLock_FileDoesNotExist(t *testing.T) {
 
 	packages, err := lockfile.ParseCargoLock("fixtures/cargo/does-not-exist")
 
-	expectErrContaining(t, err, "no such file or directory")
+	expectErrIs(t, err, fs.ErrNotExist)
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 

--- a/pkg/lockfile/parse-composer-lock_test.go
+++ b/pkg/lockfile/parse-composer-lock_test.go
@@ -1,6 +1,7 @@
 package lockfile_test
 
 import (
+	"io/fs"
 	"testing"
 
 	"github.com/google/osv-scanner/pkg/lockfile"
@@ -63,7 +64,7 @@ func TestParseComposerLock_FileDoesNotExist(t *testing.T) {
 
 	packages, err := lockfile.ParseComposerLock("fixtures/composer/does-not-exist")
 
-	expectErrContaining(t, err, "no such file or directory")
+	expectErrIs(t, err, fs.ErrNotExist)
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 

--- a/pkg/lockfile/parse-conan-lock-v1-revisions_test.go
+++ b/pkg/lockfile/parse-conan-lock-v1-revisions_test.go
@@ -1,6 +1,7 @@
 package lockfile_test
 
 import (
+	"io/fs"
 	"testing"
 
 	"github.com/google/osv-scanner/pkg/lockfile"
@@ -11,7 +12,7 @@ func TestParseConanLock_v1_revisions_FileDoesNotExist(t *testing.T) {
 
 	packages, err := lockfile.ParseConanLock("fixtures/conan/does-not-exist")
 
-	expectErrContaining(t, err, "no such file or directory")
+	expectErrIs(t, err, fs.ErrNotExist)
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 

--- a/pkg/lockfile/parse-conan-lock-v1_test.go
+++ b/pkg/lockfile/parse-conan-lock-v1_test.go
@@ -1,6 +1,7 @@
 package lockfile_test
 
 import (
+	"io/fs"
 	"testing"
 
 	"github.com/google/osv-scanner/pkg/lockfile"
@@ -11,7 +12,7 @@ func TestParseConanLock_v1_FileDoesNotExist(t *testing.T) {
 
 	packages, err := lockfile.ParseConanLock("fixtures/conan/does-not-exist")
 
-	expectErrContaining(t, err, "no such file or directory")
+	expectErrIs(t, err, fs.ErrNotExist)
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 

--- a/pkg/lockfile/parse-conan-lock-v2_test.go
+++ b/pkg/lockfile/parse-conan-lock-v2_test.go
@@ -1,6 +1,7 @@
 package lockfile_test
 
 import (
+	"io/fs"
 	"testing"
 
 	"github.com/google/osv-scanner/pkg/lockfile"
@@ -11,7 +12,7 @@ func TestParseConanLock_v2_FileDoesNotExist(t *testing.T) {
 
 	packages, err := lockfile.ParseConanLock("fixtures/conan/does-not-exist")
 
-	expectErrContaining(t, err, "no such file or directory")
+	expectErrIs(t, err, fs.ErrNotExist)
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 

--- a/pkg/lockfile/parse-gemfile-lock_test.go
+++ b/pkg/lockfile/parse-gemfile-lock_test.go
@@ -1,6 +1,7 @@
 package lockfile_test
 
 import (
+	"io/fs"
 	"testing"
 
 	"github.com/google/osv-scanner/pkg/lockfile"
@@ -63,7 +64,7 @@ func TestParseGemfileLock_FileDoesNotExist(t *testing.T) {
 
 	packages, err := lockfile.ParseGemfileLock("fixtures/bundler/does-not-exist")
 
-	expectErrContaining(t, err, "no such file or directory")
+	expectErrIs(t, err, fs.ErrNotExist)
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 

--- a/pkg/lockfile/parse-go-lock_test.go
+++ b/pkg/lockfile/parse-go-lock_test.go
@@ -1,6 +1,7 @@
 package lockfile_test
 
 import (
+	"io/fs"
 	"testing"
 
 	"github.com/google/osv-scanner/pkg/lockfile"
@@ -63,7 +64,7 @@ func TestParseGoLock_FileDoesNotExist(t *testing.T) {
 
 	packages, err := lockfile.ParseGoLock("fixtures/go/does-not-exist")
 
-	expectErrContaining(t, err, "no such file or directory")
+	expectErrIs(t, err, fs.ErrNotExist)
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 

--- a/pkg/lockfile/parse-gradle-lock_test.go
+++ b/pkg/lockfile/parse-gradle-lock_test.go
@@ -1,6 +1,7 @@
 package lockfile_test
 
 import (
+	"io/fs"
 	"testing"
 
 	"github.com/google/osv-scanner/pkg/lockfile"
@@ -88,7 +89,7 @@ func TestParseGradleLock_FileDoesNotExist(t *testing.T) {
 
 	packages, err := lockfile.ParseGradleLock("fixtures/gradle/does-not-exist")
 
-	expectErrContaining(t, err, "no such file or directory")
+	expectErrIs(t, err, fs.ErrNotExist)
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 

--- a/pkg/lockfile/parse-maven-lock_test.go
+++ b/pkg/lockfile/parse-maven-lock_test.go
@@ -1,6 +1,7 @@
 package lockfile_test
 
 import (
+	"io/fs"
 	"testing"
 
 	"github.com/google/osv-scanner/pkg/lockfile"
@@ -63,7 +64,7 @@ func TestParseMavenLock_FileDoesNotExist(t *testing.T) {
 
 	packages, err := lockfile.ParseMavenLock("fixtures/maven/does-not-exist")
 
-	expectErrContaining(t, err, "no such file or directory")
+	expectErrIs(t, err, fs.ErrNotExist)
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 

--- a/pkg/lockfile/parse-mix-lock_test.go
+++ b/pkg/lockfile/parse-mix-lock_test.go
@@ -1,6 +1,7 @@
 package lockfile_test
 
 import (
+	"io/fs"
 	"testing"
 
 	"github.com/google/osv-scanner/pkg/lockfile"
@@ -63,7 +64,7 @@ func TestParseMixLock_FileDoesNotExist(t *testing.T) {
 
 	packages, err := lockfile.ParseMixLock("fixtures/mix/does-not-exist")
 
-	expectErrContaining(t, err, "no such file or directory")
+	expectErrIs(t, err, fs.ErrNotExist)
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 

--- a/pkg/lockfile/parse-npm-lock-v1_test.go
+++ b/pkg/lockfile/parse-npm-lock-v1_test.go
@@ -1,6 +1,7 @@
 package lockfile_test
 
 import (
+	"io/fs"
 	"testing"
 
 	"github.com/google/osv-scanner/pkg/lockfile"
@@ -11,7 +12,7 @@ func TestParseNpmLock_v1_FileDoesNotExist(t *testing.T) {
 
 	packages, err := lockfile.ParseNpmLock("fixtures/npm/does-not-exist")
 
-	expectErrContaining(t, err, "no such file or directory")
+	expectErrIs(t, err, fs.ErrNotExist)
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 

--- a/pkg/lockfile/parse-npm-lock-v2_test.go
+++ b/pkg/lockfile/parse-npm-lock-v2_test.go
@@ -1,6 +1,7 @@
 package lockfile_test
 
 import (
+	"io/fs"
 	"testing"
 
 	"github.com/google/osv-scanner/pkg/lockfile"
@@ -11,7 +12,7 @@ func TestParseNpmLock_v2_FileDoesNotExist(t *testing.T) {
 
 	packages, err := lockfile.ParseNpmLock("fixtures/npm/does-not-exist")
 
-	expectErrContaining(t, err, "no such file or directory")
+	expectErrIs(t, err, fs.ErrNotExist)
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 

--- a/pkg/lockfile/parse-nuget-lock-v1_test.go
+++ b/pkg/lockfile/parse-nuget-lock-v1_test.go
@@ -1,6 +1,7 @@
 package lockfile_test
 
 import (
+	"io/fs"
 	"testing"
 
 	"github.com/google/osv-scanner/pkg/lockfile"
@@ -11,7 +12,7 @@ func TestParseNuGetLock_v1_FileDoesNotExist(t *testing.T) {
 
 	packages, err := lockfile.ParseNuGetLock("fixtures/nuget/does-not-exist")
 
-	expectErrContaining(t, err, "no such file or directory")
+	expectErrIs(t, err, fs.ErrNotExist)
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 

--- a/pkg/lockfile/parse-pipenv-lock_test.go
+++ b/pkg/lockfile/parse-pipenv-lock_test.go
@@ -1,6 +1,7 @@
 package lockfile_test
 
 import (
+	"io/fs"
 	"testing"
 
 	"github.com/google/osv-scanner/pkg/lockfile"
@@ -63,7 +64,7 @@ func TestParsePipenvLock_FileDoesNotExist(t *testing.T) {
 
 	packages, err := lockfile.ParsePipenvLock("fixtures/pipenv/does-not-exist")
 
-	expectErrContaining(t, err, "no such file or directory")
+	expectErrIs(t, err, fs.ErrNotExist)
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 

--- a/pkg/lockfile/parse-pnpm-lock_test.go
+++ b/pkg/lockfile/parse-pnpm-lock_test.go
@@ -1,6 +1,7 @@
 package lockfile_test
 
 import (
+	"io/fs"
 	"testing"
 
 	"github.com/google/osv-scanner/pkg/lockfile"
@@ -63,7 +64,7 @@ func TestParsePnpmLock_FileDoesNotExist(t *testing.T) {
 
 	packages, err := lockfile.ParsePnpmLock("fixtures/pnpm/does-not-exist")
 
-	expectErrContaining(t, err, "no such file or directory")
+	expectErrIs(t, err, fs.ErrNotExist)
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 

--- a/pkg/lockfile/parse-poetry-lock_test.go
+++ b/pkg/lockfile/parse-poetry-lock_test.go
@@ -1,6 +1,7 @@
 package lockfile_test
 
 import (
+	"io/fs"
 	"testing"
 
 	"github.com/google/osv-scanner/pkg/lockfile"
@@ -63,7 +64,7 @@ func TestParsePoetryLock_FileDoesNotExist(t *testing.T) {
 
 	packages, err := lockfile.ParsePoetryLock("fixtures/poetry/does-not-exist")
 
-	expectErrContaining(t, err, "no such file or directory")
+	expectErrIs(t, err, fs.ErrNotExist)
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 

--- a/pkg/lockfile/parse-pubspec-lock_test.go
+++ b/pkg/lockfile/parse-pubspec-lock_test.go
@@ -1,6 +1,7 @@
 package lockfile_test
 
 import (
+	"io/fs"
 	"testing"
 
 	"github.com/google/osv-scanner/pkg/lockfile"
@@ -63,7 +64,7 @@ func TestParsePubspecLock_FileDoesNotExist(t *testing.T) {
 
 	packages, err := lockfile.ParsePubspecLock("fixtures/pub/does-not-exist")
 
-	expectErrContaining(t, err, "no such file or directory")
+	expectErrIs(t, err, fs.ErrNotExist)
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 

--- a/pkg/lockfile/parse-requirements-txt_test.go
+++ b/pkg/lockfile/parse-requirements-txt_test.go
@@ -1,6 +1,7 @@
 package lockfile_test
 
 import (
+	"io/fs"
 	"testing"
 
 	"github.com/google/osv-scanner/pkg/lockfile"
@@ -63,7 +64,7 @@ func TestParseRequirementsTxt_FileDoesNotExist(t *testing.T) {
 
 	packages, err := lockfile.ParseRequirementsTxt("fixtures/pip/does-not-exist")
 
-	expectErrContaining(t, err, "no such file or directory")
+	expectErrIs(t, err, fs.ErrNotExist)
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 
@@ -482,7 +483,7 @@ func TestParseRequirementsTxt_WithBadROption(t *testing.T) {
 
 	packages, err := lockfile.ParseRequirementsTxt("fixtures/pip/with-bad-r-option.txt")
 
-	expectErrContaining(t, err, "no such file or directory")
+	expectErrIs(t, err, fs.ErrNotExist)
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 

--- a/pkg/lockfile/parse-yarn-lock-v1_test.go
+++ b/pkg/lockfile/parse-yarn-lock-v1_test.go
@@ -1,6 +1,7 @@
 package lockfile_test
 
 import (
+	"io/fs"
 	"testing"
 
 	"github.com/google/osv-scanner/pkg/lockfile"
@@ -11,7 +12,7 @@ func TestParseYarnLock_v1_FileDoesNotExist(t *testing.T) {
 
 	packages, err := lockfile.ParseYarnLock("fixtures/yarn/does-not-exist")
 
-	expectErrContaining(t, err, "no such file or directory")
+	expectErrIs(t, err, fs.ErrNotExist)
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 

--- a/pkg/lockfile/parse-yarn-lock-v2_test.go
+++ b/pkg/lockfile/parse-yarn-lock-v2_test.go
@@ -1,6 +1,7 @@
 package lockfile_test
 
 import (
+	"io/fs"
 	"testing"
 
 	"github.com/google/osv-scanner/pkg/lockfile"
@@ -11,7 +12,7 @@ func TestParseYarnLock_v2_FileDoesNotExist(t *testing.T) {
 
 	packages, err := lockfile.ParseYarnLock("fixtures/yarn/does-not-exist")
 
-	expectErrContaining(t, err, "no such file or directory")
+	expectErrIs(t, err, fs.ErrNotExist)
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 

--- a/pkg/lockfile/parse_test.go
+++ b/pkg/lockfile/parse_test.go
@@ -134,13 +134,7 @@ func TestParse_ParserNotFound(t *testing.T) {
 
 	_, err := lockfile.Parse("/path/to/my/", "")
 
-	if err == nil {
-		t.Errorf("Expected to get an error but did not")
-	}
-
-	if !errors.Is(err, lockfile.ErrParserNotFound) {
-		t.Errorf("Did not get the expected ErrParserNotFound error - got %v instead", err)
-	}
+	expectErrIs(t, err, lockfile.ErrParserNotFound)
 }
 
 func TestParse_ParserNotFound_WithExplicitParseAs(t *testing.T) {


### PR DESCRIPTION
Cherry-picked from #553

---

It's required for testing against Windows because it has a different error message, but it's also just a good overall change and landing it separately removes ~25 files from the main PR 😅 