### PR TITLE
scan and report dependency groups of vulnerabilities

### DIFF
--- a/internal/output/sarif.go
+++ b/internal/output/sarif.go
@@ -295,13 +295,19 @@ func PrintSARIFReport(vulnResult *models.VulnerabilityResults, outputWriter io.W
 				alsoKnownAsStr = fmt.Sprintf(" (also known as '%s')", strings.Join(gv.AliasedIDList[1:], "', '"))
 			}
 
+			depGroup := ""
+			if pws.Package.DepGroup != "" {
+				depGroup = fmt.Sprintf(" (%s)", pws.Package.DepGroup)
+			}
+
 			run.CreateResultForRule(gv.DisplayID).
 				WithLevel("warning").
 				WithMessage(
 					sarif.NewTextMessage(
 						fmt.Sprintf(
-							"Package '%s' is vulnerable to '%s'%s.",
+							"Package '%s'%s is vulnerable to '%s'%s.",
 							results.PkgToString(pws.Package),
+							depGroup,
 							gv.DisplayID,
 							alsoKnownAsStr,
 						))).

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -128,7 +128,11 @@ func tableBuilderInner(vulnResult *models.VulnerabilityResults, addStyling bool,
 					outputRow = append(outputRow, "GIT", pkgCommitStr, pkgCommitStr)
 					shouldMerge = true
 				} else {
-					outputRow = append(outputRow, pkg.Package.Ecosystem, pkg.Package.Name, pkg.Package.Version)
+					name := pkg.Package.Name
+					if pkg.Package.DepGroup != "" {
+						name += fmt.Sprintf(" (%s)", pkg.Package.DepGroup)
+					}
+					outputRow = append(outputRow, pkg.Package.Ecosystem, name, pkg.Package.Version)
 				}
 
 				outputRow = append(outputRow, source.Path)

--- a/pkg/lockfile/fixtures/maven/with-scope.xml
+++ b/pkg/lockfile/fixtures/maven/with-scope.xml
@@ -1,0 +1,10 @@
+<project>
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/pkg/lockfile/fixtures/npm/optional-package.v1.json
+++ b/pkg/lockfile/fixtures/npm/optional-package.v1.json
@@ -1,0 +1,22 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true,
+      "optional": true
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "optional": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    }
+  }
+}

--- a/pkg/lockfile/fixtures/npm/optional-package.v2.json
+++ b/pkg/lockfile/fixtures/npm/optional-package.v2.json
@@ -1,0 +1,30 @@
+{
+  "name": "my-library",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {},
+      "devDependencies": { "wrappy": "^1.0.0" }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "optional": true
+    },
+     "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "devOptional": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    }
+  },
+  "dependencies": {}
+}

--- a/pkg/lockfile/fixtures/poetry/optional-package.lock
+++ b/pkg/lockfile/fixtures/poetry/optional-package.lock
@@ -1,0 +1,15 @@
+[[package]]
+name = "numpy"
+version = "1.23.3"
+description = "NumPy is the fundamental package for array computing with Python."
+category = "main"
+optional = true
+python-versions = ">=3.8"
+
+[metadata]
+lock-version = "1.1"
+python-versions = "^3.8"
+content-hash = "399777887f0c3171cbc3fc8a8e350d0fca4d882cf126657f60ec83872572ed44"
+
+[metadata.files]
+numpy = []

--- a/pkg/lockfile/parse-composer-lock.go
+++ b/pkg/lockfile/parse-composer-lock.go
@@ -27,6 +27,8 @@ func (e ComposerLockExtractor) ShouldExtract(path string) bool {
 	return filepath.Base(path) == "composer.lock"
 }
 
+const ComposerDevDependency string = "dev"
+
 func (e ComposerLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 	var parsedLockfile *ComposerLock
 
@@ -60,6 +62,7 @@ func (e ComposerLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 			Commit:    composerPackage.Dist.Reference,
 			Ecosystem: ComposerEcosystem,
 			CompareAs: ComposerEcosystem,
+			DepGroup:  ComposerDevDependency,
 		})
 	}
 

