### PR TITLE
Fix filter ids

### DIFF
--- a/cmd/osv-scanner/fixtures/locks-test-ignore/osv-scanner.toml
+++ b/cmd/osv-scanner/fixtures/locks-test-ignore/osv-scanner.toml
@@ -1,0 +1,3 @@
+[[IgnoredVulns]]
+id = "CVE-2021-23424"
+reason = "Test manifest file (alpine.cdx.xml)"

--- a/cmd/osv-scanner/fixtures/locks-test-ignore/package-lock.json
+++ b/cmd/osv-scanner/fixtures/locks-test-ignore/package-lock.json
@@ -1,0 +1,9 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "ansi-html": {
+      "version": "0.0.1"
+    }
+  }
+}

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -249,7 +249,7 @@ func TestRun(t *testing.T) {
 				Scanned <rootdir>/fixtures/locks-many/yarn.lock file and found 1 package
 				Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
 				CVE-2022-48174 has been filtered out because: Test manifest file (alpine.cdx.xml)
-				GHSA-whgm-jr23-g3j9 has been filtered out because: Test manifest file
+				GHSA-whgm-jr23-g3j9 and 1 alias have been filtered out because: Test manifest file
 				Filtered 2 vulnerabilities from output
 				No issues found
 			`,
@@ -257,7 +257,7 @@ func TestRun(t *testing.T) {
 		},
 		// all supported lockfiles in the directory should be checked
 		{
-			name:         "",
+			name:         "all supported lockfiles in the directory should be checked",
 			args:         []string{"", "./fixtures/locks-many-with-invalid"},
 			wantExitCode: 127,
 			wantStdout: `
@@ -271,7 +271,7 @@ func TestRun(t *testing.T) {
 		},
 		// only the files in the given directories are checked by default (no recursion)
 		{
-			name:         "",
+			name:         "only the files in the given directories are checked by default (no recursion)",
 			args:         []string{"", "./fixtures/locks-one-with-nested"},
 			wantExitCode: 0,
 			wantStdout: `
@@ -283,7 +283,7 @@ func TestRun(t *testing.T) {
 		},
 		// nested directories are checked when `--recursive` is passed
 		{
-			name:         "",
+			name:         "nested directories are checked when `--recursive` is passed",
 			args:         []string{"", "--recursive", "./fixtures/locks-one-with-nested"},
 			wantExitCode: 0,
 			wantStdout: `
@@ -328,7 +328,7 @@ func TestRun(t *testing.T) {
 		},
 		// output with json
 		{
-			name:         "",
+			name:         "json output 1",
 			args:         []string{"", "--json", "./fixtures/locks-many/composer.lock"},
 			wantExitCode: 0,
 			wantStdout: `
@@ -351,7 +351,7 @@ func TestRun(t *testing.T) {
 			`,
 		},
 		{
-			name:         "",
+			name:         "json output 2",
 			args:         []string{"", "--format", "json", "./fixtures/locks-many/composer.lock"},
 			wantExitCode: 0,
 			wantStdout: `
@@ -521,6 +521,21 @@ func TestRun(t *testing.T) {
 			wantStderr: `
 				unsupported output format "unknown" - must be one of: table, json, markdown, sarif, gh-annotations
 			`,
+		},
+		// one specific supported lockfile with ignore
+		{
+			name:         "one specific supported lockfile with ignore",
+			args:         []string{"", "./fixtures/locks-test-ignore/package-lock.json"},
+			wantExitCode: 0,
+			wantStdout: `
+				Scanning dir ./fixtures/locks-test-ignore/package-lock.json
+				Scanned <rootdir>/fixtures/locks-test-ignore/package-lock.json file and found 1 package
+				Loaded filter from: <rootdir>/fixtures/locks-test-ignore/osv-scanner.toml
+				CVE-2021-23424 and 1 alias have been filtered out because: Test manifest file (alpine.cdx.xml)
+				Filtered 1 vulnerability from output
+				No issues found
+			`,
+			wantStderr: "",
 		},
 	}
 	for _, tt := range tests {
@@ -936,7 +951,7 @@ func TestRun_LocalDatabases(t *testing.T) {
 				Loaded Packagist local db from %%/osv-scanner/Packagist/all.zip
 				Loaded npm local db from %%/osv-scanner/npm/all.zip
 				Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
-				GHSA-whgm-jr23-g3j9 has been filtered out because: Test manifest file
+				GHSA-whgm-jr23-g3j9 and 1 alias have been filtered out because: Test manifest file
 				Filtered 1 vulnerability from output
 				No issues found
 			`,
@@ -1123,7 +1138,7 @@ func TestRun_Licenses(t *testing.T) {
 				Scanned <rootdir>/fixtures/locks-many/yarn.lock file and found 1 package
 				Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
 				CVE-2022-48174 has been filtered out because: Test manifest file (alpine.cdx.xml)
-				GHSA-whgm-jr23-g3j9 has been filtered out because: Test manifest file
+				GHSA-whgm-jr23-g3j9 and 1 alias have been filtered out because: Test manifest file
 				Filtered 2 vulnerabilities from output
 				+------------+-------------------------+
 				| LICENSE    | NO. OF PACKAGE VERSIONS |
@@ -1147,7 +1162,7 @@ Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
 Scanned <rootdir>/fixtures/locks-many/yarn.lock file and found 1 package
 Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
 CVE-2022-48174 has been filtered out because: Test manifest file (alpine.cdx.xml)
-GHSA-whgm-jr23-g3j9 has been filtered out because: Test manifest file
+GHSA-whgm-jr23-g3j9 and 1 alias have been filtered out because: Test manifest file
 Filtered 2 vulnerabilities from output
 | License | No. of package versions |
 | --- | ---:|
@@ -1229,8 +1244,7 @@ Filtered 2 vulnerabilities from output
 								"package": {
 									"name": "babel",
 									"version": "6.23.0",
-									"ecosystem": "npm",
-									"commit": ""
+									"ecosystem": "npm"
 								},
 								"licenses": [
 									"MIT"
@@ -1240,8 +1254,7 @@ Filtered 2 vulnerabilities from output
 								"package": {
 									"name": "human-signals",
 									"version": "5.0.0",
-									"ecosystem": "npm",
-									"commit": ""
+									"ecosystem": "npm"
 								},
 								"licenses": [
 									"Apache-2.0"
@@ -1254,8 +1267,7 @@ Filtered 2 vulnerabilities from output
 								"package": {
 									"name": "ms",
 									"version": "2.1.3",
-									"ecosystem": "npm",
-									"commit": ""
+									"ecosystem": "npm"
 								},
 								"licenses": [
 									"MIT"
@@ -1299,8 +1311,7 @@ Filtered 2 vulnerabilities from output
 								"package": {
 									"name": "human-signals",
 									"version": "5.0.0",
-									"ecosystem": "npm",
-									"commit": ""
+									"ecosystem": "npm"
 								},
 								"licenses": [
 									"Apache-2.0"
@@ -1347,8 +1358,7 @@ Filtered 2 vulnerabilities from output
 								"package": {
 									"name": "babel",
 									"version": "6.23.0",
-									"ecosystem": "npm",
-									"commit": ""
+									"ecosystem": "npm"
 								},
 								"licenses": [
 									"MIT"
@@ -1358,8 +1368,7 @@ Filtered 2 vulnerabilities from output
 								"package": {
 									"name": "human-signals",
 									"version": "5.0.0",
-									"ecosystem": "npm",
-									"commit": ""
+									"ecosystem": "npm"
 								},
 								"licenses": [
 									"Apache-2.0"
@@ -1369,8 +1378,7 @@ Filtered 2 vulnerabilities from output
 								"package": {
 									"name": "ms",
 									"version": "2.1.3",
-									"ecosystem": "npm",
-									"commit": ""
+									"ecosystem": "npm"
 								},
 								"licenses": [
 									"MIT"

--- a/internal/ci/fixtures/vulns/test-vuln-diff-a-a-1.json
+++ b/internal/ci/fixtures/vulns/test-vuln-diff-a-a-1.json
@@ -75,11 +75,21 @@
             {
               "ids": [
                 "GO-2021-0053"
-              ]
+              ],
+              "aliases": null
             }
           ]
         }
       ]
     }
-  ]
+  ],
+  "experimental_config": {
+    "call_analysis": {
+      "enabled": false
+    },
+    "licenses": {
+      "enabled": false,
+      "allowlist": null
+    }
+  }
 }

--- a/internal/ci/fixtures/vulns/test-vuln-diff-a-a.json
+++ b/internal/ci/fixtures/vulns/test-vuln-diff-a-a.json
@@ -1,3 +1,12 @@
 {
-  "results": []
+  "results": [],
+  "experimental_config": {
+    "call_analysis": {
+      "enabled": false
+    },
+    "licenses": {
+      "enabled": false,
+      "allowlist": null
+    }
+  }
 }

--- a/internal/ci/fixtures/vulns/test-vuln-diff-a-b.json
+++ b/internal/ci/fixtures/vulns/test-vuln-diff-a-b.json
@@ -112,11 +112,24 @@
             {
               "ids": [
                 "GHSA-c3h9-896r-86jm"
+              ],
+              "aliases": [
+                "CVE-2021-3121",
+                "GHSA-c3h9-896r-86jm"
               ]
             }
           ]
         }
       ]
     }
