### PR TITLE
Parse severities for guided remediation

### DIFF
--- a/cmd/osv-scanner/__snapshots__/main_test.snap
+++ b/cmd/osv-scanner/__snapshots__/main_test.snap
@@ -232,12 +232,12 @@ Scanned <rootdir>/fixtures/sbom-insecure/postgres-stretch.cdx.xml as CycloneDX S
 | https://osv.dev/CVE-2022-48174      | 9.8  | Alpine    | busybox                        | 1.35.0-r29                         | fixtures/sbom-insecure/alpine.cdx.xml           |
 | https://osv.dev/CVE-2022-37434      | 9.8  | Alpine    | zlib                           | 1.2.10-r2                          | fixtures/sbom-insecure/alpine.cdx.xml           |
 | https://osv.dev/DLA-3022-1          |      | Debian    | dpkg                           | 1.18.25                            | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/GHSA-v95c-p5hm-xq8f | 6    | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
+| https://osv.dev/GHSA-v95c-p5hm-xq8f | 6.0  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/GO-2022-0274        |      |           |                                |                                    |                                                 |
 | https://osv.dev/GHSA-f3fp-gc8g-vw66 | 5.9  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/GHSA-g2j6-57v7-gm8c | 6.1  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/GHSA-m8cg-xc2p-r3fc | 2.5  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/GHSA-vpvm-3wq2-2wvm | 7    | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
+| https://osv.dev/GHSA-vpvm-3wq2-2wvm | 7.0  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/GHSA-p782-xgp4-8hr8 | 5.3  | Go        | golang.org/x/sys               | v0.0.0-20210817142637-7d9622a276b7 | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/GO-2022-0493        |      |           |                                |                                    |                                                 |
 | https://osv.dev/DLA-3012-1          |      | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
@@ -941,8 +941,8 @@ Loaded OSS-Fuzz local db from <tempdir>/osv-scanner/OSS-Fuzz/all.zip
 | https://osv.dev/GHSA-f3fp-gc8g-vw66 | 5.9  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/GHSA-g2j6-57v7-gm8c | 6.1  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/GHSA-m8cg-xc2p-r3fc | 2.5  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/GHSA-v95c-p5hm-xq8f | 6    | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/GHSA-vpvm-3wq2-2wvm | 7    | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
+| https://osv.dev/GHSA-v95c-p5hm-xq8f | 6.0  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
+| https://osv.dev/GHSA-vpvm-3wq2-2wvm | 7.0  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/GHSA-p782-xgp4-8hr8 | 5.3  | Go        | golang.org/x/sys               | v0.0.0-20210817142637-7d9622a276b7 | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 +-------------------------------------+------+-----------+--------------------------------+------------------------------------+-------------------------------------------------+
 
@@ -964,8 +964,8 @@ Loaded OSS-Fuzz local db from <tempdir>/osv-scanner/OSS-Fuzz/all.zip
 | https://osv.dev/GHSA-f3fp-gc8g-vw66 | 5.9  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/GHSA-g2j6-57v7-gm8c | 6.1  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/GHSA-m8cg-xc2p-r3fc | 2.5  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/GHSA-v95c-p5hm-xq8f | 6    | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/GHSA-vpvm-3wq2-2wvm | 7    | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
+| https://osv.dev/GHSA-v95c-p5hm-xq8f | 6.0  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
+| https://osv.dev/GHSA-vpvm-3wq2-2wvm | 7.0  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/GHSA-p782-xgp4-8hr8 | 5.3  | Go        | golang.org/x/sys               | v0.0.0-20210817142637-7d9622a276b7 | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 +-------------------------------------+------+-----------+--------------------------------+------------------------------------+-------------------------------------------------+
 

--- a/internal/remediation/remediation.go
+++ b/internal/remediation/remediation.go
@@ -1,6 +1,7 @@
 package remediation
 
 import (
+	"math"
 	"slices"
 
 	"github.com/google/osv-scanner/internal/resolution"
@@ -44,8 +45,11 @@ func (opts RemediationOptions) matchSeverity(v resolution.ResolutionVuln) bool {
 		}
 	}
 