--- a/pkg/lockfile/parse-composer-lock_test.go
+++ b/pkg/lockfile/parse-composer-lock_test.go
@@ -125,6 +125,7 @@ func TestParseComposerLock_OnePackageDev(t *testing.T) {
 			Commit:    "4c115873c86ad5bd0ac6d962db70ca53bf8fb874",
 			Ecosystem: lockfile.ComposerEcosystem,
 			CompareAs: lockfile.ComposerEcosystem,
+			DepGroup:  lockfile.ComposerDevDependency,
 		},
 	})
 }
@@ -152,6 +153,7 @@ func TestParseComposerLock_TwoPackages(t *testing.T) {
 			Commit:    "11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
 			Ecosystem: lockfile.ComposerEcosystem,
 			CompareAs: lockfile.ComposerEcosystem,
+			DepGroup:  lockfile.ComposerDevDependency,
 		},
 	})
 }

--- a/pkg/lockfile/parse-conan-lock-v2_test.go
+++ b/pkg/lockfile/parse-conan-lock-v2_test.go
@@ -158,6 +158,7 @@ func TestParseConanLock_v2_OnePackageDev(t *testing.T) {
 			Version:   "1.11.1",
 			Ecosystem: lockfile.ConanEcosystem,
 			CompareAs: lockfile.ConanEcosystem,
+			DepGroup:  lockfile.ConanBuildRequires,
 		},
 	})
 }

--- a/pkg/lockfile/parse-conan-lock.go
+++ b/pkg/lockfile/parse-conan-lock.go
@@ -132,7 +132,12 @@ func parseConanV1Lock(lockfile ConanLockFile) []PackageDetails {
 	return packages
 }
 
-func parseConanRequires(packages *[]PackageDetails, requires []string) {
+const (
+	ConanBuildRequires  string = "build-requires"
+	ConanPythonRequires string = "python-requires"
+)
+
+func parseConanRequires(packages *[]PackageDetails, requires []string, group string) {
 	for _, ref := range requires {
 		reference := parseConanRenference(ref)
 		// skip entries with no name, they are most likely consumer's conanfiles
@@ -146,6 +151,7 @@ func parseConanRequires(packages *[]PackageDetails, requires []string) {
 			Version:   reference.Version,
 			Ecosystem: ConanEcosystem,
 			CompareAs: ConanEcosystem,
+			DepGroup:  group,
 		})
 	}
 }
@@ -157,9 +163,9 @@ func parseConanV2Lock(lockfile ConanLockFile) []PackageDetails {
 		uint64(len(lockfile.Requires))+uint64(len(lockfile.BuildRequires))+uint64(len(lockfile.PythonRequires)),
 	)
 
-	parseConanRequires(&packages, lockfile.Requires)
-	parseConanRequires(&packages, lockfile.BuildRequires)
-	parseConanRequires(&packages, lockfile.PythonRequires)
+	parseConanRequires(&packages, lockfile.Requires, "")
+	parseConanRequires(&packages, lockfile.BuildRequires, ConanBuildRequires)
+	parseConanRequires(&packages, lockfile.PythonRequires, ConanPythonRequires)
 
 	return packages
 }

--- a/pkg/lockfile/parse-maven-lock.go
+++ b/pkg/lockfile/parse-maven-lock.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/google/osv-scanner/internal/cachedregexp"
 )
@@ -14,6 +15,7 @@ type MavenLockDependency struct {
 	GroupID    string   `xml:"groupId"`
 	ArtifactID string   `xml:"artifactId"`
 	Version    string   `xml:"version"`
+	Scope      string   `xml:"scope"`
 }
 
 func (mld MavenLockDependency) parseResolvedVersion(version string) string {
@@ -126,6 +128,7 @@ func (e MavenLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 			Version:   lockPackage.ResolveVersion(*parsedLockfile),
 			Ecosystem: MavenEcosystem,
 			CompareAs: MavenEcosystem,
+			DepGroup:  strings.TrimSpace(lockPackage.Scope),
 		}
 	}
 
