### PR TITLE
Add support for verbosity levels

### DIFF
--- a/cmd/osv-reporter/main.go
+++ b/cmd/osv-reporter/main.go
@@ -41,8 +41,8 @@ func run(args []string, stdout, stderr io.Writer) int {
 
 	cli.VersionPrinter = func(ctx *cli.Context) {
 		// Use the app Writer and ErrWriter since they will be the writers to keep parallel tests consistent
-		tableReporter = reporter.NewTableReporter(ctx.App.Writer, ctx.App.ErrWriter, false, 0)
-		tableReporter.PrintTextf("osv-scanner version: %s\ncommit: %s\nbuilt at: %s\n", ctx.App.Version, commit, date)
+		tableReporter = reporter.NewTableReporter(ctx.App.Writer, ctx.App.ErrWriter, reporter.InfoLevel, false, 0)
+		tableReporter.Infof("osv-scanner version: %s\ncommit: %s\nbuilt at: %s\n", ctx.App.Version, commit, date)
 	}
 
 	app := &cli.App{
@@ -87,7 +87,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 				}
 			}
 
-			if tableReporter, err = reporter.New("table", stdout, stderr, termWidth); err != nil {
+			if tableReporter, err = reporter.New("table", stdout, stderr, reporter.InfoLevel, termWidth); err != nil {
 				return err
 			}
 
@@ -133,7 +133,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 
 			if context.Bool("gh-annotations") {
 				var ghAnnotationsReporter reporter.Reporter
-				if ghAnnotationsReporter, err = reporter.New("gh-annotations", stdout, stderr, termWidth); err != nil {
+				if ghAnnotationsReporter, err = reporter.New("gh-annotations", stdout, stderr, reporter.InfoLevel, termWidth); err != nil {
 					return err
 				}
 
@@ -151,7 +151,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 				}
 				termWidth = 0
 				var sarifReporter reporter.Reporter
-				if sarifReporter, err = reporter.New("sarif", stdout, stderr, termWidth); err != nil {
+				if sarifReporter, err = reporter.New("sarif", stdout, stderr, reporter.InfoLevel, termWidth); err != nil {
 					return err
 				}
 
@@ -172,23 +172,23 @@ func run(args []string, stdout, stderr io.Writer) int {
 
 	if err := app.Run(args); err != nil {
 		if tableReporter == nil {
-			tableReporter = reporter.NewTableReporter(stdout, stderr, false, 0)
+			tableReporter = reporter.NewTableReporter(stdout, stderr, reporter.InfoLevel, false, 0)
 		}
 		if errors.Is(err, osvscanner.VulnerabilitiesFoundErr) {
 			return 1
 		}
 
 		if errors.Is(err, osvscanner.NoPackagesFoundErr) {
-			tableReporter.PrintErrorf("No package sources found, --help for usage information.\n")
+			tableReporter.Errorf("No package sources found, --help for usage information.\n")
 			return 128
 		}
 
-		tableReporter.PrintErrorf("%v\n", err)
+		tableReporter.Errorf("%v\n", err)
 	}
 
 	// if we've been told to print an error, and not already exited with
 	// a specific error code, then exit with a generic non-zero code
-	if tableReporter != nil && tableReporter.HasPrintedError() {
+	if tableReporter != nil && tableReporter.HasErrored() {
 		return 127
 	}
 

--- a/cmd/osv-scanner/main.go
+++ b/cmd/osv-scanner/main.go
@@ -116,6 +116,11 @@ func run(args []string, stdout, stderr io.Writer) int {
 				Name:  "no-call-analysis",
 				Usage: "disables call graph analysis",
 			},
+			&cli.StringFlag{
+				Name:  "verbosity",
+				Usage: fmt.Sprintf("specify the level of information that should be provided during runtime; value can be: %s", strings.Join(reporter.VerbosityLevels(), ", ")),
+				Value: "info",
+			},
 			&cli.BoolFlag{
 				Name:  "experimental-local-db",
 				Usage: "checks for vulnerabilities using local databases",
@@ -182,7 +187,12 @@ func run(args []string, stdout, stderr io.Writer) int {
 				}
 			}
 
-			if r, err = reporter.New(format, stdout, stderr, reporter.InfoLevel, termWidth); err != nil {
+			verbosityLevel, err := reporter.ParseVerbosityLevel(context.String("verbosity"))
+			if err != nil {
+				return err
+			}
+
+			if r, err = reporter.New(format, stdout, stderr, verbosityLevel, termWidth); err != nil {
 				return err
 			}
 

--- a/cmd/osv-scanner/main.go
+++ b/cmd/osv-scanner/main.go
@@ -28,8 +28,8 @@ func run(args []string, stdout, stderr io.Writer) int {
 
 	cli.VersionPrinter = func(ctx *cli.Context) {
 		// Use the app Writer and ErrWriter since they will be the writers to keep parallel tests consistent
-		r = reporter.NewTableReporter(ctx.App.Writer, ctx.App.ErrWriter, false, 0)
-		r.PrintTextf("osv-scanner version: %s\ncommit: %s\nbuilt at: %s\n", ctx.App.Version, commit, date)
+		r = reporter.NewTableReporter(ctx.App.Writer, ctx.App.ErrWriter, reporter.InfoLevel, false, 0)
+		r.Infof("osv-scanner version: %s\ncommit: %s\nbuilt at: %s\n", ctx.App.Version, commit, date)
 	}
 
 	osv.RequestUserAgent = "osv-scanner/" + version.OSVVersion
@@ -182,14 +182,14 @@ func run(args []string, stdout, stderr io.Writer) int {
 				}
 			}
 
-			if r, err = reporter.New(format, stdout, stderr, termWidth); err != nil {
+			if r, err = reporter.New(format, stdout, stderr, reporter.InfoLevel, termWidth); err != nil {
 				return err
 			}
 
 			var callAnalysisStates map[string]bool
 			if context.IsSet("experimental-call-analysis") {
 				callAnalysisStates = createCallAnalysisStates([]string{"all"}, context.StringSlice("no-call-analysis"))
-				r.PrintTextf("Warning: the experimental-call-analysis flag has been replaced. Please use the call-analysis and no-call-analysis flags instead.\n")
+				r.Infof("Warning: the experimental-call-analysis flag has been replaced. Please use the call-analysis and no-call-analysis flags instead.\n")
 			} else {
 				callAnalysisStates = createCallAnalysisStates(context.StringSlice("call-analysis"), context.StringSlice("no-call-analysis"))
 			}
@@ -234,21 +234,21 @@ func run(args []string, stdout, stderr io.Writer) int {
 
 	if err := app.Run(args); err != nil {
 		if r == nil {
-			r = reporter.NewTableReporter(stdout, stderr, false, 0)
+			r = reporter.NewTableReporter(stdout, stderr, reporter.InfoLevel, false, 0)
 		}
 		switch {
 		case errors.Is(err, osvscanner.VulnerabilitiesFoundErr):
 			return 1
 		case errors.Is(err, osvscanner.NoPackagesFoundErr):
-			r.PrintErrorf("No package sources found, --help for usage information.\n")
+			r.Errorf("No package sources found, --help for usage information.\n")
 			return 128
 		}
-		r.PrintErrorf("%v\n", err)
+		r.Errorf("%v\n", err)
 	}
 
 	// if we've been told to print an error, and not already exited with
 	// a specific error code, then exit with a generic non-zero code
-	if r != nil && r.HasPrintedError() {
+	if r != nil && r.HasErrored() {
 		return 127
 	}
 

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -548,6 +548,35 @@ func TestRun(t *testing.T) {
 			`,
 			wantStderr: "",
 		},
+		{
+			name:         "invalid --verbosity value",
+			args:         []string{"", "--verbosity", "unknown", "./fixtures/locks-many/composer.lock"},
+			wantExitCode: 127,
+			wantStdout:   "",
+			wantStderr: `
+			invalid verbosity level "unknown" - must be one of: error, warn, info, verbose
+			`,
+		},
+		{
+			name:         "verbosity level = error",
+			args:         []string{"", "--verbosity", "error", "--format", "table", "./fixtures/locks-many/composer.lock"},
+			wantExitCode: 0,
+			wantStdout: `
+			No issues found
+			`,
+			wantStderr: ``,
+		},
+		{
+			name:         "verbosity level = info",
+			args:         []string{"", "--verbosity", "info", "--format", "table", "./fixtures/locks-many/composer.lock"},
+			wantExitCode: 0,
+			wantStdout: `
+			Scanning dir ./fixtures/locks-many/composer.lock
+			Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
+			No issues found
+			`,
+			wantStderr: ``,
+		},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/internal/local/check.go
+++ b/internal/local/check.go
@@ -108,7 +108,7 @@ func MakeRequest(r reporter.Reporter, query osv.BatchedQuery, offline bool, loca
 			return nil, err
 		}
 
-		r.PrintTextf("Loaded %s local db from %s\n", db.Name, db.StoredAt)
+		r.Infof("Loaded %s local db from %s\n", db.Name, db.StoredAt)
 
 		dbs[ecosystem] = db
 
@@ -120,7 +120,7 @@ func MakeRequest(r reporter.Reporter, query osv.BatchedQuery, offline bool, loca
 
 		if err != nil {
 			// currently, this will actually only error if the PURL cannot be parses
-			r.PrintErrorf("skipping %s as it is not a valid PURL: %v\n", query.Package.PURL, err)
+			r.Errorf("skipping %s as it is not a valid PURL: %v\n", query.Package.PURL, err)
 			results = append(results, osv.Response{Vulns: []models.Vulnerability{}})
 
 			continue
@@ -134,7 +134,7 @@ func MakeRequest(r reporter.Reporter, query osv.BatchedQuery, offline bool, loca
 
 			// Is a commit based query, skip local scanning
 			results = append(results, osv.Response{})
-			r.PrintTextf("Skipping commit scanning for: %s\n", pkg.Commit)
+			r.Infof("Skipping commit scanning for: %s\n", pkg.Commit)
 
 			continue
 		}
@@ -143,7 +143,7 @@ func MakeRequest(r reporter.Reporter, query osv.BatchedQuery, offline bool, loca
 
 		if err != nil {
 			// currently, this will actually only error if the PURL cannot be parses
-			r.PrintErrorf("could not load db for %s ecosystem: %v\n", pkg.Ecosystem, err)
+			r.Errorf("could not load db for %s ecosystem: %v\n", pkg.Ecosystem, err)
 			results = append(results, osv.Response{Vulns: []models.Vulnerability{}})
 
 			continue

--- a/internal/sourceanalysis/go.go
+++ b/internal/sourceanalysis/go.go
@@ -21,7 +21,7 @@ func goAnalysis(r reporter.Reporter, pkgs []models.PackageVulns, source models.S
 	cmd := exec.Command("go", "version")
 	_, err := cmd.Output()
 	if err != nil {
-		r.PrintTextf("Skipping call analysis on Go code since Go is not installed.\n")
+		r.Infof("Skipping call analysis on Go code since Go is not installed.\n")
 		return
 	}
 
@@ -29,7 +29,7 @@ func goAnalysis(r reporter.Reporter, pkgs []models.PackageVulns, source models.S
 	res, err := runGovulncheck(filepath.Dir(source.Path), vulns)
 	if err != nil {
 		// TODO: Better method to identify the type of error and give advice specific to the error
-		r.PrintErrorf(
+		r.Errorf(
 			"Failed to run code analysis (govulncheck) on '%s' because %s\n"+
 				"(the Go toolchain is required)\n", source.Path, err.Error(),
 		)

--- a/internal/sourceanalysis/rust.go
+++ b/internal/sourceanalysis/rust.go
@@ -34,7 +34,7 @@ const (
 func rustAnalysis(r reporter.Reporter, pkgs []models.PackageVulns, source models.SourceInfo) {
 	binaryPaths, err := rustBuildSource(r, source)
 	if err != nil {
-		r.PrintErrorf("failed to build cargo/rust project from source: %s\n", err)
+		r.Errorf("failed to build cargo/rust project from source: %s\n", err)
 		return
 	}
 
@@ -50,14 +50,14 @@ func rustAnalysis(r reporter.Reporter, pkgs []models.PackageVulns, source models
 			// Is a library, so need an extra step to extract the object binary file before passing to parseDWARFData
 			buf, err := extractRlibArchive(path)
 			if err != nil {
-				r.PrintErrorf("failed to analyse '%s': %s\n", path, err)
+				r.Errorf("failed to analyse '%s': %s\n", path, err)
 				continue
 			}
 			readAt = bytes.NewReader(buf.Bytes())
 		} else {
 			f, err := os.Open(path)
 			if err != nil {
-				r.PrintErrorf("failed to read binary '%s': %s\n", path, err)
+				r.Errorf("failed to read binary '%s': %s\n", path, err)
 				continue
 			}
 			// This is fine to defer til the end of the function as there's
@@ -68,7 +68,7 @@ func rustAnalysis(r reporter.Reporter, pkgs []models.PackageVulns, source models
 
 		calls, err := functionsFromDWARF(readAt)
 		if err != nil {
-			r.PrintErrorf("failed to analyse '%s': %s\n", path, err)
+			r.Errorf("failed to analyse '%s': %s\n", path, err)
 			continue
 		}
 
@@ -233,11 +233,11 @@ func rustBuildSource(r reporter.Reporter, source models.SourceInfo) ([]string, e
 	cmd.Stdout = &stdoutBuffer
 	cmd.Stderr = &stderrBuffer
 
-	r.PrintTextf("Begin building rust/cargo project\n")
+	r.Infof("Begin building rust/cargo project\n")
 
 	if err := cmd.Run(); err != nil {
-		r.PrintErrorf("cargo stdout:\n%s", stdoutBuffer.String())
-		r.PrintErrorf("cargo stderr:\n%s", stderrBuffer.String())
+		r.Errorf("cargo stdout:\n%s", stdoutBuffer.String())
+		r.Errorf("cargo stderr:\n%s", stderrBuffer.String())
 
 		return nil, fmt.Errorf("failed to run `%v`: %w", cmd.String(), err)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -83,7 +83,7 @@ func (c *ConfigManager) Get(r reporter.Reporter, targetPath string) Config {
 
 	config, configErr := tryLoadConfig(configPath)
 	if configErr == nil {
-		r.PrintTextf("Loaded filter from: %s\n", config.LoadPath)
+		r.Infof("Loaded filter from: %s\n", config.LoadPath)
 	} else {
 		// If config doesn't exist, use the default config
 		config = c.DefaultConfig

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -103,7 +103,7 @@ func scanDir(r reporter.Reporter, dir string, skipGit bool, recursive bool, useG
 		var err error
 		ignoreMatcher, err = parseGitIgnores(dir)
 		if err != nil {
-			r.PrintErrorf("Unable to parse git ignores: %v\n", err)
+			r.Errorf("Unable to parse git ignores: %v\n", err)
 			useGitIgnore = false
 		}
 	}
@@ -114,24 +114,24 @@ func scanDir(r reporter.Reporter, dir string, skipGit bool, recursive bool, useG
 
 	return scannedPackages, filepath.WalkDir(dir, func(path string, info os.DirEntry, err error) error {
 		if err != nil {
-			r.PrintTextf("Failed to walk %s: %v\n", path, err)
+			r.Infof("Failed to walk %s: %v\n", path, err)
 			return err
 		}
 
 		path, err = filepath.Abs(path)
 		if err != nil {
-			r.PrintErrorf("Failed to walk path %s\n", err)
+			r.Errorf("Failed to walk path %s\n", err)
 			return err
 		}
 
 		if useGitIgnore {
 			match, err := ignoreMatcher.match(path, info.IsDir())
 			if err != nil {
-				r.PrintTextf("Failed to resolve gitignore for %s: %v\n", path, err)
+				r.Infof("Failed to resolve gitignore for %s: %v\n", path, err)
 				// Don't skip if we can't parse now - potentially noisy for directories with lots of items
 			} else if match {
 				if root { // Don't silently skip if the argument file was ignored.
-					r.PrintErrorf("%s was not scanned because it is excluded by a .gitignore file. Use --no-ignore to scan it.\n", path)
+					r.Errorf("%s was not scanned because it is excluded by a .gitignore file. Use --no-ignore to scan it.\n", path)
 				}
 				if info.IsDir() {
 					return filepath.SkipDir
@@ -144,7 +144,7 @@ func scanDir(r reporter.Reporter, dir string, skipGit bool, recursive bool, useG
 		if !skipGit && info.IsDir() && info.Name() == ".git" {
 			pkgs, err := scanGit(r, filepath.Dir(path)+"/")
 			if err != nil {
-				r.PrintTextf("scan failed for git repository, %s: %v\n", path, err)
+				r.Infof("scan failed for git repository, %s: %v\n", path, err)
 				// Not fatal, so don't return and continue scanning other files
 			}
 			scannedPackages = append(scannedPackages, pkgs...)
@@ -156,7 +156,7 @@ func scanDir(r reporter.Reporter, dir string, skipGit bool, recursive bool, useG
 			if extractor, _ := lockfile.FindExtractor(path, ""); extractor != nil {
 				pkgs, err := scanLockfile(r, path, "")
 				if err != nil {
-					r.PrintErrorf("Attempted to scan lockfile but failed: %s\n", path)
+					r.Errorf("Attempted to scan lockfile but failed: %s\n", path)
 				}
 				scannedPackages = append(scannedPackages, pkgs...)
 			}
@@ -171,7 +171,7 @@ func scanDir(r reporter.Reporter, dir string, skipGit bool, recursive bool, useG
 			if _, ok := vendoredLibNames[strings.ToLower(filepath.Base(path))]; ok {
 				pkgs, err := scanDirWithVendoredLibs(r, path)
 				if err != nil {
-					r.PrintTextf("scan failed for dir containing vendored libs %s: %v\n", path, err)
+					r.Infof("scan failed for dir containing vendored libs %s: %v\n", path, err)
 				}
 				scannedPackages = append(scannedPackages, pkgs...)
 			}
@@ -281,7 +281,7 @@ func queryDetermineVersions(repoDir string) (*osv.DetermineVersionResponse, erro
 }
 
 func scanDirWithVendoredLibs(r reporter.Reporter, path string) ([]scannedPackage, error) {
-	r.PrintTextf("Scanning directory for vendored libs: %s\n", path)
+	r.Infof("Scanning directory for vendored libs: %s\n", path)
 	entries, err := os.ReadDir(path)
 	if err != nil {
 		return nil, err
@@ -295,17 +295,17 @@ func scanDirWithVendoredLibs(r reporter.Reporter, path string) ([]scannedPackage
 
 		libPath := filepath.Join(path, entry.Name())
 
-		r.PrintTextf("Scanning potential vendored dir: %s\n", libPath)
+		r.Infof("Scanning potential vendored dir: %s\n", libPath)
 		// TODO: make this a goroutine to parallelise this operation
 		results, err := queryDetermineVersions(libPath)
 		if err != nil {
-			r.PrintTextf("Error scanning sub-directory '%s' with error: %v", libPath, err)
+			r.Infof("Error scanning sub-directory '%s' with error: %v", libPath, err)
 			continue
 		}
 
 		if len(results.Matches) > 0 && results.Matches[0].Score > determineVersionThreshold {
 			match := results.Matches[0]
-			r.PrintTextf("Identified %s as %s at %s.\n", libPath, match.RepoInfo.Address, match.RepoInfo.Commit)
+			r.Infof("Identified %s as %s at %s.\n", libPath, match.RepoInfo.Address, match.RepoInfo.Commit)
 			packages = append(packages, createCommitQueryPackage(match.RepoInfo.Commit, libPath))
 		}
 	}
@@ -363,7 +363,7 @@ func scanLockfile(r reporter.Reporter, path string, parseAs string) ([]scannedPa
 		parsedAsComment = fmt.Sprintf("as a %s ", parseAs)
 	}
 
-	r.PrintTextf(
+	r.Infof(
 		"Scanned %s file %sand found %d %s\n",
 		path,
 		parsedAsComment,
@@ -443,7 +443,7 @@ func scanSBOMFile(r reporter.Reporter, path string, fromFSScan bool) ([]scannedP
 
 				continue
 			}
-			r.PrintTextf(
+			r.Infof(
 				"Scanned %s as %s SBOM and found %d %s\n",
 				path,
 				provider.Name(),
@@ -451,7 +451,7 @@ func scanSBOMFile(r reporter.Reporter, path string, fromFSScan bool) ([]scannedP
 				output.Form(len(packages), "package", "packages"),
 			)
 			if ignoredCount > 0 {
-				r.PrintTextf(
+				r.Infof(
 					"Ignored %d %s with invalid PURLs\n",
 					ignoredCount,
 					output.Form(ignoredCount, "package", "packages"),
@@ -472,9 +472,9 @@ func scanSBOMFile(r reporter.Reporter, path string, fromFSScan bool) ([]scannedP
 
 	// Don't log these errors if we're coming from an FS scan, since it can get very noisy.
 	if !fromFSScan {
-		r.PrintTextf("Failed to parse SBOM using all supported formats:\n")
+		r.Infof("Failed to parse SBOM using all supported formats:\n")
 		for _, err := range errs {
-			r.PrintTextf(err.Error() + "\n")
+			r.Infof(err.Error() + "\n")
 		}
 	}
 
@@ -524,7 +524,7 @@ func scanGit(r reporter.Reporter, repoDir string) ([]scannedPackage, error) {
 	if err != nil {
 		return nil, err
 	}
-	r.PrintTextf("Scanning %s at commit %s\n", repoDir, commit)
+	r.Infof("Scanning %s at commit %s\n", repoDir, commit)
 
 	//nolint:prealloc // Not sure how many there will be in advance.
 	var packages []scannedPackage
@@ -536,7 +536,7 @@ func scanGit(r reporter.Reporter, repoDir string) ([]scannedPackage, error) {
 	}
 
 	for _, s := range submodules {
-		r.PrintTextf("Scanning submodule %s at commit %s\n", s.Path, s.Expected.String())
+		r.Infof("Scanning submodule %s at commit %s\n", s.Path, s.Expected.String())
 		packages = append(packages, createCommitQueryPackage(s.Expected.String(), path.Join(repoDir, s.Path)))
 	}
 
@@ -558,12 +558,12 @@ func scanDebianDocker(r reporter.Reporter, dockerImageName string) ([]scannedPac
 	stdout, err := cmd.StdoutPipe()
 
 	if err != nil {
-		r.PrintErrorf("Failed to get stdout: %s\n", err)
+		r.Errorf("Failed to get stdout: %s\n", err)
 		return nil, err
 	}
 	err = cmd.Start()
 	if err != nil {
-		r.PrintErrorf("Failed to start docker image: %s\n", err)
+		r.Errorf("Failed to start docker image: %s\n", err)
 		return nil, err
 	}
 	// TODO: Do error checking here
@@ -579,7 +579,7 @@ func scanDebianDocker(r reporter.Reporter, dockerImageName string) ([]scannedPac
 		}
 		splitText := strings.Split(text, "###")
 		if len(splitText) != 2 {
-			r.PrintErrorf("Unexpected output from Debian container: \n\n%s\n", text)
+			r.Errorf("Unexpected output from Debian container: \n\n%s\n", text)
 			return nil, fmt.Errorf("unexpected output from Debian container: \n\n%s", text)
 		}
 		// TODO(rexpan): Get and specify exact debian release version
@@ -593,7 +593,7 @@ func scanDebianDocker(r reporter.Reporter, dockerImageName string) ([]scannedPac
 			},
 		})
 	}
-	r.PrintTextf(
+	r.Infof(
 		"Scanned docker image with %d %s\n",
 		len(packages),
 		output.Form(len(packages), "package", "packages"),
@@ -643,11 +643,11 @@ func filterPackageVulns(r reporter.Reporter, pkgVulns models.PackageVulns, confi
 				// NB: This only prints the first reason encountered in all the aliases.
 				switch len(group.Aliases) {
 				case 1:
-					r.PrintTextf("%s has been filtered out because: %s\n", ignoreLine.ID, ignoreLine.Reason)
+					r.Infof("%s has been filtered out because: %s\n", ignoreLine.ID, ignoreLine.Reason)
 				case 2:
-					r.PrintTextf("%s and 1 alias have been filtered out because: %s\n", ignoreLine.ID, ignoreLine.Reason)
+					r.Infof("%s and 1 alias have been filtered out because: %s\n", ignoreLine.ID, ignoreLine.Reason)
 				default:
-					r.PrintTextf("%s and %d aliases have been filtered out because: %s\n", ignoreLine.ID, len(group.Aliases)-1, ignoreLine.Reason)
+					r.Infof("%s and %d aliases have been filtered out because: %s\n", ignoreLine.ID, len(group.Aliases)-1, ignoreLine.Reason)
 				}
 
 				break
@@ -723,7 +723,7 @@ func DoScan(actions ScannerActions, r reporter.Reporter) (models.VulnerabilityRe
 	if actions.ConfigOverridePath != "" {
 		err := configManager.UseOverride(actions.ConfigOverridePath)
 		if err != nil {
-			r.PrintErrorf("Failed to read config file: %s\n", err)
+			r.Errorf("Failed to read config file: %s\n", err)
 			return models.VulnerabilityResults{}, err
 		}
 	}
@@ -739,7 +739,7 @@ func DoScan(actions ScannerActions, r reporter.Reporter) (models.VulnerabilityRe
 		parseAs, lockfilePath := parseLockfilePath(lockfileElem)
 		lockfilePath, err := filepath.Abs(lockfilePath)
 		if err != nil {
-			r.PrintErrorf("Failed to resolved path with error %s\n", err)
+			r.Errorf("Failed to resolved path with error %s\n", err)
 			return models.VulnerabilityResults{}, err
 		}
 		pkgs, err := scanLockfile(r, lockfilePath, parseAs)
@@ -766,7 +766,7 @@ func DoScan(actions ScannerActions, r reporter.Reporter) (models.VulnerabilityRe
 	}
 
 	for _, dir := range actions.DirectoryPaths {
-		r.PrintTextf("Scanning dir %s\n", dir)
+		r.Infof("Scanning dir %s\n", dir)
 		pkgs, err := scanDir(r, dir, actions.SkipGit, actions.Recursive, !actions.NoIgnore, actions.CompareOffline)
 		if err != nil {
 			return models.VulnerabilityResults{}, err
@@ -781,7 +781,7 @@ func DoScan(actions ScannerActions, r reporter.Reporter) (models.VulnerabilityRe
 	filteredScannedPackages := filterUnscannablePackages(scannedPackages)
 
 	if len(filteredScannedPackages) != len(scannedPackages) {
-		r.PrintTextf("Filtered %d local package/s from the scan.\n", len(scannedPackages)-len(filteredScannedPackages))
+		r.Infof("Filtered %d local package/s from the scan.\n", len(scannedPackages)-len(filteredScannedPackages))
 	}
 
 	vulnsResp, err := makeRequest(r, filteredScannedPackages, actions.CompareLocally, actions.CompareOffline, actions.LocalDBPath)
@@ -800,7 +800,7 @@ func DoScan(actions ScannerActions, r reporter.Reporter) (models.VulnerabilityRe
 
 	filtered := filterResults(r, &results, &configManager, actions.ShowAllPackages)
 	if filtered > 0 {
-		r.PrintTextf(
+		r.Infof(
 			"Filtered %d %s from output\n",
 			filtered,
 			output.Form(filtered, "vulnerability", "vulnerabilities"),

--- a/pkg/osvscanner/vulnerability_result.go
+++ b/pkg/osvscanner/vulnerability_result.go
@@ -37,7 +37,7 @@ func buildVulnerabilityResults(
 			var err error
 			pkg.Package, err = models.PURLToPackage(rawPkg.PURL)
 			if err != nil {
-				r.PrintErrorf("Failed to parse purl: %s, with error: %s", rawPkg.PURL, err)
+				r.Errorf("Failed to parse purl: %s, with error: %s", rawPkg.PURL, err)
 
 				continue
 			}

--- a/pkg/reporter/format.go
+++ b/pkg/reporter/format.go
@@ -13,18 +13,18 @@ func Format() []string {
 
 // New returns an implementation of the reporter interface depending on the format passed in
 // set terminalWidth as 0 to indicate the output is not a terminal
-func New(format string, stdout, stderr io.Writer, terminalWidth int) (Reporter, error) {
+func New(format string, stdout, stderr io.Writer, level VerbosityLevel, terminalWidth int) (Reporter, error) {
 	switch format {
 	case "json":
-		return NewJSONReporter(stdout, stderr), nil
+		return NewJSONReporter(stdout, stderr, level), nil
 	case "table":
-		return NewTableReporter(stdout, stderr, false, terminalWidth), nil
+		return NewTableReporter(stdout, stderr, level, false, terminalWidth), nil
 	case "markdown":
-		return NewTableReporter(stdout, stderr, true, terminalWidth), nil
+		return NewTableReporter(stdout, stderr, level, true, terminalWidth), nil
 	case "sarif":
-		return NewSarifReporter(stdout, stderr), nil
+		return NewSarifReporter(stdout, stderr, level), nil
 	case "gh-annotations":
-		return NewGHAnnotationsReporter(stdout, stderr), nil
+		return NewGHAnnotationsReporter(stdout, stderr, level), nil
 	default:
 		return nil, fmt.Errorf("%v is not a valid format", format)
 	}

--- a/pkg/reporter/format_test.go
+++ b/pkg/reporter/format_test.go
@@ -14,7 +14,7 @@ func TestNew(t *testing.T) {
 		stdout := &bytes.Buffer{}
 		stderr := &bytes.Buffer{}
 
-		_, err := reporter.New(format, stdout, stderr, 0)
+		_, err := reporter.New(format, stdout, stderr, reporter.InfoLevel, 0)
 		if err != nil {
 			t.Errorf("Reporter for '%s' format not implemented", format)
 		}
@@ -27,7 +27,7 @@ func TestNew_UnsupportedFormatter(t *testing.T) {
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 
-	_, err := reporter.New("unsupported", stdout, stderr, 0)
+	_, err := reporter.New("unsupported", stdout, stderr, reporter.InfoLevel, 0)
 
 	if err == nil {
 		t.Errorf("Did not get expected error")

--- a/pkg/reporter/gh-annotations_reporter.go
+++ b/pkg/reporter/gh-annotations_reporter.go
@@ -9,30 +9,46 @@ import (
 )
 
 type GHAnnotationsReporter struct {
-	hasPrintedError bool
-	stdout          io.Writer
-	stderr          io.Writer
+	hasErrored bool
+	stdout     io.Writer
+	stderr     io.Writer
+	level      VerbosityLevel
 }
 
-func NewGHAnnotationsReporter(stdout io.Writer, stderr io.Writer) *GHAnnotationsReporter {
+func NewGHAnnotationsReporter(stdout io.Writer, stderr io.Writer, level VerbosityLevel) *GHAnnotationsReporter {
 	return &GHAnnotationsReporter{
-		stdout:          stdout,
-		stderr:          stderr,
-		hasPrintedError: false,
+		stdout:     stdout,
+		stderr:     stderr,
+		level:      level,
+		hasErrored: false,
 	}
 }
 
-func (r *GHAnnotationsReporter) PrintErrorf(msg string, a ...any) {
-	fmt.Fprintf(r.stderr, msg, a...)
-	r.hasPrintedError = true
+func (r *GHAnnotationsReporter) Errorf(format string, a ...any) {
+	fmt.Fprintf(r.stderr, format, a...)
+	r.hasErrored = true
 }
 
-func (r *GHAnnotationsReporter) HasPrintedError() bool {
-	return r.hasPrintedError
+func (r *GHAnnotationsReporter) HasErrored() bool {
+	return r.hasErrored
 }
 
-func (r *GHAnnotationsReporter) PrintTextf(msg string, a ...any) {
-	fmt.Fprintf(r.stderr, msg, a...)
+func (r *GHAnnotationsReporter) Warnf(format string, a ...any) {
+	if WarnLevel <= r.level {
+		fmt.Fprintf(r.stderr, format, a...)
+	}
+}
+
+func (r *GHAnnotationsReporter) Infof(format string, a ...any) {
+	if InfoLevel <= r.level {
+		fmt.Fprintf(r.stderr, format, a...)
+	}
+}
+
+func (r *GHAnnotationsReporter) Verbosef(format string, a ...any) {
+	if VerboseLevel <= r.level {
+		fmt.Fprintf(r.stderr, format, a...)
+	}
 }
 
 func (r *GHAnnotationsReporter) PrintResult(vulnResult *models.VulnerabilityResults) error {

--- a/pkg/reporter/gh-annotations_reporter_test.go
+++ b/pkg/reporter/gh-annotations_reporter_test.go
@@ -1,0 +1,96 @@
+package reporter
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+func TestGHAnnotationsReporter_Errorf(t *testing.T) {
+	t.Parallel()
+
+	writer := &bytes.Buffer{}
+	r := NewGHAnnotationsReporter(io.Discard, writer, ErrorLevel)
+	text := "hello world!"
+
+	r.Errorf(text)
+
+	if writer.String() != text {
+		t.Error("Error level message should have been printed")
+	}
+	if !r.HasErrored() {
+		t.Error("HasErrored() should have returned true")
+	}
+}
+
+func TestGHAnnotationsReporter_Warnf(t *testing.T) {
+	t.Parallel()
+
+	text := "hello world!"
+	tests := []struct {
+		lvl              VerbosityLevel
+		expectedPrintout string
+	}{
+		{lvl: WarnLevel, expectedPrintout: text},
+		{lvl: ErrorLevel, expectedPrintout: ""},
+	}
+
+	for _, test := range tests {
+		writer := &bytes.Buffer{}
+		r := NewGHAnnotationsReporter(io.Discard, writer, test.lvl)
+
+		r.Warnf(text)
+
+		if writer.String() != test.expectedPrintout {
+			t.Errorf("expected \"%s\", got \"%s\"", test.expectedPrintout, writer.String())
+		}
+	}
+}
+
+func TestGHAnnotationsReporter_Infof(t *testing.T) {
+	t.Parallel()
+
+	text := "hello world!"
+	tests := []struct {
+		lvl              VerbosityLevel
+		expectedPrintout string
+	}{
+		{lvl: InfoLevel, expectedPrintout: text},
+		{lvl: WarnLevel, expectedPrintout: ""},
+	}
+
+	for _, test := range tests {
+		writer := &bytes.Buffer{}
+		r := NewGHAnnotationsReporter(io.Discard, writer, test.lvl)
+
+		r.Infof(text)
+
+		if writer.String() != test.expectedPrintout {
+			t.Errorf("expected \"%s\", got \"%s\"", test.expectedPrintout, writer.String())
+		}
+	}
+}
+
+func TestGHAnnotationsReporter_Verbosef(t *testing.T) {
+	t.Parallel()
+
+	text := "hello world!"
+	tests := []struct {
+		lvl              VerbosityLevel
+		expectedPrintout string
+	}{
+		{lvl: VerboseLevel, expectedPrintout: text},
+		{lvl: InfoLevel, expectedPrintout: ""},
+	}
+
+	for _, test := range tests {
+		writer := &bytes.Buffer{}
+		r := NewGHAnnotationsReporter(io.Discard, writer, test.lvl)
+
+		r.Verbosef(text)
+
+		if writer.String() != test.expectedPrintout {
+			t.Errorf("expected \"%s\", got \"%s\"", test.expectedPrintout, writer.String())
+		}
+	}
+}

--- a/pkg/reporter/json_reporter.go
+++ b/pkg/reporter/json_reporter.go
@@ -8,32 +8,49 @@ import (
 	"github.com/google/osv-scanner/pkg/models"
 )
 
+// JSONReporter prints vulnerability results in JSON format to stdout. Runtime information
+// will be written to stderr.
 type JSONReporter struct {
-	hasPrintedError bool
-	stdout          io.Writer
-	stderr          io.Writer
+	hasErrored bool
+	stdout     io.Writer
+	stderr     io.Writer
+	level      VerbosityLevel
 }
 
-func NewJSONReporter(stdout io.Writer, stderr io.Writer) *JSONReporter {
+func NewJSONReporter(stdout io.Writer, stderr io.Writer, level VerbosityLevel) *JSONReporter {
 	return &JSONReporter{
-		stdout:          stdout,
-		stderr:          stderr,
-		hasPrintedError: false,
+		stdout:     stdout,
+		stderr:     stderr,
+		level:      level,
+		hasErrored: false,
 	}
 }
 
-func (r *JSONReporter) PrintErrorf(msg string, a ...any) {
-	fmt.Fprintf(r.stderr, msg, a...)
-	r.hasPrintedError = true
+func (r *JSONReporter) Errorf(format string, a ...any) {
+	fmt.Fprintf(r.stderr, format, a...)
+	r.hasErrored = true
 }
 
-func (r *JSONReporter) HasPrintedError() bool {
-	return r.hasPrintedError
+func (r *JSONReporter) HasErrored() bool {
+	return r.hasErrored
 }
 
-func (r *JSONReporter) PrintTextf(msg string, a ...any) {
-	// Print non json text to stderr
-	fmt.Fprintf(r.stderr, msg, a...)
+func (r *JSONReporter) Warnf(format string, a ...any) {
+	if WarnLevel <= r.level {
+		fmt.Fprintf(r.stderr, format, a...)
+	}
+}
+
+func (r *JSONReporter) Infof(format string, a ...any) {
+	if InfoLevel <= r.level {
+		fmt.Fprintf(r.stderr, format, a...)
+	}
+}
+
+func (r *JSONReporter) Verbosef(format string, a ...any) {
+	if VerboseLevel <= r.level {
+		fmt.Fprintf(r.stderr, format, a...)
+	}
 }
 
 func (r *JSONReporter) PrintResult(vulnResult *models.VulnerabilityResults) error {

--- a/pkg/reporter/json_reporter_test.go
+++ b/pkg/reporter/json_reporter_test.go
@@ -1,0 +1,96 @@
+package reporter
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+func TestJSONReporter_Errorf(t *testing.T) {
+	t.Parallel()
+
+	writer := &bytes.Buffer{}
+	r := NewJSONReporter(io.Discard, writer, ErrorLevel)
+	text := "hello world!"
+
+	r.Errorf(text)
+
+	if writer.String() != text {
+		t.Error("Error level message should have been printed")
+	}
+	if !r.HasErrored() {
+		t.Error("HasErrored() should have returned true")
+	}
+}
+
+func TestJSONReporter_Warnf(t *testing.T) {
+	t.Parallel()
+
+	text := "hello world!"
+	tests := []struct {
+		lvl              VerbosityLevel
+		expectedPrintout string
+	}{
+		{lvl: WarnLevel, expectedPrintout: text},
+		{lvl: ErrorLevel, expectedPrintout: ""},
+	}
+
+	for _, test := range tests {
+		writer := &bytes.Buffer{}
+		r := NewJSONReporter(io.Discard, writer, test.lvl)
+
+		r.Warnf(text)
+
+		if writer.String() != test.expectedPrintout {
+			t.Errorf("expected \"%s\", got \"%s\"", test.expectedPrintout, writer.String())
+		}
+	}
+}
+
+func TestJSONReporter_Infof(t *testing.T) {
+	t.Parallel()
+
+	text := "hello world!"
+	tests := []struct {
+		lvl              VerbosityLevel
+		expectedPrintout string
+	}{
+		{lvl: InfoLevel, expectedPrintout: text},
+		{lvl: WarnLevel, expectedPrintout: ""},
+	}
+
+	for _, test := range tests {
+		writer := &bytes.Buffer{}
+		r := NewJSONReporter(io.Discard, writer, test.lvl)
+
+		r.Infof(text)
+
+		if writer.String() != test.expectedPrintout {
+			t.Errorf("expected \"%s\", got \"%s\"", test.expectedPrintout, writer.String())
+		}
+	}
+}
+
+func TestJSONReporter_Verbosef(t *testing.T) {
+	t.Parallel()
+
+	text := "hello world!"
+	tests := []struct {
+		lvl              VerbosityLevel
+		expectedPrintout string
+	}{
+		{lvl: VerboseLevel, expectedPrintout: text},
+		{lvl: InfoLevel, expectedPrintout: ""},
+	}
+
+	for _, test := range tests {
+		writer := &bytes.Buffer{}
+		r := NewJSONReporter(io.Discard, writer, test.lvl)
+
+		r.Verbosef(text)
+
+		if writer.String() != test.expectedPrintout {
+			t.Errorf("expected \"%s\", got \"%s\"", test.expectedPrintout, writer.String())
+		}
+	}
+}

--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -4,26 +4,31 @@ import (
 	"github.com/google/osv-scanner/pkg/models"
 )
 
+// Reporter provides printing operations for vulnerability results and for runtime information (depending on the verbosity
+// level given to the Reporter implementation).
+//
+// When printing non-error-related runtime information, it is entirely up to the Reporter implementation as to where
+// the text is actually printed (if at all); in most cases for "human format" reporters this will be stdout whereas
+// for "machine format" reporters this will be stderr.
 type Reporter interface {
-	// PrintErrorf prints errors in an appropriate manner to ensure that results
+	// Errorf prints errors in an appropriate manner to ensure that results
 	// are printed in a way that is semantically valid for the intended consumer,
 	// and tracking that an error has been printed.
 	//
 	// Where the error is actually printed (if at all) is entirely up to the actual
 	// reporter, though generally it will be to stderr.
-	PrintErrorf(msg string, a ...any)
-	// HasPrintedError returns true if there have been any calls to PrintErrorf.
+	Errorf(format string, a ...any)
+	// HasErrored returns true if there have been any calls to Errorf.
 	//
 	// This does not actually represent if the error was actually printed anywhere
 	// since what happens to the error message is up to the actual reporter.
-	HasPrintedError() bool
-	// PrintTextf prints text in an appropriate manner to ensure that results
-	// are printed in a way that is semantically valid for the intended consumer.
-	//
-	// Where the text is actually printed (if at all) is entirely up to the actual
-	// reporter; in most cases for "human format" reporters this will be stdout
-	// whereas for "machine format" reporters this will stderr.
-	PrintTextf(msg string, a ...any)
+	HasErrored() bool
+	// Warnf prints text indicating potential issues or something that should be brought to the attention of users.
+	Warnf(format string, a ...any)
+	// Infof prints text providing general information about what OSV-Scanner is doing during its runtime.
+	Infof(format string, a ...any)
+	// Verbosef prints text providing additional information about the inner workings of OSV-Scanner to the user.
+	Verbosef(format string, a ...any)
 	// PrintResult prints the models.VulnerabilityResults per the logic of the
 	// actual reporter
 	PrintResult(vulnResult *models.VulnerabilityResults) error

--- a/pkg/reporter/sarif_reporter.go
+++ b/pkg/reporter/sarif_reporter.go
@@ -9,30 +9,46 @@ import (
 )
 
 type SARIFReporter struct {
-	hasPrintedError bool
-	stdout          io.Writer
-	stderr          io.Writer
+	hasErrored bool
+	stdout     io.Writer
+	stderr     io.Writer
+	level      VerbosityLevel
 }
 
-func NewSarifReporter(stdout io.Writer, stderr io.Writer) *SARIFReporter {
+func NewSarifReporter(stdout io.Writer, stderr io.Writer, level VerbosityLevel) *SARIFReporter {
 	return &SARIFReporter{
-		stdout:          stdout,
-		stderr:          stderr,
-		hasPrintedError: false,
+		stdout:     stdout,
+		stderr:     stderr,
+		level:      level,
+		hasErrored: false,
 	}
 }
 
-func (r *SARIFReporter) PrintErrorf(msg string, a ...any) {
-	fmt.Fprintf(r.stderr, msg, a...)
-	r.hasPrintedError = true
+func (r *SARIFReporter) Errorf(format string, a ...any) {
+	fmt.Fprintf(r.stderr, format, a...)
+	r.hasErrored = true
 }
 
-func (r *SARIFReporter) HasPrintedError() bool {
-	return r.hasPrintedError
+func (r *SARIFReporter) HasErrored() bool {
+	return r.hasErrored
 }
 
-func (r *SARIFReporter) PrintTextf(msg string, a ...any) {
-	fmt.Fprintf(r.stderr, msg, a...)
+func (r *SARIFReporter) Warnf(format string, a ...any) {
+	if WarnLevel <= r.level {
+		fmt.Fprintf(r.stderr, format, a...)
+	}
+}
+
+func (r *SARIFReporter) Infof(format string, a ...any) {
+	if InfoLevel <= r.level {
+		fmt.Fprintf(r.stderr, format, a...)
+	}
+}
+
+func (r *SARIFReporter) Verbosef(format string, a ...any) {
+	if VerboseLevel <= r.level {
+		fmt.Fprintf(r.stderr, format, a...)
+	}
 }
 
 func (r *SARIFReporter) PrintResult(vulnResult *models.VulnerabilityResults) error {

--- a/pkg/reporter/sarif_reporter_test.go
+++ b/pkg/reporter/sarif_reporter_test.go
@@ -1,0 +1,96 @@
+package reporter
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+func TestSarifReporter_Errorf(t *testing.T) {
+	t.Parallel()
+
+	writer := &bytes.Buffer{}
+	r := NewSarifReporter(io.Discard, writer, ErrorLevel)
+	text := "hello world!"
+
+	r.Errorf(text)
+
+	if writer.String() != text {
+		t.Error("Error level message should have been printed")
+	}
+	if !r.HasErrored() {
+		t.Error("HasErrored() should have returned true")
+	}
+}
+
+func TestSarifReporter_Warnf(t *testing.T) {
+	t.Parallel()
+
+	text := "hello world!"
+	tests := []struct {
+		lvl              VerbosityLevel
+		expectedPrintout string
+	}{
+		{lvl: WarnLevel, expectedPrintout: text},
+		{lvl: ErrorLevel, expectedPrintout: ""},
+	}
+
+	for _, test := range tests {
+		writer := &bytes.Buffer{}
+		r := NewSarifReporter(io.Discard, writer, test.lvl)
+
+		r.Warnf(text)
+
+		if writer.String() != test.expectedPrintout {
+			t.Errorf("expected \"%s\", got \"%s\"", test.expectedPrintout, writer.String())
+		}
+	}
+}
+
+func TestSarifReporter_Infof(t *testing.T) {
+	t.Parallel()
+
+	text := "hello world!"
+	tests := []struct {
+		lvl              VerbosityLevel
+		expectedPrintout string
+	}{
+		{lvl: InfoLevel, expectedPrintout: text},
+		{lvl: WarnLevel, expectedPrintout: ""},
+	}
+
+	for _, test := range tests {
+		writer := &bytes.Buffer{}
+		r := NewSarifReporter(io.Discard, writer, test.lvl)
+
+		r.Infof(text)
+
+		if writer.String() != test.expectedPrintout {
+			t.Errorf("expected \"%s\", got \"%s\"", test.expectedPrintout, writer.String())
+		}
+	}
+}
+
+func TestSarifReporter_Verbosef(t *testing.T) {
+	t.Parallel()
+
+	text := "hello world!"
+	tests := []struct {
+		lvl              VerbosityLevel
+		expectedPrintout string
+	}{
+		{lvl: VerboseLevel, expectedPrintout: text},
+		{lvl: InfoLevel, expectedPrintout: ""},
+	}
+
+	for _, test := range tests {
+		writer := &bytes.Buffer{}
+		r := NewSarifReporter(io.Discard, writer, test.lvl)
+
+		r.Verbosef(text)
+
+		if writer.String() != test.expectedPrintout {
+			t.Errorf("expected \"%s\", got \"%s\"", test.expectedPrintout, writer.String())
+		}
+	}
+}

--- a/pkg/reporter/table_reporter.go
+++ b/pkg/reporter/table_reporter.go
@@ -9,39 +9,55 @@ import (
 )
 
 type TableReporter struct {
-	hasPrintedError bool
-	stdout          io.Writer
-	stderr          io.Writer
-	markdown        bool
+	hasErrored bool
+	stdout     io.Writer
+	stderr     io.Writer
+	level      VerbosityLevel
+	markdown   bool
 	// 0 indicates not a terminal output
 	terminalWidth int
 }
 
-func NewTableReporter(stdout io.Writer, stderr io.Writer, markdown bool, terminalWidth int) *TableReporter {
+func NewTableReporter(stdout io.Writer, stderr io.Writer, level VerbosityLevel, markdown bool, terminalWidth int) *TableReporter {
 	return &TableReporter{
-		stdout:          stdout,
-		stderr:          stderr,
-		hasPrintedError: false,
-		markdown:        markdown,
-		terminalWidth:   terminalWidth,
+		stdout:        stdout,
+		stderr:        stderr,
+		hasErrored:    false,
+		level:         level,
+		markdown:      markdown,
+		terminalWidth: terminalWidth,
 	}
 }
 
-func (r *TableReporter) PrintErrorf(msg string, a ...any) {
-	fmt.Fprintf(r.stderr, msg, a...)
-	r.hasPrintedError = true
+func (r *TableReporter) Errorf(format string, a ...any) {
+	fmt.Fprintf(r.stderr, format, a...)
+	r.hasErrored = true
 }
 
-func (r *TableReporter) HasPrintedError() bool {
-	return r.hasPrintedError
+func (r *TableReporter) HasErrored() bool {
+	return r.hasErrored
 }
 
-func (r *TableReporter) PrintTextf(msg string, a ...any) {
-	fmt.Fprintf(r.stdout, msg, a...)
+func (r *TableReporter) Warnf(format string, a ...any) {
+	if WarnLevel <= r.level {
+		fmt.Fprintf(r.stdout, format, a...)
+	}
+}
+
+func (r *TableReporter) Infof(format string, a ...any) {
+	if InfoLevel <= r.level {
+		fmt.Fprintf(r.stdout, format, a...)
+	}
+}
+
+func (r *TableReporter) Verbosef(format string, a ...any) {
+	if VerboseLevel <= r.level {
+		fmt.Fprintf(r.stdout, format, a...)
+	}
 }
 
 func (r *TableReporter) PrintResult(vulnResult *models.VulnerabilityResults) error {
-	if len(vulnResult.Results) == 0 && !r.hasPrintedError {
+	if len(vulnResult.Results) == 0 && !r.hasErrored {
 		fmt.Fprintf(r.stdout, "No issues found\n")
 		return nil
 	}

--- a/pkg/reporter/table_reporter_test.go
+++ b/pkg/reporter/table_reporter_test.go
@@ -1,0 +1,96 @@
+package reporter
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+func TestTableReporter_Errorf(t *testing.T) {
+	t.Parallel()
+
+	writer := &bytes.Buffer{}
+	r := NewTableReporter(io.Discard, writer, ErrorLevel, false, 0)
+	text := "hello world!"
+
+	r.Errorf(text)
+
+	if writer.String() != text {
+		t.Error("Error level message should have been printed")
+	}
+	if !r.HasErrored() {
+		t.Error("HasErrored() should have returned true")
+	}
+}
+
+func TestTableReporter_Warnf(t *testing.T) {
+	t.Parallel()
+
+	text := "hello world!"
+	tests := []struct {
+		lvl              VerbosityLevel
+		expectedPrintout string
+	}{
+		{lvl: WarnLevel, expectedPrintout: text},
+		{lvl: ErrorLevel, expectedPrintout: ""},
+	}
+
+	for _, test := range tests {
+		writer := &bytes.Buffer{}
+		r := NewTableReporter(writer, io.Discard, test.lvl, false, 0)
+
+		r.Warnf(text)
+
+		if writer.String() != test.expectedPrintout {
+			t.Errorf("expected \"%s\", got \"%s\"", test.expectedPrintout, writer.String())
+		}
+	}
+}
+
+func TestTableReporter_Infof(t *testing.T) {
+	t.Parallel()
+
+	text := "hello world!"
+	tests := []struct {
+		lvl              VerbosityLevel
+		expectedPrintout string
+	}{
+		{lvl: InfoLevel, expectedPrintout: text},
+		{lvl: WarnLevel, expectedPrintout: ""},
+	}
+
+	for _, test := range tests {
+		writer := &bytes.Buffer{}
+		r := NewTableReporter(writer, io.Discard, test.lvl, false, 0)
+
+		r.Infof(text)
+
+		if writer.String() != test.expectedPrintout {
+			t.Errorf("expected \"%s\", got \"%s\"", test.expectedPrintout, writer.String())
+		}
+	}
+}
+
+func TestTableReporter_Verbosef(t *testing.T) {
+	t.Parallel()
+
+	text := "hello world!"
+	tests := []struct {
+		lvl              VerbosityLevel
+		expectedPrintout string
+	}{
+		{lvl: VerboseLevel, expectedPrintout: text},
+		{lvl: InfoLevel, expectedPrintout: ""},
+	}
+
+	for _, test := range tests {
+		writer := &bytes.Buffer{}
+		r := NewTableReporter(writer, io.Discard, test.lvl, false, 0)
+
+		r.Verbosef(text)
+
+		if writer.String() != test.expectedPrintout {
+			t.Errorf("expected \"%s\", got \"%s\"", test.expectedPrintout, writer.String())
+		}
+	}
+}

--- a/pkg/reporter/verbosity.go
+++ b/pkg/reporter/verbosity.go
@@ -1,0 +1,15 @@
+package reporter
+
+// VerbosityLevel is used to determine what amount of information should be given in OSV-Scanner's runtime.
+type VerbosityLevel uint8
+
+const (
+	// ErrorLevel is for unexpected problems that require attention.
+	ErrorLevel = iota
+	// WarnLevel is for indicating potential issues or something that should be brought to the attention of users.
+	WarnLevel
+	// InfoLevel is for general information about what OSV-Scanner is doing during its runtime.
+	InfoLevel
+	// VerboseLevel is for providing even more information compared to InfoLevel about the inner workings of OSV-Scanner.
+	VerboseLevel
+)

--- a/pkg/reporter/verbosity.go
+++ b/pkg/reporter/verbosity.go
@@ -1,5 +1,10 @@
 package reporter
 
+import (
+	"fmt"
+	"strings"
+)
+
 // VerbosityLevel is used to determine what amount of information should be given in OSV-Scanner's runtime.
 type VerbosityLevel uint8
 
@@ -13,3 +18,31 @@ const (
 	// VerboseLevel is for providing even more information compared to InfoLevel about the inner workings of OSV-Scanner.
 	VerboseLevel
 )
+
+var verbosityLevels = []string{
+	"error",
+	"warn",
+	"info",
+	"verbose",
+}
+
+func VerbosityLevels() []string {
+	return verbosityLevels
+}
+
+func ParseVerbosityLevel(text string) (VerbosityLevel, error) {
+	switch text {
+	case "error":
+		return ErrorLevel, nil
+	case "warn":
+		return WarnLevel, nil
+	case "info":
+		return InfoLevel, nil
+	case "verbose":
+		return VerboseLevel, nil
+	default:
+		var l VerbosityLevel
+
+		return l, fmt.Errorf("invalid verbosity level \"%s\" - must be one of: %s", text, strings.Join(VerbosityLevels(), ", "))
+	}
+}

--- a/pkg/reporter/verbosity_test.go
+++ b/pkg/reporter/verbosity_test.go
@@ -1,0 +1,40 @@
+package reporter_test
+
+import (
+	"testing"
+
+	"github.com/google/osv-scanner/pkg/reporter"
+)
+
+func TestParseVerbosityLevel_GivenValidLevels(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input       string
+		expectedLvl reporter.VerbosityLevel
+	}{
+		{input: "error", expectedLvl: reporter.ErrorLevel},
+		{input: "warn", expectedLvl: reporter.WarnLevel},
+		{input: "info", expectedLvl: reporter.InfoLevel},
+		{input: "verbose", expectedLvl: reporter.VerboseLevel},
+	}
+
+	for _, tt := range tests {
+		lvl, err := reporter.ParseVerbosityLevel(tt.input)
+		if err != nil {
+			t.Error(err)
+		}
+		if lvl != tt.expectedLvl {
+			t.Errorf("level should be supported: %s", tt.input)
+		}
+	}
+}
+
+func TestParseVerbosityLevel_GivenInvalidLevels(t *testing.T) {
+	t.Parallel()
+
+	_, err := reporter.ParseVerbosityLevel("invalidlvl")
+	if err == nil {
+		t.Error("expected invalid level to be an error")
+	}
+}

--- a/pkg/reporter/void_reporter.go
+++ b/pkg/reporter/void_reporter.go
@@ -5,18 +5,24 @@ import (
 )
 
 type VoidReporter struct {
-	hasPrintedError bool
+	hasErrored bool
 }
 
-func (r *VoidReporter) PrintErrorf(msg string, a ...any) {
-	r.hasPrintedError = true
+func (r *VoidReporter) Errorf(msg string, a ...any) {
+	r.hasErrored = true
 }
 
-func (r *VoidReporter) HasPrintedError() bool {
-	return r.hasPrintedError
+func (r *VoidReporter) HasErrored() bool {
+	return r.hasErrored
 }
 
-func (r *VoidReporter) PrintTextf(msg string, a ...any) {
+func (r *VoidReporter) Warnf(msg string, a ...any) {
+}
+
+func (r *VoidReporter) Infof(msg string, a ...any) {
+}
+
+func (r *VoidReporter) Verbosef(msg string, a ...any) {
 }
 
 func (r *VoidReporter) PrintResult(vulnResult *models.VulnerabilityResults) error {


### PR DESCRIPTION
Inspired by what was discussed in #698, this PR makes the necessary (breaking) changes to the `reporter` package such that the `Reporter` interface now provides methods for printing at certain levels (i.e. ErrorLevel, WarnLevel, InfoLevel, and VerboseLevel). It also adds a --verbosity option so that users/automated tools can take advantage of this too.