### PR TITLE
Assume latest patch version if version does not exist

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/osv-scanner
 
-go 1.21.5
+go 1.21
 
 require (
 	deps.dev/api/v3alpha v0.0.0-20231114023923-e40c4d5c34e5

--- a/pkg/lockfile/parse-go-lock.go
+++ b/pkg/lockfile/parse-go-lock.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/google/osv-scanner/internal/semantic"
 	"golang.org/x/mod/modfile"
 )
 
@@ -84,28 +83,9 @@ func (e GoLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 	}
 
 	if parsedLockfile.Go != nil && parsedLockfile.Go.Version != "" {
-		v := semantic.ParseSemverLikeVersion(parsedLockfile.Go.Version, 3)
-
-		var goVersion string
-		if len(v.Components) >= 3 {
-			goVersion = fmt.Sprintf(
-				"%d.%d.%d",
-				v.Components.Fetch(0),
-				v.Components.Fetch(1),
-				v.Components.Fetch(2),
-			)
-		} else {
-			goVersion = fmt.Sprintf(
-				"%d.%d.%d",
-				v.Components.Fetch(0),
-				v.Components.Fetch(1),
-				9999,
-			)
-		}
-
 		packages["stdlib"] = PackageDetails{
 			Name:      "stdlib",
-			Version:   goVersion,
+			Version:   parsedLockfile.Go.Version,
 			Ecosystem: GoEcosystem,
 			CompareAs: GoEcosystem,
 		}

--- a/pkg/lockfile/parse-go-lock.go
+++ b/pkg/lockfile/parse-go-lock.go
@@ -3,7 +3,6 @@ package lockfile
 import (
 	"fmt"
 	"io"
-	"log"
 	"path/filepath"
 	"strings"
 
@@ -87,7 +86,6 @@ func (e GoLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 	if parsedLockfile.Go != nil && parsedLockfile.Go.Version != "" {
 		v := semantic.ParseSemverLikeVersion(parsedLockfile.Go.Version, 3)
 
-		log.Printf("%v", v.Components)
 		var goVersion string
 		if len(v.Components) >= 3 {
 			goVersion = fmt.Sprintf(

--- a/pkg/lockfile/parse-go-lock.go
+++ b/pkg/lockfile/parse-go-lock.go
@@ -3,6 +3,7 @@ package lockfile
 import (
 	"fmt"
 	"io"
+	"log"
 	"path/filepath"
 	"strings"
 
@@ -86,12 +87,23 @@ func (e GoLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 	if parsedLockfile.Go != nil && parsedLockfile.Go.Version != "" {
 		v := semantic.ParseSemverLikeVersion(parsedLockfile.Go.Version, 3)
 
-		goVersion := fmt.Sprintf(
-			"%d.%d.%d",
-			v.Components.Fetch(0),
-			v.Components.Fetch(1),
-			v.Components.Fetch(2),
-		)
+		log.Printf("%v", v.Components)
+		var goVersion string
+		if len(v.Components) >= 3 {
+			goVersion = fmt.Sprintf(
+				"%d.%d.%d",
+				v.Components.Fetch(0),
+				v.Components.Fetch(1),
+				v.Components.Fetch(2),
+			)
+		} else {
+			goVersion = fmt.Sprintf(
+				"%d.%d.%d",
+				v.Components.Fetch(0),
+				v.Components.Fetch(1),
+				9999,
+			)
+		}
 
 		packages["stdlib"] = PackageDetails{
 			Name:      "stdlib",

--- a/pkg/lockfile/parse-go-lock_test.go
+++ b/pkg/lockfile/parse-go-lock_test.go
@@ -132,7 +132,7 @@ func TestParseGoLock_TwoPackages(t *testing.T) {
 		},
 		{
 			Name:      "stdlib",
-			Version:   "1.17.0",
+			Version:   "1.17.9999",
 			Ecosystem: lockfile.GoEcosystem,
 			CompareAs: lockfile.GoEcosystem,
 		},
@@ -181,7 +181,7 @@ func TestParseGoLock_IndirectPackages(t *testing.T) {
 		},
 		{
 			Name:      "stdlib",
-			Version:   "1.17.0",
+			Version:   "1.17.9999",
 			Ecosystem: lockfile.GoEcosystem,
 			CompareAs: lockfile.GoEcosystem,
 		},

--- a/pkg/lockfile/parse-go-lock_test.go
+++ b/pkg/lockfile/parse-go-lock_test.go
@@ -132,7 +132,7 @@ func TestParseGoLock_TwoPackages(t *testing.T) {
 		},
 		{
 			Name:      "stdlib",
-			Version:   "1.17.9999",
+			Version:   "1.17",
 			Ecosystem: lockfile.GoEcosystem,
 			CompareAs: lockfile.GoEcosystem,
 		},
@@ -181,7 +181,7 @@ func TestParseGoLock_IndirectPackages(t *testing.T) {
 		},
 		{
 			Name:      "stdlib",
-			Version:   "1.17.9999",
+			Version:   "1.17",
 			Ecosystem: lockfile.GoEcosystem,
 			CompareAs: lockfile.GoEcosystem,
 		},

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -862,7 +862,14 @@ func filterUnscannablePackages(packages []scannedPackage) []scannedPackage {
 // patchPackageForRequest modifies packages before they are sent to osv.dev to
 // account for edge cases.
 func patchPackageForRequest(pkg scannedPackage) scannedPackage {
-	// Remove stdlib from go
+	// Assume Go stdlib patch version as the latest version
+	//
+	// This is done because go1.20 and earlier do not support patch
+	// version in go.mod file, and will fail to build.
+	//
+	// However, if we assume patch version as .0, this will cause a lot of
+	// false positives. This compromise still allows osv-scanner to pick up
+	// when the user is using a minor version that is out-of-support.
 	if pkg.Name == "stdlib" && pkg.Ecosystem == "Go" {
 		v := semantic.ParseSemverLikeVersion(pkg.Version, 3)
 		if len(v.Components) == 2 {

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/osv-scanner/internal/local"
 	"github.com/google/osv-scanner/internal/output"
 	"github.com/google/osv-scanner/internal/sbom"
+	"github.com/google/osv-scanner/internal/semantic"
 	"github.com/google/osv-scanner/pkg/config"
 	"github.com/google/osv-scanner/pkg/depsdev"
 	"github.com/google/osv-scanner/pkg/lockfile"
@@ -858,6 +859,25 @@ func filterUnscannablePackages(packages []scannedPackage) []scannedPackage {
 	return out
 }
 
+// patchPackageForRequest modifies packages before they are sent to osv.dev to
+// account for edge cases.
+func patchPackageForRequest(pkg scannedPackage) scannedPackage {
+	// Remove stdlib from go
+	if pkg.Name == "stdlib" && pkg.Ecosystem == "Go" {
+		v := semantic.ParseSemverLikeVersion(pkg.Version, 3)
+		if len(v.Components) == 2 {
+			pkg.Version = fmt.Sprintf(
+				"%d.%d.%d",
+				v.Components.Fetch(0),
+				v.Components.Fetch(1),
+				9999,
+			)
+		}
+	}
+
+	return pkg
+}
+
 func makeRequest(
 	r reporter.Reporter,
 	packages []scannedPackage,
@@ -867,6 +887,7 @@ func makeRequest(
 	// Make OSV queries from the packages.
 	var query osv.BatchedQuery
 	for _, p := range packages {
+		p = patchPackageForRequest(p)
 		switch {
 		// Prefer making package requests where possible.
 		case p.Ecosystem != "" && p.Name != "" && p.Version != "":


### PR DESCRIPTION
While the change made in #704 is the ideal solution, it only works for people using go 1.21 or later. Adding a patch version to go.mod will cause go1.20 or earlier to fail to build. Since 1.20 is still fully supported and is still the default version for many workflows, this causes too many breakages for users to be acceptable.

There's a few alternative fixes:  

- Assume latest patch version (This PR)
  - This means osv-scanner is no longer checking whether a project is updating to the latest patch version to resolve vulnerabilities, but will still catch users using an out of support go minor version that has no patch available. 
- Remove stdlib vulnerability check entirely / move stdlib vuln check behind a experimental flag
- Add a way to hint to osv-scanner the go version (e.g. .go-version file, or a comment in the go.mod file specifically for osv-scanner to check).

I am leaning towards assuming the latest patch as a fix in the mean time until go1.22 releases (at which point 1.20 will no longer be supported), and less people will be using 1.20, and perhaps reintroducing the patch version check.

---

This implementation also means when a stdlib vulnerability is found, the version that is printed will be 1.xx.99, which is not quite accurate. 