@@ -138,6 +141,7 @@ func (e MavenLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 			Version:   lockPackage.ResolveVersion(*parsedLockfile),
 			Ecosystem: MavenEcosystem,
 			CompareAs: MavenEcosystem,
+			DepGroup:  strings.TrimSpace(lockPackage.Scope),
 		}
 	}
 

--- a/pkg/lockfile/parse-maven-lock_test.go
+++ b/pkg/lockfile/parse-maven-lock_test.go
@@ -290,3 +290,23 @@ func TestMavenLockDependency_ResolveVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestParseMavenLock_WithScope(t *testing.T) {
+	t.Parallel()
+
+	packages, err := lockfile.ParseMavenLock("fixtures/maven/with-scope.xml")
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	expectPackages(t, packages, []lockfile.PackageDetails{
+		{
+			Name:      "junit:junit",
+			Version:   "4.12",
+			Ecosystem: lockfile.MavenEcosystem,
+			CompareAs: lockfile.MavenEcosystem,
+			DepGroup:  "test",
+		},
+	})
+}

--- a/pkg/lockfile/parse-npm-lock-v1_test.go
+++ b/pkg/lockfile/parse-npm-lock-v1_test.go
@@ -71,6 +71,7 @@ func TestParseNpmLock_v1_OnePackageDev(t *testing.T) {
 			Version:   "1.0.2",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
+			DepGroup:  lockfile.NpmDevDependency,
 		},
 	})
 }
@@ -241,6 +242,7 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "af885e2e890b9ef0875edd2b117305119ee5bdc5",
+			DepGroup:  lockfile.NpmDevDependency,
 		},
 		{
 			Name:      "is-number-1",
@@ -248,6 +250,7 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "be5935f8d2595bcd97b05718ef1eeae08d812e10",
+			DepGroup:  lockfile.NpmDevDependency,
 		},
 		{
 			Name:      "is-number-2",
@@ -269,6 +272,7 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "d5ac0584ee9ae7bd9288220a39780f155b9ad4c8",
+			DepGroup:  lockfile.NpmDevDependency,
 		},
 		{
 			Name:      "is-number-3",
@@ -276,6 +280,7 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "82ae8802978da40d7f1be5ad5943c9e550ab2c89",
+			DepGroup:  lockfile.NpmDevDependency,
 		},
 		{
 			Name:      "is-number-4",
@@ -283,6 +288,7 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "af885e2e890b9ef0875edd2b117305119ee5bdc5",
+			DepGroup:  lockfile.NpmDevDependency,
 		},
 		{
 			Name:      "is-number-5",
@@ -290,6 +296,7 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "af885e2e890b9ef0875edd2b117305119ee5bdc5",
+			DepGroup:  lockfile.NpmDevDependency,
 		},
 		{
 			Name:      "is-number-6",
@@ -297,6 +304,7 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "af885e2e890b9ef0875edd2b117305119ee5bdc5",
+			DepGroup:  lockfile.NpmDevDependency,
 		},
 		{
 			Name:      "postcss-calc",
@@ -318,6 +326,7 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "280b560161b751ba226d50c7db1e0a14a78c2de0",
+			DepGroup:  lockfile.NpmDevDependency,
 		},
 	})
 }
@@ -376,6 +385,33 @@ func TestParseNpmLock_v1_Alias(t *testing.T) {
 			Version:   "5.1.2",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
+		},
+	})
+}
+
+func TestParseNpmLock_v1_OptionalPackage(t *testing.T) {
+	t.Parallel()
+
+	packages, err := lockfile.ParseNpmLock("fixtures/npm/optional-package.v1.json")
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	expectPackages(t, packages, []lockfile.PackageDetails{
+		{
+			Name:      "wrappy",
+			Version:   "1.0.2",
+			Ecosystem: lockfile.NpmEcosystem,
+			CompareAs: lockfile.NpmEcosystem,
+			DepGroup:  lockfile.NpmDevOptionalDependency,
+		},
+		{
+			Name:      "supports-color",
+			Version:   "5.5.0",
+			Ecosystem: lockfile.NpmEcosystem,
+			CompareAs: lockfile.NpmEcosystem,
+			DepGroup:  lockfile.NpmOptionalDependency,
 		},
 	})
 }

