### PR TITLE
Add printouts for network calls

### DIFF
--- a/pkg/reporter/gh-annotations_reporter.go
+++ b/pkg/reporter/gh-annotations_reporter.go
@@ -51,6 +51,10 @@ func (r *GHAnnotationsReporter) Verbosef(format string, a ...any) {
 	}
 }
 
+func (r *GHAnnotationsReporter) CanPrintAtLevel(lvl VerbosityLevel) bool {
+	return lvl <= r.level
+}
+
 func (r *GHAnnotationsReporter) PrintResult(vulnResult *models.VulnerabilityResults) error {
 	return output.PrintGHAnnotationReport(vulnResult, r.stderr)
 }

--- a/pkg/reporter/gh-annotations_reporter.go
+++ b/pkg/reporter/gh-annotations_reporter.go
@@ -34,19 +34,19 @@ func (r *GHAnnotationsReporter) HasErrored() bool {
 }
 
 func (r *GHAnnotationsReporter) Warnf(format string, a ...any) {
-	if WarnLevel <= r.level {
+	if r.CanPrintAtLevel(WarnLevel) {
 		fmt.Fprintf(r.stderr, format, a...)
 	}
 }
 
 func (r *GHAnnotationsReporter) Infof(format string, a ...any) {
-	if InfoLevel <= r.level {
+	if r.CanPrintAtLevel(InfoLevel) {
 		fmt.Fprintf(r.stderr, format, a...)
 	}
 }
 
 func (r *GHAnnotationsReporter) Verbosef(format string, a ...any) {
-	if VerboseLevel <= r.level {
+	if r.CanPrintAtLevel(VerboseLevel) {
 		fmt.Fprintf(r.stderr, format, a...)
 	}
 }

--- a/pkg/reporter/gh-annotations_reporter_test.go
+++ b/pkg/reporter/gh-annotations_reporter_test.go
@@ -94,3 +94,25 @@ func TestGHAnnotationsReporter_Verbosef(t *testing.T) {
 		}
 	}
 }
+
+func TestGHAnnotationsReporter_CanPrintAtLevel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		lvl      VerbosityLevel
+		expected bool
+	}{
+		{lvl: VerboseLevel, expected: true},
+		{lvl: InfoLevel, expected: false},
+	}
+
+	for _, test := range tests {
+		r := NewGHAnnotationsReporter(io.Discard, io.Discard, test.lvl)
+
+		actual := r.CanPrintAtLevel(VerboseLevel)
+
+		if test.expected != actual {
+			t.Errorf("Expected CanPrintAtLevel to return %t given a verbosity level of VerboseLevel", test.expected)
+		}
+	}
+}

--- a/pkg/reporter/json_reporter.go
+++ b/pkg/reporter/json_reporter.go
@@ -36,19 +36,19 @@ func (r *JSONReporter) HasErrored() bool {
 }
 
 func (r *JSONReporter) Warnf(format string, a ...any) {
-	if WarnLevel <= r.level {
+	if r.CanPrintAtLevel(WarnLevel) {
 		fmt.Fprintf(r.stderr, format, a...)
 	}
 }
 
 func (r *JSONReporter) Infof(format string, a ...any) {
-	if InfoLevel <= r.level {
+	if r.CanPrintAtLevel(InfoLevel) {
 		fmt.Fprintf(r.stderr, format, a...)
 	}
 }
 
 func (r *JSONReporter) Verbosef(format string, a ...any) {
-	if VerboseLevel <= r.level {
+	if r.CanPrintAtLevel(VerboseLevel) {
 		fmt.Fprintf(r.stderr, format, a...)
 	}
 }

--- a/pkg/reporter/json_reporter.go
+++ b/pkg/reporter/json_reporter.go
@@ -53,6 +53,10 @@ func (r *JSONReporter) Verbosef(format string, a ...any) {
 	}
 }
 
+func (r *JSONReporter) CanPrintAtLevel(lvl VerbosityLevel) bool {
+	return lvl <= r.level
+}
+
 func (r *JSONReporter) PrintResult(vulnResult *models.VulnerabilityResults) error {
 	return output.PrintJSONResults(vulnResult, r.stdout)
 }

--- a/pkg/reporter/json_reporter_test.go
+++ b/pkg/reporter/json_reporter_test.go
@@ -94,3 +94,25 @@ func TestJSONReporter_Verbosef(t *testing.T) {
 		}
 	}
 }
