### PR TITLE
refactor: setup `prettier` for formatting files

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -27,6 +27,16 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 
 jobs:
+  format:
+    name: prettier
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
+      - name: Run lint action
+        uses: ./.github/workflows/format-action
   lint:
     name: golangci-lint
     runs-on: ubuntu-latest

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -16,12 +16,12 @@ name: Checks
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ main ]
+    branches: [main]
   merge_group:
-    branches: [ main ]
+    branches: [main]
 
 permissions:
   contents: read # to fetch code (actions/checkout)

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,16 +9,16 @@
 # the `language` matrix defined below to confirm you have the correct set of
 # supported CodeQL languages.
 #
-name: "CodeQL"
+name: 'CodeQL'
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ main ]
+    branches: [main]
   merge_group:
-    branches: [ main ]
+    branches: [main]
 
 permissions: read-all
 
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'go' ]
+        language: ['go']
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://git.io/codeql-language-support
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,7 +9,7 @@
 # the `language` matrix defined below to confirm you have the correct set of
 # supported CodeQL languages.
 #
-name: 'CodeQL'
+name: "CodeQL"
 
 on:
   push:
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ['go']
+        language: ["go"]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://git.io/codeql-language-support
 

--- a/.github/workflows/format-action/action.yml
+++ b/.github/workflows/format-action/action.yml
@@ -1,0 +1,23 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: format
+description: "Runs file formatters"
+
+runs:
+  using: composite
+  steps:
+    - name: Run formatters
+      shell: bash
+      run: ./scripts/run_formatters.sh

--- a/.github/workflows/format-action/action.yml
+++ b/.github/workflows/format-action/action.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: format
-description: "Runs file formatters"
+description: 'Runs file formatters'
 
 runs:
   using: composite

--- a/.github/workflows/format-action/action.yml
+++ b/.github/workflows/format-action/action.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: format
-description: 'Runs file formatters'
+description: "Runs file formatters"
 
 runs:
   using: composite

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -3,7 +3,7 @@ name: Release new version
 on:
   push:
     tags:
-      - "*" # triggers only if push new tag version, like `v0.8.4` 
+      - '*' # triggers only if push new tag version, like `v0.8.4`
 
 permissions:
   contents: read # to fetch code (actions/checkout)
@@ -15,12 +15,12 @@ jobs:
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}
     permissions:
-      contents: write  # for goreleaser/goreleaser-action to create a GitHub release
+      contents: write # for goreleaser/goreleaser-action to create a GitHub release
       packages: write # for goreleaser/goreleaser-action to publish docker images
     runs-on: ubuntu-latest
     env:
       # Required for buildx on docker 19.x
-      DOCKER_CLI_EXPERIMENTAL: "enabled"
+      DOCKER_CLI_EXPERIMENTAL: 'enabled'
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -51,7 +51,7 @@ jobs:
       - name: Generate subject
         id: hash
         env:
-          ARTIFACTS: "${{ steps.run-goreleaser.outputs.artifacts }}"
+          ARTIFACTS: '${{ steps.run-goreleaser.outputs.artifacts }}'
         run: |
           set -euo pipefail
           checksum_file=$(echo "$ARTIFACTS" | jq -r '.[] | select (.type=="Checksum") | .path')
@@ -64,6 +64,6 @@ jobs:
       contents: write # To add assets to a release.
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.9.0
     with:
-      base64-subjects: "${{ needs.goreleaser.outputs.hashes }}"
+      base64-subjects: '${{ needs.goreleaser.outputs.hashes }}'
       upload-assets: true # upload to a new release
       draft-release: true # upload to a new draft release

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -3,7 +3,7 @@ name: Release new version
 on:
   push:
     tags:
-      - '*' # triggers only if push new tag version, like `v0.8.4`
+      - "*" # triggers only if push new tag version, like `v0.8.4`
 
 permissions:
   contents: read # to fetch code (actions/checkout)
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # Required for buildx on docker 19.x
-      DOCKER_CLI_EXPERIMENTAL: 'enabled'
+      DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -51,7 +51,7 @@ jobs:
       - name: Generate subject
         id: hash
         env:
-          ARTIFACTS: '${{ steps.run-goreleaser.outputs.artifacts }}'
+          ARTIFACTS: "${{ steps.run-goreleaser.outputs.artifacts }}"
         run: |
           set -euo pipefail
           checksum_file=$(echo "$ARTIFACTS" | jq -r '.[] | select (.type=="Checksum") | .path')
@@ -64,6 +64,6 @@ jobs:
       contents: write # To add assets to a release.
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.9.0
     with:
-      base64-subjects: '${{ needs.goreleaser.outputs.hashes }}'
+      base64-subjects: "${{ needs.goreleaser.outputs.hashes }}"
       upload-assets: true # upload to a new release
       draft-release: true # upload to a new draft release

--- a/.github/workflows/link-check-on-push.yml
+++ b/.github/workflows/link-check-on-push.yml
@@ -1,16 +1,16 @@
 name: Check links on push
 
 on: push
-permissions:  # added using https://github.com/step-security/secure-repo
+permissions: # added using https://github.com/step-security/secure-repo
   contents: read
 jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-    - uses: gaurav-nelson/github-action-markdown-link-check@0f074c8562c5a8fed38282b7c741d1970bb1512d
-      with:
-        use-quiet-mode: "yes"
-        base-branch: "main"
-        check-modified-files-only: "yes"
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: gaurav-nelson/github-action-markdown-link-check@0f074c8562c5a8fed38282b7c741d1970bb1512d
+        with:
+          use-quiet-mode: 'yes'
+          base-branch: 'main'
+          check-modified-files-only: 'yes'
 # Documentation available here: https://github.com/marketplace/actions/markdown-link-check

--- a/.github/workflows/link-check-on-push.yml
+++ b/.github/workflows/link-check-on-push.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: gaurav-nelson/github-action-markdown-link-check@0f074c8562c5a8fed38282b7c741d1970bb1512d
         with:
-          use-quiet-mode: 'yes'
-          base-branch: 'main'
-          check-modified-files-only: 'yes'
+          use-quiet-mode: "yes"
+          base-branch: "main"
+          check-modified-files-only: "yes"
 # Documentation available here: https://github.com/marketplace/actions/markdown-link-check

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -3,14 +3,14 @@ name: Check markdown links on schedule
 on:
   schedule:
     - cron: '45 22 * * 1,4'
-permissions:  # added using https://github.com/step-security/secure-repo
+permissions: # added using https://github.com/step-security/secure-repo
   contents: read
 jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-    - uses: gaurav-nelson/github-action-markdown-link-check@0f074c8562c5a8fed38282b7c741d1970bb1512d
-      with:
-        use-quiet-mode: "yes"
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: gaurav-nelson/github-action-markdown-link-check@0f074c8562c5a8fed38282b7c741d1970bb1512d
+        with:
+          use-quiet-mode: 'yes'
 # Documentation available here: https://github.com/marketplace/actions/markdown-link-check

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -2,7 +2,7 @@ name: Check markdown links on schedule
 
 on:
   schedule:
-    - cron: '45 22 * * 1,4'
+    - cron: "45 22 * * 1,4"
 permissions: # added using https://github.com/step-security/secure-repo
   contents: read
 jobs:
@@ -12,5 +12,5 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: gaurav-nelson/github-action-markdown-link-check@0f074c8562c5a8fed38282b7c741d1970bb1512d
         with:
-          use-quiet-mode: 'yes'
+          use-quiet-mode: "yes"
 # Documentation available here: https://github.com/marketplace/actions/markdown-link-check

--- a/.github/workflows/lint-action/action.yml
+++ b/.github/workflows/lint-action/action.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: lint
-description: "Runs go lints"
+description: 'Runs go lints'
 
 runs:
   using: composite

--- a/.github/workflows/lint-action/action.yml
+++ b/.github/workflows/lint-action/action.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: lint
-description: 'Runs go lints'
+description: "Runs go lints"
 
 runs:
   using: composite

--- a/.github/workflows/osv-scanner-pr.yml
+++ b/.github/workflows/osv-scanner-pr.yml
@@ -16,19 +16,19 @@ name: OSV-Scanner PR Scan
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [main]
   merge_group:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   scan-pr:
-    uses: "./.github/workflows/osv-scanner-reusable-pr.yml"
+    uses: './.github/workflows/osv-scanner-reusable-pr.yml'
     with:
       # Just scan the root directory and docs, since everything else is fixtures
       scan-args: |-
-          --skip-git
-          ./
-          ./docs/
+        --skip-git
+        ./
+        ./docs/
     permissions:
       security-events: write
       contents: read

--- a/.github/workflows/osv-scanner-pr.yml
+++ b/.github/workflows/osv-scanner-pr.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   scan-pr:
-    uses: './.github/workflows/osv-scanner-reusable-pr.yml'
+    uses: "./.github/workflows/osv-scanner-reusable-pr.yml"
     with:
       # Just scan the root directory and docs, since everything else is fixtures
       scan-args: |-

--- a/.github/workflows/osv-scanner-reusable-pr.yml
+++ b/.github/workflows/osv-scanner-reusable-pr.yml
@@ -22,18 +22,18 @@ on:
   workflow_call:
     inputs:
       scan-args:
-        description: "Custom osv-scanner arguments (See https://google.github.io/osv-scanner/usage/ for options, you cannot set --format or --output)"
+        description: 'Custom osv-scanner arguments (See https://google.github.io/osv-scanner/usage/ for options, you cannot set --format or --output)'
         type: string
         default: |-
           -r
           --skip-git
           ./
       results-file-name:
-        description: "File name of the result SARIF file"
+        description: 'File name of the result SARIF file'
         type: string
         default: results.sarif
       upload-sarif:
-        description: "Whether to upload to Security > Code Scanning"
+        description: 'Whether to upload to Security > Code Scanning'
         type: boolean
         required: false
         default: true
@@ -46,9 +46,9 @@ jobs:
         with:
           fetch-depth: 0
           # Do persist credentials, as we need it for the git checkout later
-      - name: "Checkout target branch"
+      - name: 'Checkout target branch'
         run: git checkout $GITHUB_BASE_REF
-      - name: "Run scanner on existing code"
+      - name: 'Run scanner on existing code'
         uses: google/osv-scanner/actions/scanner@main
         continue-on-error: true
         with:
@@ -56,9 +56,9 @@ jobs:
             --format=json
             --output=old-results.json
             ${{ inputs.scan-args }}
-      - name: "Checkout current branch"
+      - name: 'Checkout current branch'
         run: git checkout $GITHUB_SHA
-      - name: "Run scanner on new code"
+      - name: 'Run scanner on new code'
         uses: google/osv-scanner/actions/scanner@main
         with:
           scan-args: |-
@@ -66,7 +66,7 @@ jobs:
             --output=new-results.json
             ${{ inputs.scan-args }}
         continue-on-error: true
-      - name: "Run osv-scanner-reporter"
+      - name: 'Run osv-scanner-reporter'
         uses: google/osv-scanner/actions/reporter@main
         with:
           scan-args: |-
@@ -76,29 +76,29 @@ jobs:
             --gh-annotations=true
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
-      - name: "Upload artifact"
-        if: "!cancelled()"
+      - name: 'Upload artifact'
+        if: '!cancelled()'
         uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: SARIF file
           path: ${{ inputs.results-file-name }}
           retention-days: 5
-      - name: "Upload old scan json results"
-        if: "!cancelled()"
+      - name: 'Upload old scan json results'
+        if: '!cancelled()'
         uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: old-json-results
           path: old-results.json
           retention-days: 5
-      - name: "Upload new scan json results"
-        if: "!cancelled()"
+      - name: 'Upload new scan json results'
+        if: '!cancelled()'
         uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: new-json-results
           path: new-results.json
           retention-days: 5
       # Upload the results to GitHub's code scanning dashboard.
-      - name: "Upload to code-scanning"
+      - name: 'Upload to code-scanning'
         if: ${{ !cancelled() && inputs.upload-sarif == true }}
         uses: github/codeql-action/upload-sarif@407ffafae6a767df3e0230c3df91b6443ae8df75 # v2.22.8
         with:

--- a/.github/workflows/osv-scanner-reusable-pr.yml
+++ b/.github/workflows/osv-scanner-reusable-pr.yml
@@ -22,18 +22,18 @@ on:
   workflow_call:
     inputs:
       scan-args:
