### PR TITLE
Update changelog to include minimum go version changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@
 - [Bug #634](https://github.com/google/osv-scanner/issues/634)
   Fix filtering of aliases to also include non OSV aliases
 
+### Miscellaneous
+- The minimum go version has been updated to go1.21 from go1.18.
+
 # v1.4.3:
 
 ### Features

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -33,7 +33,7 @@ Arch Linux users can install osv-scanner from the official repo:
 pacman -S osv-scanner
 ```
 ### Alpine Linux
-Alpine Linux users can install osv-scanner from the official repo: 
+Alpine Linux users can install osv-scanner from the official repo:
 
 ```bash
 apk add osv-scanner
@@ -53,17 +53,17 @@ Alternatively, you can install this from source by running:
 go install github.com/google/osv-scanner/cmd/osv-scanner@v1
 ```
 
-This requires Go 1.18+ to be installed.
+This requires Go 1.21+ to be installed.
 
 ## Build from source
 
 See our [contribution guidelines](https://github.com/google/osv-scanner/blob/main/CONTRIBUTING.md) for instructions on how to build from source.
 
 ## Verifying Builds
-Each of our releases come with SLSA provenance data (`multiple.intoto.jsonl`), 
+Each of our releases come with SLSA provenance data (`multiple.intoto.jsonl`),
 which can be used to verify the source and provenance of the binaries with the [`slsa-verifier`](https://github.com/slsa-framework/slsa-verifier) tool.
 
-E.g. 
+E.g.
 ```bash
 slsa-verifier verify-artifact ./osv-scanner_1.2.0_linux_amd64 --provenance-path multiple.intoto2.jsonl --source-uri github.com/google/osv-scanner --source-tag v1.2.0
 ```


### PR DESCRIPTION
Missed updating the minimum go version change in the changelog, so updating it now.