### PR TITLE
Update goreleaser to fix release pipeline

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -55,7 +55,9 @@ jobs:
         run: |
           set -euo pipefail
           checksum_file=$(echo "$ARTIFACTS" | jq -r '.[] | select (.type=="Checksum") | .path')
-          echo "hashes=$(cat $checksum_file | base64 -w0)" >> "$GITHUB_OUTPUT"
+          if ${checksum_file:0:7} != *"osv-reporter"
+            echo "hashes=$(cat $checksum_file | base64 -w0)" >> "$GITHUB_OUTPUT"
+          fi
   provenance:
     needs: [goreleaser]
     permissions:

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           set -euo pipefail
           checksum_file=$(echo "$ARTIFACTS" | jq -r '.[] | select (.type=="Checksum") | .path')
-          if ${checksum_file:0:7} != *"osv-reporter"
+          if $checksum_file != *"osv-reporter"
             echo "hashes=$(cat $checksum_file | base64 -w0)" >> "$GITHUB_OUTPUT"
           fi
   provenance:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,7 +2,10 @@ before:
   hooks:
     - go mod tidy
 builds:
-  - env:
+  - main: ./cmd/osv-scanner/
+    id: osv-scanner
+    binary: osv-scanner
+    env:
       # goreleaser does not work with CGO, it could also complicate
       # usage by users in CI/CD systems like Terraform Cloud where
       # they are unable to install libraries.
@@ -27,7 +30,22 @@ builds:
       # Further testing before supporting arm
       # - arm
       - arm64
-    main: ./cmd/osv-scanner/
+  - main: ./cmd/osv-reporter/
+    id: osv-reporter
+    binary: osv-reporter
+    env: # osv-reporter for github action
+      - CGO_ENABLED=0
+      - GO111MODULE=on
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    flags:
+      - -trimpath
+    ldflags:
+      # prettier-ignore
+      - '-s -w -X github.com/google/osv-scanner/internal/version.OSVVersion={{.Version}} -X main.commit={{.Commit}} -X main.date={{.CommitDate}}'
+    goos:
+      - linux
+    goarch:
+      - amd64
 
 dockers:
   # Arch: amd64
@@ -68,8 +86,10 @@ dockers:
   # Github Action
   - image_templates:
       - "ghcr.io/google/osv-scanner-action:{{ .Tag }}"
-    dockerfile: action.dockerfile
+    dockerfile: goreleaser-action.dockerfile
     use: buildx
+    extra_files:
+      - exit_code_redirect.sh
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.title=osv-scanner-action"

--- a/goreleaser-action.dockerfile
+++ b/goreleaser-action.dockerfile
@@ -1,0 +1,31 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM alpine:3.19@sha256:51b67269f354137895d43f3b3d810bfacd3945438e94dc5ac55fdac340352f48
+RUN apk --no-cache add \
+  ca-certificates \
+  git \
+  bash
+
+# Allow git to run on mounted directories
+RUN git config --global --add safe.directory '*'
+
+WORKDIR /root/
+COPY ./osv-scanner ./
+COPY ./osv-reporter ./
+COPY ./exit_code_redirect.sh ./
+
+ENV PATH="${PATH}:/root"
+
+ENTRYPOINT ["bash", "/root/exit_code_redirect.sh"]


### PR DESCRIPTION
Goreleaser only puts the built binaries in the context. (https://goreleaser.com/errors/docker-build/) This causes the custom github action docker build to fail.

This PR adds osv-reporter as something goreleaser builds, and correctly copies in the bash script. Tested to build locally.

I also updated the goreleaser.yml file to exclude the osv-reporter in the output, but I don't know if that will be successful as there's no way to test it. 