### PR TITLE
ci: remove unneeded `setup-go` step and pin `actions/download-artifact`

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       # Update go to the latest version to support minor go versions is go.mod file
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version-file: go.mod
       # Initializes the CodeQL tools for scanning.

--- a/.github/workflows/osv-scanner-reusable.yml
+++ b/.github/workflows/osv-scanner-reusable.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           persist-credentials: false
       - name: "Download custom artifact if specified"
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
         if: "${{ inputs.download-artifact != '' }}"
         with:
           name: "${{ inputs.download-artifact }}"


### PR DESCRIPTION
I was having a look at the openssf scorecard score as I've not really dug into that before, and saw it was flagging some unpinned actions.

Most of them were about the `osv-scanner` action itself which I don't think can be pinned since the point is to use the latest version for self testing right? but we can pin `actions/download-artifact` and `actions/setup-go` _though_ I'm pretty sure that isn't needed anymore because it was a workaround for https://github.com/github/codeql/issues/13992 and we were just waiting on a new version? either way we'll find out.