### PR TITLE
Do not fail if no lockfiles found in github action

### DIFF
--- a/cmd/osv-reporter/main.go
+++ b/cmd/osv-reporter/main.go
@@ -103,13 +103,17 @@ func run(args []string, stdout, stderr io.Writer) int {
 			if oldPath != "" {
 				oldVulns, err = ci.LoadVulnResults(oldPath)
 				if err != nil {
-					return fmt.Errorf("failed to open old results at %s: %w", oldPath, err)
+					fmt.Fprintf(os.Stderr, "failed to open old results at %s: %v - likely because target branch has no lockfiles.\n", oldPath, err)
+					// Do not return, assume there is no oldVulns (which will display all new vulns).
+					oldVulns = models.VulnerabilityResults{}
 				}
 			}
 
 			newVulns, err := ci.LoadVulnResults(newPath)
 			if err != nil {
-				return fmt.Errorf("failed to open new results at %s: %w", newPath, err)
+				fmt.Fprintf(os.Stderr, "failed to open new results at %s: %v - likely because previous step failed.\n", newPath, err)
+				newVulns = models.VulnerabilityResults{}
+				// Do not return a non zero error code.
 			}
 
 			var diffVulns models.VulnerabilityResults


### PR DESCRIPTION
This is to match the decision made when creating `exit_code_redirect.sh` to not fail if no lockfiles are found.

With the reporter the action will still fail when lockfiles are not found, this just updates it so that it will not fail now. 