### PR TITLE
Add support for NuGet lock files version 2

### DIFF
--- a/pkg/lockfile/parse-nuget-lock.go
+++ b/pkg/lockfile/parse-nuget-lock.go
@@ -62,7 +62,7 @@ func (e NuGetLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 		return []PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
 	}
 
-	if parsedLockfile.Version != 1 {
+	if parsedLockfile.Version != 1 && parsedLockfile.Version != 2 {
 		return []PackageDetails{}, fmt.Errorf("could not extract: unsupported lock file version")
 	}
 

--- a/pkg/lockfile/parse-nuget-lock.go
+++ b/pkg/lockfile/parse-nuget-lock.go
@@ -63,7 +63,7 @@ func (e NuGetLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 	}
 
 	if parsedLockfile.Version != 1 && parsedLockfile.Version != 2 {
-		return []PackageDetails{}, fmt.Errorf("could not extract: unsupported lock file version")
+		return []PackageDetails{}, fmt.Errorf("could not extract: unsupported lock file version %d", parsedLockfile.Version)
 	}
 
 	return parseNuGetLock(*parsedLockfile)

--- a/pkg/lockfile/parse-nuget-lock_test.go
+++ b/pkg/lockfile/parse-nuget-lock_test.go
@@ -63,6 +63,6 @@ func TestParseNuGetLock_InvalidVersion(t *testing.T) {
 
 	packages, err := lockfile.ParseNuGetLock("fixtures/nuget/empty.v0.json")
 
-	expectErrContaining(t, err, "unsupported lock file version")
+	expectErrContaining(t, err, "unsupported lock file version 0")
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }


### PR DESCRIPTION
If [NuGet central package management](https://learn.microsoft.com/en-us/nuget/consume-packages/central-package-management) is enabled, V2 lock files will be generated when restoring projects.
Check out [NuGet source](https://github.com/NuGet/NuGet.Client/blob/a59e64507383b64bcfbe9bf63b34aca946ab0da9/src/NuGet.Core/NuGet.Commands/PackagesLockFileBuilder.cs#L119-L128) for reference.

Since version V2 is backward compatible with V1, the required change to support it is straightforward.