### PR TITLE
Add user agent to deps.dev requests

### DIFF
--- a/internal/resolution/client/npm_registry_client.go
+++ b/internal/resolution/client/npm_registry_client.go
@@ -15,6 +15,7 @@ import (
 	"deps.dev/util/semver"
 	"github.com/google/osv-scanner/internal/resolution/datasource"
 	"github.com/google/osv-scanner/pkg/depsdev"
+	"github.com/google/osv-scanner/pkg/osv"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )
@@ -40,7 +41,13 @@ func NewNpmRegistryClient(workdir string) (*NpmRegistryClient, error) {
 		return nil, fmt.Errorf("getting system cert pool: %w", err)
 	}
 	creds := credentials.NewClientTLSFromCert(certPool, "")
-	conn, err := grpc.Dial(depsdev.DepsdevAPI, grpc.WithTransportCredentials(creds))
+	dialOpts := []grpc.DialOption{grpc.WithTransportCredentials(creds)}
+
+	if osv.RequestUserAgent != "" {
+		dialOpts = append(dialOpts, grpc.WithUserAgent(osv.RequestUserAgent))
+	}
+
+	conn, err := grpc.Dial(depsdev.DepsdevAPI, dialOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("dialling %q: %w", depsdev.DepsdevAPI, err)
 	}

--- a/internal/resolution/datasource/depsdev_api.go
+++ b/internal/resolution/datasource/depsdev_api.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	pb "deps.dev/api/v3alpha"
+	"github.com/google/osv-scanner/pkg/osv"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )
@@ -57,7 +58,13 @@ func NewDepsDevAPIClient(addr string) (*DepsDevAPIClient, error) {
 		return nil, fmt.Errorf("getting system cert pool: %w", err)
 	}
 	creds := credentials.NewClientTLSFromCert(certPool, "")
-	conn, err := grpc.Dial(addr, grpc.WithTransportCredentials(creds))
+	dialOpts := []grpc.DialOption{grpc.WithTransportCredentials(creds)}
+
+	if osv.RequestUserAgent != "" {
+		dialOpts = append(dialOpts, grpc.WithUserAgent(osv.RequestUserAgent))
+	}
+
+	conn, err := grpc.Dial(addr, dialOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("dialling %q: %w", addr, err)
 	}


### PR DESCRIPTION
Adds the `osv-scanner/[VERSION]` user agent the grpc requests going to the deps.dev API.
I thought it'd be nice to for deps.dev to be able to see which traffic is coming from license scanning and guided remediation.

CC: @josieang 