### PR TITLE
fix: remove deprecated `Reporter` methods

### DIFF
--- a/pkg/reporter/gh-annotations_reporter.go
+++ b/pkg/reporter/gh-annotations_reporter.go
@@ -22,10 +22,6 @@ func NewGHAnnotationsReporter(stdout io.Writer, stderr io.Writer) *GHAnnotations
 	}
 }
 
-func (r *GHAnnotationsReporter) PrintError(msg string) {
-	r.PrintErrorf(msg)
-}
-
 func (r *GHAnnotationsReporter) PrintErrorf(msg string, a ...any) {
 	fmt.Fprintf(r.stderr, msg, a...)
 	r.hasPrintedError = true
@@ -33,10 +29,6 @@ func (r *GHAnnotationsReporter) PrintErrorf(msg string, a ...any) {
 
 func (r *GHAnnotationsReporter) HasPrintedError() bool {
 	return r.hasPrintedError
-}
-
-func (r *GHAnnotationsReporter) PrintText(msg string) {
-	r.PrintTextf(msg)
 }
 
 func (r *GHAnnotationsReporter) PrintTextf(msg string, a ...any) {

--- a/pkg/reporter/json_reporter.go
+++ b/pkg/reporter/json_reporter.go
@@ -22,10 +22,6 @@ func NewJSONReporter(stdout io.Writer, stderr io.Writer) *JSONReporter {
 	}
 }
 
-func (r *JSONReporter) PrintError(msg string) {
-	r.PrintErrorf(msg)
-}
-
 func (r *JSONReporter) PrintErrorf(msg string, a ...any) {
 	fmt.Fprintf(r.stderr, msg, a...)
 	r.hasPrintedError = true
@@ -33,10 +29,6 @@ func (r *JSONReporter) PrintErrorf(msg string, a ...any) {
 
 func (r *JSONReporter) HasPrintedError() bool {
 	return r.hasPrintedError
-}
-
-func (r *JSONReporter) PrintText(msg string) {
-	r.PrintTextf(msg)
 }
 
 func (r *JSONReporter) PrintTextf(msg string, a ...any) {

--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -5,15 +5,6 @@ import (
 )
 
 type Reporter interface {
-	// PrintError prints errors in an appropriate manner to ensure that results
-	// are printed in a way that is semantically valid for the intended consumer,
-	// and tracking that an error has been printed.
-	//
-	// Where the error is actually printed (if at all) is entirely up to the actual
-	// reporter, though generally it will be to stderr.
-	//
-	// Deprecated: use PrintErrorf instead
-	PrintError(msg string)
 	// PrintErrorf prints errors in an appropriate manner to ensure that results
 	// are printed in a way that is semantically valid for the intended consumer,
 	// and tracking that an error has been printed.
@@ -21,21 +12,11 @@ type Reporter interface {
 	// Where the error is actually printed (if at all) is entirely up to the actual
 	// reporter, though generally it will be to stderr.
 	PrintErrorf(msg string, a ...any)
-	// HasPrintedError returns true if there have been any calls to PrintError or
-	// PrintErrorf.
+	// HasPrintedError returns true if there have been any calls to PrintErrorf.
 	//
 	// This does not actually represent if the error was actually printed anywhere
 	// since what happens to the error message is up to the actual reporter.
 	HasPrintedError() bool
-	// PrintText prints text in an appropriate manner to ensure that results
-	// are printed in a way that is semantically valid for the intended consumer.
-	//
-	// Where the text is actually printed (if at all) is entirely up to the actual
-	// reporter; in most cases for "human format" reporters this will be stdout
-	// whereas for "machine format" reporters this will stderr.
-	//
-	// Deprecated: use PrintTextf instead
-	PrintText(msg string)
 	// PrintTextf prints text in an appropriate manner to ensure that results
 	// are printed in a way that is semantically valid for the intended consumer.
 	//

--- a/pkg/reporter/sarif_reporter.go
+++ b/pkg/reporter/sarif_reporter.go
@@ -22,10 +22,6 @@ func NewSarifReporter(stdout io.Writer, stderr io.Writer) *SARIFReporter {
 	}
 }
 
-func (r *SARIFReporter) PrintError(msg string) {
-	r.PrintErrorf(msg)
-}
-
 func (r *SARIFReporter) PrintErrorf(msg string, a ...any) {
 	fmt.Fprintf(r.stderr, msg, a...)
 	r.hasPrintedError = true
@@ -33,10 +29,6 @@ func (r *SARIFReporter) PrintErrorf(msg string, a ...any) {
 
 func (r *SARIFReporter) HasPrintedError() bool {
 	return r.hasPrintedError
-}
-
-func (r *SARIFReporter) PrintText(msg string) {
-	r.PrintTextf(msg)
 }
 
 func (r *SARIFReporter) PrintTextf(msg string, a ...any) {

--- a/pkg/reporter/table_reporter.go
+++ b/pkg/reporter/table_reporter.go
@@ -27,10 +27,6 @@ func NewTableReporter(stdout io.Writer, stderr io.Writer, markdown bool, termina
 	}
 }
 
-func (r *TableReporter) PrintError(msg string) {
-	r.PrintErrorf(msg)
-}
-
 func (r *TableReporter) PrintErrorf(msg string, a ...any) {
 	fmt.Fprintf(r.stderr, msg, a...)
 	r.hasPrintedError = true
@@ -38,10 +34,6 @@ func (r *TableReporter) PrintErrorf(msg string, a ...any) {
 
 func (r *TableReporter) HasPrintedError() bool {
 	return r.hasPrintedError
-}
-
-func (r *TableReporter) PrintText(msg string) {
-	r.PrintTextf(msg)
 }
 
 func (r *TableReporter) PrintTextf(msg string, a ...any) {

--- a/pkg/reporter/void_reporter.go
+++ b/pkg/reporter/void_reporter.go
@@ -8,20 +8,12 @@ type VoidReporter struct {
 	hasPrintedError bool
 }
 
-func (r *VoidReporter) PrintError(msg string) {
-	r.PrintErrorf(msg)
-}
-
 func (r *VoidReporter) PrintErrorf(msg string, a ...any) {
 	r.hasPrintedError = true
 }
 
 func (r *VoidReporter) HasPrintedError() bool {
 	return r.hasPrintedError
-}
-
-func (r *VoidReporter) PrintText(msg string) {
-	r.PrintTextf(msg)
 }
 
 func (r *VoidReporter) PrintTextf(msg string, a ...any) {


### PR DESCRIPTION
Per https://github.com/google/osv-scanner/pull/706#issuecomment-1870668808