### PR TITLE
Setup manual release pipeline

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -67,4 +67,3 @@ jobs:
       base64-subjects: "${{ needs.goreleaser.outputs.hashes }}"
       upload-assets: true # upload to a new release
       draft-release: true # upload to a new draft release
-      upload-tag-name: "${{ inputs.version }}"

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,16 +1,9 @@
 name: Release new version
 
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'The version tag to release, (e.g. v1.2.3)'
-        required: true
-        type: string
-      commit:
-        description: 'The commit hash to release'
-        required: true
-        type: string
+  push:
+    tags:
+      - "*" # triggers only if push new tag version, like `v0.8.4` 
 
 permissions:
   contents: read # to fetch code (actions/checkout)
@@ -18,70 +11,6 @@ permissions:
   security-events: write
 
 jobs:
-  osv-scan:
-    uses: ./.github/workflows/osv-scanner-reusable.yml
-    with:
-      # Only scan the top level go.mod file without recursively scanning directories since
-      # this is pipeline is about releasing the go module and binary
-      scan-args: |-
-        --skip-git
-        ./
-
-  lint:
-    name: golangci-lint
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          persist-credentials: false
-          ref: ${{ inputs.commit }}
-      - name: Set up Go
-        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
-        with:
-          go-version-file: .go-version
-          check-latest: true
-      - name: Run lint action
-        uses: ./.github/workflows/lint-action
-  tests:
-    name: Run unit tests
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Check out code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          persist-credentials: false
-          ref: ${{ inputs.commit }}
-      - name: Set up Go
-        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
-        with:
-          go-version-file: .go-version
-          check-latest: true
-      - name: Run test action
-        uses: ./.github/workflows/test-action
-  tag-release:
-    runs-on: ubuntu-latest
-    needs:
-      - lint
-      - tests
-      - osv-scan
-    permissions:
-      contents: write  # to write a tag
-    steps:
-      - name: Create tag
-        uses: actions/github-script@v6
-        with:
-          script: |
-            github.rest.git.createRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: 'refs/tags/${{ inputs.version }}',
-              sha: '${{ inputs.commit }}'
-            })
   goreleaser:
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}
@@ -89,8 +18,6 @@ jobs:
       contents: write  # for goreleaser/goreleaser-action to create a GitHub release
       packages: write # for goreleaser/goreleaser-action to publish docker images
     runs-on: ubuntu-latest
-    needs:
-      - tag-release
     env:
       # Required for buildx on docker 19.x
       DOCKER_CLI_EXPERIMENTAL: "enabled"

--- a/.github/workflows/prerelease-check.yml
+++ b/.github/workflows/prerelease-check.yml
@@ -1,0 +1,81 @@
+name: Pre-release check
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'The version tag to release, (e.g. v1.2.3)'
+        required: true
+        type: string
+      commit:
+        description: 'The commit hash to release'
+        required: true
+        type: string
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+  # Require writing security events to upload SARIF file to security tab
+  security-events: write
+
+jobs:
+  osv-scan:
+    uses: ./.github/workflows/osv-scanner-reusable.yml
+    with:
+      # Only scan the top level go.mod file without recursively scanning directories since
+      # this is pipeline is about releasing the go module and binary
+      scan-args: |-
+        --skip-git
+        ./
+
+  lint:
+    name: golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.commit }}
+      - name: Set up Go
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        with:
+          go-version-file: .go-version
+          check-latest: true
+      - name: Run lint action
+        uses: ./.github/workflows/lint-action
+  tests:
+    name: Run unit tests
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.commit }}
+      - name: Set up Go
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        with:
+          go-version-file: .go-version
+          check-latest: true
+      - name: Run test action
+        uses: ./.github/workflows/test-action
+  release-helper:
+    runs-on: ubuntu-latest
+    needs:
+      - lint
+      - tests
+      - osv-scan
+    steps:
+      - name: Print Scripts
+        env:
+          OUTPUT: |
+            git fetch upstream &&
+            git tag ${{ inputs.version }} ${{ inputs.commit }} &&
+            git push upstream ${{ inputs.version }}
+        shell: bash
+        run: |
+          echo $OUTPUT


### PR DESCRIPTION
Setup a manual release pipeline and convert the old pipeline back to listening on tag pushes. Fixes #632. 

This pipeline allows us to manually run all the pre-release checks before we manually push the tags. 