### PR TITLE
Guided Remediation: Add computation for all relaxation patches

### DIFF
--- a/internal/remediation/relax.go
+++ b/internal/remediation/relax.go
@@ -10,10 +10,68 @@ import (
 	"github.com/google/osv-scanner/internal/resolution"
 )
 
-//nolint:unused
+// ComputeRelaxPatches attempts to resolve each vulnerability found in result independently, returning the list of unique possible patches
+func ComputeRelaxPatches(ctx context.Context, cl resolve.Client, result *resolution.ResolutionResult, opts RemediationOptions) ([]resolution.ResolutionDiff, error) {
+	// Filter the original result just in case it hasn't been already
+	result.FilterVulns(opts.MatchVuln)
+
+	// Do the resolutions concurrently
+	type relaxResult struct {
+		vulnIDs []string
+		result  *resolution.ResolutionResult
+		err     error
+	}
+	ch := make(chan relaxResult)
+	doRelax := func(vulnIDs []string) {
+		res, err := tryRelaxRemediate(ctx, cl, result, vulnIDs, opts)
+		if err == nil {
+			res.FilterVulns(opts.MatchVuln)
+		}
+		ch <- relaxResult{
+			vulnIDs: vulnIDs,
+			result:  res,
+			err:     err,
+		}
+	}
+
+	toProcess := 0
+	for _, vuln := range result.Vulns {
+		// TODO: limit the number of goroutines
+		go doRelax([]string{vuln.Vulnerability.ID})
+		toProcess++
+	}
+
+	var allResults []resolution.ResolutionDiff
+	for toProcess > 0 {
+		res := <-ch
+		toProcess--
+		if errors.Is(res.err, errRelaxRemediateImpossible) { // failed because it cannot be resolved - do not add it to list
+			continue
+		}
+		if res.err != nil { // failed for some other reason - abort
+			// TODO: stop goroutines
+			return nil, res.err
+		}
+		diff := result.CalculateDiff(res.result)
+		allResults = append(allResults, diff)
+
+		// If this patch adds a new vuln, see if we can fix it also
+		// TODO: If there's more than 1 added vuln, this can possibly cause every permutation of those vulns to be computed
+		for _, added := range diff.AddedVulns {
+			go doRelax(append(slices.Clone(res.vulnIDs), added.Vulnerability.ID))
+			toProcess++
+		}
+	}
+
+	// Sort and remove duplicate patches
+	slices.SortFunc(allResults, func(a, b resolution.ResolutionDiff) int { return a.Compare(b) })
+	allResults = slices.CompactFunc(allResults, func(a, b resolution.ResolutionDiff) bool { return a.Compare(b) == 0 })
+
+	return allResults, nil
+}
+
 var errRelaxRemediateImpossible = errors.New("cannot fix vulns by relaxing")
 