-  ]
+  ],
+  "experimental_config": {
+    "call_analysis": {
+      "enabled": false
+    },
+    "licenses": {
+      "enabled": false,
+      "allowlist": null
+    }
+  }
 }

--- a/internal/ci/fixtures/vulns/test-vuln-diff-b-a.json
+++ b/internal/ci/fixtures/vulns/test-vuln-diff-b-a.json
@@ -1,3 +1,12 @@
 {
-  "results": []
+  "results": [],
+  "experimental_config": {
+    "call_analysis": {
+      "enabled": false
+    },
+    "licenses": {
+      "enabled": false,
+      "allowlist": null
+    }
+  }
 }

--- a/internal/ci/fixtures/vulns/test-vuln-diff-b-c.json
+++ b/internal/ci/fixtures/vulns/test-vuln-diff-b-c.json
@@ -1,3 +1,12 @@
 {
-  "results": []
+  "results": [],
+  "experimental_config": {
+    "call_analysis": {
+      "enabled": false
+    },
+    "licenses": {
+      "enabled": false,
+      "allowlist": null
+    }
+  }
 }

--- a/internal/ci/fixtures/vulns/test-vuln-diff-c-b.json
+++ b/internal/ci/fixtures/vulns/test-vuln-diff-c-b.json
@@ -112,6 +112,10 @@
             {
               "ids": [
                 "GHSA-c3h9-896r-86jm"
+              ],
+              "aliases": [
+                "CVE-2021-3121",
+                "GHSA-c3h9-896r-86jm"
               ]
             }
           ]
@@ -319,11 +323,21 @@
               "ids": [
                 "GHSA-m5pq-gvj9-9vr8",
                 "RUSTSEC-2022-0013"
-              ]
+              ],
+              "aliases": null
             }
           ]
         }
       ]
     }
-  ]
+  ],
+  "experimental_config": {
+    "call_analysis": {
+      "enabled": false
+    },
+    "licenses": {
+      "enabled": false,
+      "allowlist": null
+    }
+  }
 }

--- a/internal/testutility/utility.go
+++ b/internal/testutility/utility.go
@@ -48,6 +48,9 @@ func AssertMatchFixtureJSON[V any](t *testing.T, path string, val V) {
 	}
 }
 