--- a/pkg/lockfile/parse-npm-lock-v2_test.go
+++ b/pkg/lockfile/parse-npm-lock-v2_test.go
@@ -71,6 +71,7 @@ func TestParseNpmLock_v2_OnePackageDev(t *testing.T) {
 			Version:   "1.0.2",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
+			DepGroup:  lockfile.NpmDevDependency,
 		},
 	})
 }
@@ -223,6 +224,7 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "c5a7ba5e0ad98b8db1cb8ce105403dd4b768cced",
+			DepGroup:  lockfile.NpmDevDependency,
 		},
 		{
 			Name:      "is-number-1",
@@ -230,6 +232,7 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "af885e2e890b9ef0875edd2b117305119ee5bdc5",
+			DepGroup:  lockfile.NpmDevDependency,
 		},
 		{
 			Name:      "is-number-1",
@@ -237,6 +240,7 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "be5935f8d2595bcd97b05718ef1eeae08d812e10",
+			DepGroup:  lockfile.NpmDevDependency,
 		},
 		{
 			Name:      "is-number-2",
@@ -244,6 +248,7 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "d5ac0584ee9ae7bd9288220a39780f155b9ad4c8",
+			DepGroup:  lockfile.NpmDevDependency,
 		},
 		{
 			Name:      "is-number-2",
@@ -251,6 +256,7 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "82dcc8e914dabd9305ab9ae580709a7825e824f5",
+			DepGroup:  lockfile.NpmDevDependency,
 		},
 		{
 			Name:      "is-number-3",
@@ -258,6 +264,7 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "d5ac0584ee9ae7bd9288220a39780f155b9ad4c8",
+			DepGroup:  lockfile.NpmDevDependency,
 		},
 		{
 			Name:      "is-number-3",
@@ -265,6 +272,7 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "82ae8802978da40d7f1be5ad5943c9e550ab2c89",
+			DepGroup:  lockfile.NpmDevDependency,
 		},
 		{
 			Name:      "is-number-4",
@@ -272,6 +280,7 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "af885e2e890b9ef0875edd2b117305119ee5bdc5",
+			DepGroup:  lockfile.NpmDevDependency,
 		},
 		{
 			Name:      "is-number-5",
@@ -279,6 +288,7 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "af885e2e890b9ef0875edd2b117305119ee5bdc5",
+			DepGroup:  lockfile.NpmDevDependency,
 		},
 		{
 			Name:      "postcss-calc",
@@ -300,6 +310,7 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "280b560161b751ba226d50c7db1e0a14a78c2de0",
+			DepGroup:  lockfile.NpmDevDependency,
 		},
 	})
 }
@@ -320,6 +331,7 @@ func TestParseNpmLock_v2_Files(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
+			DepGroup:  lockfile.NpmDevDependency,
 		},
 		{
 			Name:      "abbrev",
@@ -327,6 +339,7 @@ func TestParseNpmLock_v2_Files(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
+			DepGroup:  lockfile.NpmDevDependency,
 		},
 		{
 			Name:      "abbrev",
@@ -334,6 +347,7 @@ func TestParseNpmLock_v2_Files(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
+			DepGroup:  lockfile.NpmDevDependency,
 		},
 	})
 }