-//nolint:unused
 func tryRelaxRemediate(
 	ctx context.Context,
 	cl resolve.Client,
@@ -55,7 +113,6 @@ func tryRelaxRemediate(
 	return newRes, nil
 }
 
-//nolint:unused
 func reqsToRelax(res *resolution.ResolutionResult, vulnIDs []string, opts RemediationOptions) []int {
 	toRelax := make(map[resolve.VersionKey]string)
 	for _, v := range res.Vulns {

--- a/internal/resolution/resolve.go
+++ b/internal/resolution/resolve.go
@@ -1,6 +1,7 @@
 package resolution
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -11,7 +12,6 @@ import (
 	"github.com/google/osv-scanner/internal/resolution/client"
 	"github.com/google/osv-scanner/internal/resolution/manifest"
 	"github.com/google/osv-scanner/pkg/models"
-	"github.com/google/osv-scanner/pkg/osv"
 )
 
 type ResolutionVuln struct {
@@ -81,92 +81,131 @@ var OSVEcosystem = map[resolve.System]models.Ecosystem{
 	resolve.Maven: models.EcosystemMaven,
 }
 
-// computeVulns scans for vulnerabilities in a resolved graph and populates res.Vulns
-func (res *ResolutionResult) computeVulns(ctx context.Context, cl resolve.Client) error {
-	// TODO: local vulnerability db support
-	// TODO: when remediating, this is going to get called many times for the same packages, we should cache requests to the OSV API
-	// Find all vulnerability IDs affecting each node in the graph.
-	var request osv.BatchedQuery
-	request.Queries = make([]*osv.Query, len(res.Graph.Nodes)-1)
-	for i, n := range res.Graph.Nodes[1:] { // skipping the root node
-		request.Queries[i] = &osv.Query{
-			Package: osv.Package{
-				Name:      n.Version.Name,
-				Ecosystem: string(OSVEcosystem[n.Version.System]),
-			},
-			Version: n.Version.Version,
+// FilterVulns populates Vulns with the UnfilteredVulns that satisfy matchFn
+func (res *ResolutionResult) FilterVulns(matchFn func(ResolutionVuln) bool) {
+	var matchedVulns []ResolutionVuln
+	for _, v := range res.UnfilteredVulns {
+		if matchFn(v) {
+			matchedVulns = append(matchedVulns, v)
 		}
 	}
-	response, err := osv.MakeRequest(request)
-	if err != nil {
-		return err
-	}
-	nodeVulns := response.Results
+	res.Vulns = matchedVulns
+}
 
-	// Get the details for each vulnerability
-	// To save on request size, hydrate only unique IDs
-	vulnInfo := make(map[string]*models.Vulnerability)
-	var hydrateQuery osv.BatchedResponse
-	for _, vulns := range nodeVulns {
-		for _, vuln := range vulns.Vulns {
-			if _, ok := vulnInfo[vuln.ID]; !ok {
-				vulnInfo[vuln.ID] = nil
-				hydrateQuery.Results = append(hydrateQuery.Results, osv.MinimalResponse{Vulns: []osv.MinimalVulnerability{vuln}})
+type ResolutionDiff struct {
+	Original     *ResolutionResult
+	New          *ResolutionResult
+	RemovedVulns []ResolutionVuln
+	AddedVulns   []ResolutionVuln
+	manifest.ManifestPatch
+}
+
+func (res *ResolutionResult) CalculateDiff(other *ResolutionResult) ResolutionDiff {
+	diff := ResolutionDiff{
+		Original:      res,
+		New:           other,
+		ManifestPatch: manifest.ManifestPatch{Manifest: &res.Manifest},
+	}
+	// Find the changed requirements and the versions they resolve to
+	for i, oldReq := range res.Manifest.Requirements { // assuming these are in the same order and none are added/removed
+		newReq := other.Manifest.Requirements[i]
+		if oldReq.Version == newReq.Version {
+			continue
+		}
+		// Find the node in the graph to find which actual version it resolved to
+		var oldResolved string
+		for _, e := range res.Graph.Edges {
+			toNode := res.Graph.Nodes[e.To]
+			if e.From == 0 && toNode.Version.PackageKey == oldReq.PackageKey {
+				oldResolved = toNode.Version.Version
+				break
 			}
 		}
-	}
-	//nolint:contextcheck // TODO: Should Hydrate be accepting a context?
-	hydrated, err := osv.Hydrate(&hydrateQuery)
-	if err != nil {
-		return err
-	}
-
-	for _, resp := range hydrated.Results {
-		for _, vuln := range resp.Vulns {
-			vuln := vuln
-			vulnInfo[vuln.ID] = &vuln
-		}
-	}
-
-	// Find all dependency paths to the vulnerable dependencies
-	var vulnerableNodes []resolve.NodeID
-	var vulnNodeIdxs []int
-	for i, vulns := range nodeVulns {
-		if len(vulns.Vulns) > 0 {
-			vulnNodeIdxs = append(vulnNodeIdxs, i)
-			vulnerableNodes = append(vulnerableNodes, resolve.NodeID(i+1))
-		}
-	}
-	nodeChains := computeChains(res.Graph, vulnerableNodes)
-	vulnChains := make(map[string][]DependencyChain)
-	for i, idx := range vulnNodeIdxs {
-		for _, vuln := range nodeVulns[idx].Vulns {
-			vulnChains[vuln.ID] = append(vulnChains[vuln.ID], nodeChains[i]...)
-		}
-	}
-
-	// construct the ResolutionVulns
-	// TODO: This constructs a single ResolutionVuln per vulnerability ID.
-	// The scan action treats vulns with the same ID but affecting different versions of a package as distinct.
-	// TODO: Combine aliased IDs
-	for id, vuln := range vulnInfo {
-		rv := ResolutionVuln{Vulnerability: *vuln, DevOnly: true}
-		for _, chain := range vulnChains[id] {
-			if chainConstrains(ctx, cl, chain, vuln) {
-				rv.ProblemChains = append(rv.ProblemChains, chain)
-			} else {
-				rv.NonProblemChains = append(rv.NonProblemChains, chain)
+		var newResolved string
+		for _, e := range other.Graph.Edges {
+			toNode := other.Graph.Nodes[e.To]
+			if e.From == 0 && toNode.Version.PackageKey == newReq.PackageKey {
+				newResolved = toNode.Version.Version
+				break
 			}
-			rv.DevOnly = rv.DevOnly && ChainIsDev(chain, res.Manifest)
 		}
-		if len(rv.ProblemChains) == 0 {
-			// There has to be at least one problem chain for the vulnerability to appear.
-			// If our heuristic couldn't determine any, treat them all as problematic.
-			rv.ProblemChains = rv.NonProblemChains
-			rv.NonProblemChains = nil
-		}
-		res.Vulns = append(res.Vulns, rv)
+		diff.Deps = append(diff.Deps, manifest.DependencyPatch{
+			Pkg:          oldReq.PackageKey,
+			Type:         oldReq.Type.Clone(),
+			OrigRequire:  oldReq.Version,
+			OrigResolved: oldResolved,
+			NewRequire:   newReq.Version,
+			NewResolved:  newResolved,
+		})
 	}
 
-	return nil
+	// Compute differences in present vulnerabilities.
+	// Currently this relies on vulnerability IDs being unique in the Vulns slice.
+	oldVulns := make(map[string]int, len(res.Vulns))
+	for i, v := range res.Vulns {
+		oldVulns[v.Vulnerability.ID] = i
+	}
+	for _, v := range other.Vulns {
+		if _, ok := oldVulns[v.Vulnerability.ID]; ok {
+			// The vuln already existed.
+			delete(oldVulns, v.Vulnerability.ID) // delete so we know what's been removed
+		} else {
+			// This vuln was not in the original resolution - it was newly added
+			diff.AddedVulns = append(diff.AddedVulns, v)
+		}
+	}
+	// Any remaining oldVulns have been removed in the new resolution
+	for _, idx := range oldVulns {
+		diff.RemovedVulns = append(diff.RemovedVulns, res.Vulns[idx])
+	}
+
+	return diff
+}
+
+// Compare compares ResolutionDiffs based on 'effectiveness' (best first):
+//
+// Sort order:
+//  1. (number of fixed vulns - introduced vulns) / (number of changed direct dependencies) [descending]
+//     (i.e. more efficient first)
+//  2. number of fixed vulns [descending]
+//  3. number of changed direct dependencies [ascending]
+//  4. changed direct dependency name package names [ascending]
+//  5. size of changed direct dependency bump [ascending]
+func (a ResolutionDiff) Compare(b ResolutionDiff) int {
+	// 1. (fixed - introduced) / (changes) [desc]
+	// Multiply out to avoid float casts
+	aRatio := (len(a.RemovedVulns) - len(a.AddedVulns)) * (len(b.Deps))
+	bRatio := (len(b.RemovedVulns) - len(b.AddedVulns)) * (len(a.Deps))
+	if c := cmp.Compare(aRatio, bRatio); c != 0 {
+		return -c
+	}
+
+	// 2. number of fixed vulns [desc]
+	if c := cmp.Compare(len(a.RemovedVulns), len(b.RemovedVulns)); c != 0 {
+		return -c
+	}
+
+	// 3. number of changed deps [asc]
+	if c := cmp.Compare(len(a.Deps), len(b.Deps)); c != 0 {
+		return c
+	}
+
+	// 4. changed names [asc]
+	for i, aDep := range a.Deps {
+		bDep := b.Deps[i]
+		if c := aDep.Pkg.Compare(bDep.Pkg); c != 0 {
+			return c
+		}
+	}
+
+	// 5. dependency bump amount [asc]
+	for i, aDep := range a.Deps {
+		bDep := b.Deps[i]
+		sv := aDep.Pkg.Semver()
+		if c := sv.Compare(aDep.NewResolved, bDep.NewResolved); c != 0 {
+			return c
+		}
+	}
+
+	return 0
 }

--- a/internal/resolution/resolve_vulns.go
+++ b/internal/resolution/resolve_vulns.go
@@ -1,0 +1,149 @@
+package resolution
+
+import (
+	"context"
+	"maps"
+	"sync"
+
+	"deps.dev/util/resolve"
+	"github.com/google/osv-scanner/internal/utility/vulns"
+	"github.com/google/osv-scanner/pkg/lockfile"
+	"github.com/google/osv-scanner/pkg/models"
+	"github.com/google/osv-scanner/pkg/osv"
+)
+
+// computeVulns scans for vulnerabilities in a resolved graph and populates res.Vulns
+func (res *ResolutionResult) computeVulns(ctx context.Context, cl resolve.Client) error {
+	// TODO: local vulnerability db support
+
+	//nolint:contextcheck // TODO: Should Hydrate be accepting a context?
+	nodeVulns, err := queryOSV(res.Graph)
+	if err != nil {
+		return err
+	}
+	// Find all dependency paths to the vulnerable dependencies
+	var vulnerableNodes []resolve.NodeID
+	vulnInfo := make(map[string]models.Vulnerability)
+	for i, vulns := range nodeVulns {
+		if len(vulns) > 0 {
+			vulnerableNodes = append(vulnerableNodes, resolve.NodeID(i))
+		}
+		for _, vuln := range vulns {
+			vulnInfo[vuln.ID] = vuln
+		}
+	}
+
+	nodeChains := computeChains(res.Graph, vulnerableNodes)
+	vulnChains := make(map[string][]DependencyChain)
+	for i, idx := range vulnerableNodes {
+		for _, vuln := range nodeVulns[idx] {
+			vulnChains[vuln.ID] = append(vulnChains[vuln.ID], nodeChains[i]...)
+		}
+	}
+
+	// construct the ResolutionVulns
+	// TODO: This constructs a single ResolutionVuln per vulnerability ID.
+	// The scan action treats vulns with the same ID but affecting different versions of a package as distinct.
+	// TODO: Combine aliased IDs
+	for id, vuln := range vulnInfo {
+		rv := ResolutionVuln{Vulnerability: vuln, DevOnly: true}
+		for _, chain := range vulnChains[id] {
+			if chainConstrains(ctx, cl, chain, &rv.Vulnerability) {
+				rv.ProblemChains = append(rv.ProblemChains, chain)
+			} else {
+				rv.NonProblemChains = append(rv.NonProblemChains, chain)
+			}
+			rv.DevOnly = rv.DevOnly && ChainIsDev(chain, res.Manifest)
+		}
+		if len(rv.ProblemChains) == 0 {
+			// There has to be at least one problem chain for the vulnerability to appear.
+			// If our heuristic couldn't determine any, treat them all as problematic.
+			rv.ProblemChains = rv.NonProblemChains
+			rv.NonProblemChains = nil
+		}
+		res.Vulns = append(res.Vulns, rv)
+	}
+
+	return nil
+}
+
+// vulnCache caches all vulnerabilities affecting any versions of particular packages.
+// We cache call vulns & manually check affected, rather than querying the affected versions directly
+// since remediation needs to query for OSV vulnerabilities multiple times for the same packages.
+var vulnCache sync.Map // map[resolve.PackageKey][]models.Vulnerability
+// TODO: This tends to get the full info of a lot of vulns that never show up in the dependency graphs.
+// Worst case is something like PyPI:tensorflow, which has >600 vulns across all versions, but a specific version may be affected by 0.
+
+func queryOSV(g *resolve.Graph) ([][]models.Vulnerability, error) {
+	// Determine which packages we don't already have cached
+	toQuery := make(map[resolve.PackageKey]struct{})
+	for _, node := range g.Nodes[1:] { // skipping the root node
+		pk := node.Version.PackageKey
+		if _, ok := vulnCache.Load(pk); !ok {
+			toQuery[pk] = struct{}{}
+		}
+	}
+
+	// Query OSV for the missing records
+	if len(toQuery) > 0 {
+		pks := maps.Keys(toQuery)
+		var batchRequest osv.BatchedQuery
+		batchRequest.Queries = make([]*osv.Query, len(pks))
+		for i, pk := range pks {
+			batchRequest.Queries[i] = &osv.Query{
+				Package: osv.Package{
+					Name:      pk.Name,
+					Ecosystem: string(OSVEcosystem[pk.System]),
+				},
+				// Omitting the Version from the query gets all vulns affecting any version of the package
+				// (I'm not actually sure if this behaviour is explicitly documented anywhere)
+			}
+		}
+		batchResponse, err := osv.MakeRequest(batchRequest)
+		if err != nil {
+			return nil, err
+		}
+		hydrated, err := osv.Hydrate(batchResponse)
+		if err != nil {
+			return nil, err
+		}
+		// fill in the cache with the responses
+		for i, pk := range pks {
+			vulnCache.Store(pk, hydrated.Results[i].Vulns)
+		}
+	}
+
+	// Compute the actual affected vulnerabilities for each node
+	nodeVulns := make([][]models.Vulnerability, len(g.Nodes))
+	// For convenience, include the root node as an empty slice in the results
+	for i, n := range g.Nodes {
+		if i == 0 {
+			continue
+		}
+		pkgVulnsAny, ok := vulnCache.Load(n.Version.PackageKey)
+		if !ok {
+			// This should be impossible
+			panic("vulnerability caching failed")
+		}
+		pkgVulns, ok := pkgVulnsAny.([]models.Vulnerability)
+		if !ok {
+			panic("vulnerability caching failed")
+		}
+
+		var affectedVulns []models.Vulnerability
+		pkgDetails := lockfile.PackageDetails{
+			Name:      n.Version.Name,
+			Version:   n.Version.Version,
+			Ecosystem: lockfile.Ecosystem(OSVEcosystem[n.Version.System]),
+			CompareAs: lockfile.Ecosystem(OSVEcosystem[n.Version.System]),
+		}
+		for _, vuln := range pkgVulns {
+			if vulns.IsAffected(vuln, pkgDetails) {
+				affectedVulns = append(affectedVulns, vuln)
+			}
+		}
+		nodeVulns[i] = affectedVulns
+	}
+
+	return nodeVulns, nil
+}

--- a/internal/resolution/resolve_vulns.go
+++ b/internal/resolution/resolve_vulns.go
@@ -67,6 +67,7 @@ func (res *ResolutionResult) computeVulns(ctx context.Context, cl resolve.Client
 	return nil
 }
 
+// TODO: Remove global cache; make an OSVClient to be passed alongside the resolve.Client to do requests.
 // vulnCache caches all vulnerabilities affecting any versions of particular packages.
 // We cache call vulns & manually check affected, rather than querying the affected versions directly
 // since remediation needs to query for OSV vulnerabilities multiple times for the same packages.

--- a/internal/resolution/resolve_vulns.go
+++ b/internal/resolution/resolve_vulns.go
@@ -2,7 +2,6 @@ package resolution
 
 import (
 	"context"
-	"maps"
 	"sync"
 
 	"deps.dev/util/resolve"
@@ -10,6 +9,7 @@ import (
 	"github.com/google/osv-scanner/pkg/lockfile"
 	"github.com/google/osv-scanner/pkg/models"
 	"github.com/google/osv-scanner/pkg/osv"
+	"golang.org/x/exp/maps"
 )
 
 // computeVulns scans for vulnerabilities in a resolved graph and populates res.Vulns


### PR DESCRIPTION
Following on from #765, adds `ComputeRelaxPatches` for generating the possible remediation options after a relock.
Also added a new(ish) cache for OSV API requests, which speeds up the above quite a bit.