### PR TITLE
Show ecosystem and version even if git is shown if the info exists.

### DIFF
--- a/cmd/osv-scanner/fixtures/locks-insecure/composer.lock
+++ b/cmd/osv-scanner/fixtures/locks-insecure/composer.lock
@@ -1,1 +1,104 @@
-{}
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "6c6062d7d583c861be005a004755b5cf",
+    "packages": [
+        {
+            "name": "league/flysystem",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/flysystem.git",
+                "reference": "941a320939cf9421bb6573fad417c841f8b862f3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/941a320939cf9421bb6573fad417c841f8b862f3",
+                "reference": "941a320939cf9421bb6573fad417c841f8b862f3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "ext-fileinfo": "*",
+                "mockery/mockery": "~0.9",
+                "phpspec/phpspec": "^2.2",
+                "phpspec/prophecy-phpunit": "~1.0",
+                "phpunit/phpunit": "~4.1"
+            },
+            "suggest": {
+                "ext-fileinfo": "Required for MimeType",
+                "league/flysystem-aws-s3-v2": "Allows you to use S3 storage with AWS SDK v2",
+                "league/flysystem-aws-s3-v3": "Allows you to use S3 storage with AWS SDK v3",
+                "league/flysystem-azure": "Allows you to use Windows Azure Blob storage",
+                "league/flysystem-cached-adapter": "Flysystem adapter decorator for metadata caching",
+                "league/flysystem-copy": "Allows you to use Copy.com storage",
+                "league/flysystem-dropbox": "Allows you to use Dropbox storage",
+                "league/flysystem-eventable-filesystem": "Allows you to use EventableFilesystem",
+                "league/flysystem-rackspace": "Allows you to use Rackspace Cloud Files",
+                "league/flysystem-sftp": "Allows you to use SFTP server storage via phpseclib",
+                "league/flysystem-webdav": "Allows you to use WebDAV storage",
+                "league/flysystem-ziparchive": "Allows you to use ZipArchive adapter"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Flysystem\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frenky.net"
+                }
+            ],
+            "description": "Filesystem abstraction: Many filesystems, one API.",
+            "keywords": [
+                "Cloud Files",
+                "WebDAV",
+                "abstraction",
+                "aws",
+                "cloud",
+                "copy.com",
+                "dropbox",
+                "file systems",
+                "files",
+                "filesystem",
+                "filesystems",
+                "ftp",
+                "rackspace",
+                "remote",
+                "s3",
+                "sftp",
+                "storage"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/flysystem/issues",
+                "source": "https://github.com/thephpleague/flysystem/tree/master"
+            },
+            "time": "2015-07-12T21:01:33+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "2.6.0"
+}

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -642,12 +642,13 @@ func TestRun_LockfileWithExplicitParseAs(t *testing.T) {
 			wantStdout: `
 				Scanned <rootdir>/fixtures/locks-insecure/my-package-lock.json file as a package-lock.json and found 1 package
 				Scanning dir ./fixtures/locks-insecure
-				Scanned <rootdir>/fixtures/locks-insecure/composer.lock file and found 0 packages
-				+-------------------------------------+------+-----------+-----------+---------+----------------------------------------------+
-				| OSV URL                             | CVSS | ECOSYSTEM | PACKAGE   | VERSION | SOURCE                                       |
-				+-------------------------------------+------+-----------+-----------+---------+----------------------------------------------+
-				| https://osv.dev/GHSA-whgm-jr23-g3j9 | 7.5  | npm       | ansi-html | 0.0.1   | fixtures/locks-insecure/my-package-lock.json |
-				+-------------------------------------+------+-----------+-----------+---------+----------------------------------------------+
+				Scanned <rootdir>/fixtures/locks-insecure/composer.lock file and found 1 package
+				+-------------------------------------+------+-----------+------------------+---------+----------------------------------------------+
+				| OSV URL                             | CVSS | ECOSYSTEM | PACKAGE          | VERSION | SOURCE                                       |
+				+-------------------------------------+------+-----------+------------------+---------+----------------------------------------------+
+				| https://osv.dev/GHSA-9f46-5r25-5wfm | 9.8  | Packagist | league/flysystem | 1.0.8   | fixtures/locks-insecure/composer.lock        |
+				| https://osv.dev/GHSA-whgm-jr23-g3j9 | 7.5  | npm       | ansi-html        | 0.0.1   | fixtures/locks-insecure/my-package-lock.json |
+				+-------------------------------------+------+-----------+------------------+---------+----------------------------------------------+
 			`,
 			wantStderr: "",
 		},
