### PR TITLE
Fix goreleaser build

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,7 +27,7 @@ builds:
       # Further testing before supporting arm
       # - arm
       - arm64
-    main: ./cmd/osv-scanner/main.go
+    main: ./cmd/osv-scanner/
 
 dockers:
   # Arch: amd64


### PR DESCRIPTION
Now that there are multiple files under `cmd/osv-scanner/` in addition to `main.go` we need to specify the entire package rather than just the main.go file when releasing.