+// Deprecated: Not actually deprecated, deprecated tag used to warn users from checking in as
+// it's meant to be used as a helper func to generate fixtures
+//
 // CreateJSONFixture creates a JSON file at path of the value val,
 // can be used with AssertMatchFixtureJSON to compare against future values.
 func CreateJSONFixture[V any](t *testing.T, path string, val V) {

--- a/pkg/grouper/grouper.go
+++ b/pkg/grouper/grouper.go
@@ -51,8 +51,10 @@ func Group(vulns []IDAliases) []models.GroupInfo {
 
 	// Extract groups into the final result structure.
 	extractedGroups := map[int][]string{}
+	extractedAliases := map[int][]string{}
 	for i, gid := range groups {
 		extractedGroups[gid] = append(extractedGroups[gid], vulns[i].ID)
+		extractedAliases[gid] = append(extractedAliases[gid], vulns[i].Aliases...)
 	}
 
 	// Sort by group ID to maintain stable order for tests.
@@ -63,7 +65,15 @@ func Group(vulns []IDAliases) []models.GroupInfo {
 	for _, key := range sortedKeys {
 		// Sort the strings so they are always in the same order
 		sort.Strings(extractedGroups[key])
-		result = append(result, models.GroupInfo{IDs: extractedGroups[key]})
+
+		// Add IDs to aliases
+		extractedAliases[key] = append(extractedAliases[key], extractedGroups[key]...)
+
+		// Dedup entries
+		sort.Strings(extractedAliases[key])
+		extractedAliases[key] = slices.Compact(extractedAliases[key])
+
+		result = append(result, models.GroupInfo{IDs: extractedGroups[key], Aliases: extractedAliases[key]})
 	}
 
 	return result

--- a/pkg/grouper/grouper_test.go
+++ b/pkg/grouper/grouper_test.go
@@ -81,16 +81,20 @@ func TestGroup(t *testing.T) {
 			},
 			want: []models.GroupInfo{
 				{
-					IDs: []string{v1.ID, v2.ID, v3.ID},
+					IDs:     []string{v1.ID, v2.ID, v3.ID},
+					Aliases: []string{v1.ID, v2.ID, v3.ID},
 				},
 				{
-					IDs: []string{v4.ID, v5.ID, v6.ID},
+					IDs:     []string{v4.ID, v5.ID, v6.ID},
+					Aliases: []string{v4.ID, v5.ID, v6.ID, v4.Aliases[0], v4.Aliases[1], v5.Aliases[1]},
 				},
 				{
-					IDs: []string{v7.ID},
+					IDs:     []string{v7.ID},
+					Aliases: []string{v7.Aliases[0], v7.ID},
 				},
 				{
-					IDs: []string{v8.ID},
+					IDs:     []string{v8.ID},
+					Aliases: []string{v8.Aliases[0], v8.ID},
 				},
 			},
 		},
@@ -100,22 +104,28 @@ func TestGroup(t *testing.T) {
 			},
 			want: []models.GroupInfo{
 				{
-					IDs: []string{v8.ID},
+					IDs:     []string{v8.ID},
+					Aliases: []string{v8.Aliases[0], v8.ID},
 				},
 				{
-					IDs: []string{v1.ID, v2.ID, v3.ID}, // Deterministic order
+					IDs:     []string{v1.ID, v2.ID, v3.ID}, // Deterministic order
+					Aliases: []string{v1.ID, v2.ID, v3.ID}, // Deterministic order
 				},
 				{
-					IDs: []string{v4.ID, v5.ID, v6.ID},
+					IDs:     []string{v4.ID, v5.ID, v6.ID},
+					Aliases: []string{v4.ID, v5.ID, v6.ID, v4.Aliases[0], v4.Aliases[1], v5.Aliases[1]},
 				},
 				{
-					IDs: []string{v7.ID},
+					IDs:     []string{v7.ID},
+					Aliases: []string{v7.Aliases[0], v7.ID},
 				},
 				{
-					IDs: []string{v9.ID},
+					IDs:     []string{v9.ID},
+					Aliases: []string{v9.ID},
 				},
 				{
-					IDs: []string{v10.ID},
+					IDs:     []string{v10.ID},
+					Aliases: []string{v10.ID},
 				},
 			},
 		},
@@ -125,10 +135,12 @@ func TestGroup(t *testing.T) {
 			},
 			want: []models.GroupInfo{
 				{
-					IDs: []string{v9.ID},
+					IDs:     []string{v9.ID},
+					Aliases: []string{v9.ID},
 				},
 				{
-					IDs: []string{v10.ID},
+					IDs:     []string{v10.ID},
+					Aliases: []string{v10.ID},
 				},
 			},
 		},

--- a/pkg/models/results.go
+++ b/pkg/models/results.go
@@ -108,6 +108,8 @@ type PackageVulns struct {
 type GroupInfo struct {
 	// IDs expected to be sorted in alphanumeric order
 	IDs []string `json:"ids"`
+	// Aliases include all aliases and IDs
+	Aliases []string `json:"aliases"`
 	// Map of Vulnerability IDs to AnalysisInfo
 	ExperimentalAnalysis map[string]AnalysisInfo `json:"experimentalAnalysis,omitempty"`
 }
@@ -170,5 +172,5 @@ type PackageInfo struct {
 	Name      string `json:"name"`
 	Version   string `json:"version"`
 	Ecosystem string `json:"ecosystem"`
-	Commit    string `json:"commit"`
+	Commit    string `json:"commit,omitempty"`
 }

--- a/pkg/osvscanner/fixtures/filter/all/configs/b/osv-scanner.toml
+++ b/pkg/osvscanner/fixtures/filter/all/configs/b/osv-scanner.toml
@@ -11,6 +11,6 @@ reason = "Ignore 2"
 # Alias of GHSA-xrjj-mj9h-534m
 
 [[IgnoredVulns]]
-id = "GO-2023-1571"
+id = "CVE-2022-41723"
 reason = "Ignore 3"
-# Alias of GHSA-vvpx-j8f3-3w6h
+# Alias of GHSA-vvpx-j8f3-3w6h and GO-2023-1571

--- a/pkg/osvscanner/fixtures/filter/all/input.json
+++ b/pkg/osvscanner/fixtures/filter/all/input.json
@@ -149,6 +149,10 @@
               "ids": [
                 "GHSA-mc8h-8q98-g5hr",
                 "RUSTSEC-2023-0018"
+              ],
+              "aliases": [
+                "GHSA-mc8h-8q98-g5hr",
+                "RUSTSEC-2023-0018"
               ]
             }
           ]