@@ -365,6 +379,33 @@ func TestParseNpmLock_v2_Alias(t *testing.T) {
 			Version:   "5.1.2",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
+		},
+	})
+}
+
+func TestParseNpmLock_v2_OptionalPackage(t *testing.T) {
+	t.Parallel()
+
+	packages, err := lockfile.ParseNpmLock("fixtures/npm/optional-package.v2.json")
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	expectPackages(t, packages, []lockfile.PackageDetails{
+		{
+			Name:      "wrappy",
+			Version:   "1.0.2",
+			Ecosystem: lockfile.NpmEcosystem,
+			CompareAs: lockfile.NpmEcosystem,
+			DepGroup:  lockfile.NpmOptionalDependency,
+		},
+		{
+			Name:      "supports-color",
+			Version:   "5.5.0",
+			Ecosystem: lockfile.NpmEcosystem,
+			CompareAs: lockfile.NpmEcosystem,
+			DepGroup:  lockfile.NpmDevOptionalDependency,
 		},
 	})
 }

--- a/pkg/lockfile/parse-npm-lock.go
+++ b/pkg/lockfile/parse-npm-lock.go
@@ -12,6 +12,9 @@ type NpmLockDependency struct {
 	// For an aliased package, Version is like "npm:[name]@[version]"
 	Version      string                       `json:"version"`
 	Dependencies map[string]NpmLockDependency `json:"dependencies,omitempty"`
+
+	Dev      bool `json:"dev,omitempty"`
+	Optional bool `json:"optional,omitempty"`
 }
 
 type NpmLockPackage struct {
@@ -20,6 +23,10 @@ type NpmLockPackage struct {
 	Version      string            `json:"version"`
 	Resolved     string            `json:"resolved"`
 	Dependencies map[string]string `json:"dependencies"`
+
+	Dev         bool `json:"dev,omitempty"`
+	DevOptional bool `json:"devOptional,omitempty"`
+	Optional    bool `json:"optional,omitempty"`
 }
 
 type NpmLockfile struct {
@@ -54,6 +61,25 @@ func mergePkgDetailsMap(m1 map[string]PackageDetails, m2 map[string]PackageDetai
 	}
 
 	return details
+}
+
+const (
+	NpmDevDependency         string = "dev"
+	NpmOptionalDependency    string = "optional"
+	NpmDevOptionalDependency string = "devOptional"
+)
+
+func (dep NpmLockDependency) depGroup() string {
+	if dep.Dev && dep.Optional {
+		return NpmDevOptionalDependency
+	}
+	if dep.Dev {
+		return NpmDevDependency
+	}
+	if dep.Optional {
+		return NpmOptionalDependency
+	}
+	return ""
 }
 
 func parseNpmLockDependencies(dependencies map[string]NpmLockDependency) map[string]PackageDetails {
@@ -97,6 +123,7 @@ func parseNpmLockDependencies(dependencies map[string]NpmLockDependency) map[str
 			Ecosystem: NpmEcosystem,
 			CompareAs: NpmEcosystem,
 			Commit:    commit,
+			DepGroup:  detail.depGroup(),
 		}
 	}
 
@@ -112,6 +139,19 @@ func extractNpmPackageName(name string) string {
 	}
 
 	return pkgName
+}
+
+func (pkg NpmLockPackage) depGroup() string {
+	if pkg.Dev {
+		return NpmDevDependency
+	}
+	if pkg.Optional {
+		return NpmOptionalDependency
+	}
+	if pkg.DevOptional {
+		return NpmDevOptionalDependency
+	}
+	return ""
 }
 
 func parseNpmLockPackages(packages map[string]NpmLockPackage) map[string]PackageDetails {
@@ -143,6 +183,7 @@ func parseNpmLockPackages(packages map[string]NpmLockPackage) map[string]Package
 			Ecosystem: NpmEcosystem,
 			CompareAs: NpmEcosystem,
 			Commit:    commit,
+			DepGroup:  detail.depGroup(),
 		}
 	}
 

