### PR TITLE
chore: disable `goconst` linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -30,6 +30,7 @@ linters:
     - testpackage      # will re-add later (another-rex)
     - goerr113         # will re-add later (another-rex)
     - nonamedreturns   # disagree with, for now (another-rex)
+    - goconst          # not everything should be a constant
   presets:
     - bugs
     - comment


### PR DESCRIPTION
We recently discussed this and agreed that not everything should be a constant - notably this linter seems to have changed in v1.55 so it finds a few more strings it thinks should be constants