@@ -391,6 +395,10 @@
           "groups": [
             {
               "ids": [
+                "GHSA-wcg3-cvx6-7396",
+                "RUSTSEC-2020-0071"
+              ],
+              "aliases": [
                 "GHSA-wcg3-cvx6-7396",
                 "RUSTSEC-2020-0071"
               ]
@@ -867,10 +875,17 @@
               "ids": [
                 "GHSA-fxg5-wq6x-vr4w",
                 "GO-2023-1495"
+              ],
+              "aliases": [
+                "GHSA-fxg5-wq6x-vr4w",
+                "GO-2023-1495"
               ]
             },
             {
               "ids": [
+                "GO-2022-1144"
+              ],
+              "aliases": [
                 "GO-2022-1144"
               ]
             },
@@ -878,6 +893,11 @@
               "ids": [
                 "GHSA-vvpx-j8f3-3w6h",
                 "GO-2023-1571"
+              ],
+              "aliases": [
+                "GHSA-vvpx-j8f3-3w6h",
+                "GO-2023-1571",
+                "CVE-2022-41723"
               ]
             }
           ]
@@ -1021,10 +1041,16 @@
             {
               "ids": [
                 "GHSA-mrrw-grhq-86gf"
+              ],
+              "aliases": [
+                "GHSA-mrrw-grhq-86gf"
               ]
             },
             {
               "ids": [
+                "RUSTSEC-2023-0015"
+              ],
+              "aliases": [
                 "RUSTSEC-2023-0015"
               ]
             }