--- a/pkg/lockfile/parse-pipenv-lock_test.go
+++ b/pkg/lockfile/parse-pipenv-lock_test.go
@@ -123,6 +123,7 @@ func TestParsePipenvLock_OnePackageDev(t *testing.T) {
 			Version:   "2.1.1",
 			Ecosystem: lockfile.PipenvEcosystem,
 			CompareAs: lockfile.PipenvEcosystem,
+			DepGroup:  lockfile.PipenvDevelopDependency,
 		},
 	})
 }
@@ -148,6 +149,7 @@ func TestParsePipenvLock_TwoPackages(t *testing.T) {
 			Version:   "2.1.1",
 			Ecosystem: lockfile.PipenvEcosystem,
 			CompareAs: lockfile.PipenvEcosystem,
+			DepGroup:  lockfile.PipenvDevelopDependency,
 		},
 	})
 }
@@ -204,6 +206,7 @@ func TestParsePipenvLock_MultiplePackages(t *testing.T) {
 			Version:   "1.0.0",
 			Ecosystem: lockfile.PipenvEcosystem,
 			CompareAs: lockfile.PipenvEcosystem,
+			DepGroup:  lockfile.PipenvDevelopDependency,
 		},
 		{
 			Name:      "markupsafe",

--- a/pkg/lockfile/parse-pnpm-lock.go
+++ b/pkg/lockfile/parse-pnpm-lock.go
@@ -23,6 +23,7 @@ type PnpmLockPackage struct {
 	Resolution PnpmLockPackageResolution `yaml:"resolution"`
 	Name       string                    `yaml:"name"`
 	Version    string                    `yaml:"version"`
+	Dev        string                    `yaml:"dev"`
 }
 
 type PnpmLockfile struct {
@@ -119,6 +120,8 @@ func parseNameAtVersion(value string) (name string, version string) {
 	return matches[1], matches[2]
 }
 
+const PnpmDevDependency string = "dev"
+
 func parsePnpmLock(lockfile PnpmLockfile) []PackageDetails {
 	packages := make([]PackageDetails, 0, len(lockfile.Packages))
 
@@ -152,12 +155,18 @@ func parsePnpmLock(lockfile PnpmLockfile) []PackageDetails {
 			}
 		}
 
+		depGroup := ""
+		if strings.TrimSpace(pkg.Dev) == "true" {
+			depGroup = PnpmDevDependency
+		}
+
 		packages = append(packages, PackageDetails{
 			Name:      name,
 			Version:   version,
 			Ecosystem: PnpmEcosystem,
 			CompareAs: PnpmEcosystem,
 			Commit:    commit,
+			DepGroup:  depGroup,
 		})
 	}
 

--- a/pkg/lockfile/parse-pnpm-lock_test.go
+++ b/pkg/lockfile/parse-pnpm-lock_test.go
@@ -432,6 +432,7 @@ func TestParsePnpmLock_Tarball(t *testing.T) {
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 			Commit:    "",
+			DepGroup:  lockfile.PnpmDevDependency,
 		},
 	})
 }

--- a/pkg/lockfile/parse-poetry-lock_test.go
+++ b/pkg/lockfile/parse-poetry-lock_test.go
@@ -191,3 +191,23 @@ func TestParsePoetryLock_PackageWithLegacySource(t *testing.T) {
 		},
 	})
 }
+
+func TestParsePoetryLock_OptionalPackage(t *testing.T) {
+	t.Parallel()
+
+	packages, err := lockfile.ParsePoetryLock("fixtures/poetry/optional-package.lock")
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	expectPackages(t, packages, []lockfile.PackageDetails{
+		{
+			Name:      "numpy",
+			Version:   "1.23.3",
+			Ecosystem: lockfile.PoetryEcosystem,
+			CompareAs: lockfile.PoetryEcosystem,
+			DepGroup:  lockfile.PoetryOptionalDependency,
+		},
+	})
+}

