### PR TITLE
Add changelog for verson 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,39 @@
+# v1.5.0:
+
+### Features
+- [Feature #501](https://github.com/google/osv-scanner/pull/501)
+  Add experimental license scanning support! See https://osv.dev/blog/posts/introducing-license-scanning-with-osv-scanner/ for more information!
+- [Feature #642](https://github.com/google/osv-scanner/pull/642)
+  Support scanning `renv` files for the R language ecosystem.
+- [Feature #513](https://github.com/google/osv-scanner/pull/513)
+  Stabilize call analysis for Go! The experimental `--experimental-call-analysis` flag has now been updated to:
+  ```
+  --call-analysis=<language/all>
+  --no-call-analysis=<language/all>
+  ```
+  with call analysis for Go enabled by default. See https://google.github.io/osv-scanner/usage/#scanning-with-call-analysis for the documentation!
+- [Feature #676](https://github.com/google/osv-scanner/pull/676)
+  Simplify return codes:
+    - Return 0 if there are no findings or errors.
+    - Return 1 if there are any findings (license or vulns).
+    - Return 128 if no packages are found.
+- [Feature #651](https://github.com/google/osv-scanner/pull/651)
+  CVSS v4.0 support.
+- [Feature #60](https://github.com/google/osv-scanner/pull/60)
+  [Pre-commit hook](https://pre-commit.com/) support.
+
+### Fixes
+- [Bug #639](https://github.com/google/osv-scanner/issues/639)
+  We now filter local packages from scans, and report the filtering of those packages.
+- [Bug #645](https://github.com/google/osv-scanner/issues/645)
+  Properly handle file/url paths on Windows.
+- [Bug #660](https://github.com/google/osv-scanner/issues/660)
+  Remove noise from failed lockfile parsing.
+- [Bug #649](https://github.com/google/osv-scanner/issues/649)
+  No longer include vendored libraries in C/C++ package analysis.
+- [Bug #634](https://github.com/google/osv-scanner/issues/634)
+  Fix filtering of aliases to also include non OSV aliases
+
 # v1.4.3:
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - [Feature #676](https://github.com/google/osv-scanner/pull/676)
   Simplify return codes:
     - Return 0 if there are no findings or errors.
-    - Return 1 if there are any findings (license or vulns).
+    - Return 1 if there are any findings (license violations or vulnerabilities).
     - Return 128 if no packages are found.
 - [Feature #651](https://github.com/google/osv-scanner/pull/651)
   CVSS v4.0 support.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -128,27 +128,27 @@ osv-scanner -L package-lock.json --output scan-results.txt
 
 ## C/C++ scanning
 
-OSV-Scanner supports C/C++ projects. 
+OSV-Scanner supports C/C++ projects.
 
-Because the C/C++ ecosystem does not have a centralized package manager, C/C++ dependencies tend to be bundled with the project's source code. Dependencies are either [submoduled](#submoduled-dependencies) or [vendored](#vendored-dependencies). In either case, OSV-Scanner is able to find known vulnerabilities in your project dependencies. 
+Because the C/C++ ecosystem does not have a centralized package manager, C/C++ dependencies tend to be bundled with the project's source code. Dependencies are either [submoduled](#submoduled-dependencies) or [vendored](#vendored-dependencies). In either case, OSV-Scanner is able to find known vulnerabilities in your project dependencies.
 
-OSV-Scanner's C/C++ support is based on commit-level data. OSV's commit-level data covers the majority of C/C++ vulnerabilities within the OSV database, but users should be aware that there may be vulnerabilities in their dependencies that may not be in the OSV database and therefore not included in OSV-Scanner results. Adding more commit-level data to the database is an ongoing project, follow [#783](https://github.com/google/osv.dev/issues/783) for more details. 
+OSV-Scanner's C/C++ support is based on commit-level data. OSV's commit-level data covers the majority of C/C++ vulnerabilities within the OSV database, but users should be aware that there may be vulnerabilities in their dependencies that may not be in the OSV database and therefore not included in OSV-Scanner results. Adding more commit-level data to the database is an ongoing project, follow [#783](https://github.com/google/osv.dev/issues/783) for more details.
 
 ### Submoduled dependencies
 
 [Submoduled](https://git-scm.com/book/en/v2/Git-Tools-Submodules) dependencies are included in the project's source code and retain their Git histories. To scan a C/C++ project with submoduled dependencies:
 
-1. Navigate to the root folder of your project. 
-2. Ensure that your submodules are up to date using `git submodule update`. 
-3. Run scanner using `osv-scanner -r .`. 
+1. Navigate to the root folder of your project.
+2. Ensure that your submodules are up to date using `git submodule update`.
+3. Run scanner using `osv-scanner -r .`.
 
 ### Vendored dependencies
 
-Vendored dependencies have been directly copied into the project folder, but do not retain their Git histories. OSV-Scanner uses OSV's [determineversion API](https://google.github.io/osv.dev/post-v1-determineversion/) to estimate each dependency's version (and associated Git commit). Vulnerabilities for the estimated version are returned. This process requires no additional work from the user. Run OSV-Scanner as you normally would. 
+Vendored dependencies have been directly copied into the project folder, but do not retain their Git histories. OSV-Scanner uses OSV's [determineversion API](https://google.github.io/osv.dev/post-v1-determineversion/) to estimate each dependency's version (and associated Git commit). Vulnerabilities for the estimated version are returned. This process requires no additional work from the user. Run OSV-Scanner as you normally would.
 
 ## Scanning with call analysis
 
-Call stack analysis can be performed on some languages to check if the 
+Call stack analysis can be performed on some languages to check if the
 vulnerable code is actually being executed by your project. If the code
 is not being executed, these vulnerabilities will be marked as unexecuted.
 
@@ -164,8 +164,10 @@ OSV-Scanner uses the [`govulncheck`](https://pkg.go.dev/golang.org/x/vuln/cmd/go
 
 ### Call analysis in Rust
 
-Experimental {: .label }
-Call analysis in Rust is still considered experimental. 
+Experimental
+{: .label }
+
+Call analysis in Rust is still considered experimental.
 
 OSV-Scanner compiles Rust source code and analyzes the output binary's DWARF debug information to identify called vulnerable functions.
 

--- a/internal/output/fixtures/test-vuln-results-a.sarif
+++ b/internal/output/fixtures/test-vuln-results-a.sarif
@@ -49,7 +49,7 @@
               }
             }
           ],
-          "version": "1.4.3"
+          "version": "1.5.0"
         }
       },
       "artifacts": [

--- a/internal/output/fixtures/test-vuln-results-a_windows.sarif
+++ b/internal/output/fixtures/test-vuln-results-a_windows.sarif
@@ -49,7 +49,7 @@
               }
             }
           ],
-          "version": "1.4.3"
+          "version": "1.5.0"
         }
       },
       "artifacts": [

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // OSVVersion is the current release version, you should update this variable when doing a release
-var OSVVersion = "1.4.3"
+var OSVVersion = "1.5.0"


### PR DESCRIPTION
And fix experimental label in the documentation.

The blog link won't work yet until the blog is released. To test it use the `test.osv.dev` domain.