### PR TITLE
add MakeVersionRequestsWithContext()

### DIFF
--- a/pkg/depsdev/license.go
+++ b/pkg/depsdev/license.go
@@ -45,12 +45,16 @@ func VersionQuery(system depsdevpb.System, name string, version string) *depsdev
 	}
 }
 
-// MakeVersionRequests calls the deps.dev GetVersion gRPC API endpoint for each
+// MakeVersionRequests wraps MakeVersionRequestsWithContext using context.Background.
+func MakeVersionRequests(queries []*depsdevpb.GetVersionRequest) ([][]models.License, error) {
+	return MakeVersionRequestsWithContext(context.Background(), queries)
+}
+
+// MakeVersionRequestsWithContext calls the deps.dev GetVersion gRPC API endpoint for each
 // query. It makes these requests concurrently, sharing the single HTTP/2
 // connection. The order in which the requests are specified should correspond
 // to the order of licenses returned by this function.
-func MakeVersionRequests(queries []*depsdevpb.GetVersionRequest) ([][]models.License, error) {
-	ctx := context.TODO()
+func MakeVersionRequestsWithContext(ctx context.Context, queries []*depsdevpb.GetVersionRequest) ([][]models.License, error) {
 	certPool, err := x509.SystemCertPool()
 	if err != nil {
 		return nil, fmt.Errorf("getting system cert pool: %w", err)
@@ -63,7 +67,7 @@ func MakeVersionRequests(queries []*depsdevpb.GetVersionRequest) ([][]models.Lic
 	client := depsdevpb.NewInsightsClient(conn)
 
 	licenses := make([][]models.License, len(queries))
-	var g errgroup.Group
+	g, ctx := errgroup.WithContext(ctx)
 	for i := range queries {
 		if queries[i] == nil {
 			// This may be a private package.


### PR DESCRIPTION
Fixes: #777 

- add MakeVersionRequestsWithContext()
- change old function `MakeVersionRequests` to wrap `MakeVersionRequestsWithContext` with context.Background