### PR TITLE
Return an error if both license scanning and local/offline scanning is enabled simultaneously

### DIFF
--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -706,6 +706,10 @@ func DoScan(actions ScannerActions, r reporter.Reporter) (models.VulnerabilityRe
 
 	if actions.CompareLocally {
 		actions.SkipGit = true
+
+		if len(actions.ScanLicensesAllowlist) > 0 || actions.ScanLicensesSummary {
+			return models.VulnerabilityResults{}, fmt.Errorf("cannot retrieve licenses locally")
+		}
 	}
 
 	configManager := config.ConfigManager{


### PR DESCRIPTION
When --local-db or --offline flags are passed in the user expects no requests containing individual packages to be made to an external service.