@@ -1171,6 +1197,10 @@
           "groups": [
             {
               "ids": [
+                "GHSA-mc8h-8q98-g5hr",
+                "RUSTSEC-2023-0018"
+              ],
+              "aliases": [
                 "GHSA-mc8h-8q98-g5hr",
                 "RUSTSEC-2023-0018"
               ]
@@ -1415,6 +1445,10 @@
           "groups": [
             {
               "ids": [
+                "GHSA-wcg3-cvx6-7396",
+                "RUSTSEC-2020-0071"
+              ],
+              "aliases": [
                 "GHSA-wcg3-cvx6-7396",
                 "RUSTSEC-2020-0071"
               ]

--- a/pkg/osvscanner/fixtures/filter/all/want.json
+++ b/pkg/osvscanner/fixtures/filter/all/want.json
@@ -1,3 +1,12 @@
 {
-  "results": []
+  "results": [],
+  "experimental_config": {
+    "call_analysis": {
+      "enabled": false
+    },
+    "licenses": {
+      "enabled": false,
+      "allowlist": null
+    }
+  }
 }

--- a/pkg/osvscanner/fixtures/filter/none/input.json
+++ b/pkg/osvscanner/fixtures/filter/none/input.json
@@ -149,6 +149,10 @@
               "ids": [
                 "GHSA-mc8h-8q98-g5hr",
                 "RUSTSEC-2023-0018"
+              ],
+              "aliases": [
+                "GHSA-mc8h-8q98-g5hr",
+                "RUSTSEC-2023-0018"
               ]
             }
           ]
@@ -391,6 +395,10 @@
           "groups": [
             {
               "ids": [
+                "GHSA-wcg3-cvx6-7396",
+                "RUSTSEC-2020-0071"
+              ],
+              "aliases": [
                 "GHSA-wcg3-cvx6-7396",
                 "RUSTSEC-2020-0071"
               ]
@@ -867,15 +875,26 @@
               "ids": [
                 "GHSA-fxg5-wq6x-vr4w",
                 "GO-2023-1495"
+              ],
+              "aliases": [
+                "GHSA-fxg5-wq6x-vr4w",
+                "GO-2023-1495"
               ]
             },
             {
               "ids": [
                 "GO-2022-1144"
+              ],
+              "aliases": [
+                "GO-2022-1144"
               ]
             },
             {
               "ids": [
+                "GHSA-vvpx-j8f3-3w6h",
+                "GO-2023-1571"
+              ],
+              "aliases": [
                 "GHSA-vvpx-j8f3-3w6h",
                 "GO-2023-1571"
               ]
@@ -1021,11 +1040,17 @@
             {
               "ids": [
                 "GHSA-mrrw-grhq-86gf"
+              ],
+              "aliases": [
+                "GHSA-mrrw-grhq-86gf"
               ]
             },
             {
               "ids": [
                 "RUSTSEC-2023-0015"
+              ],
+              "aliases": [
+                "RUSTSEC-2023-0015"    
               ]
             }
           ]
@@ -1171,6 +1196,10 @@
           "groups": [
             {
               "ids": [
+                "GHSA-mc8h-8q98-g5hr",
+                "RUSTSEC-2023-0018"
+              ],
+              "aliases": [
                 "GHSA-mc8h-8q98-g5hr",
                 "RUSTSEC-2023-0018"
               ]
@@ -1415,6 +1444,10 @@
           "groups": [
             {
               "ids": [
+                "GHSA-wcg3-cvx6-7396",
+                "RUSTSEC-2020-0071"
+              ],
+              "aliases": [
                 "GHSA-wcg3-cvx6-7396",
                 "RUSTSEC-2020-0071"
               ]

--- a/pkg/osvscanner/fixtures/filter/none/want.json
+++ b/pkg/osvscanner/fixtures/filter/none/want.json
@@ -14,11 +14,10 @@
           },
           "vulnerabilities": [
             {
-              "schema_version": "1.4.0",
-              "id": "GHSA-mc8h-8q98-g5hr",
               "modified": "2023-02-24T16:23:59Z",
               "published": "2023-02-24T16:23:59Z",
-              "aliases": null,
+              "schema_version": "1.4.0",
+              "id": "GHSA-mc8h-8q98-g5hr",
               "summary": "Race Condition Enabling Link Following and Time-of-check Time-of-use (TOCTOU) Race Condition in remove_dir_all",
               "details": "The `remove_dir_all` crate is a Rust library that offers additional features over the Rust standard library `fs::remove_dir_all` function. It suffers the same class of failure as the code it was layering over: TOCTOU race conditions, with the ability to cause arbitrary paths to be deleted by substituting a symlink for a path after the type of the path was checked.\n\nThanks to the Rust security team for identifying the problem and alerting us to it.",
               "affected": [
@@ -76,10 +75,10 @@
               }
             },
             {
-              "schema_version": "1.4.0",
-              "id": "RUSTSEC-2023-0018",
               "modified": "2023-03-04T21:50:30Z",
               "published": "2023-02-24T12:00:00Z",
+              "schema_version": "1.4.0",
+              "id": "RUSTSEC-2023-0018",
               "aliases": [
                 "GHSA-mc8h-8q98-g5hr"
               ],
@@ -149,6 +148,10 @@
               "ids": [
                 "GHSA-mc8h-8q98-g5hr",
                 "RUSTSEC-2023-0018"
+              ],
+              "aliases": [
+                "GHSA-mc8h-8q98-g5hr",
+                "RUSTSEC-2023-0018"
               ]
             }
           ]
@@ -161,10 +164,10 @@
           },
           "vulnerabilities": [
             {
-              "schema_version": "1.4.0",
-              "id": "GHSA-wcg3-cvx6-7396",
               "modified": "2022-12-06T00:16:25Z",
               "published": "2021-08-25T20:56:46Z",
+              "schema_version": "1.4.0",
+              "id": "GHSA-wcg3-cvx6-7396",
               "aliases": [
                 "CVE-2020-26235"
               ],
@@ -263,10 +266,10 @@
               }
             },
             {
-              "schema_version": "1.4.0",
-              "id": "RUSTSEC-2020-0071",
               "modified": "2023-02-08T15:06:38Z",
               "published": "2020-11-18T12:00:00Z",
+              "schema_version": "1.4.0",
+              "id": "RUSTSEC-2020-0071",
               "aliases": [
                 "CVE-2020-26235"
               ],
@@ -393,6 +396,10 @@
               "ids": [
                 "GHSA-wcg3-cvx6-7396",
                 "RUSTSEC-2020-0071"
+              ],
+              "aliases": [
+                "GHSA-wcg3-cvx6-7396",
+                "RUSTSEC-2020-0071"
               ]
             }
           ]
@@ -413,10 +420,10 @@
           },
           "vulnerabilities": [
             {
-              "schema_version": "1.4.0",
-              "id": "GHSA-fxg5-wq6x-vr4w",
               "modified": "2023-01-24T18:56:46Z",
               "published": "2023-01-14T00:30:23Z",
+              "schema_version": "1.4.0",
+              "id": "GHSA-fxg5-wq6x-vr4w",
               "aliases": [
                 "CVE-2022-41721"
               ],
@@ -503,15 +510,14 @@
               }
             },
             {
-              "schema_version": "1.4.0",
-              "id": "GO-2023-1495",
               "modified": "2023-01-31T21:39:17Z",
               "published": "2023-01-13T22:39:40Z",
+              "schema_version": "1.4.0",
+              "id": "GO-2023-1495",
               "aliases": [
                 "CVE-2022-41721",
                 "GHSA-fxg5-wq6x-vr4w"
               ],
-              "summary": "",
               "details": "A request smuggling attack is possible when using MaxBytesHandler.\n\nWhen using MaxBytesHandler, the body of an HTTP request is not fully consumed. When the server attempts to read HTTP2 frames from the connection, it will instead be reading the body of the HTTP request, which could be attacker-manipulated to represent arbitrary HTTP2 requests.",
               "affected": [
                 {
@@ -562,15 +568,14 @@
               ]
             },
             {
-              "schema_version": "1.4.0",
-              "id": "GO-2022-1144",
               "modified": "2023-01-31T21:39:15Z",
               "published": "2022-12-08T19:01:21Z",
+              "schema_version": "1.4.0",
+              "id": "GO-2022-1144",
               "aliases": [
                 "CVE-2022-41717",
                 "GHSA-xrjj-mj9h-534m"
               ],
-              "summary": "",
               "details": "An attacker can cause excessive memory growth in a Go server accepting HTTP/2 requests.\n\nHTTP/2 server connections contain a cache of HTTP header keys sent by the client. While the total number of entries in this cache is capped, an attacker sending very large keys can cause the server to allocate approximately 64 MiB per open connection.",
               "affected": [
                 {
@@ -678,10 +683,10 @@
               ]
             },
             {
-              "schema_version": "1.4.0",
-              "id": "GHSA-vvpx-j8f3-3w6h",
               "modified": "2023-03-09T21:20:44Z",
               "published": "2023-02-17T14:00:02Z",
+              "schema_version": "1.4.0",
+              "id": "GHSA-vvpx-j8f3-3w6h",
               "aliases": [
                 "CVE-2022-41723"
               ],
@@ -753,15 +758,14 @@
               }
             },
             {
-              "schema_version": "1.4.0",
-              "id": "GO-2023-1571",
               "modified": "2023-02-22T20:13:12Z",
               "published": "2023-02-16T22:31:36Z",
+              "schema_version": "1.4.0",
+              "id": "GO-2023-1571",
               "aliases": [
                 "CVE-2022-41723",
                 "GHSA-vvpx-j8f3-3w6h"
               ],
-              "summary": "",
               "details": "A maliciously crafted HTTP/2 stream could cause excessive CPU consumption in the HPACK decoder, sufficient to cause a denial of service from a small number of small requests.",
               "affected": [
                 {
@@ -867,15 +871,26 @@
               "ids": [
                 "GHSA-fxg5-wq6x-vr4w",
                 "GO-2023-1495"
+              ],
+              "aliases": [
+                "GHSA-fxg5-wq6x-vr4w",
+                "GO-2023-1495"
               ]
             },
             {
               "ids": [
                 "GO-2022-1144"
+              ],
+              "aliases": [
+                "GO-2022-1144"
               ]
             },
             {
               "ids": [
+                "GHSA-vvpx-j8f3-3w6h",
+                "GO-2023-1571"
+              ],
+              "aliases": [
                 "GHSA-vvpx-j8f3-3w6h",
                 "GO-2023-1571"
               ]
@@ -898,11 +913,10 @@
           },
           "vulnerabilities": [
             {
-              "schema_version": "1.4.0",
-              "id": "GHSA-mrrw-grhq-86gf",
               "modified": "2023-02-28T20:30:10Z",
               "published": "2023-02-28T20:30:10Z",
-              "aliases": null,
+              "schema_version": "1.4.0",
+              "id": "GHSA-mrrw-grhq-86gf",
               "summary": "Ascii (crate) allows out-of-bounds array indexing in safe code",
               "details": "Affected version of this crate had implementation of `From\u003c\u0026mut AsciiStr\u003e` for `\u0026mut [u8]` and `\u0026mut str`. This can result in out-of-bounds array indexing in safe code.\n\nThe flaw was corrected in commit [8a6c779](https://github.com/tomprogrammer/rust-ascii/pull/63/commits/8a6c7798c202766bd57d70fb8d12739dd68fb9dc) by removing those impls.\n",
               "affected": [
@@ -957,11 +971,10 @@
               }
             },
             {
-              "schema_version": "1.4.0",
-              "id": "RUSTSEC-2023-0015",
               "modified": "2023-02-25T15:13:09Z",
               "published": "2023-02-25T12:00:00Z",
-              "aliases": null,
+              "schema_version": "1.4.0",
+              "id": "RUSTSEC-2023-0015",
               "summary": "Ascii allows out-of-bounds array indexing in safe code",
               "details": "Affected version of this crate had implementation of `From\u003c\u0026mut AsciiStr\u003e` for `\u0026mut [u8]` and `\u0026mut str`. This can result in out-of-bounds array indexing in safe code.\n\nThe flaw was corrected in commit [8a6c779](https://github.com/tomprogrammer/rust-ascii/pull/63/commits/8a6c7798c202766bd57d70fb8d12739dd68fb9dc) by removing those impls.",
               "affected": [
@@ -1021,10 +1034,16 @@
             {
               "ids": [
                 "GHSA-mrrw-grhq-86gf"
+              ],
+              "aliases": [
+                "GHSA-mrrw-grhq-86gf"
               ]
             },
             {
               "ids": [
+                "RUSTSEC-2023-0015"
+              ],
+              "aliases": [
                 "RUSTSEC-2023-0015"
               ]
             }
@@ -1038,11 +1057,10 @@
           },
           "vulnerabilities": [
             {
-              "schema_version": "1.4.0",
-              "id": "GHSA-mc8h-8q98-g5hr",
               "modified": "2023-02-24T16:23:59Z",
               "published": "2023-02-24T16:23:59Z",
-              "aliases": null,
+              "schema_version": "1.4.0",
+              "id": "GHSA-mc8h-8q98-g5hr",
               "summary": "Race Condition Enabling Link Following and Time-of-check Time-of-use (TOCTOU) Race Condition in remove_dir_all",
               "details": "The `remove_dir_all` crate is a Rust library that offers additional features over the Rust standard library `fs::remove_dir_all` function. It suffers the same class of failure as the code it was layering over: TOCTOU race conditions, with the ability to cause arbitrary paths to be deleted by substituting a symlink for a path after the type of the path was checked.\n\nThanks to the Rust security team for identifying the problem and alerting us to it.",
               "affected": [
@@ -1100,10 +1118,10 @@
               }
             },
             {
-              "schema_version": "1.4.0",
-              "id": "RUSTSEC-2023-0018",
               "modified": "2023-03-04T21:50:30Z",
               "published": "2023-02-24T12:00:00Z",
+              "schema_version": "1.4.0",
+              "id": "RUSTSEC-2023-0018",
               "aliases": [
                 "GHSA-mc8h-8q98-g5hr"
               ],
@@ -1173,6 +1191,10 @@
               "ids": [
                 "GHSA-mc8h-8q98-g5hr",
                 "RUSTSEC-2023-0018"
+              ],
+              "aliases": [
+                "GHSA-mc8h-8q98-g5hr",
+                "RUSTSEC-2023-0018"
               ]
             }
           ]
@@ -1185,10 +1207,10 @@
           },
           "vulnerabilities": [
             {
-              "schema_version": "1.4.0",
-              "id": "GHSA-wcg3-cvx6-7396",
               "modified": "2022-12-06T00:16:25Z",
               "published": "2021-08-25T20:56:46Z",
+              "schema_version": "1.4.0",
+              "id": "GHSA-wcg3-cvx6-7396",
               "aliases": [
                 "CVE-2020-26235"
               ],
@@ -1287,10 +1309,10 @@
               }
             },
             {
-              "schema_version": "1.4.0",
-              "id": "RUSTSEC-2020-0071",
               "modified": "2023-02-08T15:06:38Z",
               "published": "2020-11-18T12:00:00Z",
+              "schema_version": "1.4.0",
+              "id": "RUSTSEC-2020-0071",
               "aliases": [
                 "CVE-2020-26235"
               ],
@@ -1417,11 +1439,24 @@
               "ids": [
                 "GHSA-wcg3-cvx6-7396",
                 "RUSTSEC-2020-0071"
+              ],
+              "aliases": [
+                "GHSA-wcg3-cvx6-7396",
+                "RUSTSEC-2020-0071"
               ]
             }
           ]
         }
       ]
     }
-  ]
+  ],
+  "experimental_config": {
+    "call_analysis": {
+      "enabled": false
+    },
+    "licenses": {
+      "enabled": false,
+      "allowlist": null
+    }
+  }
 }

