### PR TITLE
feat: support `PrintTextf` and `PrintErrorf` on `Reporter`

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -42,6 +42,12 @@ linters:
     - unused
 
 linters-settings:
+  govet:
+    settings:
+      printf:
+        funcs:
+          - (github.com/google/osv-scanner/pkg/reporter.Reporter).PrintErrorf
+          - (github.com/google/osv-scanner/pkg/reporter.Reporter).PrintTextf
   depguard:
     rules:
       regexp:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -66,6 +66,9 @@ linters-settings:
 
 issues:
   exclude-rules:
+    - path: pkg/reporter
+      linters:
+        - dupl
     - path: _test\.go
       linters:
         - goerr113

--- a/cmd/osv-reporter/main.go
+++ b/cmd/osv-reporter/main.go
@@ -179,11 +179,11 @@ func run(args []string, stdout, stderr io.Writer) int {
 		}
 
 		if errors.Is(err, osvscanner.NoPackagesFoundErr) {
-			tableReporter.PrintError("No package sources found, --help for usage information.\n")
+			tableReporter.PrintErrorf("No package sources found, --help for usage information.\n")
 			return 128
 		}
 
-		tableReporter.PrintError(fmt.Sprintf("%v\n", err))
+		tableReporter.PrintErrorf("%v\n", err)
 	}
 
 	// if we've been told to print an error, and not already exited with

--- a/cmd/osv-reporter/main.go
+++ b/cmd/osv-reporter/main.go
@@ -42,7 +42,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 	cli.VersionPrinter = func(ctx *cli.Context) {
 		// Use the app Writer and ErrWriter since they will be the writers to keep parallel tests consistent
 		tableReporter = reporter.NewTableReporter(ctx.App.Writer, ctx.App.ErrWriter, false, 0)
-		tableReporter.PrintText(fmt.Sprintf("osv-scanner version: %s\ncommit: %s\nbuilt at: %s\n", ctx.App.Version, commit, date))
+		tableReporter.PrintTextf("osv-scanner version: %s\ncommit: %s\nbuilt at: %s\n", ctx.App.Version, commit, date)
 	}
 
 	app := &cli.App{

--- a/cmd/osv-scanner/main.go
+++ b/cmd/osv-scanner/main.go
@@ -28,7 +28,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 	cli.VersionPrinter = func(ctx *cli.Context) {
 		// Use the app Writer and ErrWriter since they will be the writers to keep parallel tests consistent
 		r = reporter.NewTableReporter(ctx.App.Writer, ctx.App.ErrWriter, false, 0)
-		r.PrintText(fmt.Sprintf("osv-scanner version: %s\ncommit: %s\nbuilt at: %s\n", ctx.App.Version, commit, date))
+		r.PrintTextf("osv-scanner version: %s\ncommit: %s\nbuilt at: %s\n", ctx.App.Version, commit, date)
 	}
 
 	osv.RequestUserAgent = "osv-scanner/" + version.OSVVersion
@@ -185,7 +185,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 			var callAnalysisStates map[string]bool
 			if context.IsSet("experimental-call-analysis") {
 				callAnalysisStates = createCallAnalysisStates([]string{"all"}, context.StringSlice("no-call-analysis"))
-				r.PrintText("Warning: the experimental-call-analysis flag has been replaced. Please use the call-analysis and no-call-analysis flags instead.\n")
+				r.PrintTextf("Warning: the experimental-call-analysis flag has been replaced. Please use the call-analysis and no-call-analysis flags instead.\n")
 			} else {
 				callAnalysisStates = createCallAnalysisStates(context.StringSlice("call-analysis"), context.StringSlice("no-call-analysis"))
 			}

--- a/cmd/osv-scanner/main.go
+++ b/cmd/osv-scanner/main.go
@@ -236,10 +236,10 @@ func run(args []string, stdout, stderr io.Writer) int {
 		case errors.Is(err, osvscanner.VulnerabilitiesFoundErr):
 			return 1
 		case errors.Is(err, osvscanner.NoPackagesFoundErr):
-			r.PrintError("No package sources found, --help for usage information.\n")
+			r.PrintErrorf("No package sources found, --help for usage information.\n")
 			return 128
 		}
-		r.PrintError(fmt.Sprintf("%v\n", err))
+		r.PrintErrorf("%v\n", err)
 	}
 
 	// if we've been told to print an error, and not already exited with

--- a/internal/local/check.go
+++ b/internal/local/check.go
@@ -108,7 +108,7 @@ func MakeRequest(r reporter.Reporter, query osv.BatchedQuery, offline bool, loca
 			return nil, err
 		}
 
-		r.PrintText(fmt.Sprintf("Loaded %s local db from %s\n", db.Name, db.StoredAt))
+		r.PrintTextf("Loaded %s local db from %s\n", db.Name, db.StoredAt)
 
 		dbs[ecosystem] = db
 
@@ -134,7 +134,7 @@ func MakeRequest(r reporter.Reporter, query osv.BatchedQuery, offline bool, loca
 
 			// Is a commit based query, skip local scanning
 			results = append(results, osv.Response{})
-			r.PrintText(fmt.Sprintf("Skipping commit scanning for: %s\n", pkg.Commit))
+			r.PrintTextf("Skipping commit scanning for: %s\n", pkg.Commit)
 
 			continue
 		}

