### PR TITLE
Add option to not fail on vulnerability being found for github action

### DIFF
--- a/cmd/osv-reporter/main.go
+++ b/cmd/osv-reporter/main.go
@@ -165,11 +165,8 @@ func run(args []string, stdout, stderr io.Writer) int {
 				}
 			}
 
-			failOnVuln := true // Default true
-			if context.IsSet("fail-on-vuln") && !context.Bool("fail-on-vuln") {
-				// If flag is set to false, only then set to false
-				failOnVuln = false
-			}
+			// Default to true, only false when explicitly set to false
+			failOnVuln := !context.IsSet("fail-on-vuln") || context.Bool("fail-on-vuln")
 
 			// if vulnerability exists it should return error
 			if len(diffVulns.Results) > 0 && failOnVuln {

--- a/cmd/osv-reporter/main.go
+++ b/cmd/osv-reporter/main.go
@@ -76,6 +76,11 @@ func run(args []string, stdout, stderr io.Writer) int {
 				Name:  "gh-annotations",
 				Usage: "prints github action annotations",
 			},
+			&cli.BoolFlag{
+				Name:        "fail-on-vuln",
+				Usage:       "whether to return 1 when vulnerabilities are found",
+				DefaultText: "true",
+			},
 		},
 		Action: func(context *cli.Context) error {
 			var termWidth int
@@ -160,9 +165,14 @@ func run(args []string, stdout, stderr io.Writer) int {
 				}
 			}
 
+			failOnVuln := true // Default true
+			if context.IsSet("fail-on-vuln") && !context.Bool("fail-on-vuln") {
+				// If flag is set to false, only then set to false
+				failOnVuln = false
+			}
+
 			// if vulnerability exists it should return error
-			if len(diffVulns.Results) > 0 {
-				// Otherwise return OnlyUncalledVulnerabilitiesFoundErr
+			if len(diffVulns.Results) > 0 && failOnVuln {
 				return osvscanner.VulnerabilitiesFoundErr
 			}
 


### PR DESCRIPTION
Add an option for the github action reporter to not return a failing code when vulnerabilities are found. This can be used to switch the osv-scanner action into a more "informative" mode rather than forcing strictly 0 vulnerabilities. 

The success/failure of a workflow can now indicate whether the workflow itself completely successfully and uploaded scan results, rather than showing the contents of the results. 

A followup PR will be created adding the option to the workflows once this is merged.