--- a/pkg/lockfile/parse-pubspec-lock.go
+++ b/pkg/lockfile/parse-pubspec-lock.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -54,6 +55,7 @@ type PubspecLockPackage struct {
 	Source      string                 `yaml:"source"`
 	Description PubspecLockDescription `yaml:"description"`
 	Version     string                 `yaml:"version"`
+	Dependency  string                 `yaml:"dependency"`
 }
 
 type PubspecLockfile struct {
@@ -68,6 +70,8 @@ type PubspecLockExtractor struct{}
 func (e PubspecLockExtractor) ShouldExtract(path string) bool {
 	return filepath.Base(path) == "pubspec.lock"
 }
+
+const PubDevDependency string = "dev"
 
 func (e PubspecLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 	var parsedLockfile *PubspecLockfile
@@ -84,12 +88,19 @@ func (e PubspecLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 	packages := make([]PackageDetails, 0, len(parsedLockfile.Packages))
 
 	for name, pkg := range parsedLockfile.Packages {
-		packages = append(packages, PackageDetails{
+		pkgDetails := PackageDetails{
 			Name:      name,
 			Version:   pkg.Version,
 			Commit:    pkg.Description.Ref,
 			Ecosystem: PubEcosystem,
-		})
+		}
+		for _, str := range strings.Split(pkg.Dependency, " ") {
+			if str == PubDevDependency {
+				pkgDetails.DepGroup = PubDevDependency
+				break
+			}
+		}
+		packages = append(packages, pkgDetails)
 	}
 
 	return packages, nil

--- a/pkg/lockfile/parse-pubspec-lock_test.go
+++ b/pkg/lockfile/parse-pubspec-lock_test.go
@@ -133,6 +133,7 @@ func TestParsePubspecLock_OnePackageDev(t *testing.T) {
 			Name:      "build_runner",
 			Version:   "2.2.1",
 			Ecosystem: lockfile.PubEcosystem,
+			DepGroup:  lockfile.PubDevDependency,
 		},
 	})
 }