+
+func TestJSONReporter_CanPrintAtLevel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		lvl      VerbosityLevel
+		expected bool
+	}{
+		{lvl: VerboseLevel, expected: true},
+		{lvl: InfoLevel, expected: false},
+	}
+
+	for _, test := range tests {
+		r := NewJSONReporter(io.Discard, io.Discard, test.lvl)
+
+		actual := r.CanPrintAtLevel(VerboseLevel)
+
+		if test.expected != actual {
+			t.Errorf("Expected CanPrintAtLevel to return %t given a verbosity level of VerboseLevel", test.expected)
+		}
+	}
+}

--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -29,6 +29,8 @@ type Reporter interface {
 	Infof(format string, a ...any)
 	// Verbosef prints text providing additional information about the inner workings of OSV-Scanner to the user.
 	Verbosef(format string, a ...any)
+	// CanPrintAtLevel determines if text can be printed at the given level.
+	CanPrintAtLevel(lvl VerbosityLevel) bool
 	// PrintResult prints the models.VulnerabilityResults per the logic of the
 	// actual reporter
 	PrintResult(vulnResult *models.VulnerabilityResults) error

--- a/pkg/reporter/sarif_reporter.go
+++ b/pkg/reporter/sarif_reporter.go
@@ -34,19 +34,19 @@ func (r *SARIFReporter) HasErrored() bool {
 }
 
 func (r *SARIFReporter) Warnf(format string, a ...any) {
-	if WarnLevel <= r.level {
+	if r.CanPrintAtLevel(WarnLevel) {
 		fmt.Fprintf(r.stderr, format, a...)
 	}
 }
 
 func (r *SARIFReporter) Infof(format string, a ...any) {
-	if InfoLevel <= r.level {
+	if r.CanPrintAtLevel(InfoLevel) {
 		fmt.Fprintf(r.stderr, format, a...)
 	}
 }
 
 func (r *SARIFReporter) Verbosef(format string, a ...any) {
-	if VerboseLevel <= r.level {
+	if r.CanPrintAtLevel(VerboseLevel) {
 		fmt.Fprintf(r.stderr, format, a...)
 	}
 }

--- a/pkg/reporter/sarif_reporter.go
+++ b/pkg/reporter/sarif_reporter.go
@@ -51,6 +51,10 @@ func (r *SARIFReporter) Verbosef(format string, a ...any) {
 	}
 }
 
+func (r *SARIFReporter) CanPrintAtLevel(lvl VerbosityLevel) bool {
+	return lvl <= r.level
+}
+
 func (r *SARIFReporter) PrintResult(vulnResult *models.VulnerabilityResults) error {
 	return output.PrintSARIFReport(vulnResult, r.stdout)
 }

--- a/pkg/reporter/sarif_reporter_test.go
+++ b/pkg/reporter/sarif_reporter_test.go
@@ -94,3 +94,25 @@ func TestSarifReporter_Verbosef(t *testing.T) {
 		}
 	}
 }
+
+func TestSarifReporter_CanPrintAtLevel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		lvl      VerbosityLevel
+		expected bool
+	}{
+		{lvl: VerboseLevel, expected: true},
+		{lvl: InfoLevel, expected: false},
+	}
+
+	for _, test := range tests {
+		r := NewSarifReporter(io.Discard, io.Discard, test.lvl)
+
+		actual := r.CanPrintAtLevel(VerboseLevel)
+
+		if test.expected != actual {
+			t.Errorf("Expected CanPrintAtLevel to return %t given a verbosity level of VerboseLevel", test.expected)
+		}
+	}
+}

--- a/pkg/reporter/table_reporter.go
+++ b/pkg/reporter/table_reporter.go
@@ -56,6 +56,10 @@ func (r *TableReporter) Verbosef(format string, a ...any) {
 	}
 }
 