@@ -665,13 +666,14 @@ func TestRun_LockfileWithExplicitParseAs(t *testing.T) {
 				Scanned <rootdir>/fixtures/locks-insecure/my-package-lock.json file as a package-lock.json and found 1 package
 				Scanned <rootdir>/fixtures/locks-insecure/my-yarn.lock file as a yarn.lock and found 1 package
 				Scanning dir ./fixtures/locks-insecure
-				Scanned <rootdir>/fixtures/locks-insecure/composer.lock file and found 0 packages
-				+-------------------------------------+------+-----------+-----------+---------+----------------------------------------------+
-				| OSV URL                             | CVSS | ECOSYSTEM | PACKAGE   | VERSION | SOURCE                                       |
-				+-------------------------------------+------+-----------+-----------+---------+----------------------------------------------+
-				| https://osv.dev/GHSA-whgm-jr23-g3j9 | 7.5  | npm       | ansi-html | 0.0.1   | fixtures/locks-insecure/my-package-lock.json |
-				| https://osv.dev/GHSA-whgm-jr23-g3j9 | 7.5  | npm       | ansi-html | 0.0.1   | fixtures/locks-insecure/my-yarn.lock         |
-				+-------------------------------------+------+-----------+-----------+---------+----------------------------------------------+
+				Scanned <rootdir>/fixtures/locks-insecure/composer.lock file and found 1 package
+				+-------------------------------------+------+-----------+------------------+---------+----------------------------------------------+
+				| OSV URL                             | CVSS | ECOSYSTEM | PACKAGE          | VERSION | SOURCE                                       |
+				+-------------------------------------+------+-----------+------------------+---------+----------------------------------------------+
+				| https://osv.dev/GHSA-9f46-5r25-5wfm | 9.8  | Packagist | league/flysystem | 1.0.8   | fixtures/locks-insecure/composer.lock        |
+				| https://osv.dev/GHSA-whgm-jr23-g3j9 | 7.5  | npm       | ansi-html        | 0.0.1   | fixtures/locks-insecure/my-package-lock.json |
+				| https://osv.dev/GHSA-whgm-jr23-g3j9 | 7.5  | npm       | ansi-html        | 0.0.1   | fixtures/locks-insecure/my-yarn.lock         |
+				+-------------------------------------+------+-----------+------------------+---------+----------------------------------------------+
 			`,
 			wantStderr: "",
 		},
@@ -688,13 +690,14 @@ func TestRun_LockfileWithExplicitParseAs(t *testing.T) {
 				Scanned <rootdir>/fixtures/locks-insecure/my-yarn.lock file as a yarn.lock and found 1 package
 				Scanned <rootdir>/fixtures/locks-insecure/my-package-lock.json file as a package-lock.json and found 1 package
 				Scanning dir ./fixtures/locks-insecure
-				Scanned <rootdir>/fixtures/locks-insecure/composer.lock file and found 0 packages
-				+-------------------------------------+------+-----------+-----------+---------+----------------------------------------------+
-				| OSV URL                             | CVSS | ECOSYSTEM | PACKAGE   | VERSION | SOURCE                                       |
-				+-------------------------------------+------+-----------+-----------+---------+----------------------------------------------+
-				| https://osv.dev/GHSA-whgm-jr23-g3j9 | 7.5  | npm       | ansi-html | 0.0.1   | fixtures/locks-insecure/my-package-lock.json |
-				| https://osv.dev/GHSA-whgm-jr23-g3j9 | 7.5  | npm       | ansi-html | 0.0.1   | fixtures/locks-insecure/my-yarn.lock         |
-				+-------------------------------------+------+-----------+-----------+---------+----------------------------------------------+
+				Scanned <rootdir>/fixtures/locks-insecure/composer.lock file and found 1 package
+				+-------------------------------------+------+-----------+------------------+---------+----------------------------------------------+
+				| OSV URL                             | CVSS | ECOSYSTEM | PACKAGE          | VERSION | SOURCE                                       |
+				+-------------------------------------+------+-----------+------------------+---------+----------------------------------------------+
+				| https://osv.dev/GHSA-9f46-5r25-5wfm | 9.8  | Packagist | league/flysystem | 1.0.8   | fixtures/locks-insecure/composer.lock        |
+				| https://osv.dev/GHSA-whgm-jr23-g3j9 | 7.5  | npm       | ansi-html        | 0.0.1   | fixtures/locks-insecure/my-package-lock.json |
+				| https://osv.dev/GHSA-whgm-jr23-g3j9 | 7.5  | npm       | ansi-html        | 0.0.1   | fixtures/locks-insecure/my-yarn.lock         |
+				+-------------------------------------+------+-----------+------------------+---------+----------------------------------------------+
 			`,
 			wantStderr: "",
 		},

--- a/pkg/osvscanner/vulnerability_result.go
+++ b/pkg/osvscanner/vulnerability_result.go
@@ -29,25 +29,28 @@ func buildVulnerabilityResults(
 	for i, rawPkg := range packages {
 		includePackage := actions.ShowAllPackages
 		var pkg models.PackageVulns
+
 		if rawPkg.Commit != "" {
 			pkg.Package.Commit = rawPkg.Commit
 			pkg.Package.Name = rawPkg.Name
-			// pkg.Package.Ecosystem = "GIT"
 		} else if rawPkg.PURL != "" {
 			var err error
 			pkg.Package, err = models.PURLToPackage(rawPkg.PURL)
+
 			if err != nil {
 				r.PrintErrorf("Failed to parse purl: %s, with error: %s", rawPkg.PURL, err)
-
 				continue
 			}
-		} else {
+		}
+
+		if rawPkg.Version != "" && rawPkg.Ecosystem != "" {
 			pkg.Package = models.PackageInfo{
 				Name:      rawPkg.Name,
 				Version:   rawPkg.Version,
 				Ecosystem: string(rawPkg.Ecosystem),
 			}
 		}
+
 		pkg.DepGroups = rawPkg.DepGroups
 
 		if len(vulnsResp.Results[i].Vulns) > 0 {


### PR DESCRIPTION
Fixes #735 

Also update composer.lock in our integration tests fixture to contain a vulnerability to catch this issue in the future. 