@@ -179,6 +180,7 @@ func TestParsePubspecLock_MixedPackages(t *testing.T) {
 			Name:      "build_runner",
 			Version:   "2.2.1",
 			Ecosystem: lockfile.PubEcosystem,
+			DepGroup:  lockfile.PubDevDependency,
 		},
 		{
 			Name:      "shelf",

--- a/pkg/lockfile/parse-requirements-txt.go
+++ b/pkg/lockfile/parse-requirements-txt.go
@@ -109,6 +109,8 @@ func (e RequirementsTxtExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 	return parseRequirementsTxt(f, map[string]struct{}{})
 }
 
+const PipDevDependency string = "dev"
+
 func parseRequirementsTxt(f DepFile, requiredAlready map[string]struct{}) ([]PackageDetails, error) {
 	packages := map[string]PackageDetails{}
 
@@ -125,6 +127,7 @@ func parseRequirementsTxt(f DepFile, requiredAlready map[string]struct{}) ([]Pac
 		}
 
 		line = removeComments(line)
+		isDev := strings.HasSuffix(f.Path(), "dev.txt")
 
 		if ar := strings.TrimPrefix(line, "-r "); ar != line {
 			err := func() error {
@@ -167,7 +170,9 @@ func parseRequirementsTxt(f DepFile, requiredAlready map[string]struct{}) ([]Pac
 		}
 
 		detail := parseLine(line)
-
+		if isDev {
+			detail.DepGroup = PipDevDependency
+		}
 		packages[detail.Name+"@"+detail.Version] = detail
 	}
 

--- a/pkg/lockfile/parse-requirements-txt_test.go
+++ b/pkg/lockfile/parse-requirements-txt_test.go
@@ -508,12 +508,14 @@ func TestParseRequirementsTxt_DuplicateROptions(t *testing.T) {
 			Version:   "0.23.4",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
+			DepGroup:  lockfile.PipDevDependency,
 		},
 		{
 			Name:      "requests",
 			Version:   "1.2.3",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
+			DepGroup:  lockfile.PipDevDependency,
 		},
 		{
 			Name:      "unittest",

--- a/pkg/lockfile/types.go
+++ b/pkg/lockfile/types.go
@@ -6,6 +6,7 @@ type PackageDetails struct {
 	Commit    string    `json:"commit,omitempty"`
 	Ecosystem Ecosystem `json:"ecosystem,omitempty"`
 	CompareAs Ecosystem `json:"compareAs,omitempty"`
+	DepGroup  string    `json:"-"`
 }
 
 type Ecosystem string

--- a/pkg/models/results.go
+++ b/pkg/models/results.go
@@ -79,7 +79,8 @@ type SourceInfo struct {
 }
 
 type Metadata struct {
-	RepoURL string `json:"repo_url"`
+	RepoURL  string `json:"repo_url"`
+	DepGroup string `json:"-"`
 }
 
 func (s SourceInfo) String() string {
@@ -171,4 +172,5 @@ type PackageInfo struct {
 	Version   string `json:"version"`
 	Ecosystem string `json:"ecosystem"`
 	Commit    string `json:"commit"`
+	DepGroup  string `json:"dependencyGroup,omitempty"`
 }

--- a/pkg/osv/osv.go
+++ b/pkg/osv/osv.go
@@ -123,7 +123,8 @@ func MakePkgRequest(pkgDetails lockfile.PackageDetails) *Query {
 	if pkgDetails.Ecosystem == "" && pkgDetails.Commit != "" {
 		return &Query{
 			Metadata: models.Metadata{
-				RepoURL: pkgDetails.Name,
+				RepoURL:  pkgDetails.Name,
+				DepGroup: pkgDetails.DepGroup,
 			},
 			Commit: pkgDetails.Commit,
 		}
@@ -133,6 +134,9 @@ func MakePkgRequest(pkgDetails lockfile.PackageDetails) *Query {
 			Package: Package{
 				Name:      pkgDetails.Name,
 				Ecosystem: string(pkgDetails.Ecosystem),
+			},
+			Metadata: models.Metadata{
+				DepGroup: pkgDetails.DepGroup,
 			},
 		}
 	}

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -380,6 +380,7 @@ func scanLockfile(r reporter.Reporter, path string, parseAs string) ([]scannedPa
 			Version:   pkgDetail.Version,
 			Commit:    pkgDetail.Commit,
 			Ecosystem: pkgDetail.Ecosystem,
+			DepGroup:  pkgDetail.DepGroup,
 			Source: models.SourceInfo{
 				Path: path,
 				Type: "lockfile",
@@ -692,6 +693,7 @@ type scannedPackage struct {
 	Commit    string
 	Version   string
 	Source    models.SourceInfo
+	DepGroup  string
 }
 
 // Perform osv scanner action, with optional reporter to output information

--- a/pkg/osvscanner/vulnerability_result.go
+++ b/pkg/osvscanner/vulnerability_result.go
@@ -54,6 +54,7 @@ func buildVulnerabilityResults(
 				Name:      rawPkg.Name,
 				Version:   rawPkg.Version,
 				Ecosystem: string(rawPkg.Ecosystem),
+				DepGroup:  rawPkg.DepGroup,
 			}
 		}
 


### PR DESCRIPTION
Issue https://github.com/google/osv-scanner/issues/332

Non-default dependency groups are recorded in string as per eco-system:
 - **Composer:** development dependencies in `packages-dev`
 - **Conan:** dependencies in `build-requires` and `python-requires`
 - **Maven:** `<scope/>` in `<dependency/>`
 - **npm:** `dev` and `optional` dependencies
 - **pipenv:** development dependencies in `develop`
 - **pnpm:** development dependencies with `dev` as true
 - **Poetry:** optional dependencies with `optional = true`
 - **Pubspec:** development dependencies marked with `dev`
 - **requirements.txt:** development requirements are defined in `dev.txt`

Reporters:
 - **table:** non-default groups are appended to the end of package name, for example: `abc (development)`
 - **json:** non-default group information in `dependencyGroup`
 - **sarif:** non-default groups are appended to the end of package name and version, for example: `Package 'abc@1.2.3 (development)'`