+func (r *TableReporter) CanPrintAtLevel(lvl VerbosityLevel) bool {
+	return lvl <= r.level
+}
+
 func (r *TableReporter) PrintResult(vulnResult *models.VulnerabilityResults) error {
 	if len(vulnResult.Results) == 0 && !r.hasErrored {
 		fmt.Fprintf(r.stdout, "No issues found\n")

--- a/pkg/reporter/table_reporter.go
+++ b/pkg/reporter/table_reporter.go
@@ -39,19 +39,19 @@ func (r *TableReporter) HasErrored() bool {
 }
 
 func (r *TableReporter) Warnf(format string, a ...any) {
-	if WarnLevel <= r.level {
+	if r.CanPrintAtLevel(WarnLevel) {
 		fmt.Fprintf(r.stdout, format, a...)
 	}
 }
 
 func (r *TableReporter) Infof(format string, a ...any) {
-	if InfoLevel <= r.level {
+	if r.CanPrintAtLevel(InfoLevel) {
 		fmt.Fprintf(r.stdout, format, a...)
 	}
 }
 
 func (r *TableReporter) Verbosef(format string, a ...any) {
-	if VerboseLevel <= r.level {
+	if r.CanPrintAtLevel(VerboseLevel) {
 		fmt.Fprintf(r.stdout, format, a...)
 	}
 }

--- a/pkg/reporter/table_reporter_test.go
+++ b/pkg/reporter/table_reporter_test.go
@@ -94,3 +94,25 @@ func TestTableReporter_Verbosef(t *testing.T) {
 		}
 	}
 }
+
+func TestTableReporter_CanPrintAtLevel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		lvl      VerbosityLevel
+		expected bool
+	}{
+		{lvl: VerboseLevel, expected: true},
+		{lvl: InfoLevel, expected: false},
+	}
+
+	for _, test := range tests {
+		r := NewTableReporter(io.Discard, io.Discard, test.lvl, true, 0)
+
+		actual := r.CanPrintAtLevel(VerboseLevel)
+
+		if test.expected != actual {
+			t.Errorf("Expected CanPrintAtLevel to return %t given a verbosity level of VerboseLevel", test.expected)
+		}
+	}
+}

--- a/pkg/reporter/void_reporter.go
+++ b/pkg/reporter/void_reporter.go
@@ -25,6 +25,10 @@ func (r *VoidReporter) Infof(msg string, a ...any) {
 func (r *VoidReporter) Verbosef(msg string, a ...any) {
 }
 
+func (r *VoidReporter) CanPrintAtLevel(lvl VerbosityLevel) bool {
+	return false
+}
+
 func (r *VoidReporter) PrintResult(vulnResult *models.VulnerabilityResults) error {
 	return nil
 }


### PR DESCRIPTION
Since in #698 it was deemed that a dry run mode may not be feasible, it was determined that printing these network calls during runtime maybe a good alternative.

I'm not quite sure if this is still desired, but I believe this would add more transparency as to what the runtime of OSV-Scanner is doing without the need to look at the code or docs. While implementing this, the following guided my thought process:
1. What endpoints should be printed?
2. Where in the codebase should we add these printouts?
3. How should we printout these network calls?
4. How can we avoid creating expensive messages when users don't wish to print messages at the `VerboseLevel`?

For point 3, I wasn't too sure how to display the data, so I decided to marshall it into JSON and took a page out of `curl`'s book and prefixed these messages with `>` and `<` to represent an HTTP request and response respectfully. I also prefixed the JSON result for better readability. As a side note I have been using the osv.dev API docs as a reference.

For point 4, I went with doing lazy evaluation. I implemented a `CanPrintLevel()` method in the `Reporter` interface and used it to determine if I should create these expensive messages. I also used this method across the Warnf, Errorf, and other methods to try and keep things DRY. Another approach I thought of was to have a `PrintFunc(lvl VerbosityLevel, func() string)` where callers would need to build these expensive messages in the callback (and we check lvl to see if we even should build it), but the `CanPrintLevel()` approach seems simpler.

If there is interest, I'll go ahead and try to tackle the following endpoints as well:

- [ ]  The determine version HTTP GET endpoint
- [ ] The license checking gRPC endpoint
- [ ] The local database-related HTTP endpoints (i.e. the HEAD and GET endpoints)