-        description: 'Custom osv-scanner arguments (See https://google.github.io/osv-scanner/usage/ for options, you cannot set --format or --output)'
+        description: "Custom osv-scanner arguments (See https://google.github.io/osv-scanner/usage/ for options, you cannot set --format or --output)"
         type: string
         default: |-
           -r
           --skip-git
           ./
       results-file-name:
-        description: 'File name of the result SARIF file'
+        description: "File name of the result SARIF file"
         type: string
         default: results.sarif
       upload-sarif:
-        description: 'Whether to upload to Security > Code Scanning'
+        description: "Whether to upload to Security > Code Scanning"
         type: boolean
         required: false
         default: true
@@ -46,9 +46,9 @@ jobs:
         with:
           fetch-depth: 0
           # Do persist credentials, as we need it for the git checkout later
-      - name: 'Checkout target branch'
+      - name: "Checkout target branch"
         run: git checkout $GITHUB_BASE_REF
-      - name: 'Run scanner on existing code'
+      - name: "Run scanner on existing code"
         uses: google/osv-scanner/actions/scanner@main
         continue-on-error: true
         with:
@@ -56,9 +56,9 @@ jobs:
             --format=json
             --output=old-results.json
             ${{ inputs.scan-args }}
-      - name: 'Checkout current branch'
+      - name: "Checkout current branch"
         run: git checkout $GITHUB_SHA
-      - name: 'Run scanner on new code'
+      - name: "Run scanner on new code"
         uses: google/osv-scanner/actions/scanner@main
         with:
           scan-args: |-
@@ -66,7 +66,7 @@ jobs:
             --output=new-results.json
             ${{ inputs.scan-args }}
         continue-on-error: true
-      - name: 'Run osv-scanner-reporter'
+      - name: "Run osv-scanner-reporter"
         uses: google/osv-scanner/actions/reporter@main
         with:
           scan-args: |-
@@ -76,29 +76,29 @@ jobs:
             --gh-annotations=true
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
-      - name: 'Upload artifact'
-        if: '!cancelled()'
+      - name: "Upload artifact"
+        if: "!cancelled()"
         uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: SARIF file
           path: ${{ inputs.results-file-name }}
           retention-days: 5
-      - name: 'Upload old scan json results'
-        if: '!cancelled()'
+      - name: "Upload old scan json results"
+        if: "!cancelled()"
         uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: old-json-results
           path: old-results.json
           retention-days: 5
-      - name: 'Upload new scan json results'
-        if: '!cancelled()'
+      - name: "Upload new scan json results"
+        if: "!cancelled()"
         uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: new-json-results
           path: new-results.json
           retention-days: 5
       # Upload the results to GitHub's code scanning dashboard.
-      - name: 'Upload to code-scanning'
+      - name: "Upload to code-scanning"
         if: ${{ !cancelled() && inputs.upload-sarif == true }}
         uses: github/codeql-action/upload-sarif@407ffafae6a767df3e0230c3df91b6443ae8df75 # v2.22.8
         with:

--- a/.github/workflows/osv-scanner-reusable.yml
+++ b/.github/workflows/osv-scanner-reusable.yml
@@ -22,23 +22,23 @@ on:
   workflow_call:
     inputs:
       scan-args:
-        description: 'Custom osv-scanner arguments (See https://google.github.io/osv-scanner/usage/ for options, you cannot set --format or --output)'
+        description: "Custom osv-scanner arguments (See https://google.github.io/osv-scanner/usage/ for options, you cannot set --format or --output)"
         type: string
         default: |-
           -r
           --skip-git
           ./
       results-file-name:
-        description: 'File name of the result SARIF file'
+        description: "File name of the result SARIF file"
         type: string
         default: results.sarif
       download-artifact:
-        description: 'Optional artifact to download for scanning'
+        description: "Optional artifact to download for scanning"
         required: false
-        default: ''
+        default: ""
         type: string
       upload-sarif:
-        description: 'Whether to upload to Security > Code Scanning'
+        description: "Whether to upload to Security > Code Scanning"
         type: boolean
         required: false
         default: true
@@ -50,13 +50,13 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           persist-credentials: false
-      - name: 'Download custom artifact if specified'
+      - name: "Download custom artifact if specified"
         uses: actions/download-artifact@v3
         if: "${{ inputs.download-artifact != '' }}"
         with:
-          name: '${{ inputs.download-artifact }}'
-          path: './'
-      - name: 'Run scanner'
+          name: "${{ inputs.download-artifact }}"
+          path: "./"
+      - name: "Run scanner"
         uses: google/osv-scanner/actions/scanner@main
         with:
           scan-args: |-
@@ -64,7 +64,7 @@ jobs:
             --format=json
             ${{ inputs.scan-args }}
         continue-on-error: true
-      - name: 'Run osv-scanner-reporter'
+      - name: "Run osv-scanner-reporter"
         uses: google/osv-scanner/actions/reporter@main
         with:
           scan-args: |-
@@ -73,16 +73,16 @@ jobs:
             --gh-annotations=false
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
-      - name: 'Upload artifact'
-        if: '!cancelled()'
+      - name: "Upload artifact"
+        if: "!cancelled()"
         uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: SARIF file
           path: ${{ inputs.results-file-name }}
           retention-days: 5
       # Upload the results to GitHub's code scanning dashboard.
-      - name: 'Upload to code-scanning'
-        if: '${{ !cancelled() && inputs.upload-sarif == true }}'
+      - name: "Upload to code-scanning"
+        if: "${{ !cancelled() && inputs.upload-sarif == true }}"
         uses: github/codeql-action/upload-sarif@407ffafae6a767df3e0230c3df91b6443ae8df75 # v2.22.8
         with:
           sarif_file: ${{ inputs.results-file-name }}

--- a/.github/workflows/osv-scanner-reusable.yml
+++ b/.github/workflows/osv-scanner-reusable.yml
@@ -22,23 +22,23 @@ on:
   workflow_call:
     inputs:
       scan-args:
-        description: "Custom osv-scanner arguments (See https://google.github.io/osv-scanner/usage/ for options, you cannot set --format or --output)"
+        description: 'Custom osv-scanner arguments (See https://google.github.io/osv-scanner/usage/ for options, you cannot set --format or --output)'
         type: string
         default: |-
           -r
           --skip-git
           ./
       results-file-name:
-        description: "File name of the result SARIF file"
+        description: 'File name of the result SARIF file'
         type: string
         default: results.sarif
       download-artifact:
-        description: "Optional artifact to download for scanning"
+        description: 'Optional artifact to download for scanning'
         required: false
-        default: ""
+        default: ''
         type: string
       upload-sarif:
-        description: "Whether to upload to Security > Code Scanning"
+        description: 'Whether to upload to Security > Code Scanning'
         type: boolean
         required: false
         default: true
@@ -50,13 +50,13 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           persist-credentials: false
-      - name: "Download custom artifact if specified"
+      - name: 'Download custom artifact if specified'
         uses: actions/download-artifact@v3
         if: "${{ inputs.download-artifact != '' }}"
         with:
-          name: "${{ inputs.download-artifact }}"
-          path: "./"
-      - name: "Run scanner"
+          name: '${{ inputs.download-artifact }}'
+          path: './'
+      - name: 'Run scanner'
         uses: google/osv-scanner/actions/scanner@main
         with:
           scan-args: |-
@@ -64,7 +64,7 @@ jobs:
             --format=json
             ${{ inputs.scan-args }}
         continue-on-error: true
-      - name: "Run osv-scanner-reporter"
+      - name: 'Run osv-scanner-reporter'
         uses: google/osv-scanner/actions/reporter@main
         with:
           scan-args: |-
@@ -73,17 +73,16 @@ jobs:
             --gh-annotations=false
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
-      - name: "Upload artifact"
-        if: "!cancelled()"
+      - name: 'Upload artifact'
+        if: '!cancelled()'
         uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: SARIF file
           path: ${{ inputs.results-file-name }}
           retention-days: 5
       # Upload the results to GitHub's code scanning dashboard.
-      - name: "Upload to code-scanning"
-        if: "${{ !cancelled() && inputs.upload-sarif == true }}"
+      - name: 'Upload to code-scanning'
+        if: '${{ !cancelled() && inputs.upload-sarif == true }}'
         uses: github/codeql-action/upload-sarif@407ffafae6a767df3e0230c3df91b6443ae8df75 # v2.22.8
         with:
           sarif_file: ${{ inputs.results-file-name }}
-

--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -16,13 +16,13 @@ name: OSV-Scanner Scheduled Scan
 
 on:
   schedule:
-    - cron: '12 12 * * 1'
+    - cron: "12 12 * * 1"
   push:
-    branches: ['main']
+    branches: ["main"]
 
 jobs:
   scan-scheduled:
-    uses: './.github/workflows/osv-scanner-reusable.yml'
+    uses: "./.github/workflows/osv-scanner-reusable.yml"
     with:
       # Just scan the root directory and docs, since everything else is fixtures
       scan-args: |-

--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -18,20 +18,19 @@ on:
   schedule:
     - cron: '12 12 * * 1'
   push:
-    branches: [ "main" ]
+    branches: ['main']
 
 jobs:
   scan-scheduled:
-    uses: "./.github/workflows/osv-scanner-reusable.yml"
+    uses: './.github/workflows/osv-scanner-reusable.yml'
     with:
       # Just scan the root directory and docs, since everything else is fixtures
       scan-args: |-
-          --skip-git
-          ./
-          ./docs/
+        --skip-git
+        ./
+        ./docs/
     permissions:
       # Require writing security events to upload SARIF file to security tab
       security-events: write
       # Read commit contents
       contents: read
-

--- a/.github/workflows/prerelease-check.yml
+++ b/.github/workflows/prerelease-check.yml
@@ -4,11 +4,11 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'The version tag to release, (e.g. v1.2.3)'
+        description: "The version tag to release, (e.g. v1.2.3)"
         required: true
         type: string
       commit:
-        description: 'The commit hash to release'
+        description: "The commit hash to release"
         required: true
         type: string
 

--- a/.github/workflows/prerelease-check.yml
+++ b/.github/workflows/prerelease-check.yml
@@ -27,6 +27,16 @@ jobs:
         --skip-git
         ./
 
+  format:
+    name: prettier
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
+      - name: Run lint action
+        uses: ./.github/workflows/format-action
   lint:
     name: golangci-lint
     runs-on: ubuntu-latest
@@ -66,6 +76,7 @@ jobs:
   release-helper:
     runs-on: ubuntu-latest
     needs:
+      - format
       - lint
       - tests
       - osv-scan

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -12,7 +12,7 @@ on:
   schedule:
     - cron: '32 22 * * 6'
   push:
-    branches: [ "main" ]
+    branches: ['main']
 
 # Declare default permissions as read only.
 permissions: read-all
@@ -31,12 +31,12 @@ jobs:
       # actions: read
 
     steps:
-      - name: "Checkout code"
+      - name: 'Checkout code'
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           persist-credentials: false
 
-      - name: "Run analysis"
+      - name: 'Run analysis'
         uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736 # v2.3.1
         with:
           results_file: results.sarif
@@ -58,7 +58,7 @@ jobs:
 
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
-      - name: "Upload artifact"
+      - name: 'Upload artifact'
         uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: SARIF file
@@ -66,7 +66,7 @@ jobs:
           retention-days: 5
 
       # Upload the results to GitHub's code scanning dashboard.
-      - name: "Upload to code-scanning"
+      - name: 'Upload to code-scanning'
         uses: github/codeql-action/upload-sarif@407ffafae6a767df3e0230c3df91b6443ae8df75 # v2.22.8
         with:
           sarif_file: results.sarif

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -10,9 +10,9 @@ on:
   # To guarantee Maintained check is occasionally updated. See
   # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
   schedule:
-    - cron: '32 22 * * 6'
+    - cron: "32 22 * * 6"
   push:
-    branches: ['main']
+    branches: ["main"]
 
 # Declare default permissions as read only.
 permissions: read-all
@@ -31,12 +31,12 @@ jobs:
       # actions: read
 
     steps:
-      - name: 'Checkout code'
+      - name: "Checkout code"
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           persist-credentials: false
 
-      - name: 'Run analysis'
+      - name: "Run analysis"
         uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736 # v2.3.1
         with:
           results_file: results.sarif
@@ -58,7 +58,7 @@ jobs:
 
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
-      - name: 'Upload artifact'
+      - name: "Upload artifact"
         uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: SARIF file
@@ -66,7 +66,7 @@ jobs:
           retention-days: 5
 
       # Upload the results to GitHub's code scanning dashboard.
