### PR TITLE
fix: remove noise lockfile warnings

### DIFF
--- a/pkg/lockfile/apk-installed.go
+++ b/pkg/lockfile/apk-installed.go
@@ -3,7 +3,6 @@ package lockfile
 import (
 	"bufio"
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 )
@@ -34,7 +33,7 @@ func groupApkPackageLines(scanner *bufio.Scanner) [][]string {
 	return groups
 }
 
-func parseApkPackageGroup(group []string, pathToLockfile string) PackageDetails {
+func parseApkPackageGroup(group []string) PackageDetails {
 	var pkg = PackageDetails{
 		Ecosystem: AlpineEcosystem,
 		CompareAs: AlpineEcosystem,
@@ -50,20 +49,6 @@ func parseApkPackageGroup(group []string, pathToLockfile string) PackageDetails 
 		case strings.HasPrefix(line, "c:"):
 			pkg.Commit = strings.TrimPrefix(line, "c:")
 		}
-	}
-
-	if pkg.Version == "" {
-		pkgPrintName := pkg.Name
-		if pkgPrintName == "" {
-			pkgPrintName = unknownPkgName
-		}
-
-		_, _ = fmt.Fprintf(
-			os.Stderr,
-			"warning: malformed APK installed file. Found no version number in record. Package %s. File: %s\n",
-			pkgPrintName,
-			pathToLockfile,
-		)
 	}
 
 	return pkg
@@ -87,15 +72,9 @@ func (e ApkInstalledExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 	packages := make([]PackageDetails, 0, len(packageGroups))
 
 	for _, group := range packageGroups {
-		pkg := parseApkPackageGroup(group, f.Path())
+		pkg := parseApkPackageGroup(group)
 
 		if pkg.Name == "" {
-			_, _ = fmt.Fprintf(
-				os.Stderr,
-				"warning: malformed APK installed file. Found no package name in record. File: %s\n",
-				f.Path(),
-			)
-
 			continue
 		}
 

--- a/pkg/lockfile/parse-gradle-lock.go
+++ b/pkg/lockfile/parse-gradle-lock.go
@@ -3,7 +3,6 @@ package lockfile
 import (
 	"bufio"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 )
@@ -63,7 +62,6 @@ func (e GradleLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 
 		pkg, err := parseToGradlePackageDetail(lockLine)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "failed to extract from lockline: %s\n", err.Error())
 			continue
 		}
 

--- a/pkg/lockfile/parse.go
+++ b/pkg/lockfile/parse.go
@@ -8,11 +8,6 @@ import (
 	"strings"
 )
 
-// Represents when a package name could not be determined while parsing.
-// Currently, parsers are expected to omit such packages from their results.
-// Using a const is required to avoid linter error (goconst) due to multiple usage in parsers.
-const unknownPkgName = "<unknown>"
-
 func FindParser(pathToLockfile string, parseAs string) (PackageDetailsParser, string) {
 	if parseAs == "" {
 		parseAs = filepath.Base(pathToLockfile)


### PR DESCRIPTION
We're previously agreed that in these situations we should be erroring since the native package manager does not support them but cannot make that change until v2 as it's technical breaking.

In the meantime we've currently got tests that cover these situations but unlike panics we cannot suppress the warnings because of how Go works resulting in a very noisy time when _any_ test fails; it's gotten to the point that I've decided to actually make this PR 😅 

Since in theory these could actually still be useful especially for folks like Scorecard as part of helping confirm the parsers are handling edge-cases, I'm happy to alternatively gate these behind an env variable that is disabled by default but I don't have strong opinions on this.