--- a/pkg/osvscanner/fixtures/filter/some/input.json
+++ b/pkg/osvscanner/fixtures/filter/some/input.json
@@ -149,6 +149,10 @@
               "ids": [
                 "GHSA-mc8h-8q98-g5hr",
                 "RUSTSEC-2023-0018"
+              ],
+              "aliases": [
+                "GHSA-mc8h-8q98-g5hr",
+                "RUSTSEC-2023-0018"
               ]
             }
           ]
@@ -391,6 +395,10 @@
           "groups": [
             {
               "ids": [
+                "GHSA-wcg3-cvx6-7396",
+                "RUSTSEC-2020-0071"
+              ],
+              "aliases": [
                 "GHSA-wcg3-cvx6-7396",
                 "RUSTSEC-2020-0071"
               ]
@@ -867,15 +875,26 @@
               "ids": [
                 "GHSA-fxg5-wq6x-vr4w",
                 "GO-2023-1495"
+              ],
+              "aliases": [
+                "GHSA-fxg5-wq6x-vr4w",
+                "GO-2023-1495"
               ]
             },
             {
               "ids": [
                 "GO-2022-1144"
+              ],
+              "aliases": [
+                "GO-2022-1144"
               ]
             },
             {
               "ids": [
+                "GHSA-vvpx-j8f3-3w6h",
+                "GO-2023-1571"
+              ],
+              "aliases": [
                 "GHSA-vvpx-j8f3-3w6h",
                 "GO-2023-1571"
               ]
@@ -1021,10 +1040,16 @@
             {
               "ids": [
                 "GHSA-mrrw-grhq-86gf"
+              ],
+              "aliases": [
+                "GHSA-mrrw-grhq-86gf"
               ]
             },
             {
               "ids": [
+                "RUSTSEC-2023-0015"
+              ],
+              "aliases": [
                 "RUSTSEC-2023-0015"
               ]
             }
@@ -1171,6 +1196,10 @@
           "groups": [
             {
               "ids": [
+                "GHSA-mc8h-8q98-g5hr",
+                "RUSTSEC-2023-0018"
+              ],
+              "aliases": [
                 "GHSA-mc8h-8q98-g5hr",
                 "RUSTSEC-2023-0018"
               ]
@@ -1415,6 +1444,10 @@
           "groups": [
             {
               "ids": [
+                "GHSA-wcg3-cvx6-7396",
+                "RUSTSEC-2020-0071"
+              ],
+              "aliases": [
                 "GHSA-wcg3-cvx6-7396",
                 "RUSTSEC-2020-0071"
               ]

--- a/pkg/osvscanner/fixtures/filter/some/want.json
+++ b/pkg/osvscanner/fixtures/filter/some/want.json
@@ -14,10 +14,10 @@
           },
           "vulnerabilities": [
             {
-              "schema_version": "1.4.0",
-              "id": "GHSA-vvpx-j8f3-3w6h",
               "modified": "2023-03-09T21:20:44Z",
               "published": "2023-02-17T14:00:02Z",
+              "schema_version": "1.4.0",
+              "id": "GHSA-vvpx-j8f3-3w6h",
               "aliases": [
                 "CVE-2022-41723"
               ],
@@ -89,15 +89,14 @@
               }
             },
             {
-              "schema_version": "1.4.0",
-              "id": "GO-2023-1571",
               "modified": "2023-02-22T20:13:12Z",
               "published": "2023-02-16T22:31:36Z",
+              "schema_version": "1.4.0",
+              "id": "GO-2023-1571",
               "aliases": [
                 "CVE-2022-41723",
                 "GHSA-vvpx-j8f3-3w6h"
               ],
-              "summary": "",
               "details": "A maliciously crafted HTTP/2 stream could cause excessive CPU consumption in the HPACK decoder, sufficient to cause a denial of service from a small number of small requests.",
               "affected": [
                 {
@@ -203,6 +202,10 @@
               "ids": [
                 "GHSA-vvpx-j8f3-3w6h",
                 "GO-2023-1571"
+              ],
+              "aliases": [
+                "GHSA-vvpx-j8f3-3w6h",
+                "GO-2023-1571"
               ]
             }
           ]
@@ -223,11 +226,10 @@
           },
           "vulnerabilities": [
             {
-              "schema_version": "1.4.0",
-              "id": "GHSA-mrrw-grhq-86gf",
               "modified": "2023-02-28T20:30:10Z",
               "published": "2023-02-28T20:30:10Z",
-              "aliases": null,
+              "schema_version": "1.4.0",
+              "id": "GHSA-mrrw-grhq-86gf",
               "summary": "Ascii (crate) allows out-of-bounds array indexing in safe code",
               "details": "Affected version of this crate had implementation of `From\u003c\u0026mut AsciiStr\u003e` for `\u0026mut [u8]` and `\u0026mut str`. This can result in out-of-bounds array indexing in safe code.\n\nThe flaw was corrected in commit [8a6c779](https://github.com/tomprogrammer/rust-ascii/pull/63/commits/8a6c7798c202766bd57d70fb8d12739dd68fb9dc) by removing those impls.\n",
               "affected": [
@@ -286,6 +288,9 @@
             {
               "ids": [
                 "GHSA-mrrw-grhq-86gf"
+              ],
+              "aliases": [
+                "GHSA-mrrw-grhq-86gf"
               ]
             }
           ]
@@ -298,10 +303,10 @@
           },
           "vulnerabilities": [
             {
-              "schema_version": "1.4.0",
-              "id": "GHSA-wcg3-cvx6-7396",
               "modified": "2022-12-06T00:16:25Z",
               "published": "2021-08-25T20:56:46Z",
+              "schema_version": "1.4.0",
+              "id": "GHSA-wcg3-cvx6-7396",
               "aliases": [
                 "CVE-2020-26235"
               ],
@@ -400,10 +405,10 @@
               }
             },
             {
-              "schema_version": "1.4.0",
-              "id": "RUSTSEC-2020-0071",
               "modified": "2023-02-08T15:06:38Z",
               "published": "2020-11-18T12:00:00Z",
+              "schema_version": "1.4.0",
+              "id": "RUSTSEC-2020-0071",
               "aliases": [
                 "CVE-2020-26235"
               ],
@@ -530,11 +535,24 @@
               "ids": [
                 "GHSA-wcg3-cvx6-7396",
                 "RUSTSEC-2020-0071"
+              ],
+              "aliases": [
+                "GHSA-wcg3-cvx6-7396",
+                "RUSTSEC-2020-0071"
               ]
             }
           ]
         }
       ]
     }
-  ]
+  ],
+  "experimental_config": {
+    "call_analysis": {
+      "enabled": false
+    },
+    "licenses": {
+      "enabled": false,
+      "allowlist": null
+    }
+  }
 }

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -635,20 +635,20 @@ func filterPackageVulns(r reporter.Reporter, pkgVulns models.PackageVulns, confi
 	var newGroups []models.GroupInfo
 	for _, group := range pkgVulns.Groups {
 		ignore := false
-		for _, id := range group.IDs {
+		for _, id := range group.Aliases {
 			var ignoreLine config.IgnoreEntry
 			if ignore, ignoreLine = configToUse.ShouldIgnore(id); ignore {
-				for _, id := range group.IDs {
+				for _, id := range group.Aliases {
 					ignoredVulns[id] = struct{}{}
 				}
 				// NB: This only prints the first reason encountered in all the aliases.
-				switch len(group.IDs) {
+				switch len(group.Aliases) {
 				case 1:
 					r.PrintText(fmt.Sprintf("%s has been filtered out because: %s\n", ignoreLine.ID, ignoreLine.Reason))
 				case 2:
 					r.PrintText(fmt.Sprintf("%s and 1 alias have been filtered out because: %s\n", ignoreLine.ID, ignoreLine.Reason))
 				default:
-					r.PrintText(fmt.Sprintf("%s and %d aliases have been filtered out because: %s\n", ignoreLine.ID, len(group.IDs)-1, ignoreLine.Reason))
+					r.PrintText(fmt.Sprintf("%s and %d aliases have been filtered out because: %s\n", ignoreLine.ID, len(group.Aliases)-1, ignoreLine.Reason))
 				}
 
 				break

--- a/pkg/osvscanner/osvscanner_internal_test.go
+++ b/pkg/osvscanner/osvscanner_internal_test.go
@@ -65,6 +65,7 @@ func Test_filterResults(t *testing.T) {
 				out := filepath.Join(tt.testCase.path, "out.json")
 				t.Errorf("filterResults() returned an unexpected results (-want, +got):\n%s\n"+
 					"Full json output written to %s", diff, out)
+				//nolint:staticcheck
 				testutility.CreateJSONFixture(t, out, got)
 			}
 			if filtered != tt.testCase.numFiltered {

--- a/pkg/osvscanner/vulnerability_result_internal_test.go
+++ b/pkg/osvscanner/vulnerability_result_internal_test.go
@@ -115,7 +115,10 @@ func Test_assembleResult(t *testing.T) {
 								},
 							},
 							Groups: []models.GroupInfo{
-								{IDs: []string{"CVE-123", "GHSA-123"}},
+								{
+									IDs:     []string{"CVE-123", "GHSA-123"},
+									Aliases: []string{"CVE-123", "GHSA-123"},
+								},
 							},
 						},
 					},
@@ -136,7 +139,10 @@ func Test_assembleResult(t *testing.T) {
 								{ID: "GHSA-456"},
 							},
 							Groups: []models.GroupInfo{
-								{IDs: []string{"GHSA-456"}},
+								{
+									IDs:     []string{"GHSA-456"},
+									Aliases: []string{"GHSA-456"},
+								},
 							},
 						},
 					},
@@ -179,7 +185,10 @@ func Test_assembleResult(t *testing.T) {
 								},
 							},
 							Groups: []models.GroupInfo{
-								{IDs: []string{"CVE-123", "GHSA-123"}},
+								{
+									IDs:     []string{"CVE-123", "GHSA-123"},
+									Aliases: []string{"CVE-123", "GHSA-123"},
+								},
 							},
 						}, {
 							Package: models.PackageInfo{
@@ -206,7 +215,10 @@ func Test_assembleResult(t *testing.T) {
 								{ID: "GHSA-456"},
 							},
 							Groups: []models.GroupInfo{
-								{IDs: []string{"GHSA-456"}},
+								{
+									IDs:     []string{"GHSA-456"},
+									Aliases: []string{"GHSA-456"},
+								},
 							},
 						},
 					},
@@ -255,7 +267,10 @@ func Test_assembleResult(t *testing.T) {
 								},
 							},
 							Groups: []models.GroupInfo{
-								{IDs: []string{"CVE-123", "GHSA-123"}},
+								{
+									IDs:     []string{"CVE-123", "GHSA-123"},
+									Aliases: []string{"CVE-123", "GHSA-123"},
+								},
 							},
 							Licenses:          makeLicenses([]string{"MIT", "0BSD"}),
 							LicenseViolations: makeLicenses([]string{"MIT", "0BSD"}),