-      - name: 'Upload to code-scanning'
+      - name: "Upload to code-scanning"
         uses: github/codeql-action/upload-sarif@407ffafae6a767df3e0230c3df91b6443ae8df75 # v2.22.8
         with:
           sarif_file: results.sarif

--- a/.github/workflows/test-action/action.yml
+++ b/.github/workflows/test-action/action.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: test
-description: 'Runs go tests'
+description: "Runs go tests"
 
 runs:
   using: composite

--- a/.github/workflows/test-action/action.yml
+++ b/.github/workflows/test-action/action.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: test
-description: "Runs go tests"
+description: 'Runs go tests'
 
 runs:
   using: composite

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /osv-scanner
 /coverage.out
 /coverage.html
+fixtures/

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -46,11 +46,11 @@ linters-settings:
     rules:
       regexp:
         files:
-          - '!**/internal/cachedregexp/**'
-          - '!**/main_test.go'
+          - "!**/internal/cachedregexp/**"
+          - "!**/main_test.go"
         deny:
-          - pkg: 'regexp'
-            desc: 'Use github.com/google/osv-scanner/internal/cachedregexp instead'
+          - pkg: "regexp"
+            desc: "Use github.com/google/osv-scanner/internal/cachedregexp instead"
   gocritic:
     disabled-checks:
       - ifElseChain

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -50,8 +50,7 @@ linters-settings:
           - '!**/main_test.go'
         deny:
           - pkg: 'regexp'
-            desc:
-              'Use github.com/google/osv-scanner/internal/cachedregexp instead'
+            desc: 'Use github.com/google/osv-scanner/internal/cachedregexp instead'
   gocritic:
     disabled-checks:
       - ifElseChain

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,7 +8,7 @@ builds:
       # they are unable to install libraries.
       - CGO_ENABLED=0
       - GO111MODULE=on
-    mod_timestamp: '{{ .CommitTimestamp }}'
+    mod_timestamp: "{{ .CommitTimestamp }}"
     flags:
       - -trimpath
     ldflags:
@@ -32,55 +32,55 @@ builds:
 dockers:
   # Arch: amd64
   - image_templates:
-      - 'ghcr.io/google/osv-scanner:{{ .Tag }}-amd64'
+      - "ghcr.io/google/osv-scanner:{{ .Tag }}-amd64"
     dockerfile: goreleaser.dockerfile
     use: buildx
     build_flag_templates:
