### PR TITLE
Add `osv-scanner` pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+- id: osv-scanner
+  name: osv-scanner
+  description: Vulnerability scanner written in Go which uses the data provided by https://osv.dev
+  entry: osv-scanner
+  always_run: true
+  pass_filenames: false
+  language: golang

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -188,3 +188,16 @@ Current implementation has a few limitations:
 ```bash
 osv-scanner --call-analysis=rust --no-call-analysis=go ./my/project/path
 ```
+
+## Pre-commit integration
+If you wish to install OSV-Scanner as a [pre-commit](https://pre-commit.com) plugin in your project, you may use the `osv-scanner` pre-commit hook. Use the `args` key in your `.pre-commit-config.yaml` to pass your command-line arguments as you would using OSV-Scanner in the command line.
+
+### Example
+```yaml
+repos:
+  - repo: https://github.com/google/osv-scanner/
+    rev: # pass a Git tag or commit hash here
+    hooks:
+      - id: osv-scanner
+        args: ["-r", "/path/to/your/dir"]
+```


### PR DESCRIPTION
This change exposes a pre-commit hook for people to use that would run osv-scanner when commiting code to their codebase.

Resolves #60.

I manually tested this change by modifying the `.pre-commit-config.yaml` file from the [pipdeptree](https://github.com/tox-dev/pipdeptree) project to the following:
```yml
repos:
  - repo: https://github.com/kemzeb/osv-scanner
    rev: 321d06b03fbea723004247e6e29aa811861a882f
    hooks:
      - id: osv-scanner
        args: ["-r", "."]
```

...where I ran pre-commit locally by doing the following:

Install the pre-commit script:
```console
pre-commit install 
```

Run while using all the files in the pipdeptree repo, while also providing verbose output produced by osv-scanner (I truncated the output but wanted to make aware that the `-v` option is available):
``` console
pre-commit run -av
osv-scanner..............................................................Passed
- hook id: osv-scanner
- duration: 0.47s
.... // verbose output here
```

Let me know if there is an interest in using any of the other pre-commit hook [configurations ](https://pre-commit.com/#creating-new-hooks)