### PR TITLE
Guided Remediation: Add `package-lock.json` LockfileIO

### DIFF
--- a/internal/resolution/lockfile/lockfile.go
+++ b/internal/resolution/lockfile/lockfile.go
@@ -1,0 +1,57 @@
+package lockfile
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"deps.dev/util/resolve"
+	"github.com/google/osv-scanner/pkg/lockfile"
+)
+
+type DependencyPatch struct {
+	Pkg         resolve.PackageKey
+	OrigVersion string
+	NewVersion  string
+}
+
+type LockfileIO interface {
+	// Read parses a lockfile into a resolved graph
+	Read(file lockfile.DepFile) (*resolve.Graph, error)
+	// Write applies the DependencyPatches to the lockfile, with minimal changes to the file.
+	// `original` is the original lockfile to read from. The updated lockfile is written to `output`.
+	Write(original lockfile.DepFile, output io.Writer, patches []DependencyPatch) error
+}
+
+func Overwrite(rw LockfileIO, filename string, patches []DependencyPatch) error {
+	r, err := lockfile.OpenLocalDepFile(filename)
+	if err != nil {
+		return err
+	}
+	var buf bytes.Buffer
+	err = rw.Write(r, &buf, patches)
+	r.Close() // Make sure the file is closed before we start writing to it.
+	if err != nil {
+		return err
+	}
+
+	//nolint:gosec // Complaining about the 0644 permissions.
+	// The file already exists anyway so the permissions don't matter.
+	if err := os.WriteFile(filename, buf.Bytes(), 0644); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func GetLockfileIO(pathToLockfile string) (LockfileIO, error) {
+	base := filepath.Base(pathToLockfile)
+	switch {
+	case base == "package-lock.json":
+		return NpmLockfileIO{}, nil
+	default:
+		return nil, fmt.Errorf("unsupported lockfile type: %s", base)
+	}
+}

--- a/internal/resolution/lockfile/npm.go
+++ b/internal/resolution/lockfile/npm.go
@@ -1,0 +1,172 @@
+package lockfile
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"deps.dev/util/resolve"
+	"deps.dev/util/resolve/dep"
+	"github.com/google/osv-scanner/internal/resolution/datasource"
+	"github.com/google/osv-scanner/internal/resolution/manifest"
+	"github.com/google/osv-scanner/pkg/lockfile"
+)
+
+type NpmLockfileIO struct{}
+
+type npmNodeModule struct {
+	NodeID       resolve.NodeID
+	Parent       *npmNodeModule
+	Children     map[string]*npmNodeModule // keyed on package name
+	Deps         map[string]string
+	OptionalDeps map[string]string
+	ActualName   string // set if the node is an alias, the real package name this refers to
+}
+
+func (n npmNodeModule) IsAliased() bool {
+	return len(n.ActualName) > 0
+}
+
+func (rw NpmLockfileIO) Read(file lockfile.DepFile) (*resolve.Graph, error) {
+	dec := json.NewDecoder(file)
+	var lockJSON lockfile.NpmLockfile
+	if err := dec.Decode(&lockJSON); err != nil {
+		return nil, err
+	}
+
+	// Build the node_modules directory tree in memory & add unconnected nodes into graph
+	var g *resolve.Graph
+	var nodeModuleTree *npmNodeModule
+	var err error
+	switch {
+	case lockJSON.Packages != nil:
+		g, nodeModuleTree, err = rw.nodesFromPackages(lockJSON)
+	case lockJSON.Dependencies != nil:
+		manifestFile, ferr := file.Open("package.json")
+		if ferr != nil {
+			return nil, fmt.Errorf("failed to open package.json (required for parsing lockfileVersion 1): %w", err)
+		}
+		defer manifestFile.Close()
+		g, nodeModuleTree, err = rw.nodesFromDependencies(lockJSON, manifestFile)
+	default:
+		return nil, errors.New("no dependencies in package-lock.json")
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// Traverse the graph (somewhat inefficiently) to add edges between nodes
+	aliasNodes := make(map[resolve.NodeID]string)
+	todo := []*npmNodeModule{nodeModuleTree}
+	seen := make(map[*npmNodeModule]struct{})
+	seen[nodeModuleTree] = struct{}{}
+
+	for len(todo) > 0 {
+		node := todo[0]
+		todo = todo[1:]
+		if node.IsAliased() {
+			// Note which nodes that have to be renamed because of aliasing
+			// Don't rename them now because we rely on the names for working out edges
+			aliasNodes[node.NodeID] = node.ActualName
+		}
+
+		// Add the directory's children to the queue
+		for _, child := range node.Children {
+			if _, ok := seen[child]; !ok {
+				todo = append(todo, child)
+				seen[child] = struct{}{}
+			}
+		}
+
+		// Add edges to the correct dependency nodes
+		for depName, depVer := range node.Deps {
+			depNode := rw.findDependencyNode(node, depName)
+			// Using the correct dep.Type{} doesn't really matter for our purposes
+			if err := g.AddEdge(node.NodeID, depNode, depVer, dep.Type{}); err != nil {
+				return nil, err
+			}
+		}
+		for depName, depVer := range node.OptionalDeps {
+			depNode := rw.findDependencyNode(node, depName)
+			// don't error if an optional dependency is not installed
+			if depNode == -1 {
+				continue
+			}
+			if err := g.AddEdge(node.NodeID, depNode, depVer, dep.Type{}); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	// Add alias KnownAs attribute and rename them correctly
+	for i, e := range g.Edges {
+		if _, ok := aliasNodes[e.To]; ok {
+			name := g.Nodes[e.To].Version.Name
+			g.Edges[i].Type.AddAttr(dep.KnownAs, name)
+		}
+	}
+	for i := range g.Nodes {
+		if name, ok := aliasNodes[resolve.NodeID(i)]; ok {
+			g.Nodes[i].Version.Name = name
+		}
+	}
+
+	return g, nil
+}
+
+func (rw NpmLockfileIO) findDependencyNode(node *npmNodeModule, depName string) resolve.NodeID {
+	// Walk up the node_modules to find which node would be used as the requirement
+	for node != nil {
+		if child, ok := node.Children[depName]; ok {
+			return child.NodeID
+		}
+		node = node.Parent
+	}
+
+	return resolve.NodeID(-1)
+}
+
+func (rw NpmLockfileIO) reVersionAliasedDeps(deps map[string]string) {
+	// for the dependency maps, change versions from "npm:pkg@version" to "version"
+	for k, v := range deps {
+		_, deps[k] = manifest.SplitNPMAlias(v)
+	}
+}
+
+func (rw NpmLockfileIO) Write(original lockfile.DepFile, output io.Writer, patches []DependencyPatch) error {
+	var buf strings.Builder
+	_, err := io.Copy(&buf, original)
+	if err != nil {
+		return err
+	}
+	lock := buf.String()
+
+	patchMap := make(map[string]map[string]string) // name -> old -> new
+	for _, p := range patches {
+		if _, ok := patchMap[p.Pkg.Name]; !ok {
+			patchMap[p.Pkg.Name] = make(map[string]string)
+		}
+		patchMap[p.Pkg.Name][p.OrigVersion] = p.NewVersion
+	}
+
+	api, err := datasource.NewNpmRegistryAPIClient(filepath.Dir(original.Path()))
+	if err != nil {
+		return err
+	}
+
+	if lock, err = rw.modifyPackageLockPackages(lock, patchMap, api); err != nil {
+		return err
+	}
+
+	if lock, err = rw.modifyPackageLockDependencies(lock, patchMap, api); err != nil {
+		return err
+	}
+
+	// Write out modified package-lock.json
+	_, err = io.WriteString(output, lock)
+
+	return err
+}

--- a/internal/resolution/lockfile/npm_v1.go
+++ b/internal/resolution/lockfile/npm_v1.go
@@ -1,0 +1,151 @@
+package lockfile
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"deps.dev/util/resolve"
+	"github.com/google/osv-scanner/internal/resolution/datasource"
+	"github.com/google/osv-scanner/internal/resolution/manifest"
+	"github.com/google/osv-scanner/pkg/lockfile"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+	"golang.org/x/exp/maps"
+)
+
+// Old-style (npm < 7 / lockfileVersion 1) dependencies structure
+// https://docs.npmjs.com/cli/v6/configuring-npm/package-lock-json
+// Installed packages stored in recursive "dependencies" object
+// with "requires" field listing direct dependencies, and each possibly having their own "dependencies"
+// No dependency information package-lock.json for the root node, so we must also have the package.json
+func (rw NpmLockfileIO) nodesFromDependencies(lockJSON lockfile.NpmLockfile, manifestFile io.Reader) (*resolve.Graph, *npmNodeModule, error) {
+	// Need to grab the root requirements from the package.json, since it's not in the lockfile
+	var manifestJSON manifest.PackageJSON
+	if err := json.NewDecoder(manifestFile).Decode(&manifestJSON); err != nil {
+		return nil, nil, err
+	}
+	deps := make(map[string]string)
+	maps.Copy(deps, manifestJSON.Dependencies)
+	maps.Copy(deps, manifestJSON.DevDependencies)
+	optDeps := make(map[string]string)
+	maps.Copy(optDeps, manifestJSON.OptionalDependencies)
+	// Some versions of npm apparently do not automatically install peerDependencies, so treat them as optional
+	maps.Copy(optDeps, manifestJSON.PeerDependencies)
+	rw.reVersionAliasedDeps(deps)
+	rw.reVersionAliasedDeps(optDeps)
+
+	var g resolve.Graph
+	nID := g.AddNode(resolve.VersionKey{
+		PackageKey: resolve.PackageKey{
+			System: resolve.NPM,
+			Name:   manifestJSON.Name,
+		},
+		VersionType: resolve.Concrete,
+		Version:     manifestJSON.Version,
+	})
+	nodeModuleTree := &npmNodeModule{
+		NodeID:       nID,
+		Children:     make(map[string]*npmNodeModule),
+		Deps:         deps,
+		OptionalDeps: optDeps,
+	}
+
+	err := rw.computeDependenciesRecursive(&g, nodeModuleTree, lockJSON.Dependencies)
+
+	return &g, nodeModuleTree, err
+}
+
+func (rw NpmLockfileIO) computeDependenciesRecursive(g *resolve.Graph, parent *npmNodeModule, deps map[string]lockfile.NpmLockDependency) error {
+	for name, d := range deps {
+		actualName, version := manifest.SplitNPMAlias(d.Version)
+		nID := g.AddNode(resolve.VersionKey{
+			PackageKey: resolve.PackageKey{
+				System: resolve.NPM,
+				Name:   name,
+			},
+			VersionType: resolve.Concrete,
+			Version:     version,
+		})
+		// The requires map includes regular dependencies AND optionalDependencies
+		// but it does not include peerDependencies or devDependencies.
+		// The generated graphs will lack the edges between peers
+		optDeps := maps.Clone(d.Requires)
+		rw.reVersionAliasedDeps(optDeps)
+		nm := &npmNodeModule{
+			Parent:       parent,
+			NodeID:       nID,
+			Children:     make(map[string]*npmNodeModule),
+			OptionalDeps: optDeps,
+			ActualName:   actualName,
+		}
+		parent.Children[name] = nm
+		if d.Dependencies != nil {
+			if err := rw.computeDependenciesRecursive(g, nm, d.Dependencies); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (rw NpmLockfileIO) modifyPackageLockDependencies(lockJSON string, patches map[string]map[string]string, api *datasource.NpmRegistryAPIClient) (string, error) {
+	if !gjson.Get(lockJSON, "dependencies").Exists() {
+		return lockJSON, nil
+	}
+
+	return rw.modifyPackageLockDependenciesRecurse(lockJSON, "dependencies", 1, patches, api)
+}
+
+func (rw NpmLockfileIO) modifyPackageLockDependenciesRecurse(lockJSON, path string, depth int, patches map[string]map[string]string, api *datasource.NpmRegistryAPIClient) (string, error) {
+	for pkg, data := range gjson.Get(lockJSON, path).Map() {
+		pkgPath := fmt.Sprintf("%s.%s", path, strings.ReplaceAll(pkg, ".", "\\."))
+		if data.Get("dependencies").Exists() {
+			var err error
+			lockJSON, err = rw.modifyPackageLockDependenciesRecurse(lockJSON, pkgPath+".dependencies", depth+1, patches, api)
+			if err != nil {
+				return lockJSON, err
+			}
+		}
+		isAlias := false
+		realPkg, version := manifest.SplitNPMAlias(data.Get("version").String())
+		if realPkg != "" {
+			isAlias = true
+			pkg = realPkg
+		}
+
+		if upgrades, ok := patches[pkg]; ok {
+			if newVer, ok := upgrades[version]; ok {
+				// update dependency in place
+				npmData, err := api.FullJSON(context.Background(), pkg, newVer)
+				if err != nil {
+					return lockJSON, err
+				}
+				// From what I can tell, the only fields to update are "version" "resolved" "integrity" and "requires"
+				newVersion := npmData.Get("version").String()
+				if isAlias {
+					newVersion = fmt.Sprintf("npm:%s@%s", pkg, newVersion)
+				}
+				lockJSON, _ = sjson.Set(lockJSON, pkgPath+".version", newVersion)
+				lockJSON, _ = sjson.Set(lockJSON, pkgPath+".resolved", npmData.Get("dist.tarball").String())
+				lockJSON, _ = sjson.Set(lockJSON, pkgPath+".integrity", npmData.Get("dist.integrity").String())
+				// formatting & padding to output for the correct level at this depth
+				pretty := fmt.Sprintf("|@pretty:{\"prefix\": %q}", strings.Repeat(" ", 4*depth+2))
+				reqs := npmData.Get("dependencies" + pretty)
+				if !reqs.Exists() {
+					lockJSON, _ = sjson.Delete(lockJSON, pkgPath+".requires")
+				} else {
+					text := reqs.Raw
+					// remove trailing newlines that @pretty creates for objects
+					text = strings.TrimSuffix(text, "\n")
+					lockJSON, _ = sjson.SetRaw(lockJSON, pkgPath+".requires", text)
+				}
+			}
+		}
+	}
+
+	return lockJSON, nil
+}

--- a/internal/resolution/lockfile/npm_v2.go
+++ b/internal/resolution/lockfile/npm_v2.go
@@ -1,0 +1,270 @@
+package lockfile
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"deps.dev/util/resolve"
+	"github.com/google/osv-scanner/internal/resolution/datasource"
+	"github.com/google/osv-scanner/pkg/lockfile"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+	"golang.org/x/exp/maps"
+)
+
+// New-style (npm >= 7 / lockfileVersion 2+) structure
+// https://docs.npmjs.com/cli/v9/configuring-npm/package-lock-json
+// Installed packages are in the flat "packages" object, keyed by the install path
+// e.g. "node_modules/foo/node_modules/bar"
+// packages contain most information from their own manifests.
+func (rw NpmLockfileIO) nodesFromPackages(lockJSON lockfile.NpmLockfile) (*resolve.Graph, *npmNodeModule, error) {
+	var g resolve.Graph
+	// Create graph nodes and reconstruct the node_modules folder structure in memory
+	root, ok := lockJSON.Packages[""]
+	if !ok {
+		return nil, nil, errors.New("missing root node")
+	}
+	nID := g.AddNode(resolve.VersionKey{
+		PackageKey: resolve.PackageKey{
+			System: resolve.NPM,
+			Name:   root.Name,
+		},
+		VersionType: resolve.Concrete,
+		Version:     root.Version,
+	})
+	nodeModuleTree := rw.makeNodeModuleDeps(root, true)
+	nodeModuleTree.NodeID = nID
+
+	// paths for npm workspace subfolders, not inside root node_modules
+	workspaceModules := make(map[string]*npmNodeModule)
+	workspaceModules[""] = nodeModuleTree
+
+	// iterate keys by node_modules depth
+	for _, k := range rw.packageNamesByNodeModuleDepth(lockJSON.Packages) {
+		if k == "" {
+			// skip the root node
+			continue
+		}
+		pkg, ok := lockJSON.Packages[k]
+		if !ok {
+			panic("key not in packages")
+		}
+		path := strings.Split(k, "node_modules/")
+		if len(path) == 1 {
+			// the path does not contain "node_modules/", assume this is a workspace directory
+			nID := g.AddNode(resolve.VersionKey{
+				PackageKey: resolve.PackageKey{
+					System: resolve.NPM,
+					Name:   path[0], // This will get replaced by the name from the symlink
+				},
+				VersionType: resolve.Concrete,
+				Version:     pkg.Version,
+			})
+			m := rw.makeNodeModuleDeps(pkg, true) // NB: including the dev dependencies
+			m.NodeID = nID
+			workspaceModules[path[0]] = m
+
+			continue
+		}
+
+		if pkg.Link {
+			// This is the symlink to the workspace directory in node_modules
+			if len(path) != 2 || path[0] != "" {
+				// Not sure what situation would lead to this
+				panic("Found symlink in package-lock.json that's not in root node_modules directory")
+			}
+			m := workspaceModules[pkg.Resolved]
+			if m == nil {
+				// Can symlinks show up without workspaces?
+				panic("symlink in package-lock.json processed before real directory")
+			}
+
+			// attach the workspace to the tree
+			pkgName := path[1]
+			nodeModuleTree.Children[pkgName] = m
+			if pkg.Resolved == "" {
+				// weird case: the root directory is symlinked into its own node_modules
+				continue
+			}
+			m.Parent = nodeModuleTree
+
+			// rename the node to the name it would be referred to as in package.json
+			g.Nodes[m.NodeID].Version.Name = pkgName
+			// add it as a dependency of the root node, so it's not orphaned
+			if _, ok := nodeModuleTree.Deps[pkgName]; !ok {
+				nodeModuleTree.Deps[pkgName] = "*"
+			}
+
+			continue
+		}
+
+		// find the direct parent package by traversing the path
+		parent := nodeModuleTree
+		if path[0] != "" {
+			// jump to the corresponding workspace if package is in one
+			parent = workspaceModules[strings.TrimSuffix(path[0], "/")]
+		}
+		for _, p := range path[1 : len(path)-1] { // skip root directory
+			p = strings.TrimSuffix(p, "/")
+			parent = parent.Children[p]
+		}
+
+		name := path[len(path)-1]
+		nID := g.AddNode(resolve.VersionKey{
+			PackageKey: resolve.PackageKey{
+				System: resolve.NPM,
+				Name:   name,
+			},
+			VersionType: resolve.Concrete,
+			Version:     pkg.Version,
+		})
+		parent.Children[name] = rw.makeNodeModuleDeps(pkg, false)
+		parent.Children[name].NodeID = nID
+		parent.Children[name].Parent = parent
+		parent.Children[name].ActualName = pkg.Name
+	}
+
+	return &g, nodeModuleTree, nil
+}
+
+func (rw NpmLockfileIO) makeNodeModuleDeps(pkg lockfile.NpmLockPackage, includeDev bool) *npmNodeModule {
+	deps := make(map[string]string)
+	maps.Copy(deps, pkg.Dependencies)
+	if includeDev {
+		maps.Copy(deps, pkg.DevDependencies)
+	}
+	optDeps := make(map[string]string)
+	maps.Copy(optDeps, pkg.OptionalDependencies)
+	// Some versions of npm apparently do not automatically install peerDependencies, so treat them as optional
+	maps.Copy(optDeps, pkg.PeerDependencies)
+	rw.reVersionAliasedDeps(deps)
+	rw.reVersionAliasedDeps(optDeps)
+
+	return &npmNodeModule{
+		Children:     make(map[string]*npmNodeModule),
+		Deps:         deps,
+		OptionalDeps: optDeps,
+	}
+}
+
+func (rw NpmLockfileIO) packageNamesByNodeModuleDepth(packages map[string]lockfile.NpmLockPackage) []string {
+	keys := maps.Keys(packages)
+	slices.SortFunc(keys, func(a, b string) int {
+		aSplit := strings.Split(a, "node_modules/")
+		bSplit := strings.Split(b, "node_modules/")
+		if c := cmp.Compare(len(aSplit), len(bSplit)); c != 0 {
+			return c
+		}
+		// sort alphabetically if they're the same depth
+		return cmp.Compare(a, b)
+	})
+
+	return keys
+}
+
+func (rw NpmLockfileIO) modifyPackageLockPackages(lockJSON string, patches map[string]map[string]string, api *datasource.NpmRegistryAPIClient) (string, error) {
+	packages := gjson.Get(lockJSON, "packages")
+	if !packages.Exists() {
+		return lockJSON, nil
+	}
+
+	for key, value := range packages.Map() {
+		parts := strings.Split(key, "node_modules/")
+		if len(parts) == 0 {
+			continue
+		}
+		pkg := parts[len(parts)-1]
+		if n := value.Get("name"); n.Exists() { // if this is an alias, use the real package as the name
+			pkg = n.String()
+		}
+		if upgrades, ok := patches[pkg]; ok {
+			if newVer, ok := upgrades[value.Get("version").String()]; ok {
+				fullPath := "packages." + strings.ReplaceAll(key, ".", "\\.")
+				var err error
+				if lockJSON, err = rw.updatePackage(lockJSON, fullPath, pkg, newVer, api); err != nil {
+					return lockJSON, err
+				}
+			}
+		}
+	}
+
+	return lockJSON, nil
+}
+
+func (rw NpmLockfileIO) updatePackage(jsonText, jsonPath, packageName, newVersion string, api *datasource.NpmRegistryAPIClient) (string, error) {
+	npmData, err := api.FullJSON(context.Background(), packageName, newVersion)
+	if err != nil {
+		return "", err
+	}
+
+	// The "dependencies" returned from the registry includes (can include?) both optional and regular dependencies
+	// But the "optionalDependencies" are (always?) removed from "dependencies" package-lock.json.
+	for _, opt := range npmData.Get("optionalDependencies|@keys").Array() {
+		s, _ := sjson.Delete(npmData.Raw, "dependencies."+opt.String())
+		npmData = gjson.Parse(s)
+	}
+
+	// I can't find a consistent list of what fields should be included in package-lock.json packages
+	// https://docs.npmjs.com/cli/v9/configuring-npm/package-lock-json#packages seems list some
+	// but I've seen fields not listed there get included, and fields that it says to include (e.g. license) missing;
+	// Might fill in as much of package.json? https://docs.npmjs.com/cli/v9/configuring-npm/package-json
+	// It also seems to depend on npm version?
+	// Instead, just modify the fields that are present
+	for _, key := range gjson.Get(jsonText, jsonPath+"|@keys").Array() {
+		switch key.String() {
+		case "resolved":
+			jsonText, _ = sjson.Set(jsonText, jsonPath+".resolved", npmData.Get("dist.tarball").String())
+		case "integrity":
+			jsonText, _ = sjson.Set(jsonText, jsonPath+".integrity", npmData.Get("dist.integrity").String())
+		case "bin":
+			// the api formats the paths as "./path/to", while package-lock.json seem to use "path/to"
+			// TODO: smarter way for indentation
+			newVal := npmData.Get(key.String() + "|@pretty:{\"prefix\": \"      \"}")
+			if newVal.Exists() {
+				text := newVal.Raw
+				// remove trailing newlines that @pretty creates for objects
+				text = strings.TrimSuffix(text, "\n")
+				for k, v := range newVal.Map() {
+					text, _ = sjson.Set(text, k, filepath.Clean(v.String()))
+				}
+				jsonText, _ = sjson.SetRaw(jsonText, jsonPath+".bin", text)
+			} else {
+				// explicitly remove it if it's no longer present
+				jsonText, _ = sjson.Delete(jsonText, jsonPath+".bin")
+			}
+		// if all dependencies have been removed, explicitly remove the field
+		case "dependencies":
+			fallthrough
+		case "devDependencies": // shouldn't show up in package-lock.json
+			fallthrough
+		case "peerDependencies":
+			fallthrough
+		case "optionalDependencies":
+			if !npmData.Get(key.String()).Exists() {
+				// TODO: Think of the orphaned children
+				jsonText, _ = sjson.Delete(jsonText, jsonPath+"."+key.String())
+				continue
+			}
+
+			fallthrough
+		default:
+			// use @pretty to format objects correctly & with correct indentation
+			// TODO: smarter way for indentation
+			newVal := npmData.Get(key.String() + "|@pretty:{\"prefix\": \"      \"}")
+			if newVal.Exists() {
+				text := newVal.Raw
+				// remove trailing newlines that @pretty creates for objects
+				text = strings.TrimSuffix(text, "\n")
+				jsonText, _ = sjson.SetRaw(jsonText, jsonPath+"."+key.String(), text)
+			}
+			// if it doesn't exist, assume it's one of the package-lock flags e.g. "dev"
+			// TODO: It could be a removed field
+		}
+	}
+
+	return jsonText, nil
+}

--- a/pkg/lockfile/parse-npm-lock.go
+++ b/pkg/lockfile/parse-npm-lock.go
@@ -15,24 +15,32 @@ type NpmLockDependency struct {
 
 	Dev      bool `json:"dev,omitempty"`
 	Optional bool `json:"optional,omitempty"`
+
+	Requires map[string]string `json:"requires,omitempty"`
 }
 
 type NpmLockPackage struct {
 	// For an aliased package, Name is the real package name
-	Name         string            `json:"name"`
-	Version      string            `json:"version"`
-	Resolved     string            `json:"resolved"`
-	Dependencies map[string]string `json:"dependencies"`
+	Name     string `json:"name"`
+	Version  string `json:"version"`
+	Resolved string `json:"resolved"`
+
+	Dependencies         map[string]string `json:"dependencies,omitempty"`
+	DevDependencies      map[string]string `json:"devDependencies,omitempty"`
+	OptionalDependencies map[string]string `json:"optionalDependencies,omitempty"`
+	PeerDependencies     map[string]string `json:"peerDependencies,omitempty"`
 
 	Dev         bool `json:"dev,omitempty"`
 	DevOptional bool `json:"devOptional,omitempty"`
 	Optional    bool `json:"optional,omitempty"`
+
+	Link bool `json:"link,omitempty"`
 }
 
 type NpmLockfile struct {
 	Version int `json:"lockfileVersion"`
 	// npm v1- lockfiles use "dependencies"
-	Dependencies map[string]NpmLockDependency `json:"dependencies"`
+	Dependencies map[string]NpmLockDependency `json:"dependencies,omitempty"`
 	// npm v2+ lockfiles use "packages"
 	Packages map[string]NpmLockPackage `json:"packages,omitempty"`
 }


### PR DESCRIPTION
Adds the lockfile parsing for in-place updating.
Code is mostly unchanged from what exists internally, mostly just split it up into multiple files.

I've reused and added to the existing (public) npm structs, but this shouldn't impact the scan action.