@@ -286,7 +301,10 @@ func Test_assembleResult(t *testing.T) {
 								{ID: "GHSA-456"},
 							},
 							Groups: []models.GroupInfo{
-								{IDs: []string{"GHSA-456"}},
+								{
+									IDs:     []string{"GHSA-456"},
+									Aliases: []string{"GHSA-456"},
+								},
 							},
 							Licenses:          makeLicenses([]string{"UNKNOWN"}),
 							LicenseViolations: makeLicenses([]string{"UNKNOWN"}),
@@ -337,7 +355,10 @@ func Test_assembleResult(t *testing.T) {
 								},
 							},
 							Groups: []models.GroupInfo{
-								{IDs: []string{"CVE-123", "GHSA-123"}},
+								{
+									IDs:     []string{"CVE-123", "GHSA-123"},
+									Aliases: []string{"CVE-123", "GHSA-123"},
+								},
 							},
 							Licenses: makeLicenses([]string{"MIT", "0BSD"}),
 						},
@@ -359,7 +380,10 @@ func Test_assembleResult(t *testing.T) {
 								{ID: "GHSA-456"},
 							},
 							Groups: []models.GroupInfo{
-								{IDs: []string{"GHSA-456"}},
+								{
+									IDs:     []string{"GHSA-456"},
+									Aliases: []string{"GHSA-456"},
+								},
 							},
 							Licenses:          makeLicenses([]string{"UNKNOWN"}),
 							LicenseViolations: makeLicenses([]string{"UNKNOWN"}),