-	return maxScore < 0 || // Always include vulns with unknown severities
-		int(10*maxScore) >= int(10*opts.MinSeverity) // CVSS scores are only to 1 decimal place
+	// CVSS scores are meant to only be to 1 decimal place
+	// and we want to avoid something being falsely rejected/included due to floating point precision.
+	// Multiply and round to only consider relevant parts of the score.
+	return math.Round(10*maxScore) >= math.Round(10*opts.MinSeverity) ||
+		maxScore < 0 // Always include vulns with unknown severities
 }
 
 func (opts RemediationOptions) matchDepth(v resolution.ResolutionVuln) bool {

--- a/internal/utility/severity/severity.go
+++ b/internal/utility/severity/severity.go
@@ -1,0 +1,53 @@
+package severity
+
+import (
+	"strings"
+
+	"github.com/google/osv-scanner/pkg/models"
+	gocvss20 "github.com/pandatix/go-cvss/20"
+	gocvss30 "github.com/pandatix/go-cvss/30"
+	gocvss31 "github.com/pandatix/go-cvss/31"
+	gocvss40 "github.com/pandatix/go-cvss/40"
+)
+
+func CalculateScore(severity models.Severity) (float64, string, error) {
+	score := -1.0
+	rating := "UNKNOWN"
+	var err error
+	switch severity.Type {
+	case models.SeverityCVSSV2:
+		var vec *gocvss20.CVSS20
+		vec, err = gocvss20.ParseVector(severity.Score)
+		if err == nil {
+			score = vec.BaseScore()
+			// CVSS 2.0 does not define a rating, use CVSS 3.0's rating instead
+			rating, err = gocvss30.Rating(score)
+		}
+	case models.SeverityCVSSV3:
+		switch {
+		case strings.HasPrefix(severity.Score, "CVSS:3.0"):
+			var vec *gocvss30.CVSS30
+			vec, err = gocvss30.ParseVector(severity.Score)
+			if err == nil {
+				score = vec.BaseScore()
+				rating, err = gocvss30.Rating(score)
+			}
+		case strings.HasPrefix(severity.Score, "CVSS:3.1"):
+			var vec *gocvss31.CVSS31
+			vec, err = gocvss31.ParseVector(severity.Score)
+			if err == nil {
+				score = vec.BaseScore()
+				rating, err = gocvss31.Rating(score)
+			}
+		}
+	case models.SeverityCVSSV4:
+		var vec *gocvss40.CVSS40
+		vec, err = gocvss40.ParseVector(severity.Score)
+		if err == nil {
+			score = vec.Score()
+			rating, err = gocvss40.Rating(score)
+		}
+	}
+
+	return score, rating, err
+}

--- a/internal/utility/severity/severity_test.go
+++ b/internal/utility/severity/severity_test.go
@@ -1,6 +1,7 @@
 package severity_test
 
 import (
+	"math"
 	"testing"
 
 	"github.com/google/osv-scanner/internal/utility/severity"
@@ -82,8 +83,9 @@ func TestSeverity_CalculateScore(t *testing.T) {
 			if err != nil {
 				t.Errorf("CalculateScore() error: %v", err)
 			}
-			// CVSS scores are to 1 decimal place, do an int comparison
-			if int(10*gotScore) != int(10*tt.want.score) || gotRating != tt.want.rating {
+			// CVSS scores are only supposed to be to 1 decimal place.
+			// Multiply and round to get around potential precision issues.
+			if math.Round(10*gotScore) != math.Round(10*tt.want.score) || gotRating != tt.want.rating {
 				t.Errorf("CalculateScore() = (%.1f, %s), want (%.1f, %s)", gotScore, gotRating, tt.want.score, tt.want.rating)
 			}
 		})

--- a/internal/utility/severity/severity_test.go
+++ b/internal/utility/severity/severity_test.go
@@ -1,0 +1,91 @@
+package severity_test
+
+import (
+	"testing"
+
+	"github.com/google/osv-scanner/internal/utility/severity"
+	"github.com/google/osv-scanner/pkg/models"
+)
+
+func TestSeverity_CalculateScore(t *testing.T) {
+	t.Parallel()
+
+	type result struct {
+		score  float64
+		rating string
+	}
+	tests := []struct {
+		name string
+		sev  models.Severity
+		want result
+	}{
+		{
+			name: "Empty Severity Type",
+			sev:  models.Severity{},
+			want: result{
+				score:  -1,
+				rating: "UNKNOWN",
+			},
+		},
+		{
+			name: "CVSS v2.0",
+			sev: models.Severity{
+				Type:  models.SeverityCVSSV2,
+				Score: "AV:L/AC:M/Au:N/C:N/I:P/A:C/E:H/RL:U/RC:C/CDP:LM/TD:M/CR:L/IR:M/AR:H",
+			},
+			want: result{
+				score:  5.4,
+				rating: "MEDIUM",
+			},
+		},
+		{
+			name: "CVSS v3.0",
+			sev: models.Severity{
+				Type:  models.SeverityCVSSV3,
+				Score: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H/E:U/RL:T/RC:U/CR:L/IR:L/AR:H/MAV:P/MAC:H/MPR:H/MUI:R/MS:C/MC:H/MI:H/MA:H",
+			},
+			want: result{
+				score:  10.0,
+				rating: "CRITICAL",
+			},
+		},
+		{
+			name: "CVSS v3.1",
+			sev: models.Severity{
+				Type:  models.SeverityCVSSV3,
+				Score: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H/E:U/RL:T/RC:U/CR:L/IR:L/AR:H/MAV:P/MAC:H/MPR:H/MUI:R/MS:C/MC:H/MI:H/MA:H",
+			},
+			want: result{
+				score:  10.0,
+				rating: "CRITICAL",
+			},
+		},
+		{
+			name: "CVSS v4.0",
+			sev: models.Severity{
+				Type:  models.SeverityCVSSV4,
+				Score: "CVSS:4.0/AV:P/AC:H/AT:P/PR:H/UI:A/VC:N/VI:N/VA:N/SC:N/SI:N/SA:N/E:U/CR:L/IR:L/AR:L/MAV:P/MAC:H/MAT:P/MPR:H/MUI:A/MVC:N/MVI:N/MVA:N/MSC:N/MSI:N/MSA:N/S:N/AU:N/R:A/V:D/RE:L/U:Clear",
+			},
+			want: result{
+				score:  0.0,
+				rating: "NONE",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotScore, gotRating, err := severity.CalculateScore(tt.sev)
+			if err != nil {
+				t.Errorf("CalculateScore() error: %v", err)
+			}
+			// CVSS scores are to 1 decimal place, do an int comparison
+			if int(10*gotScore) != int(10*tt.want.score) || gotRating != tt.want.rating {
+				t.Errorf("CalculateScore() = (%.1f, %s), want (%.1f, %s)", gotScore, gotRating, tt.want.score, tt.want.rating)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Factored out the CVSS Score parsing from the table output into its own function to reuse it in guided remediation. The new function also returns the human-readable rating string ("LOW", "HIGH", etc.) which I will end up using for the interactive guided remediation mode.

I also made some changes to the table output of the scores:
- Always render the scores to 1 decimal place, so `6.0` instead of just `6`
- Display `0.0` if the CVSS score actually evaluates to 0, vs nothing when there is no severity listed