-      - '--pull'
-      - '--label=org.opencontainers.image.title=osv-scanner'
-      - '--label=org.opencontainers.image.description=Vulnerability scanner written in Go which uses the data provided by https://osv.dev'
-      - '--label=org.opencontainers.image.licenses=Apache License 2.0'
-      - '--label=org.opencontainers.image.created={{.Date}}'
-      - '--label=org.opencontainers.image.name={{.ProjectName}}'
-      - '--label=org.opencontainers.image.revision={{.FullCommit}}'
-      - '--label=org.opencontainers.image.version={{.Version}}'
-      - '--label=org.opencontainers.image.source={{.GitURL}}'
-      - '--label=org.opencontainers.image.url={{.GitURL}}'
-      - '--platform=linux/amd64'
+      - "--pull"
+      - "--label=org.opencontainers.image.title=osv-scanner"
+      - "--label=org.opencontainers.image.description=Vulnerability scanner written in Go which uses the data provided by https://osv.dev"
+      - "--label=org.opencontainers.image.licenses=Apache License 2.0"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.name={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
+      - "--label=org.opencontainers.image.url={{.GitURL}}"
+      - "--platform=linux/amd64"
   # Arch: arm64
   - image_templates:
-      - 'ghcr.io/google/osv-scanner:{{ .Tag }}-arm64'
+      - "ghcr.io/google/osv-scanner:{{ .Tag }}-arm64"
     dockerfile: goreleaser.dockerfile
     use: buildx
     build_flag_templates:
-      - '--pull'
-      - '--label=org.opencontainers.image.title=osv-scanner'
-      - '--label=org.opencontainers.image.description=Vulnerability scanner written in Go which uses the data provided by https://osv.dev'
-      - '--label=org.opencontainers.image.licenses=Apache-2.0'
-      - '--label=org.opencontainers.image.created={{.Date}}'
-      - '--label=org.opencontainers.image.name={{.ProjectName}}'
-      - '--label=org.opencontainers.image.revision={{.FullCommit}}'
-      - '--label=org.opencontainers.image.version={{.Version}}'
-      - '--label=org.opencontainers.image.source={{.GitURL}}'
-      - '--label=org.opencontainers.image.url={{.GitURL}}'
-      - '--platform=linux/arm64'
+      - "--pull"
+      - "--label=org.opencontainers.image.title=osv-scanner"
+      - "--label=org.opencontainers.image.description=Vulnerability scanner written in Go which uses the data provided by https://osv.dev"
+      - "--label=org.opencontainers.image.licenses=Apache-2.0"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.name={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
+      - "--label=org.opencontainers.image.url={{.GitURL}}"
+      - "--platform=linux/arm64"
     goarch: arm64
 
 docker_manifests:
-  - name_template: 'ghcr.io/google/osv-scanner:{{ .Tag }}'
+  - name_template: "ghcr.io/google/osv-scanner:{{ .Tag }}"
     image_templates:
-      - 'ghcr.io/google/osv-scanner:{{ .Tag }}-amd64'
-      - 'ghcr.io/google/osv-scanner:{{ .Tag }}-arm64'
-  - name_template: 'ghcr.io/google/osv-scanner:latest'
+      - "ghcr.io/google/osv-scanner:{{ .Tag }}-amd64"
+      - "ghcr.io/google/osv-scanner:{{ .Tag }}-arm64"
+  - name_template: "ghcr.io/google/osv-scanner:latest"
     image_templates:
-      - 'ghcr.io/google/osv-scanner:{{ .Tag }}-amd64'
-      - 'ghcr.io/google/osv-scanner:{{ .Tag }}-arm64'
+      - "ghcr.io/google/osv-scanner:{{ .Tag }}-amd64"
+      - "ghcr.io/google/osv-scanner:{{ .Tag }}-arm64"
 
 archives:
   - format: binary
-    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 checksum:
-  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
+  name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
   algorithm: sha256
 release:
   draft: true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,34 +36,34 @@ dockers:
     dockerfile: goreleaser.dockerfile
     use: buildx
     build_flag_templates:
-      - "--pull"
-      - "--label=org.opencontainers.image.title=osv-scanner"
-      - "--label=org.opencontainers.image.description=Vulnerability scanner written in Go which uses the data provided by https://osv.dev"
-      - "--label=org.opencontainers.image.licenses=Apache License 2.0"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.name={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.source={{.GitURL}}"
-      - "--label=org.opencontainers.image.url={{.GitURL}}"
-      - "--platform=linux/amd64"
+      - '--pull'
+      - '--label=org.opencontainers.image.title=osv-scanner'
+      - '--label=org.opencontainers.image.description=Vulnerability scanner written in Go which uses the data provided by https://osv.dev'
+      - '--label=org.opencontainers.image.licenses=Apache License 2.0'
+      - '--label=org.opencontainers.image.created={{.Date}}'
+      - '--label=org.opencontainers.image.name={{.ProjectName}}'
+      - '--label=org.opencontainers.image.revision={{.FullCommit}}'
+      - '--label=org.opencontainers.image.version={{.Version}}'
+      - '--label=org.opencontainers.image.source={{.GitURL}}'
+      - '--label=org.opencontainers.image.url={{.GitURL}}'
+      - '--platform=linux/amd64'
   # Arch: arm64
   - image_templates:
       - 'ghcr.io/google/osv-scanner:{{ .Tag }}-arm64'
     dockerfile: goreleaser.dockerfile
     use: buildx
     build_flag_templates:
-      - "--pull"
-      - "--label=org.opencontainers.image.title=osv-scanner"
-      - "--label=org.opencontainers.image.description=Vulnerability scanner written in Go which uses the data provided by https://osv.dev"
-      - "--label=org.opencontainers.image.licenses=Apache-2.0"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.name={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.source={{.GitURL}}"
-      - "--label=org.opencontainers.image.url={{.GitURL}}"
-      - "--platform=linux/arm64"
+      - '--pull'
+      - '--label=org.opencontainers.image.title=osv-scanner'
+      - '--label=org.opencontainers.image.description=Vulnerability scanner written in Go which uses the data provided by https://osv.dev'
+      - '--label=org.opencontainers.image.licenses=Apache-2.0'
+      - '--label=org.opencontainers.image.created={{.Date}}'
+      - '--label=org.opencontainers.image.name={{.ProjectName}}'
+      - '--label=org.opencontainers.image.revision={{.FullCommit}}'
+      - '--label=org.opencontainers.image.version={{.Version}}'
+      - '--label=org.opencontainers.image.source={{.GitURL}}'
+      - '--label=org.opencontainers.image.url={{.GitURL}}'
+      - '--platform=linux/arm64'
     goarch: arm64
 
 docker_manifests:

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+**/fixtures/**
+**/fixtures-go/**

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 **/fixtures/**
 **/fixtures-go/**
+/docs/vendor/**

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/prettierrc",
-  "singleQuote": true,
+  "singleQuote": false,
   "proseWrap": "preserve",
   "endOfLine": "lf",
   "arrowParens": "avoid",

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json.schemastore.org/prettierrc",
+  "singleQuote": true,
+  "proseWrap": "preserve",
+  "endOfLine": "lf",
+  "arrowParens": "avoid",
+  "trailingComma": "none",
+  "htmlWhitespaceSensitivity": "ignore"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v1.5.0:
 
 ### Features
+
 - [Feature #501](https://github.com/google/osv-scanner/pull/501)
   Add experimental license scanning support! See https://osv.dev/blog/posts/introducing-license-scanning-with-osv-scanner/ for more information!
 - [Feature #642](https://github.com/google/osv-scanner/pull/642)
@@ -14,15 +15,16 @@
   with call analysis for Go enabled by default. See https://google.github.io/osv-scanner/usage/#scanning-with-call-analysis for the documentation!
 - [Feature #676](https://github.com/google/osv-scanner/pull/676)
   Simplify return codes:
-    - Return 0 if there are no findings or errors.
-    - Return 1 if there are any findings (license violations or vulnerabilities).
-    - Return 128 if no packages are found.
+  - Return 0 if there are no findings or errors.
+  - Return 1 if there are any findings (license violations or vulnerabilities).
+  - Return 128 if no packages are found.
 - [Feature #651](https://github.com/google/osv-scanner/pull/651)
   CVSS v4.0 support.
 - [Feature #60](https://github.com/google/osv-scanner/pull/60)
   [Pre-commit hook](https://pre-commit.com/) support.
 
 ### Fixes
+
 - [Bug #639](https://github.com/google/osv-scanner/issues/639)
   We now filter local packages from scans, and report the filtering of those packages.
 - [Bug #645](https://github.com/google/osv-scanner/issues/645)
@@ -35,17 +37,20 @@
   Fix filtering of aliases to also include non OSV aliases
 
 ### Miscellaneous
+
 - The minimum go version has been updated to go1.21 from go1.18.
 
 # v1.4.3:
 
 ### Features
+
 - [Feature #621](https://github.com/google/osv-scanner/pull/621)
   Add support for scanning vendored C/C++ files.
 - [Feature #581](https://github.com/google/osv-scanner/pull/581)
   Scan submodules commit hashes.
 
 ### Fixes
+
 - [Bug #626](https://github.com/google/osv-scanner/issues/626)
   Fix gitignore matching for root directory
 - [Bug #622](https://github.com/google/osv-scanner/issues/622)
@@ -58,6 +63,7 @@
 # v1.4.2:
 
 ### Fixes
+
 - [Bug #574](https://github.com/google/osv-scanner/issues/574)
   Support versions with build metadata in `yarn.lock` files
 - [Bug #599](https://github.com/google/osv-scanner/issues/599)
@@ -66,6 +72,7 @@
 # v1.4.1:
 
 ### Features
+
 - [Feature #534](https://github.com/google/osv-scanner/pull/534)
   New SARIF format that separates out individual vulnerabilities, see https://github.com/google/osv-scanner/issue/216
 - [Experimental Feature #57](https://github.com/google/osv-scanner/issues/57) Experimental Github Action!
@@ -73,11 +80,13 @@
   Experimental, so might change with only a minor update.
 
 ### API Features
+
 - [Feature #557](https://github.com/google/osv-scanner/pull/557) Add new ecosystems, and a slice containing all of them.
 
 # v1.4.0:
 
 ### Features
+
 - [Feature #183](https://github.com/google/osv-scanner/pull/183)
   Add (experimental) offline mode! See [our documentation](https://google.github.io/osv-scanner/experimental/#offline-mode) for how to use it.
 - [Feature #452](https://github.com/google/osv-scanner/pull/452)
@@ -86,9 +95,11 @@
 - [Feature #505](https://github.com/google/osv-scanner/pull/505) OSV-Scanner doesn't support your lockfile format? You can now use your own parser for your format, and create an intermediate `osv-scanner.json` for osv-scanner to scan. See [our documentation](https://google.github.io/osv-scanner/usage/#custom-lockfiles) for instructions.
 
 ### API Features
+
 - [Feature #451](https://github.com/google/osv-scanner/pull/451) The lockfile package now support extracting dependencies directly from any io.Reader, removing the requirement of a file path.
 
 ### Fixes
+
 - [Bug #457](https://github.com/google/osv-scanner/pull/457)
   Fix PURL mapping for Alpine packages
 - [Bug #462](https://github.com/google/osv-scanner/pull/462)
@@ -97,20 +108,22 @@
 # v1.3.6:
 
 ### Minor Updates
+
 - [Feature #431](https://github.com/google/osv-scanner/pull/431)
   Update GoVulnCheck integration.
 - [Feature #439](https://github.com/google/osv-scanner/pull/439)
   Create `models.PURLToPackage()`, and deprecate `osvscanner.PURLToPackage()`.
 
 ### Fixes
+
 - [Feature #439](https://github.com/google/osv-scanner/pull/439)
   Fix `PURLToPackage` not returning the full namespace of packages in ecosystems
   that use them (e.g. golang).
 
-
 # v1.3.5:
 
 ### Features
+
 - [Feature #409](https://github.com/google/osv-scanner/pull/409)
   Adds an additional column to the table output which shows the severity if available.
 
@@ -127,7 +140,6 @@
     - Add new reference types
     - Add YAML tags
 
-
 # v1.3.4:
 
 ### Minor Updates
@@ -139,164 +151,164 @@
 
 ### Fixes
 
--   [Bug #369](https://github.com/google/osv-scanner/issues/369) Fix
-    requirements.txt misparsing lines that contain `--hash`.
--   [Bug #237](https://github.com/google/osv-scanner/issues/237) Clarify when no
-    vulnerabilities are found.
--   [Bug #354](https://github.com/google/osv-scanner/issues/354) Fix cycle in
-    requirements.txt causing infinite recursion.
--   [Bug #367](https://github.com/google/osv-scanner/issues/367) Fix panic when
-    parsing empty lockfile.
+- [Bug #369](https://github.com/google/osv-scanner/issues/369) Fix
+  requirements.txt misparsing lines that contain `--hash`.
+- [Bug #237](https://github.com/google/osv-scanner/issues/237) Clarify when no
+  vulnerabilities are found.
+- [Bug #354](https://github.com/google/osv-scanner/issues/354) Fix cycle in
+  requirements.txt causing infinite recursion.
+- [Bug #367](https://github.com/google/osv-scanner/issues/367) Fix panic when
+  parsing empty lockfile.
 
 ### API Features
 
--   [Feature #357](https://github.com/google/osv-scanner/pull/357) Update
-    `pkg/osv` to allow overriding the http client / transport
+- [Feature #357](https://github.com/google/osv-scanner/pull/357) Update
+  `pkg/osv` to allow overriding the http client / transport
 
 # v1.3.2:
 
 ### Fixes
 
--   [Bug #341](https://github.com/google/osv-scanner/pull/341) Make the reporter
-    public to allow calling DoScan with non nil reporters.
--   [Bug #335](https://github.com/google/osv-scanner/issues/335) Improve SBOM
-    parsing and relaxing name requirements when explicitly scanning with
-    `--sbom`.
--   [Bug #333](https://github.com/google/osv-scanner/issues/333) Improve
-    scanning speed for regex heavy lockfiles by caching regex compilation.
--   [Bug #349](https://github.com/google/osv-scanner/pull/349) Improve SBOM
-    documentation and error messages.
+- [Bug #341](https://github.com/google/osv-scanner/pull/341) Make the reporter
+  public to allow calling DoScan with non nil reporters.
+- [Bug #335](https://github.com/google/osv-scanner/issues/335) Improve SBOM
+  parsing and relaxing name requirements when explicitly scanning with
+  `--sbom`.
+- [Bug #333](https://github.com/google/osv-scanner/issues/333) Improve
+  scanning speed for regex heavy lockfiles by caching regex compilation.
+- [Bug #349](https://github.com/google/osv-scanner/pull/349) Improve SBOM
+  documentation and error messages.
 
 # v1.3.1:
 
 ### Fixes
 
--   [Bug #319](https://github.com/google/osv-scanner/issues/319) Fix
-    segmentation fault when parsing CycloneDX without dependencies.
+- [Bug #319](https://github.com/google/osv-scanner/issues/319) Fix
+  segmentation fault when parsing CycloneDX without dependencies.
 
 # v1.3.0:
 
 ### Major Features:
 
--   [Feature #198](https://github.com/google/osv-scanner/pull/198) GoVulnCheck
-    integration! Try it out when scanning go code by adding the
-    `--experimental-call-analysis` flag.
--   [Feature #260](https://github.com/google/osv-scanner/pull/198) Support `-r`
-    flag in `requirements.txt` files.
--   [Feature #300](https://github.com/google/osv-scanner/pull/300) Make
-    `IgnoredVulns` also ignore aliases.
--   [Feature #304](https://github.com/google/osv-scanner/pull/304) OSV-Scanner
-    now runs faster when there's multiple vulnerabilities.
+- [Feature #198](https://github.com/google/osv-scanner/pull/198) GoVulnCheck
+  integration! Try it out when scanning go code by adding the
+  `--experimental-call-analysis` flag.
+- [Feature #260](https://github.com/google/osv-scanner/pull/198) Support `-r`
+  flag in `requirements.txt` files.
+- [Feature #300](https://github.com/google/osv-scanner/pull/300) Make
+  `IgnoredVulns` also ignore aliases.
+- [Feature #304](https://github.com/google/osv-scanner/pull/304) OSV-Scanner
+  now runs faster when there's multiple vulnerabilities.
 
 ### Fixes
 
--   [Bug #249](https://github.com/google/osv-scanner/issues/249) Support yarn
-    locks with quoted properties.
--   [Bug #232](https://github.com/google/osv-scanner/issues/232) Parse nested
-    CycloneDX components correctly.
--   [Bug #257](https://github.com/google/osv-scanner/issues/257) More specific
-    cyclone dx parsing.
--   [Bug #256](https://github.com/google/osv-scanner/issues/256) Avoid panic
-    when parsing `file:` dependencies in `pnpm` lockfiles.
--   [Bug #261](https://github.com/google/osv-scanner/issues/261) Deduplicate
-    packages that appear multiple times in `Pipenv.lock` files.
--   [Bug #267](https://github.com/google/osv-scanner/issues/267) Properly handle
-    comparing zero versions in Maven.
--   [Bug #279](https://github.com/google/osv-scanner/issues/279) Trim leading
-    zeros off when comparing numerical components in Maven versions.
--   [Bug #291](https://github.com/google/osv-scanner/issues/291) Check if PURL
-    is valid before adding it to queries.
--   [Bug #293](https://github.com/google/osv-scanner/issues/293) Avoid infinite
-    loops parsing Maven poms with syntax errors
--   [Bug #295](https://github.com/google/osv-scanner/issues/295) Set version in
-    the source code, this allows version to be displayed in most package
-    managers.
--   [Bug #297](https://github.com/google/osv-scanner/issues/297) Support Pipenv
-    develop packages without versions.
+- [Bug #249](https://github.com/google/osv-scanner/issues/249) Support yarn
+  locks with quoted properties.
+- [Bug #232](https://github.com/google/osv-scanner/issues/232) Parse nested
+  CycloneDX components correctly.
+- [Bug #257](https://github.com/google/osv-scanner/issues/257) More specific
+  cyclone dx parsing.
+- [Bug #256](https://github.com/google/osv-scanner/issues/256) Avoid panic
+  when parsing `file:` dependencies in `pnpm` lockfiles.
+- [Bug #261](https://github.com/google/osv-scanner/issues/261) Deduplicate
+  packages that appear multiple times in `Pipenv.lock` files.
+- [Bug #267](https://github.com/google/osv-scanner/issues/267) Properly handle
+  comparing zero versions in Maven.
+- [Bug #279](https://github.com/google/osv-scanner/issues/279) Trim leading
+  zeros off when comparing numerical components in Maven versions.
+- [Bug #291](https://github.com/google/osv-scanner/issues/291) Check if PURL
+  is valid before adding it to queries.
+- [Bug #293](https://github.com/google/osv-scanner/issues/293) Avoid infinite
+  loops parsing Maven poms with syntax errors
+- [Bug #295](https://github.com/google/osv-scanner/issues/295) Set version in
+  the source code, this allows version to be displayed in most package
+  managers.
+- [Bug #297](https://github.com/google/osv-scanner/issues/297) Support Pipenv
+  develop packages without versions.
 
 ### API Features
 
--   [Feature #310](https://github.com/google/osv-scanner/pull/310) Improve the
-    OSV models to allow for 3rd party use of the library.
+- [Feature #310](https://github.com/google/osv-scanner/pull/310) Improve the
+  OSV models to allow for 3rd party use of the library.
 
 # v1.2.0:
 
 ### Major Features:
 
--   [Feature #168](https://github.com/google/osv-scanner/pull/168) Support for
-    scanning debian package status file, usually located in
-    `/var/lib/dpkg/status`. Thanks @cmaritan
--   [Feature #94](https://github.com/google/osv-scanner/pull/94) Specify what
-    parser should be used in `--lockfile`.
--   [Feature #158](https://github.com/google/osv-scanner/pull/158) Specify
-    output format to use with the `--format` flag.
--   [Feature #165](https://github.com/google/osv-scanner/pull/165) Respect
-    `.gitignore` files by default when scanning.
--   [Feature #156](https://github.com/google/osv-scanner/pull/156) Support
-    markdown table output format. Thanks @deftdawg
--   [Feature #59](https://github.com/google/osv-scanner/pull/59) Support
-    `conan.lock` lockfiles and ecosystem Thanks @SSE4
--   Updated documentation! Check it out here:
-    https://google.github.io/osv-scanner/
+- [Feature #168](https://github.com/google/osv-scanner/pull/168) Support for
+  scanning debian package status file, usually located in
+  `/var/lib/dpkg/status`. Thanks @cmaritan
+- [Feature #94](https://github.com/google/osv-scanner/pull/94) Specify what
+  parser should be used in `--lockfile`.
+- [Feature #158](https://github.com/google/osv-scanner/pull/158) Specify
+  output format to use with the `--format` flag.
+- [Feature #165](https://github.com/google/osv-scanner/pull/165) Respect
+  `.gitignore` files by default when scanning.
+- [Feature #156](https://github.com/google/osv-scanner/pull/156) Support
+  markdown table output format. Thanks @deftdawg
+- [Feature #59](https://github.com/google/osv-scanner/pull/59) Support
+  `conan.lock` lockfiles and ecosystem Thanks @SSE4
+- Updated documentation! Check it out here:
+  https://google.github.io/osv-scanner/
 
 ### Minor Updates:
 
--   [Feature #178](https://github.com/google/osv-scanner/pull/178) Support SPDX
-    2.3.
--   [Feature #221](https://github.com/google/osv-scanner/pull/221) Support
-    dependencyManagement section in Maven poms.
--   [Feature #167](https://github.com/google/osv-scanner/pull/167) Make
-    osvscanner API library public.
--   [Feature #141](https://github.com/google/osv-scanner/pull/141) Retry OSV API
-    calls to mitigate transient network issues. Thanks @davift
--   [Feature #220](https://github.com/google/osv-scanner/pull/220) Vulnerability
-    output is ordered deterministically.
--   [Feature #179](https://github.com/google/osv-scanner/pull/179) Log number of
-    packages scanned from SBOM.
--   General dependency updates
+- [Feature #178](https://github.com/google/osv-scanner/pull/178) Support SPDX
+  2.3.
+- [Feature #221](https://github.com/google/osv-scanner/pull/221) Support
+  dependencyManagement section in Maven poms.
+- [Feature #167](https://github.com/google/osv-scanner/pull/167) Make
+  osvscanner API library public.
+- [Feature #141](https://github.com/google/osv-scanner/pull/141) Retry OSV API
+  calls to mitigate transient network issues. Thanks @davift
+- [Feature #220](https://github.com/google/osv-scanner/pull/220) Vulnerability
+  output is ordered deterministically.
+- [Feature #179](https://github.com/google/osv-scanner/pull/179) Log number of
+  packages scanned from SBOM.
+- General dependency updates
 
 ### Fixes
 
--   [Bug #161](https://github.com/google/osv-scanner/pull/161) Exit with non
-    zero exit code when there is a general error.
--   [Bug #185](https://github.com/google/osv-scanner/pull/185) Properly omit
-    Source from JSON output.
+- [Bug #161](https://github.com/google/osv-scanner/pull/161) Exit with non
+  zero exit code when there is a general error.
+- [Bug #185](https://github.com/google/osv-scanner/pull/185) Properly omit
+  Source from JSON output.
 
 # v1.1.0:
 
 This update adds support for NuGet ecosystem and various bug fixes by the
 community.
 
--   [Feature #98](https://github.com/google/osv-scanner/pull/98): Support for
-    NuGet ecosystem.
--   [Feature #71](https://github.com/google/osv-scanner/issues/71): Now supports
-    Pipfile.lock scanning.
--   [Bug #85](https://github.com/google/osv-scanner/issues/85): Even better
-    support for narrow terminals by shortening osv.dev URLs.
--   [Bug #105](https://github.com/google/osv-scanner/issues/105): Fix rare cases
-    of too many open file handles.
--   [Bug #131](https://github.com/google/osv-scanner/pull/131): Fix table
-    highlighting overflow.
--   [Bug #101](https://github.com/google/osv-scanner/issues/101): Now supports
-    32 bit systems.
+- [Feature #98](https://github.com/google/osv-scanner/pull/98): Support for
+  NuGet ecosystem.
+- [Feature #71](https://github.com/google/osv-scanner/issues/71): Now supports
+  Pipfile.lock scanning.
+- [Bug #85](https://github.com/google/osv-scanner/issues/85): Even better
+  support for narrow terminals by shortening osv.dev URLs.
+- [Bug #105](https://github.com/google/osv-scanner/issues/105): Fix rare cases
+  of too many open file handles.
+- [Bug #131](https://github.com/google/osv-scanner/pull/131): Fix table
+  highlighting overflow.
+- [Bug #101](https://github.com/google/osv-scanner/issues/101): Now supports
+  32 bit systems.
 
 # v1.0.2
 
 This is a minor patch release to mitigate human readable output issues on narrow
 terminals (#85).
 
--   [Bug #85](https://github.com/google/osv-scanner/issues/85): Better support
-    for narrow terminals.
+- [Bug #85](https://github.com/google/osv-scanner/issues/85): Better support
+  for narrow terminals.
 
 # v1.0.1
 
 Various bug fixes and improvements. Many thanks to the amazing contributions and
 suggestions from the community!
 
--   Feature: ARM64 builds are now also available!
--   [Feature #46](https://github.com/google/osv-scanner/pull/46): Gradle
-    lockfile support.
--   [Feature #50](https://github.com/google/osv-scanner/pull/46): Add version
-    command.
--   [Bug #52](https://github.com/google/osv-scanner/issues/52): Fixes 0 exit
-    code being wrongly emitted when vulnerabilities are present.
+- Feature: ARM64 builds are now also available!
+- [Feature #46](https://github.com/google/osv-scanner/pull/46): Gradle
+  lockfile support.
+- [Feature #50](https://github.com/google/osv-scanner/pull/46): Add version
+  command.
+- [Bug #52](https://github.com/google/osv-scanner/issues/52): Fixes 0 exit
+  code being wrongly emitted when vulnerabilities are present.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,12 +28,15 @@ This project follows
 [Google's Open Source Community Guidelines](https://opensource.google.com/conduct/).
 
 ## Contributing documentation
+
 Please review the documentation [README](docs/README.md) for more information about contributing to documentation.
 
 ## Contributing code
 
 ### Prerequisites
+
 Install:
+
 1. [Go](https://go.dev/) 1.19+, use `go version` to check.
 2. [GoReleaser](https://goreleaser.com/) (Optional, only if you want reproducible builds).
 
@@ -46,14 +49,17 @@ Install:
 #### Build using only `go`
 
 Run the following in the project directory:
+
 ```shell
 ./scripts/build.sh
 ```
+
 Produces `osv-scanner` binary in the project directory.
 
 #### Build using `goreleaser`
 
 Run the following in the project directory:
+
 ```shell
 ./scripts/build_snapshot.sh
 ```
@@ -66,6 +72,7 @@ using the same Go version as the one used during the actual release (see gorelea
 ### Running tests
 
 To run tests:
+
 ```shell
 ./scripts/run_tests.sh
 ```
@@ -80,6 +87,7 @@ You can generate an HTML coverage report by running:
 ```
 
 ### Linting
+
 To lint your code, run
 
 ```shell
@@ -93,12 +101,12 @@ Please follow these steps to successfully contribute documentation.
 1. Fork the repository.
 2. Make desired documentation changes.
 3. Preview the changes by spinning up a GitHub page for your fork, building from your working branch.
-    - On your fork, go to the settings tab and then the GitHub page settings. Sample URL: https://github.com/{your-github-profile}/osv-scanner/settings/pages
-    - Under "Build and deployment" select "Build from branch"
-    - Set the branch to your working branch
-    - Set the github page to build from the "/docs" folder
-    - Hit save and wait for your site to build
-    - Once it is ready, click the link and preview the docs
+   - On your fork, go to the settings tab and then the GitHub page settings. Sample URL: https://github.com/{your-github-profile}/osv-scanner/settings/pages
+   - Under "Build and deployment" select "Build from branch"
+   - Set the branch to your working branch
+   - Set the github page to build from the "/docs" folder
+   - Hit save and wait for your site to build
+   - Once it is ready, click the link and preview the docs
 
 ![Image shows the UI settings for building the GitHub page, which is described in step 3 of the contributing documentation instructions.](docs/images/github-page.png)
 

--- a/README.md
+++ b/README.md
@@ -19,17 +19,18 @@ The above all results in fewer, more actionable vulnerability notifications, whi
 [announcement blog post]: https://security.googleblog.com/2022/12/announcing-osv-scanner-vulnerability.html
 
 ## Documentation
+
 Read our [detailed documentation](https://google.github.io/osv-scanner) to learn how to use OSV-Scanner.
 
 ## Contribute
 
 ### Report Problems
+
 If you have what looks like a bug, please use the [GitHub issue tracking system](https://github.com/google/osv-scanner/issues). Before you file an issue, please search existing issues to see if your issue is already covered.
 
 ### Contributing code to `osv-scanner`
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for documentation on how to contribute code.
-
 
 ## Star History
 

--- a/actions/reporter/action.yml
+++ b/actions/reporter/action.yml
@@ -1,13 +1,13 @@
 # Currently experimental.
-name: 'osv-scanner-reporter'
-description: 'Specialized reporting of scanner results for github actions'
+name: "osv-scanner-reporter"
+description: "Specialized reporting of scanner results for github actions"
 inputs:
   scan-args:
-    description: 'Arguments to osv-scanner, separated by new line'
+    description: "Arguments to osv-scanner, separated by new line"
     required: true
 runs:
-  using: 'docker'
-  image: '../../action.dockerfile'
+  using: "docker"
+  image: "../../action.dockerfile"
   entrypoint: /root/osv-reporter
   args:
-    - '${{ inputs.scan-args }}'
+    - "${{ inputs.scan-args }}"

--- a/actions/scanner/action.yml
+++ b/actions/scanner/action.yml
@@ -1,15 +1,15 @@
 # Currently experimental.
-name: 'osv-scanner'
-description: 'Scans your directory against the OSV database (Experimental)'
+name: "osv-scanner"
+description: "Scans your directory against the OSV database (Experimental)"
 inputs:
   scan-args:
-    description: 'Arguments to osv-scanner, separated by new line'
+    description: "Arguments to osv-scanner, separated by new line"
     default: |-
       --skip-git
       --recursive
       ./
 runs:
-  using: 'docker'
-  image: '../../action.dockerfile'
+  using: "docker"
+  image: "../../action.dockerfile"
   args:
     - ${{ inputs.scan-args }}

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,10 @@
 # README
-The [OSV-Scanner docs](https://google.github.io/osv-scanner) are hosted on a [GitHub page](https://pages.github.com/). 
+
+The [OSV-Scanner docs](https://google.github.io/osv-scanner) are hosted on a [GitHub page](https://pages.github.com/).
 
 ## Running docs locally
-To run docs locally, you will need [Jekyll](https://jekyllrb.com/docs/installation/) on your machine. 
+
+To run docs locally, you will need [Jekyll](https://jekyllrb.com/docs/installation/) on your machine.
 
 Here are other [pre-requisites] and instructions for running the [docs locally].
 
@@ -10,8 +12,10 @@ Here are other [pre-requisites] and instructions for running the [docs locally].
 [docs locally]: https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/testing-your-github-pages-site-locally-with-jekyll#building-your-site-locally
 
 ## Contributing to the docs
-Please see [CONTRIBUTING.md](https://github.com/google/osv-scanner/blob/main/CONTRIBUTING.md/#contributing-documentation) for information on contributing documentation. 
+
+Please see [CONTRIBUTING.md](https://github.com/google/osv-scanner/blob/main/CONTRIBUTING.md/#contributing-documentation) for information on contributing documentation.
 
 ## Documentation theme
+
 We are using the [Just the Docs](https://just-the-docs.github.io/just-the-docs/)
 theme.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -21,9 +21,9 @@
 title: OSV-Scanner
 description: >- # this means to ignore newlines until "baseurl:"
   Use OSV-Scanner to find existing vulnerabilities affecting your project's dependencies.
-baseurl: "/osv-scanner" # the subpath of your site, e.g. /blog
-url: "" # the base hostname & protocol for your site, e.g. http://example.com
-github_username:  google
+baseurl: '/osv-scanner' # the subpath of your site, e.g. /blog
+url: '' # the base hostname & protocol for your site, e.g. http://example.com
+github_username: google
 ga_tracking: G-60SWD6J0TM
 
 # Build settings
@@ -37,8 +37,8 @@ markdown: kramdown
 kramdown:
   toc_levels: 1..3
 
-logo: "/assets/logo.png"
-favicon_ico: "/assets/icon.png"
+logo: '/assets/logo.png'
+favicon_ico: '/assets/icon.png'
 
 callouts_level: quiet # or loud
 callouts:
@@ -58,7 +58,7 @@ callouts:
     color: red
 
 aux_links:
-  "OSV-Scanner on GitHub":
+  'OSV-Scanner on GitHub':
     - https://github.com/google/osv-scanner
 
 nav_external_links:

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -21,8 +21,8 @@
 title: OSV-Scanner
 description: >- # this means to ignore newlines until "baseurl:"
   Use OSV-Scanner to find existing vulnerabilities affecting your project's dependencies.
-baseurl: '/osv-scanner' # the subpath of your site, e.g. /blog
-url: '' # the base hostname & protocol for your site, e.g. http://example.com
+baseurl: "/osv-scanner" # the subpath of your site, e.g. /blog
+url: "" # the base hostname & protocol for your site, e.g. http://example.com
 github_username: google
 ga_tracking: G-60SWD6J0TM
 
@@ -37,8 +37,8 @@ markdown: kramdown
 kramdown:
   toc_levels: 1..3
 
-logo: '/assets/logo.png'
-favicon_ico: '/assets/icon.png'
+logo: "/assets/logo.png"
+favicon_ico: "/assets/icon.png"
 
 callouts_level: quiet # or loud
 callouts:
@@ -58,7 +58,7 @@ callouts:
     color: red
 
 aux_links:
-  'OSV-Scanner on GitHub':
+  "OSV-Scanner on GitHub":
     - https://github.com/google/osv-scanner
 
 nav_external_links:

--- a/docs/_sass/color_schemes/better_contrast.scss
+++ b/docs/_sass/color_schemes/better_contrast.scss
@@ -1,45 +1,45 @@
 // Code snippet colors
 .highlight .c {
-    color: #514E56;
-    background: #f5f6fa;
-  } // comment //
+  color: #514e56;
+  background: #f5f6fa;
+} // comment //
 .highlight .nb {
-    color: #8F6B00;
-  } // name.builtin //
+  color: #8f6b00;
+} // name.builtin //
 .highlight .nt {
-    color: #2075B1;
-  } // name.tag //
+  color: #2075b1;
+} // name.tag //
 .highlight .s1 {
-    color: #207E74;
-  } // literal.string.single //
+  color: #207e74;
+} // literal.string.single //
 .highlight .k {
-    color: #667500;
-  } // keyword //
+  color: #667500;
+} // keyword //
 .highlight .nn {
-    color: #647373;
-  } // name.namespace //
+  color: #647373;
+} // name.namespace //
 .highlight .py {
-    color: #647373;
-  } // name.property //
+  color: #647373;
+} // name.property //
 .highlight .c {
-    color: #586e75;
-  } // comment //
+  color: #586e75;
+} // comment //
 .highlight .s {
-    color: #207E74;
-  } // literal.string //
+  color: #207e74;
+} // literal.string //
 .highlight .s2 {
-    color: #207E74;
-  } // literal.string.double //
+  color: #207e74;
+} // literal.string.double //
 .highlight .err {
-    color: #647373;
-    background: #f5f6fa;
-  } // error //
+  color: #647373;
+  background: #f5f6fa;
+} // error //
 .highlight .p {
-    color: #647373;
-  } // punctuation //
+  color: #647373;
+} // punctuation //
 .highlight .nl {
-    color: #514E56;
-  } // name.label //
+  color: #514e56;
+} // name.label //
 .highlight .w {
-    color: #647373;
-  } // text.whitespace //
+  color: #647373;
+} // text.whitespace //

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,6 +4,7 @@ title: Configuration
 permalink: /configuration/
 nav_order: 5
 ---
+
 # Configure OSV-Scanner
 
 To configure scanning, place an osv-scanner.toml file in the scanned file's directory. To override this osv-scanner.toml file, pass the `--config=/path/to/config.toml` flag with the path to the configuration you want to apply instead.

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -4,9 +4,11 @@ title: Contribute
 permalink: /contribute/
 nav_order: 9
 ---
+
 # Contribute
 
 ## Report Problems
+
 If you have what looks like a bug, please use the [Github issue tracking system](https://github.com/google/osv-scanner/issues). Before you file an issue, please search existing issues to see if your issue is already covered.
 
 ## Contributing to `osv-scanner`

--- a/docs/experimental.md
+++ b/docs/experimental.md
@@ -4,6 +4,7 @@ title: Experimental Features
 permalink: /experimental/
 nav_order: 8
 ---
+
 # Experimental Features
 
 {: .no_toc }
@@ -26,7 +27,7 @@ OSV-Scanner now supports offline scanning as an experimental feature. Offline sc
 
 ### Specify database location
 
-Our offline features require the use of a local database, the location of which is determined through the use of the `OSV_SCANNER_LOCAL_DB_CACHE_DIRECTORY` environment variable. 
+Our offline features require the use of a local database, the location of which is determined through the use of the `OSV_SCANNER_LOCAL_DB_CACHE_DIRECTORY` environment variable.
 
 The local database file structure is in this form:
 
@@ -39,17 +40,18 @@ The local database file structure is in this form:
     {ecosystem}/all.zip
 ```
 
-Where `{local_db_dir}` can be set by the `OSV_SCANNER_LOCAL_DB_CACHE_DIRECTORY` environment variable. 
+Where `{local_db_dir}` can be set by the `OSV_SCANNER_LOCAL_DB_CACHE_DIRECTORY` environment variable.
 
-If the `OSV_SCANNER_LOCAL_DB_CACHE_DIRECTORY` environment variable is _not_ set, OSV-Scanner will attempt to look for the database in the following locations, in this order: 
+If the `OSV_SCANNER_LOCAL_DB_CACHE_DIRECTORY` environment variable is _not_ set, OSV-Scanner will attempt to look for the database in the following locations, in this order:
 
 1. The location returned by [`os.UserCacheDir`](https://pkg.go.dev/os#UserCacheDir)
 2. The location returned by [`os.TempDir`](https://pkg.go.dev/os#TempDir)
 
-The database can be [downloaded manually](./experimental.md#manual-database-download) or by using the [`--experimental-local-db` flag](./experimental.md#local-database-option). 
+The database can be [downloaded manually](./experimental.md#manual-database-download) or by using the [`--experimental-local-db` flag](./experimental.md#local-database-option).
 
 ### Offline option
-The offline database flag `--experimental-offline` causes OSV-Scanner to scan your project against a previously downloaded local database. OSV-Scanner will not download or update the local database, nor will it send any project or dependency information anywhere. When a local database is not present, you will get an error message. No network connection is required when using this flag.  
+
+The offline database flag `--experimental-offline` causes OSV-Scanner to scan your project against a previously downloaded local database. OSV-Scanner will not download or update the local database, nor will it send any project or dependency information anywhere. When a local database is not present, you will get an error message. No network connection is required when using this flag.
 
 ```bash
 osv-scanner --experimental-offline ./path/to/your/dir
@@ -57,19 +59,20 @@ osv-scanner --experimental-offline ./path/to/your/dir
 
 ### Local database option
 
-The local database flag `--experimental-local-db` causes OSV-Scanner to download or update your local database and then scan your project against it. 
+The local database flag `--experimental-local-db` causes OSV-Scanner to download or update your local database and then scan your project against it.
 
 ```bash
 osv-scanner --experimental-local-db ./path/to/your/dir
 ```
 
 ### Manual database download
-Instead of using the `--experimental-local-db` flag to download the database, it is possible to manually download the database. 
+
+Instead of using the `--experimental-local-db` flag to download the database, it is possible to manually download the database.
 
 A downloadable copy of the OSV database is stored in a GCS bucket maintained by OSV:
 [`gs://osv-vulnerabilities`](https://osv-vulnerabilities.storage.googleapis.com)
 
-This bucket contains zip files  containing all vulnerabilities for each ecosystem at:
+This bucket contains zip files containing all vulnerabilities for each ecosystem at:
 `gs://osv-vulnerabilities/<ECOSYSTEM>/all.zip`.
 
 E.g. for PyPI vulnerabilities:
@@ -80,14 +83,14 @@ gsutil cp gs://osv-vulnerabilities/PyPI/all.zip .
 
 You can also download over HTTP via https://osv-vulnerabilities.storage.googleapis.com/<ECOSYSTEM>/all.zip .
 
-A list of all current ecosystems is available at 
+A list of all current ecosystems is available at
 [`gs://osv-vulnerabilities/ecosystems.txt`](https://osv-vulnerabilities.storage.googleapis.com/ecosystems.txt).
 
 Set the location of your manually downloaded database by following the instructions [here](./experimental.md#specify-database-location).
 
 ### Limitations
 
-1. Commit level scanning is not supported. 
+1. Commit level scanning is not supported.
 
 ## License scanning
 
@@ -108,7 +111,8 @@ To set an allowed license list and see the details of packages that do not confo
 ```bash
 osv-scanner --experimental-licenses="comma-separated list of allowed licenses" path/to/directory
 ```
-Include your allowed licenses as a comma-separated list. OSV-Scanner recognizes licenses in SPDX format. Please indicate your allowed licenses using [SPDX license](https://spdx.org/licenses/) identifiers. 
+
+Include your allowed licenses as a comma-separated list. OSV-Scanner recognizes licenses in SPDX format. Please indicate your allowed licenses using [SPDX license](https://spdx.org/licenses/) identifiers.
 
 #### License violations example
 

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -6,6 +6,7 @@ nav_order: 7
 ---
 
 # GitHub Action
+
 {: .no_toc }
 
 <details open markdown="block">
@@ -38,9 +39,9 @@ name: OSV-Scanner PR Scan
 # Change "main" to your default branch if you use a different name, i.e. "master"
 on:
   pull_request:
-    branches: [ main ]
+    branches: [main]
   merge_group:
-    branches: [ main ]
+    branches: [main]
 
 permissions:
   # Require writing security events to upload SARIF file to security tab
@@ -50,7 +51,7 @@ permissions:
 
 jobs:
   scan-pr:
-    uses: "google/osv-scanner/.github/workflows/osv-scanner-reusable-pr.yml@main"
+    uses: 'google/osv-scanner/.github/workflows/osv-scanner-reusable-pr.yml@main'
 ```
 
 ### View results
@@ -81,20 +82,23 @@ Examples
 </summary>
 
 ##### Scan specific lockfiles
+
 ```yml
 jobs:
   scan-pr:
-    uses: "google/osv-scanner/.github/workflows/osv-scanner-reusable.yml"
+    uses: 'google/osv-scanner/.github/workflows/osv-scanner-reusable.yml'
     with:
       scan-args: |-
         --lockfile=./path/to/lockfile1
         --lockfile=requirements.txt:./path/to/python-lockfile2.txt
 ```
+
 ##### Default arguments
+
 ```yml
 jobs:
   scan-pr:
-    uses: "google/osv-scanner/.github/workflows/osv-scanner-reusable.yml"
+    uses: 'google/osv-scanner/.github/workflows/osv-scanner-reusable.yml'
     with:
       scan-args: |-
         --recursive
@@ -103,6 +107,7 @@ jobs:
 ```
 
 ##### Using download-artifact input to support preprocessing
+
 ```yml
 jobs:
   extract-deps:
@@ -110,7 +115,7 @@ jobs:
     # ...
     steps:
       # ... Steps to extract your dependencies
-      - name: "upload osv-scanner deps" # Upload the deps
+      - name: 'upload osv-scanner deps' # Upload the deps
         uses: actions/upload-artifact@v4
         with:
           name: converted-OSV-Scanner-deps
@@ -119,9 +124,8 @@ jobs:
   vuln-scan:
     name: Vulnerability scanning
     # makes sure the extraction step is completed before running the scanner
-    needs:
-      extract-deps
-    uses: "google/osv-scanner/.github/workflows/osv-scanner-reusable.yml@main"
+    needs: extract-deps
+    uses: 'google/osv-scanner/.github/workflows/osv-scanner-reusable.yml@main'
     with:
       # Download the artifact uploaded in extract-deps step
       download-artifact: converted-OSV-Scanner-deps
@@ -152,9 +156,9 @@ name: OSV-Scanner Scheduled Scan
 on:
   schedule:
     - cron: '30 12 * * 1'
-# Change "main" to your default branch if you use a different name, i.e. "master"
+  # Change "main" to your default branch if you use a different name, i.e. "master"
   push:
-    branches: [ main ]
+    branches: [main]
 
 permissions:
   # Require writing security events to upload SARIF file to security tab
@@ -164,7 +168,7 @@ permissions:
 
 jobs:
   scan-scheduled:
-    uses: "google/osv-scanner/.github/workflows/osv-scanner-reusable.yml@main"
+    uses: 'google/osv-scanner/.github/workflows/osv-scanner-reusable.yml@main'
 ```
 
 As written, the scanner will run on 12:30 pm UTC every Monday, and also on every push to the main branch. You can change the schedule by following the instructions [here](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule).
@@ -176,7 +180,6 @@ As written, the scanner will run on 12:30 pm UTC every Monday, and also on every
 ### View results
 
 Maintainers can review results of the scan by navigating to their project's `security > code scanning` tab. Vulnerability details can also be viewed by clicking on the details of the failed action.
-
 
 ## Scan on release
 
@@ -220,4 +223,3 @@ jobs:
 ### View results
 
 Results may be viewed by clicking on the details of the failed release action from the action tab.
-

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -51,7 +51,7 @@ permissions:
 
 jobs:
   scan-pr:
-    uses: 'google/osv-scanner/.github/workflows/osv-scanner-reusable-pr.yml@main'
+    uses: "google/osv-scanner/.github/workflows/osv-scanner-reusable-pr.yml@main"
 ```
 
 ### View results
@@ -86,7 +86,7 @@ Examples
 ```yml
 jobs:
   scan-pr:
-    uses: 'google/osv-scanner/.github/workflows/osv-scanner-reusable.yml'
+    uses: "google/osv-scanner/.github/workflows/osv-scanner-reusable.yml"
     with:
       scan-args: |-
         --lockfile=./path/to/lockfile1
@@ -98,7 +98,7 @@ jobs:
 ```yml
 jobs:
   scan-pr:
-    uses: 'google/osv-scanner/.github/workflows/osv-scanner-reusable.yml'
+    uses: "google/osv-scanner/.github/workflows/osv-scanner-reusable.yml"
     with:
       scan-args: |-
         --recursive
@@ -115,7 +115,7 @@ jobs:
     # ...
     steps:
       # ... Steps to extract your dependencies
-      - name: 'upload osv-scanner deps' # Upload the deps
+      - name: "upload osv-scanner deps" # Upload the deps
         uses: actions/upload-artifact@v4
         with:
           name: converted-OSV-Scanner-deps
@@ -125,7 +125,7 @@ jobs:
     name: Vulnerability scanning
     # makes sure the extraction step is completed before running the scanner
     needs: extract-deps
-    uses: 'google/osv-scanner/.github/workflows/osv-scanner-reusable.yml@main'
+    uses: "google/osv-scanner/.github/workflows/osv-scanner-reusable.yml@main"
     with:
       # Download the artifact uploaded in extract-deps step
       download-artifact: converted-OSV-Scanner-deps
@@ -155,7 +155,7 @@ name: OSV-Scanner Scheduled Scan
 
 on:
   schedule:
-    - cron: '30 12 * * 1'
+    - cron: "30 12 * * 1"
   # Change "main" to your default branch if you use a different name, i.e. "master"
   push:
     branches: [main]
@@ -168,7 +168,7 @@ permissions:
 
 jobs:
   scan-scheduled:
-    uses: 'google/osv-scanner/.github/workflows/osv-scanner-reusable.yml@main'
+    uses: "google/osv-scanner/.github/workflows/osv-scanner-reusable.yml@main"
 ```
 
 As written, the scanner will run on 12:30 pm UTC every Monday, and also on every push to the main branch. You can change the schedule by following the instructions [here](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule).

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,7 @@
 layout: home
 nav_order: 1
 ---
+
 # OSV-Scanner
 
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/google/osv-scanner/badge)](https://api.securityscorecards.dev/projects/github.com/google/osv-scanner)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -14,12 +14,15 @@ You may download the [SLSA3](https://slsa.dev) compliant binaries for Linux, mac
 [![Packaging status](https://repology.org/badge/vertical-allrepos/osv-scanner.svg)](https://repology.org/project/osv-scanner/versions)
 
 ### Windows Scoop
+
 [Windows Scoop](https://scoop.sh) users can install osv-scanner from the [official bucket](https://github.com/ScoopInstaller/Main/blob/master/bucket/osv-scanner.json):
 
 ```bash
 scoop install osv-scanner
 ```
+
 ### Homebrew
+
 [Homebrew](https://brew.sh/) users can install [osv-scanner](https://formulae.brew.sh/formula/osv-scanner) via:
 
 ```bash
@@ -27,18 +30,23 @@ brew install osv-scanner
 ```
 
 ### Arch Linux
+
 Arch Linux users can install osv-scanner from the official repo:
 
 ```bash
 pacman -S osv-scanner
 ```
+
 ### Alpine Linux
+
 Alpine Linux users can install osv-scanner from the official repo:
 
 ```bash
 apk add osv-scanner
 ```
+
 ### OpenBSD
+
 OpenBSD users can install osv-scanner from the official repo:
 
 ```bash
@@ -60,10 +68,12 @@ This requires Go 1.21+ to be installed.
 See our [contribution guidelines](https://github.com/google/osv-scanner/blob/main/CONTRIBUTING.md) for instructions on how to build from source.
 
 ## Verifying Builds
+
 Each of our releases come with SLSA provenance data (`multiple.intoto.jsonl`),
 which can be used to verify the source and provenance of the binaries with the [`slsa-verifier`](https://github.com/slsa-framework/slsa-verifier) tool.
 
 E.g.
+
 ```bash
 slsa-verifier verify-artifact ./osv-scanner_1.2.0_linux_amd64 --provenance-path multiple.intoto2.jsonl --source-uri github.com/google/osv-scanner --source-tag v1.2.0
 ```

--- a/docs/output.md
+++ b/docs/output.md
@@ -4,7 +4,9 @@ title: Output
 permalink: /output/
 nav_order: 6
 ---
+
 # Output
+
 {: .no_toc }
 
 <details open markdown="block">
@@ -28,6 +30,7 @@ For every vulnerability found, OSV-Scanner will display the following informatio
 - Source: Path to the sbom or lockfile where the package originated
 
 ## Output formats
+
 You can control the format used by the scanner to output results with the `--format` flag.
 
 ### Table (Default)
@@ -49,6 +52,7 @@ osv-scanner --format table your/project/dir
 │ https://osv.dev/GHSA-m5pq-gvj9-9vr8 | 7.5  │ crates.io │ regex                    │ 1.3.1   │ path/to/Cargo.lock │
 ╰─────────────────────────────────────┴──────┴───────────┴──────────────────────────┴─────────┴────────────────────╯
 ```
+
 </details>
 
 ---
@@ -73,10 +77,10 @@ osv-scanner --format markdown your/project/dir
 
 **Rendered:**
 
-| OSV URL | CVSS | Ecosystem | Package | Version | Source |
-| --- | --- | --- | --- | --- | --- |
-| https://osv.dev/GHSA-c3h9-896r-86jm<br/>https://osv.dev/GO-2021-0053 | 8.6 | Go | github.com/gogo/protobuf | 1.3.1 | ../scorecard-check-osv-e2e/go.mod |
-| https://osv.dev/GHSA-m5pq-gvj9-9vr8<br/>https://osv.dev/RUSTSEC-2022-0013 | 7.5 | crates.io | regex | 1.5.1 | ../scorecard-check-osv-e2e/sub-rust-project/Cargo.lock |
+| OSV URL                                                                   | CVSS | Ecosystem | Package                  | Version | Source                                                 |
+| ------------------------------------------------------------------------- | ---- | --------- | ------------------------ | ------- | ------------------------------------------------------ |
+| https://osv.dev/GHSA-c3h9-896r-86jm<br/>https://osv.dev/GO-2021-0053      | 8.6  | Go        | github.com/gogo/protobuf | 1.3.1   | ../scorecard-check-osv-e2e/go.mod                      |
+| https://osv.dev/GHSA-m5pq-gvj9-9vr8<br/>https://osv.dev/RUSTSEC-2022-0013 | 7.5  | crates.io | regex                    | 1.5.1   | ../scorecard-check-osv-e2e/sub-rust-project/Cargo.lock |
 
 </details>
 
@@ -89,6 +93,7 @@ osv-scanner --format json your/project/dir
 ```
 
 Outputs the results as a JSON object to stdout, with all other output being directed to stderr - this makes it safe to redirect the output to a file with
+
 ```bash
 osv-scanner --format json -L path/to/lockfile > /path/to/file.json
 ```
@@ -115,17 +120,12 @@ osv-scanner --format json -L path/to/lockfile > /path/to/file.json
           "vulnerabilities": [
             {
               "id": "GHSA-c3h9-896r-86jm",
-              "aliases": [
-                "CVE-2021-3121"
-              ],
+              "aliases": ["CVE-2021-3121"]
               // ... Full OSV
             },
             {
               "id": "GO-2021-0053",
-              "aliases": [
-                "CVE-2021-3121",
-                "GHSA-c3h9-896r-86jm"
-              ],
+              "aliases": ["CVE-2021-3121", "GHSA-c3h9-896r-86jm"]
               // ... Full OSV
             }
           ],
@@ -133,10 +133,7 @@ osv-scanner --format json -L path/to/lockfile > /path/to/file.json
           // they are considered the same vulnerability, and is grouped here under the id field.
           "groups": [
             {
-              "ids": [
-                "GHSA-c3h9-896r-86jm",
-                "GO-2021-0053"
-              ],
+              "ids": ["GHSA-c3h9-896r-86jm", "GO-2021-0053"],
               // Call stack analysis is done using the `--experimental-call-analysis` flag
               // and result is matched against data provided by the advisory to check if
               // affected code is actually being executed.
@@ -165,25 +162,18 @@ osv-scanner --format json -L path/to/lockfile > /path/to/file.json
           "vulnerabilities": [
             {
               "id": "GHSA-m5pq-gvj9-9vr8",
-              "aliases": [
-                "CVE-2022-24713"
-              ],
+              "aliases": ["CVE-2022-24713"]
               // ... Full OSV
             },
             {
               "id": "RUSTSEC-2022-0013",
-              "aliases": [
-                "CVE-2022-24713"
-              ],
+              "aliases": ["CVE-2022-24713"]
               // ... Full OSV
             }
           ],
           "groups": [
             {
-              "ids": [
-                "GHSA-m5pq-gvj9-9vr8",
-                "RUSTSEC-2022-0013"
-              ]
+              "ids": ["GHSA-m5pq-gvj9-9vr8", "RUSTSEC-2022-0013"]
             }
           ]
         }
@@ -194,7 +184,6 @@ osv-scanner --format json -L path/to/lockfile > /path/to/file.json
 ```
 
 </details>
-
 
 ---
 
@@ -239,7 +228,7 @@ Outputs the result in the [SARIF](https://sarifweb.azurewebsites.net/) v2.1.0 fo
                 "text": "<Markdown help text>...",
                 "markdown": "<Markdown help text>..."
               }
-            },
+            }
           ],
           "version": "1.4.1"
         }
@@ -281,11 +270,11 @@ Outputs the result in the [SARIF](https://sarifweb.azurewebsites.net/) v2.1.0 fo
 <details markdown="1">
 <summary><b>Sample SARIF Help Text</b></summary>
 
-
 > **Your dependency is vulnerable to [CVE-2022-24713](https://osv.dev/list?q=CVE-2022-24713)**
-> (Also published as:  [RUSTSEC-2022-0013](https://osv.dev/vulnerability/RUSTSEC-2022-0013),  [GHSA-m5pq-gvj9-9vr8](https://osv.dev/vulnerability/GHSA-m5pq-gvj9-9vr8), ).
+> (Also published as: [RUSTSEC-2022-0013](https://osv.dev/vulnerability/RUSTSEC-2022-0013), [GHSA-m5pq-gvj9-9vr8](https://osv.dev/vulnerability/GHSA-m5pq-gvj9-9vr8), ).
 >
 > {:.no_toc}
+>
 > ## [RUSTSEC-2022-0013](https://osv.dev/vulnerability/RUSTSEC-2022-0013)
 >
 > <details>
@@ -295,8 +284,8 @@ Outputs the result in the [SARIF](https://sarifweb.azurewebsites.net/) v2.1.0 fo
 >
 > </details>
 >
->
 > {:.no_toc}
+>
 > ## [GHSA-m5pq-gvj9-9vr8](https://osv.dev/vulnerability/GHSA-m5pq-gvj9-9vr8)
 >
 > <details>
@@ -306,31 +295,30 @@ Outputs the result in the [SARIF](https://sarifweb.azurewebsites.net/) v2.1.0 fo
 >
 > </details>
 >
->
 > ---
 >
 > {:.no_toc}
+>
 > ### Affected Packages
 >
-> | Source | Package Name | Package Version |
-> | --- | --- | --- |
-> | lockfile:/path/to/rust-project/Cargo.lock | regex | 1.5.1 |
+> | Source                                    | Package Name | Package Version |
+> | ----------------------------------------- | ------------ | --------------- |
+> | lockfile:/path/to/rust-project/Cargo.lock | regex        | 1.5.1           |
 >
 > {:.no_toc}
+>
 > ## Remediation
->
->
 >
 > To fix these vulnerabilities, update the vulnerabilities past the listed fixed versions below.
 >
 > {:.no_toc}
+>
 > ### Fixed Versions
 >
-> | Vulnerability ID | Package Name | Fixed Version |
-> | --- | --- | --- |
-> | GHSA-m5pq-gvj9-9vr8 | regex | 1.5.5 |
-> | RUSTSEC-2022-0013 | regex | 1.5.5 |
->
+> | Vulnerability ID    | Package Name | Fixed Version |
+> | ------------------- | ------------ | ------------- |
+> | GHSA-m5pq-gvj9-9vr8 | regex        | 1.5.5         |
+> | RUSTSEC-2022-0013   | regex        | 1.5.5         |
 >
 > If you believe these vulnerabilities do not affect your code and wish to ignore them, add them to the ignore list in an
 > `osv-scanner.toml` file located in the same directory as the lockfile containing the vulnerable dependency.
@@ -339,8 +327,8 @@ Outputs the result in the [SARIF](https://sarifweb.azurewebsites.net/) v2.1.0 fo
 >
 > Add or append these values to the following config files to ignore this vulnerability:
 >
->
 > `/path/to/rust-project/osv-scanner.toml`
+>
 > ```
 > [[IgnoredVulns]]
 > id = "CVE-2022-24713"
@@ -383,6 +371,7 @@ osv-scanner --format table --experimental-call-analysis your/project/dir
 │ https://osv.dev/RUSTSEC-2023-0044   │      │           │                 │         │                    │
 ╰─────────────────────────────────────┴──────┴───────────┴─────────────────┴─────────┴────────────────────╯
 ```
+
 </details>
 
 ### JSON
@@ -405,7 +394,7 @@ osv-scanner --format json --experimental-call-analysis -L path/to/lockfile > /pa
         "type": "lockfile"
       },
       "packages": [
-                {
+        {
           "package": {
             "name": "crossbeam-utils",
             "version": "0.6.6",
@@ -414,27 +403,19 @@ osv-scanner --format json --experimental-call-analysis -L path/to/lockfile > /pa
           "vulnerabilities": [
             {
               "id": "GHSA-qc84-gqf4-9926",
-              "aliases": [
-                "CVE-2022-23639"
-              ]
+              "aliases": ["CVE-2022-23639"]
               // ... Full OSV
             },
             {
               "id": "RUSTSEC-2022-0041",
-              "aliases": [
-                "GHSA-qc84-gqf4-9926",
-                "CVE-2022-23639"
-              ]
+              "aliases": ["GHSA-qc84-gqf4-9926", "CVE-2022-23639"]
               // ... Full OSV
             }
           ],
           "groups": [
             {
               // This vuln has no function info, so no call analysis done
-              "ids": [
-                "GHSA-qc84-gqf4-9926",
-                "RUSTSEC-2022-0041"
-              ]
+              "ids": ["GHSA-qc84-gqf4-9926", "RUSTSEC-2022-0041"]
             }
           ]
         },
@@ -451,18 +432,13 @@ osv-scanner --format json --experimental-call-analysis -L path/to/lockfile > /pa
             },
             {
               "id": "RUSTSEC-2023-0045",
-              "aliases": [
-                "GHSA-wfg4-322g-9vqv"
-              ]
+              "aliases": ["GHSA-wfg4-322g-9vqv"]
               // ... Full OSV
             }
           ],
           "groups": [
             {
-              "ids": [
-                "GHSA-wfg4-322g-9vqv",
-                "RUSTSEC-2023-0045"
-              ],
+              "ids": ["GHSA-wfg4-322g-9vqv", "RUSTSEC-2023-0045"],
               // RUSTSEC-2023-0045 does have function info, call analysis is performed
               // the vulnerable function is not called
               "experimentalAnalysis": {
@@ -482,26 +458,18 @@ osv-scanner --format json --experimental-call-analysis -L path/to/lockfile > /pa
           "vulnerabilities": [
             {
               "id": "GHSA-43w2-9j62-hq99",
-              "aliases": [
-                "CVE-2021-25900"
-              ]
+              "aliases": ["CVE-2021-25900"]
               // ... Full OSV
             },
             {
               "id": "RUSTSEC-2021-0003",
-              "aliases": [
-                "CVE-2021-25900",
-                "GHSA-43w2-9j62-hq99"
-              ]
+              "aliases": ["CVE-2021-25900", "GHSA-43w2-9j62-hq99"]
               // ... Full OSV
             }
           ],
           "groups": [
             {
-              "ids": [
-                "GHSA-43w2-9j62-hq99",
-                "RUSTSEC-2021-0003"
-              ],
+              "ids": ["GHSA-43w2-9j62-hq99", "RUSTSEC-2021-0003"],
               // RUSTSEC-2021-0003 does have function info, call analysis is performed
               // the vulnerable function does get called.
               "experimentalAnalysis": {

--- a/docs/supported_languages_and_lockfiles.md
+++ b/docs/supported_languages_and_lockfiles.md
@@ -22,23 +22,24 @@ nav_order: 2
 
 A wide range of lockfiles are supported by utilizing this [lockfile package](https://github.com/google/osv-scanner/tree/main/pkg/lockfile).
 
-|  Language  | Compatible Lockfile(s) |
-|:-----------|:------------------|
-| C/C++ | `conan.lock`<br>[C/C++ commit scanning](#cc-scanning)|
-| Dart | `pubspec.lock`|
-| Elixir | `mix.lock` |
-| Go | `go.mod` |
-| Java | `buildscript-gradle.lockfile`<br>`gradle.lockfile`<br>`pom.xml`[\*](https://github.com/google/osv-scanner/issues/35) |
-| Javascript | `package-lock.json`<br>`pnpm-lock.yaml`<br>`yarn.lock`|
-| PHP        | `composer.lock`|
-| Python     | `Pipfile.lock`<br>`poetry.lock`<br>`requirements.txt`[\*](https://github.com/google/osv-scanner/issues/34) |
-| R          | `renv.lock` |
-| Ruby       | `Gemfile.lock`|
-| Rust       | `Cargo.lock`|
+| Language   | Compatible Lockfile(s)                                                                                               |
+| :--------- | :------------------------------------------------------------------------------------------------------------------- |
+| C/C++      | `conan.lock`<br>[C/C++ commit scanning](#cc-scanning)                                                                |
+| Dart       | `pubspec.lock`                                                                                                       |
+| Elixir     | `mix.lock`                                                                                                           |
+| Go         | `go.mod`                                                                                                             |
+| Java       | `buildscript-gradle.lockfile`<br>`gradle.lockfile`<br>`pom.xml`[\*](https://github.com/google/osv-scanner/issues/35) |
+| Javascript | `package-lock.json`<br>`pnpm-lock.yaml`<br>`yarn.lock`                                                               |
+| PHP        | `composer.lock`                                                                                                      |
+| Python     | `Pipfile.lock`<br>`poetry.lock`<br>`requirements.txt`[\*](https://github.com/google/osv-scanner/issues/34)           |
+| R          | `renv.lock`                                                                                                          |
+| Ruby       | `Gemfile.lock`                                                                                                       |
+| Rust       | `Cargo.lock`                                                                                                         |
 
 ## Alpine Package Keeper and Debian Package Keeper
 
 The scanner also supports:
+
 - `installed` files used by the Alpine Package Keeper (apk) that typically live at `/lib/apk/db/installed`
 - `status` files used by the Debian Package manager (dpkg) that typically live at `/var/lib/dpkg/status`
 
@@ -51,23 +52,23 @@ osv-scanner --lockfile 'dpkg-status:/var/lib/dpkg/status'
 
 ## C/C++ scanning
 
-With the addition of [vulnerable commit ranges](https://osv.dev/blog/posts/introducing-broad-c-c++-support/) to the OSV.dev database, OSV-Scanner now supports vendored and submoduled C/C++ dependencies 
+With the addition of [vulnerable commit ranges](https://osv.dev/blog/posts/introducing-broad-c-c++-support/) to the OSV.dev database, OSV-Scanner now supports vendored and submoduled C/C++ dependencies
 
-Because the C/C++ ecosystem does not have a centralized package manager, C/C++ dependencies tend to be bundled with the project. Dependencies are either [submoduled](#submoduled-dependencies) or [vendored](#vendored-dependencies). In either case, OSV-Scanner is able to find known vulnerabilities in your project dependencies. 
+Because the C/C++ ecosystem does not have a centralized package manager, C/C++ dependencies tend to be bundled with the project. Dependencies are either [submoduled](#submoduled-dependencies) or [vendored](#vendored-dependencies). In either case, OSV-Scanner is able to find known vulnerabilities in your project dependencies.
 
-OSV-Scanner's C/C++ support is based on commit-level data. OSV's commit-level data covers the majority of C/C++ vulnerabilities within the OSV database, but users should be aware that there may be vulnerabilities in their dependencies that could be excluded from OSV-Scanner results. Adding more commit-level data to the database is an ongoing project. 
+OSV-Scanner's C/C++ support is based on commit-level data. OSV's commit-level data covers the majority of C/C++ vulnerabilities within the OSV database, but users should be aware that there may be vulnerabilities in their dependencies that could be excluded from OSV-Scanner results. Adding more commit-level data to the database is an ongoing project.
 
 ### Submoduled dependencies
 
 Submoduled dependencies are included in the project folder retain their Git histories. To scan a C/C++ project with submoduled dependencies:
 
-1. Navigate to the root folder of your project. 
-2. Ensure that your submodules are up to date using `git submodule update`. 
-3. Run scanner using `osv-scanner -r .`. 
+1. Navigate to the root folder of your project.
+2. Ensure that your submodules are up to date using `git submodule update`.
+3. Run scanner using `osv-scanner -r .`.
 
 ### Vendored dependencies
 
-Vendored dependencies have been directly copied into the project folder, but do not retain their Git histories. OSV-Scanner uses OSV's [determineversion API](https://google.github.io/osv.dev/post-v1-determineversion/) to estimate each dependency's version (and associated Git Commit). Vulnerabilities for the estimated version are returned. This process requires no additional work from the user. Run OSV-Scanner as you normally would. 
+Vendored dependencies have been directly copied into the project folder, but do not retain their Git histories. OSV-Scanner uses OSV's [determineversion API](https://google.github.io/osv.dev/post-v1-determineversion/) to estimate each dependency's version (and associated Git Commit). Vulnerabilities for the estimated version are returned. This process requires no additional work from the user. Run OSV-Scanner as you normally would.
 
 ## Custom Lockfiles
 
@@ -101,6 +102,7 @@ Once you extracted your own dependency information, place it in a `osv-scanner.j
 ```
 
 Then pass this to `osv-scanner` with this:
+
 ```
 osv-scanner --lockfile osv-scanner:/path/to/osv-scanner.json
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -4,6 +4,7 @@ title: Usage
 permalink: /usage/
 nav_order: 4
 ---
+
 # Usage
 
 {: .no_toc }
@@ -57,6 +58,7 @@ When scanning a directory, only SBOMs following the specification filename will 
 [Package URLs]: https://github.com/package-url/purl-spec
 
 ## Specify Lockfile(s)
+
 If you want to check for known vulnerabilities in specific lockfiles, you can use the following command:
 
 ```bash
@@ -80,6 +82,7 @@ osv-scanner --lockfile ':/path/to/my:projects/package-lock.json'
 ```
 
 ## Scanning a Debian based docker image packages
+
 Preview
 {: .label }
 
@@ -187,19 +190,22 @@ Current implementation has a few limitations:
 - Does not support dependencies that link external non-rust code
 
 ### Example
+
 ```bash
 osv-scanner --call-analysis=rust --no-call-analysis=go ./my/project/path
 ```
 
 ## Pre-commit integration
+
 If you wish to install OSV-Scanner as a [pre-commit](https://pre-commit.com) plugin in your project, you may use the `osv-scanner` pre-commit hook. Use the `args` key in your `.pre-commit-config.yaml` to pass your command-line arguments as you would using OSV-Scanner in the command line.
 
 ### Example
+
 ```yaml
 repos:
   - repo: https://github.com/google/osv-scanner/
     rev: # pass a Git tag or commit hash here
     hooks:
       - id: osv-scanner
-        args: ["-r", "/path/to/your/dir"]
+        args: ['-r', '/path/to/your/dir']
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -207,5 +207,5 @@ repos:
     rev: # pass a Git tag or commit hash here
     hooks:
       - id: osv-scanner
-        args: ['-r', '/path/to/your/dir']
+        args: ["-r", "/path/to/your/dir"]
 ```

--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ],
+  "extends": ["config:base"],
   "timezone": "Australia/Sydney",
   "schedule": ["before 6am on monday"],
   "labels": ["dependencies"],
@@ -24,11 +22,6 @@
       "groupName": "workflows"
     }
   ],
-  "ignorePaths": [
-    "**/fixtures/**",
-    "**/fixtures-go/**"
-  ],
-  "ignoreDeps": [
-    "golang.org/x/vuln" 
-  ]
+  "ignorePaths": ["**/fixtures/**", "**/fixtures-go/**"],
+  "ignoreDeps": ["golang.org/x/vuln"]
 }

--- a/scripts/run_formatters.sh
+++ b/scripts/run_formatters.sh
@@ -1,0 +1,10 @@
+#/!usr/bin/env bash
+
+set -ex
+
+# use write unless we're in CI, since Prettier should always be safe to apply
+if [ -z "$CI" ]; then
+  npx prettier --write .
+else
+  npx prettier --check .
+fi


### PR DESCRIPTION
This uses `prettier` to format non-Go files using my (opinioned) config; note that I'd recommend having `proseWrap` set to `always` but that has a _huge_ number of changes so I'll do a seperate PR for that.

Resolves #144
Resolves #129