@@ -410,7 +434,10 @@ func Test_assembleResult(t *testing.T) {
 								},
 							},
 							Groups: []models.GroupInfo{
-								{IDs: []string{"CVE-123", "GHSA-123"}},
+								{
+									IDs:     []string{"CVE-123", "GHSA-123"},
+									Aliases: []string{"CVE-123", "GHSA-123"},
+								},
 							},
 							Licenses: makeLicenses([]string{"MIT", "0BSD"}),
 						}, {
@@ -439,7 +466,10 @@ func Test_assembleResult(t *testing.T) {
 								{ID: "GHSA-456"},
 							},
 							Groups: []models.GroupInfo{
-								{IDs: []string{"GHSA-456"}},
+								{
+									IDs:     []string{"GHSA-456"},
+									Aliases: []string{"GHSA-456"},
+								},
 							},
 							Licenses:          makeLicenses([]string{"UNKNOWN"}),
 							LicenseViolations: makeLicenses([]string{"UNKNOWN"}),


### PR DESCRIPTION
Fixes #634 

The actual change is just adding an `Aliases` field to the Group output, that combines all the IDs and aliases together. A lot of fixtures had to be updated though. 

Added an additional test for this in `main_test`, and also modified a test in `osvscanner_internal_tests.go`

Also added `omitempty` tag to `PackageInfo.commit` which it should have contained in the first place.
