### PR TITLE
Refactor: attempt to transition into using models.Ecosystems rather than lockfile.Ecosystems

### DIFF
--- a/internal/semantic/compare_test.go
+++ b/internal/semantic/compare_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/google/osv-scanner/internal/semantic"
+	"github.com/google/osv-scanner/pkg/models"
 )
 
 func expectedResult(t *testing.T, comparator string) int {
@@ -43,7 +44,7 @@ func compareWord(t *testing.T, result int) string {
 	}
 }
 
-func runAgainstEcosystemFixture(t *testing.T, ecosystem semantic.Ecosystem, filename string) {
+func runAgainstEcosystemFixture(t *testing.T, ecosystem models.Ecosystem, filename string) {
 	t.Helper()
 
 	file, err := os.Open("fixtures/" + filename)
@@ -90,7 +91,7 @@ func runAgainstEcosystemFixture(t *testing.T, ecosystem semantic.Ecosystem, file
 	}
 }
 
-func parseAsVersion(t *testing.T, str string, ecosystem semantic.Ecosystem) semantic.Version {
+func parseAsVersion(t *testing.T, str string, ecosystem models.Ecosystem) semantic.Version {
 	t.Helper()
 
 	v, err := semantic.Parse(str, ecosystem)
@@ -104,7 +105,7 @@ func parseAsVersion(t *testing.T, str string, ecosystem semantic.Ecosystem) sema
 
 func expectCompareResult(
 	t *testing.T,
-	ecosystem semantic.Ecosystem,
+	ecosystem models.Ecosystem,
 	a string,
 	b string,
 	expectedResult int,
@@ -130,7 +131,7 @@ func expectCompareResult(
 
 func expectEcosystemCompareResult(
 	t *testing.T,
-	ecosystem semantic.Ecosystem,
+	ecosystem models.Ecosystem,
 	a string,
 	c string,
 	b string,
@@ -231,7 +232,7 @@ func TestVersion_Compare_Ecosystems(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			runAgainstEcosystemFixture(t, semantic.Ecosystem(tt.name), tt.file)
+			runAgainstEcosystemFixture(t, models.Ecosystem(tt.name), tt.file)
 		})
 	}
 }

--- a/internal/semantic/parse.go
+++ b/internal/semantic/parse.go
@@ -3,11 +3,13 @@ package semantic
 import (
 	"errors"
 	"fmt"
+
+	"github.com/google/osv-scanner/pkg/models"
 )
 
 var ErrUnsupportedEcosystem = errors.New("unsupported ecosystem")
 
-func MustParse(str string, ecosystem Ecosystem) Version {
+func MustParse(str string, ecosystem models.Ecosystem) Version {
 	v, err := Parse(str, ecosystem)
 
 	if err != nil {
@@ -17,7 +19,7 @@ func MustParse(str string, ecosystem Ecosystem) Version {
 	return v
 }
 
-func Parse(str string, ecosystem Ecosystem) (Version, error) {
+func Parse(str string, ecosystem models.Ecosystem) (Version, error) {
 	//nolint:exhaustive // Using strings to specify ecosystem instead of lockfile types
 	switch ecosystem {
 	case "npm":

--- a/internal/semantic/parse_test.go
+++ b/internal/semantic/parse_test.go
@@ -5,13 +5,13 @@ import (
 	"testing"
 
 	"github.com/google/osv-scanner/internal/semantic"
-	"github.com/google/osv-scanner/pkg/lockfile"
+	"github.com/google/osv-scanner/pkg/models"
 )
 
 func TestParse(t *testing.T) {
 	t.Parallel()
 
-	ecosystems := lockfile.KnownEcosystems()
+	ecosystems := models.KnownEcosystems()
 
 	// todo: remove once CRAN is supported by lockfile
 	ecosystems = append(ecosystems, "CRAN")
@@ -34,7 +34,7 @@ func TestMustParse(t *testing.T) {
 		}
 	}()
 
-	ecosystems := lockfile.KnownEcosystems()
+	ecosystems := models.KnownEcosystems()
 
 	// todo: remove once CRAN is supported by lockfile
 	ecosystems = append(ecosystems, "CRAN")

--- a/internal/semantic/parse_test.go
+++ b/internal/semantic/parse_test.go
@@ -5,19 +5,20 @@ import (
 	"testing"
 
 	"github.com/google/osv-scanner/internal/semantic"
+	"github.com/google/osv-scanner/pkg/lockfile"
 	"github.com/google/osv-scanner/pkg/models"
 )
 
 func TestParse(t *testing.T) {
 	t.Parallel()
 
-	ecosystems := models.KnownEcosystems()
+	ecosystems := lockfile.KnownEcosystems()
 
 	// todo: remove once CRAN is supported by lockfile
 	ecosystems = append(ecosystems, "CRAN")
 
 	for _, ecosystem := range ecosystems {
-		_, err := semantic.Parse("", ecosystem)
+		_, err := semantic.Parse("", models.Ecosystem(ecosystem))
 
 		if errors.Is(err, semantic.ErrUnsupportedEcosystem) {
 			t.Errorf("'%s' is not a supported ecosystem", ecosystem)
@@ -34,13 +35,13 @@ func TestMustParse(t *testing.T) {
 		}
 	}()
 
-	ecosystems := models.KnownEcosystems()
+	ecosystems := lockfile.KnownEcosystems()
 
 	// todo: remove once CRAN is supported by lockfile
 	ecosystems = append(ecosystems, "CRAN")
 
 	for _, ecosystem := range ecosystems {
-		semantic.MustParse("", ecosystem)
+		semantic.MustParse("", models.Ecosystem(ecosystem))
 	}
 }
 

--- a/internal/semantic/types.go
+++ b/internal/semantic/types.go
@@ -1,5 +1,7 @@
 package semantic
 
-import "github.com/google/osv-scanner/pkg/lockfile"
+import (
+	"github.com/google/osv-scanner/pkg/models"
+)
 
-type Ecosystem = lockfile.Ecosystem
+type Ecosystem = models.Ecosystem

--- a/internal/semantic/types.go
+++ b/internal/semantic/types.go
@@ -1,7 +1,0 @@
-package semantic
-
-import (
-	"github.com/google/osv-scanner/pkg/models"
-)
-
-type Ecosystem = models.Ecosystem

--- a/internal/utility/vulns/vulnerability.go
+++ b/internal/utility/vulns/vulnerability.go
@@ -40,7 +40,7 @@ func rangeContainsVersion(ar models.Range, pkg lockfile.PackageDetails) bool {
 		return false
 	}
 
-	vp := semantic.MustParse(pkg.Version, pkg.CompareAs)
+	vp := semantic.MustParse(pkg.Version, models.Ecosystem(pkg.CompareAs))
 
 	sort.Slice(ar.Events, func(i, j int) bool {
 		a := ar.Events[i]
@@ -54,7 +54,7 @@ func rangeContainsVersion(ar models.Range, pkg lockfile.PackageDetails) bool {
 			return false
 		}
 
-		return semantic.MustParse(eventVersion(a), pkg.CompareAs).CompareStr(eventVersion(b)) < 0
+		return semantic.MustParse(eventVersion(a), models.Ecosystem(pkg.CompareAs)).CompareStr(eventVersion(b)) < 0
 	})
 
 	var affected bool

--- a/pkg/lockfile/ecosystems.go
+++ b/pkg/lockfile/ecosystems.go
@@ -1,5 +1,6 @@
 package lockfile
 
+// Returns a slice of all known ecosystems, matching the results in pkg/models.
 func KnownEcosystems() []Ecosystem {
 	return []Ecosystem{
 		NpmEcosystem,

--- a/pkg/lockfile/ecosystems.go
+++ b/pkg/lockfile/ecosystems.go
@@ -1,6 +1,7 @@
 package lockfile
 
-// Returns a slice of all known ecosystems, matching the results in pkg/models.
+// KnownEcosystems returns a list of ecosystems that `lockfile` supports
+// automatically inferring an extractor for based on a file path.
 func KnownEcosystems() []Ecosystem {
 	return []Ecosystem{
 		NpmEcosystem,

--- a/pkg/models/constants.go
+++ b/pkg/models/constants.go
@@ -101,3 +101,12 @@ const (
 	CreditSponsor              CreditType = "SPONSOR"
 	CreditOther                CreditType = "OTHER"
 )
+
+func KnownEcosystems() []Ecosystem {
+	return []Ecosystem{
+		EcosystemNPM,
+		// Disabled temporarily,
+		// see https://github.com/google/osv-scanner/pull/128 discussion for additional context
+		// AlpineEcosystem,
+	}
+}

--- a/pkg/models/constants.go
+++ b/pkg/models/constants.go
@@ -104,7 +104,17 @@ const (
 
 func KnownEcosystems() []Ecosystem {
 	return []Ecosystem{
-		EcosystemNPM,
+		EcosystemNuGet,
+		EcosystemCratesIO,
+		EcosystemRubyGems,
+		EcosystemPackagist,
+		EcosystemGo,
+		EcosystemHex,
+		EcosystemMaven,
+		EcosystemPyPI,
+		EcosystemPub,
+		EcosystemConanCenter,
+		EcosystemCRAN,
 		// Disabled temporarily,
 		// see https://github.com/google/osv-scanner/pull/128 discussion for additional context
 		// AlpineEcosystem,

--- a/pkg/models/constants.go
+++ b/pkg/models/constants.go
@@ -102,6 +102,7 @@ const (
 	CreditOther                CreditType = "OTHER"
 )
 
+// Returns a slice of all known ecosystems, matching the results in pkg/lockfile.
 func KnownEcosystems() []Ecosystem {
 	return []Ecosystem{
 		EcosystemNPM,
@@ -118,6 +119,6 @@ func KnownEcosystems() []Ecosystem {
 		EcosystemCRAN,
 		// Disabled temporarily,
 		// see https://github.com/google/osv-scanner/pull/128 discussion for additional context
-		// AlpineEcosystem,
+		// EcosystemAlpine,
 	}
 }

--- a/pkg/models/constants.go
+++ b/pkg/models/constants.go
@@ -104,6 +104,7 @@ const (
 
 func KnownEcosystems() []Ecosystem {
 	return []Ecosystem{
+		EcosystemNPM,
 		EcosystemNuGet,
 		EcosystemCratesIO,
 		EcosystemRubyGems,

--- a/pkg/models/constants.go
+++ b/pkg/models/constants.go
@@ -101,24 +101,3 @@ const (
 	CreditSponsor              CreditType = "SPONSOR"
 	CreditOther                CreditType = "OTHER"
 )
-
-// Returns a slice of all known ecosystems, matching the results in pkg/lockfile.
-func KnownEcosystems() []Ecosystem {
-	return []Ecosystem{
-		EcosystemNPM,
-		EcosystemNuGet,
-		EcosystemCratesIO,
-		EcosystemRubyGems,
-		EcosystemPackagist,
-		EcosystemGo,
-		EcosystemHex,
-		EcosystemMaven,
-		EcosystemPyPI,
-		EcosystemPub,
-		EcosystemConanCenter,
-		EcosystemCRAN,
-		// Disabled temporarily,
-		// see https://github.com/google/osv-scanner/pull/128 discussion for additional context
-		// EcosystemAlpine,
-	}
-}


### PR DESCRIPTION
Imports ecosystems from `models`  package rather than `lockfile` for `internal/semantic`.