--- a/internal/local/check.go
+++ b/internal/local/check.go
@@ -120,7 +120,7 @@ func MakeRequest(r reporter.Reporter, query osv.BatchedQuery, offline bool, loca
 
 		if err != nil {
 			// currently, this will actually only error if the PURL cannot be parses
-			r.PrintError(fmt.Sprintf("skipping %s as it is not a valid PURL: %v\n", query.Package.PURL, err))
+			r.PrintErrorf("skipping %s as it is not a valid PURL: %v\n", query.Package.PURL, err)
 			results = append(results, osv.Response{Vulns: []models.Vulnerability{}})
 
 			continue
@@ -143,7 +143,7 @@ func MakeRequest(r reporter.Reporter, query osv.BatchedQuery, offline bool, loca
 
 		if err != nil {
 			// currently, this will actually only error if the PURL cannot be parses
-			r.PrintError(fmt.Sprintf("could not load db for %s ecosystem: %v\n", pkg.Ecosystem, err))
+			r.PrintErrorf("could not load db for %s ecosystem: %v\n", pkg.Ecosystem, err)
 			results = append(results, osv.Response{Vulns: []models.Vulnerability{}})
 
 			continue

--- a/internal/sourceanalysis/go.go
+++ b/internal/sourceanalysis/go.go
@@ -29,9 +29,10 @@ func goAnalysis(r reporter.Reporter, pkgs []models.PackageVulns, source models.S
 	res, err := runGovulncheck(filepath.Dir(source.Path), vulns)
 	if err != nil {
 		// TODO: Better method to identify the type of error and give advice specific to the error
-		r.PrintError(
-			fmt.Sprintf("Failed to run code analysis (govulncheck) on '%s' because %s\n"+
-				"(the Go toolchain is required)\n", source.Path, err.Error()))
+		r.PrintErrorf(
+			"Failed to run code analysis (govulncheck) on '%s' because %s\n"+
+				"(the Go toolchain is required)\n", source.Path, err.Error(),
+		)
 
 		return
 	}

--- a/internal/sourceanalysis/go.go
+++ b/internal/sourceanalysis/go.go
@@ -21,7 +21,7 @@ func goAnalysis(r reporter.Reporter, pkgs []models.PackageVulns, source models.S
 	cmd := exec.Command("go", "version")
 	_, err := cmd.Output()
 	if err != nil {
-		r.PrintText("Skipping call analysis on Go code since Go is not installed.\n")
+		r.PrintTextf("Skipping call analysis on Go code since Go is not installed.\n")
 		return
 	}
 

--- a/internal/sourceanalysis/rust.go
+++ b/internal/sourceanalysis/rust.go
@@ -34,7 +34,7 @@ const (
 func rustAnalysis(r reporter.Reporter, pkgs []models.PackageVulns, source models.SourceInfo) {
 	binaryPaths, err := rustBuildSource(r, source)
 	if err != nil {
-		r.PrintError(fmt.Sprintf("failed to build cargo/rust project from source: %s\n", err))
+		r.PrintErrorf("failed to build cargo/rust project from source: %s\n", err)
 		return
 	}
 
@@ -50,14 +50,14 @@ func rustAnalysis(r reporter.Reporter, pkgs []models.PackageVulns, source models
 			// Is a library, so need an extra step to extract the object binary file before passing to parseDWARFData
 			buf, err := extractRlibArchive(path)
 			if err != nil {
-				r.PrintError(fmt.Sprintf("failed to analyse '%s': %s\n", path, err))
+				r.PrintErrorf("failed to analyse '%s': %s\n", path, err)
 				continue
 			}
 			readAt = bytes.NewReader(buf.Bytes())
 		} else {
 			f, err := os.Open(path)
 			if err != nil {
-				r.PrintError(fmt.Sprintf("failed to read binary '%s': %s\n", path, err))
+				r.PrintErrorf("failed to read binary '%s': %s\n", path, err)
 				continue
 			}
 			// This is fine to defer til the end of the function as there's
@@ -68,7 +68,7 @@ func rustAnalysis(r reporter.Reporter, pkgs []models.PackageVulns, source models
 
 		calls, err := functionsFromDWARF(readAt)
 		if err != nil {
-			r.PrintError(fmt.Sprintf("failed to analyse '%s': %s\n", path, err))
+			r.PrintErrorf("failed to analyse '%s': %s\n", path, err)
 			continue
 		}
 
@@ -236,8 +236,8 @@ func rustBuildSource(r reporter.Reporter, source models.SourceInfo) ([]string, e
 	r.PrintTextf("Begin building rust/cargo project\n")
 
 	if err := cmd.Run(); err != nil {
-		r.PrintError(fmt.Sprintf("cargo stdout:\n%s", stdoutBuffer.String()))
-		r.PrintError(fmt.Sprintf("cargo stderr:\n%s", stderrBuffer.String()))
+		r.PrintErrorf("cargo stdout:\n%s", stdoutBuffer.String())
+		r.PrintErrorf("cargo stderr:\n%s", stderrBuffer.String())
 
 		return nil, fmt.Errorf("failed to run `%v`: %w", cmd.String(), err)
 	}

--- a/internal/sourceanalysis/rust.go
+++ b/internal/sourceanalysis/rust.go
@@ -233,7 +233,7 @@ func rustBuildSource(r reporter.Reporter, source models.SourceInfo) ([]string, e
 	cmd.Stdout = &stdoutBuffer
 	cmd.Stderr = &stderrBuffer
 
-	r.PrintText("Begin building rust/cargo project\n")
+	r.PrintTextf("Begin building rust/cargo project\n")
 
 	if err := cmd.Run(); err != nil {
 		r.PrintError(fmt.Sprintf("cargo stdout:\n%s", stdoutBuffer.String()))

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -83,7 +83,7 @@ func (c *ConfigManager) Get(r reporter.Reporter, targetPath string) Config {
 
 	config, configErr := tryLoadConfig(configPath)
 	if configErr == nil {
-		r.PrintText(fmt.Sprintf("Loaded filter from: %s\n", config.LoadPath))
+		r.PrintTextf("Loaded filter from: %s\n", config.LoadPath)
 	} else {
 		// If config doesn't exist, use the default config
 		config = c.DefaultConfig

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -72,7 +72,7 @@ func (c *ConfigManager) Get(r reporter.Reporter, targetPath string) Config {
 	if err != nil {
 		// TODO: This can happen when target is not a file (e.g. Docker container, git hash...etc.)
 		// Figure out a more robust way to load config from non files
-		// r.PrintError(fmt.Sprintf("Can't find config path: %s\n", err))
+		// r.PrintErrorf("Can't find config path: %s\n", err)
 		return Config{}
 	}
 

--- a/pkg/osvscanner/optional_enricher.go
+++ b/pkg/osvscanner/optional_enricher.go
@@ -1,7 +1,6 @@
 package osvscanner
 
 import (
-	"fmt"
 	"os/exec"
 	"strings"
 
@@ -29,7 +28,7 @@ func addCompilerVersion(r reporter.Reporter, parsedLockfile *lockfile.Lockfile) 
 	case "go.mod":
 		goVer, err := getGoVersion()
 		if err != nil {
-			r.PrintText(fmt.Sprintf("cannot get go standard library version, go might not be installed: %s\n", err))
+			r.PrintTextf("cannot get go standard library version, go might not be installed: %s\n", err)
 		} else {
 			parsedLockfile.Packages = append(parsedLockfile.Packages, lockfile.PackageDetails{
 				Name:      "stdlib",

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -114,7 +114,7 @@ func scanDir(r reporter.Reporter, dir string, skipGit bool, recursive bool, useG
 
 	return scannedPackages, filepath.WalkDir(dir, func(path string, info os.DirEntry, err error) error {
 		if err != nil {
-			r.PrintText(fmt.Sprintf("Failed to walk %s: %v\n", path, err))
+			r.PrintTextf("Failed to walk %s: %v\n", path, err)
 			return err
 		}
 
@@ -127,7 +127,7 @@ func scanDir(r reporter.Reporter, dir string, skipGit bool, recursive bool, useG
 		if useGitIgnore {
 			match, err := ignoreMatcher.match(path, info.IsDir())
 			if err != nil {
-				r.PrintText(fmt.Sprintf("Failed to resolve gitignore for %s: %v\n", path, err))
+				r.PrintTextf("Failed to resolve gitignore for %s: %v\n", path, err)
 				// Don't skip if we can't parse now - potentially noisy for directories with lots of items
 			} else if match {
 				if root { // Don't silently skip if the argument file was ignored.
@@ -144,7 +144,7 @@ func scanDir(r reporter.Reporter, dir string, skipGit bool, recursive bool, useG
 		if !skipGit && info.IsDir() && info.Name() == ".git" {
 			pkgs, err := scanGit(r, filepath.Dir(path)+"/")
 			if err != nil {
-				r.PrintText(fmt.Sprintf("scan failed for git repository, %s: %v\n", path, err))
+				r.PrintTextf("scan failed for git repository, %s: %v\n", path, err)
 				// Not fatal, so don't return and continue scanning other files
 			}
 			scannedPackages = append(scannedPackages, pkgs...)
@@ -171,7 +171,7 @@ func scanDir(r reporter.Reporter, dir string, skipGit bool, recursive bool, useG
 			if _, ok := vendoredLibNames[strings.ToLower(filepath.Base(path))]; ok {
 				pkgs, err := scanDirWithVendoredLibs(r, path)
 				if err != nil {
-					r.PrintText(fmt.Sprintf("scan failed for dir containing vendored libs %s: %v\n", path, err))
+					r.PrintTextf("scan failed for dir containing vendored libs %s: %v\n", path, err)
 				}
 				scannedPackages = append(scannedPackages, pkgs...)
 			}
@@ -281,7 +281,7 @@ func queryDetermineVersions(repoDir string) (*osv.DetermineVersionResponse, erro
 }
 
 func scanDirWithVendoredLibs(r reporter.Reporter, path string) ([]scannedPackage, error) {
-	r.PrintText(fmt.Sprintf("Scanning directory for vendored libs: %s\n", path))
+	r.PrintTextf("Scanning directory for vendored libs: %s\n", path)
 	entries, err := os.ReadDir(path)
 	if err != nil {
 		return nil, err
@@ -295,17 +295,17 @@ func scanDirWithVendoredLibs(r reporter.Reporter, path string) ([]scannedPackage
 
 		libPath := filepath.Join(path, entry.Name())
 
-		r.PrintText(fmt.Sprintf("Scanning potential vendored dir: %s\n", libPath))
+		r.PrintTextf("Scanning potential vendored dir: %s\n", libPath)
 		// TODO: make this a goroutine to parallelise this operation
 		results, err := queryDetermineVersions(libPath)
 		if err != nil {
-			r.PrintText(fmt.Sprintf("Error scanning sub-directory '%s' with error: %v", libPath, err))
+			r.PrintTextf("Error scanning sub-directory '%s' with error: %v", libPath, err)
 			continue
 		}
 
 		if len(results.Matches) > 0 && results.Matches[0].Score > determineVersionThreshold {
 			match := results.Matches[0]
-			r.PrintText(fmt.Sprintf("Identified %s as %s at %s.\n", libPath, match.RepoInfo.Address, match.RepoInfo.Commit))
+			r.PrintTextf("Identified %s as %s at %s.\n", libPath, match.RepoInfo.Address, match.RepoInfo.Commit)
 			packages = append(packages, createCommitQueryPackage(match.RepoInfo.Commit, libPath))
 		}
 	}
@@ -365,13 +365,13 @@ func scanLockfile(r reporter.Reporter, path string, parseAs string) ([]scannedPa
 		parsedAsComment = fmt.Sprintf("as a %s ", parseAs)
 	}
 
-	r.PrintText(fmt.Sprintf(
+	r.PrintTextf(
 		"Scanned %s file %sand found %d %s\n",
 		path,
 		parsedAsComment,
 		len(parsedLockfile.Packages),
 		output.Form(len(parsedLockfile.Packages), "package", "packages"),
-	))
+	)
 
 	packages := make([]scannedPackage, len(parsedLockfile.Packages))
 	for i, pkgDetail := range parsedLockfile.Packages {
@@ -445,19 +445,19 @@ func scanSBOMFile(r reporter.Reporter, path string, fromFSScan bool) ([]scannedP
 
 				continue
 			}
-			r.PrintText(fmt.Sprintf(
+			r.PrintTextf(
 				"Scanned %s as %s SBOM and found %d %s\n",
 				path,
 				provider.Name(),
 				len(packages),
 				output.Form(len(packages), "package", "packages"),
-			))
+			)
 			if ignoredCount > 0 {
-				r.PrintText(fmt.Sprintf(
+				r.PrintTextf(
 					"Ignored %d %s with invalid PURLs\n",
 					ignoredCount,
 					output.Form(ignoredCount, "package", "packages"),
-				))
+				)
 			}
 
 			return packages, nil
@@ -474,9 +474,9 @@ func scanSBOMFile(r reporter.Reporter, path string, fromFSScan bool) ([]scannedP
 
 	// Don't log these errors if we're coming from an FS scan, since it can get very noisy.
 	if !fromFSScan {
-		r.PrintText("Failed to parse SBOM using all supported formats:\n")
+		r.PrintTextf("Failed to parse SBOM using all supported formats:\n")
 		for _, err := range errs {
-			r.PrintText(err.Error() + "\n")
+			r.PrintTextf(err.Error() + "\n")
 		}
 	}
 
@@ -526,7 +526,7 @@ func scanGit(r reporter.Reporter, repoDir string) ([]scannedPackage, error) {
 	if err != nil {
 		return nil, err
 	}
-	r.PrintText(fmt.Sprintf("Scanning %s at commit %s\n", repoDir, commit))
+	r.PrintTextf("Scanning %s at commit %s\n", repoDir, commit)
 
 	//nolint:prealloc // Not sure how many there will be in advance.
 	var packages []scannedPackage
@@ -538,7 +538,7 @@ func scanGit(r reporter.Reporter, repoDir string) ([]scannedPackage, error) {
 	}
 
 	for _, s := range submodules {
-		r.PrintText(fmt.Sprintf("Scanning submodule %s at commit %s\n", s.Path, s.Expected.String()))
+		r.PrintTextf("Scanning submodule %s at commit %s\n", s.Path, s.Expected.String())
 		packages = append(packages, createCommitQueryPackage(s.Expected.String(), path.Join(repoDir, s.Path)))
 	}
 
@@ -595,11 +595,11 @@ func scanDebianDocker(r reporter.Reporter, dockerImageName string) ([]scannedPac
 			},
 		})
 	}
-	r.PrintText(fmt.Sprintf(
+	r.PrintTextf(
 		"Scanned docker image with %d %s\n",
 		len(packages),
 		output.Form(len(packages), "package", "packages"),
-	))
+	)
 
 	return packages, nil
 }
@@ -645,11 +645,11 @@ func filterPackageVulns(r reporter.Reporter, pkgVulns models.PackageVulns, confi
 				// NB: This only prints the first reason encountered in all the aliases.
 				switch len(group.Aliases) {
 				case 1:
-					r.PrintText(fmt.Sprintf("%s has been filtered out because: %s\n", ignoreLine.ID, ignoreLine.Reason))
+					r.PrintTextf("%s has been filtered out because: %s\n", ignoreLine.ID, ignoreLine.Reason)
 				case 2:
-					r.PrintText(fmt.Sprintf("%s and 1 alias have been filtered out because: %s\n", ignoreLine.ID, ignoreLine.Reason))
+					r.PrintTextf("%s and 1 alias have been filtered out because: %s\n", ignoreLine.ID, ignoreLine.Reason)
 				default:
-					r.PrintText(fmt.Sprintf("%s and %d aliases have been filtered out because: %s\n", ignoreLine.ID, len(group.Aliases)-1, ignoreLine.Reason))
+					r.PrintTextf("%s and %d aliases have been filtered out because: %s\n", ignoreLine.ID, len(group.Aliases)-1, ignoreLine.Reason)
 				}
 
 				break
@@ -768,7 +768,7 @@ func DoScan(actions ScannerActions, r reporter.Reporter) (models.VulnerabilityRe
 	}
 
 	for _, dir := range actions.DirectoryPaths {
-		r.PrintText(fmt.Sprintf("Scanning dir %s\n", dir))
+		r.PrintTextf("Scanning dir %s\n", dir)
 		pkgs, err := scanDir(r, dir, actions.SkipGit, actions.Recursive, !actions.NoIgnore, actions.CompareOffline)
 		if err != nil {
 			return models.VulnerabilityResults{}, err
@@ -783,7 +783,7 @@ func DoScan(actions ScannerActions, r reporter.Reporter) (models.VulnerabilityRe
 	filteredScannedPackages := filterUnscannablePackages(scannedPackages)
 
 	if len(filteredScannedPackages) != len(scannedPackages) {
-		r.PrintText(fmt.Sprintf("Filtered %d local package/s from the scan.\n", len(scannedPackages)-len(filteredScannedPackages)))
+		r.PrintTextf("Filtered %d local package/s from the scan.\n", len(scannedPackages)-len(filteredScannedPackages))
 	}
 
 	vulnsResp, err := makeRequest(r, filteredScannedPackages, actions.CompareLocally, actions.CompareOffline, actions.LocalDBPath)
@@ -802,11 +802,11 @@ func DoScan(actions ScannerActions, r reporter.Reporter) (models.VulnerabilityRe
 
 	filtered := filterResults(r, &results, &configManager, actions.ShowAllPackages)
 	if filtered > 0 {
-		r.PrintText(fmt.Sprintf(
+		r.PrintTextf(
 			"Filtered %d %s from output\n",
 			filtered,
 			output.Form(filtered, "vulnerability", "vulnerabilities"),
-		))
+		)
 	}
 
 	if len(results.Results) > 0 {

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -103,7 +103,7 @@ func scanDir(r reporter.Reporter, dir string, skipGit bool, recursive bool, useG
 		var err error
 		ignoreMatcher, err = parseGitIgnores(dir)
 		if err != nil {
-			r.PrintError(fmt.Sprintf("Unable to parse git ignores: %v\n", err))
+			r.PrintErrorf("Unable to parse git ignores: %v\n", err)
 			useGitIgnore = false
 		}
 	}
@@ -120,7 +120,7 @@ func scanDir(r reporter.Reporter, dir string, skipGit bool, recursive bool, useG
 
 		path, err = filepath.Abs(path)
 		if err != nil {
-			r.PrintError(fmt.Sprintf("Failed to walk path %s\n", err))
+			r.PrintErrorf("Failed to walk path %s\n", err)
 			return err
 		}
 
@@ -131,7 +131,7 @@ func scanDir(r reporter.Reporter, dir string, skipGit bool, recursive bool, useG
 				// Don't skip if we can't parse now - potentially noisy for directories with lots of items
 			} else if match {
 				if root { // Don't silently skip if the argument file was ignored.
-					r.PrintError(fmt.Sprintf("%s was not scanned because it is excluded by a .gitignore file. Use --no-ignore to scan it.\n", path))
+					r.PrintErrorf("%s was not scanned because it is excluded by a .gitignore file. Use --no-ignore to scan it.\n", path)
 				}
 				if info.IsDir() {
 					return filepath.SkipDir
@@ -156,7 +156,7 @@ func scanDir(r reporter.Reporter, dir string, skipGit bool, recursive bool, useG
 			if extractor, _ := lockfile.FindExtractor(path, ""); extractor != nil {
 				pkgs, err := scanLockfile(r, path, "")
 				if err != nil {
-					r.PrintError(fmt.Sprintf("Attempted to scan lockfile but failed: %s\n", path))
+					r.PrintErrorf("Attempted to scan lockfile but failed: %s\n", path)
 				}
 				scannedPackages = append(scannedPackages, pkgs...)
 			}
@@ -560,12 +560,12 @@ func scanDebianDocker(r reporter.Reporter, dockerImageName string) ([]scannedPac
 	stdout, err := cmd.StdoutPipe()
 
 	if err != nil {
-		r.PrintError(fmt.Sprintf("Failed to get stdout: %s\n", err))
+		r.PrintErrorf("Failed to get stdout: %s\n", err)
 		return nil, err
 	}
 	err = cmd.Start()
 	if err != nil {
-		r.PrintError(fmt.Sprintf("Failed to start docker image: %s\n", err))
+		r.PrintErrorf("Failed to start docker image: %s\n", err)
 		return nil, err
 	}
 	// TODO: Do error checking here
@@ -581,7 +581,7 @@ func scanDebianDocker(r reporter.Reporter, dockerImageName string) ([]scannedPac
 		}
 		splitText := strings.Split(text, "###")
 		if len(splitText) != 2 {
-			r.PrintError(fmt.Sprintf("Unexpected output from Debian container: \n\n%s\n", text))
+			r.PrintErrorf("Unexpected output from Debian container: \n\n%s\n", text)
 			return nil, fmt.Errorf("unexpected output from Debian container: \n\n%s", text)
 		}
 		// TODO(rexpan): Get and specify exact debian release version
@@ -725,7 +725,7 @@ func DoScan(actions ScannerActions, r reporter.Reporter) (models.VulnerabilityRe
 	if actions.ConfigOverridePath != "" {
 		err := configManager.UseOverride(actions.ConfigOverridePath)
 		if err != nil {
-			r.PrintError(fmt.Sprintf("Failed to read config file: %s\n", err))
+			r.PrintErrorf("Failed to read config file: %s\n", err)
 			return models.VulnerabilityResults{}, err
 		}
 	}
@@ -741,7 +741,7 @@ func DoScan(actions ScannerActions, r reporter.Reporter) (models.VulnerabilityRe
 		parseAs, lockfilePath := parseLockfilePath(lockfileElem)
 		lockfilePath, err := filepath.Abs(lockfilePath)
 		if err != nil {
-			r.PrintError(fmt.Sprintf("Failed to resolved path with error %s\n", err))
+			r.PrintErrorf("Failed to resolved path with error %s\n", err)
 			return models.VulnerabilityResults{}, err
 		}
 		pkgs, err := scanLockfile(r, lockfilePath, parseAs)

--- a/pkg/osvscanner/vulnerability_result.go
+++ b/pkg/osvscanner/vulnerability_result.go
@@ -1,7 +1,6 @@
 package osvscanner
 
 import (
-	"fmt"
 	"sort"
 	"strings"
 
@@ -38,8 +37,7 @@ func buildVulnerabilityResults(
 			var err error
 			pkg.Package, err = models.PURLToPackage(rawPkg.PURL)
 			if err != nil {
-				r.PrintError(fmt.Sprintf("Failed to parse purl: %s, with error: %s",
-					rawPkg.PURL, err))
+				r.PrintErrorf("Failed to parse purl: %s, with error: %s", rawPkg.PURL, err)
 
 				continue
 			}

--- a/pkg/reporter/gh-annotations_reporter.go
+++ b/pkg/reporter/gh-annotations_reporter.go
@@ -32,7 +32,11 @@ func (r *GHAnnotationsReporter) HasPrintedError() bool {
 }
 
 func (r *GHAnnotationsReporter) PrintText(msg string) {
-	fmt.Fprint(r.stderr, msg)
+	r.PrintTextf(msg)
+}
+
+func (r *GHAnnotationsReporter) PrintTextf(msg string, a ...any) {
+	fmt.Fprintf(r.stderr, msg, a...)
 }
 
 func (r *GHAnnotationsReporter) PrintResult(vulnResult *models.VulnerabilityResults) error {

--- a/pkg/reporter/gh-annotations_reporter.go
+++ b/pkg/reporter/gh-annotations_reporter.go
@@ -23,7 +23,11 @@ func NewGHAnnotationsReporter(stdout io.Writer, stderr io.Writer) *GHAnnotations
 }
 
 func (r *GHAnnotationsReporter) PrintError(msg string) {
-	fmt.Fprint(r.stderr, msg)
+	r.PrintErrorf(msg)
+}
+
+func (r *GHAnnotationsReporter) PrintErrorf(msg string, a ...any) {
+	fmt.Fprintf(r.stderr, msg, a...)
 	r.hasPrintedError = true
 }
 

--- a/pkg/reporter/json_reporter.go
+++ b/pkg/reporter/json_reporter.go
@@ -32,8 +32,12 @@ func (r *JSONReporter) HasPrintedError() bool {
 }
 
 func (r *JSONReporter) PrintText(msg string) {
+	r.PrintTextf(msg)
+}
+
+func (r *JSONReporter) PrintTextf(msg string, a ...any) {
 	// Print non json text to stderr
-	fmt.Fprint(r.stderr, msg)
+	fmt.Fprintf(r.stderr, msg, a...)
 }
 
 func (r *JSONReporter) PrintResult(vulnResult *models.VulnerabilityResults) error {

--- a/pkg/reporter/json_reporter.go
+++ b/pkg/reporter/json_reporter.go
@@ -23,7 +23,11 @@ func NewJSONReporter(stdout io.Writer, stderr io.Writer) *JSONReporter {
 }
 
 func (r *JSONReporter) PrintError(msg string) {
-	fmt.Fprint(r.stderr, msg)
+	r.PrintErrorf(msg)
+}
+
+func (r *JSONReporter) PrintErrorf(msg string, a ...any) {
+	fmt.Fprintf(r.stderr, msg, a...)
 	r.hasPrintedError = true
 }
 

--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -11,6 +11,8 @@ type Reporter interface {
 	//
 	// Where the error is actually printed (if at all) is entirely up to the actual
 	// reporter, though generally it will be to stderr.
+	//
+	// Deprecated: use PrintErrorf instead
 	PrintError(msg string)
 	// PrintErrorf prints errors in an appropriate manner to ensure that results
 	// are printed in a way that is semantically valid for the intended consumer,
@@ -31,6 +33,8 @@ type Reporter interface {
 	// Where the text is actually printed (if at all) is entirely up to the actual
 	// reporter; in most cases for "human format" reporters this will be stdout
 	// whereas for "machine format" reporters this will stderr.
+	//
+	// Deprecated: use PrintTextf instead
 	PrintText(msg string)
 	// PrintTextf prints text in an appropriate manner to ensure that results
 	// are printed in a way that is semantically valid for the intended consumer.

--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -8,6 +8,13 @@ type Reporter interface {
 	// PrintError writes the given message to stderr, regardless of if the reporter
 	// is outputting as JSON or not
 	PrintError(msg string)
+	// PrintErrorf prints errors in an appropriate manner to ensure that results
+	// are printed in a way that is semantically valid for the intended consumer,
+	// and tracking that an error has been printed.
+	//
+	// Where the error is actually printed (if at all) is entirely up to the actual
+	// reporter, though generally it will be to stderr.
+	PrintErrorf(msg string, a ...any)
 	HasPrintedError() bool
 	// PrintText writes the given message to stdout, _unless_ the reporter is set
 	// to output as JSON, in which case it writes the message to stderr.

--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -15,5 +15,12 @@ type Reporter interface {
 	// This should be used for content that should always be outputted, but that
 	// should not be captured when piping if outputting JSON.
 	PrintText(msg string)
+	// PrintTextf prints text in an appropriate manner to ensure that results
+	// are printed in a way that is semantically valid for the intended consumer.
+	//
+	// Where the text is actually printed (if at all) is entirely up to the actual
+	// reporter; in most cases for "human format" reporters this will be stdout
+	// whereas for "machine format" reporters this will stderr.
+	PrintTextf(msg string, a ...any)
 	PrintResult(vulnResult *models.VulnerabilityResults) error
 }

--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -5,8 +5,12 @@ import (
 )
 
 type Reporter interface {
-	// PrintError writes the given message to stderr, regardless of if the reporter
-	// is outputting as JSON or not
+	// PrintError prints errors in an appropriate manner to ensure that results
+	// are printed in a way that is semantically valid for the intended consumer,
+	// and tracking that an error has been printed.
+	//
+	// Where the error is actually printed (if at all) is entirely up to the actual
+	// reporter, though generally it will be to stderr.
 	PrintError(msg string)
 	// PrintErrorf prints errors in an appropriate manner to ensure that results
 	// are printed in a way that is semantically valid for the intended consumer,
@@ -15,12 +19,18 @@ type Reporter interface {
 	// Where the error is actually printed (if at all) is entirely up to the actual
 	// reporter, though generally it will be to stderr.
 	PrintErrorf(msg string, a ...any)
-	HasPrintedError() bool
-	// PrintText writes the given message to stdout, _unless_ the reporter is set
-	// to output as JSON, in which case it writes the message to stderr.
+	// HasPrintedError returns true if there have been any calls to PrintError or
+	// PrintErrorf.
 	//
-	// This should be used for content that should always be outputted, but that
-	// should not be captured when piping if outputting JSON.
+	// This does not actually represent if the error was actually printed anywhere
+	// since what happens to the error message is up to the actual reporter.
+	HasPrintedError() bool
+	// PrintText prints text in an appropriate manner to ensure that results
+	// are printed in a way that is semantically valid for the intended consumer.
+	//
+	// Where the text is actually printed (if at all) is entirely up to the actual
+	// reporter; in most cases for "human format" reporters this will be stdout
+	// whereas for "machine format" reporters this will stderr.
 	PrintText(msg string)
 	// PrintTextf prints text in an appropriate manner to ensure that results
 	// are printed in a way that is semantically valid for the intended consumer.
@@ -29,5 +39,7 @@ type Reporter interface {
 	// reporter; in most cases for "human format" reporters this will be stdout
 	// whereas for "machine format" reporters this will stderr.
 	PrintTextf(msg string, a ...any)
+	// PrintResult prints the models.VulnerabilityResults per the logic of the
+	// actual reporter
 	PrintResult(vulnResult *models.VulnerabilityResults) error
 }

--- a/pkg/reporter/sarif_reporter.go
+++ b/pkg/reporter/sarif_reporter.go
@@ -23,7 +23,11 @@ func NewSarifReporter(stdout io.Writer, stderr io.Writer) *SARIFReporter {
 }
 
 func (r *SARIFReporter) PrintError(msg string) {
-	fmt.Fprint(r.stderr, msg)
+	r.PrintErrorf(msg)
+}
+
+func (r *SARIFReporter) PrintErrorf(msg string, a ...any) {
+	fmt.Fprintf(r.stderr, msg, a...)
 	r.hasPrintedError = true
 }
 

--- a/pkg/reporter/sarif_reporter.go
+++ b/pkg/reporter/sarif_reporter.go
@@ -32,7 +32,11 @@ func (r *SARIFReporter) HasPrintedError() bool {
 }
 
 func (r *SARIFReporter) PrintText(msg string) {
-	fmt.Fprint(r.stderr, msg)
+	r.PrintTextf(msg)
+}
+
+func (r *SARIFReporter) PrintTextf(msg string, a ...any) {
+	fmt.Fprintf(r.stderr, msg, a...)
 }
 
 func (r *SARIFReporter) PrintResult(vulnResult *models.VulnerabilityResults) error {

--- a/pkg/reporter/table_reporter.go
+++ b/pkg/reporter/table_reporter.go
@@ -28,7 +28,11 @@ func NewTableReporter(stdout io.Writer, stderr io.Writer, markdown bool, termina
 }
 
 func (r *TableReporter) PrintError(msg string) {
-	fmt.Fprint(r.stderr, msg)
+	r.PrintErrorf(msg)
+}
+
+func (r *TableReporter) PrintErrorf(msg string, a ...any) {
+	fmt.Fprintf(r.stderr, msg, a...)
 	r.hasPrintedError = true
 }
 

--- a/pkg/reporter/table_reporter.go
+++ b/pkg/reporter/table_reporter.go
@@ -37,7 +37,11 @@ func (r *TableReporter) HasPrintedError() bool {
 }
 
 func (r *TableReporter) PrintText(msg string) {
-	fmt.Fprint(r.stdout, msg)
+	r.PrintTextf(msg)
+}
+
+func (r *TableReporter) PrintTextf(msg string, a ...any) {
+	fmt.Fprintf(r.stdout, msg, a...)
 }
 
 func (r *TableReporter) PrintResult(vulnResult *models.VulnerabilityResults) error {

--- a/pkg/reporter/void_reporter.go
+++ b/pkg/reporter/void_reporter.go
@@ -1,9 +1,19 @@
 package reporter
 
-import "github.com/google/osv-scanner/pkg/models"
+import (
+	"github.com/google/osv-scanner/pkg/models"
+)
 
 type VoidReporter struct {
 	hasPrintedError bool
+}
+
+func (r *VoidReporter) PrintError(msg string) {
+	r.PrintErrorf(msg)
+}
+
+func (r *VoidReporter) PrintErrorf(msg string, a ...any) {
+	r.hasPrintedError = true
 }
 
 func (r *VoidReporter) HasPrintedError() bool {
@@ -19,8 +29,4 @@ func (r *VoidReporter) PrintTextf(msg string, a ...any) {
 
 func (r *VoidReporter) PrintResult(vulnResult *models.VulnerabilityResults) error {
 	return nil
-}
-
-func (r *VoidReporter) PrintError(msg string) {
-	r.hasPrintedError = true
 }

--- a/pkg/reporter/void_reporter.go
+++ b/pkg/reporter/void_reporter.go
@@ -11,6 +11,10 @@ func (r *VoidReporter) HasPrintedError() bool {
 }
 
 func (r *VoidReporter) PrintText(msg string) {
+	r.PrintTextf(msg)
+}
+
+func (r *VoidReporter) PrintTextf(msg string, a ...any) {
 }
 
 func (r *VoidReporter) PrintResult(vulnResult *models.VulnerabilityResults) error {


### PR DESCRIPTION
When I originally implemented `Reporter`, IDEs such as GoLand didn't support custom `Printf` functions so I stuck with plain methods and did the `fmt` formatting on the string; that's changed as of GoLand 2023.3 via [GO-5841](https://youtrack.jetbrains.com/issue/GO-5841) 🎉 

Technically adding to `Reporter` is a breaking change but as covered [in this comment](https://github.com/google/osv-scanner/pull/698#issuecomment-1853318857):

> I believe there are no other implementations (at least public on github, from a quick code search) of this interface, and there are no good use cases for implementing this manually instead of using one of the preset implementations we provide.

Either way I think it's better to land these ASAP to reduce the blast radius then to carry them around for possibly a lot longer - note that I'm not strictly against deprecating/removing `PrintText` and `PrintError` though I don't think there's a lot of value in keeping them.

As penance, I've also added rich method comments for the interface.

(having said that, since this is a breaking change already maybe we should just remove `PrintText` and `PrintError` right now)