### PR TITLE
ci: enforce that `cachedregexp` is always used instead of `regexp`

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -30,7 +30,6 @@ linters:
     - testpackage      # will re-add later (another-rex)
     - goerr113         # will re-add later (another-rex)
     - nonamedreturns   # disagree with, for now (another-rex)
-    - depguard         # not necessary at the moment (another-rex)
   presets:
     - bugs
     - comment
@@ -42,6 +41,16 @@ linters:
     - unused
 
 linters-settings:
+  depguard:
+    rules:
+      regexp:
+        files:
+          - '!**/internal/cachedregexp/**'
+          - '!**/main_test.go'
+        deny:
+          - pkg: 'regexp'
+            desc:
+              'Use github.com/google/osv-scanner/internal/cachedregexp instead'
   gocritic:
     disabled-checks:
       - ifElseChain


### PR DESCRIPTION
I did this as a bit of an exercise in how to configure linting a bit more - while not critical, might as well have it and should help with external contributors e.g. it'll flag #658 