### PR TITLE
Automated Updates: add version suggester for Maven

### DIFF
--- a/internal/remediation/suggester/maven.go
+++ b/internal/remediation/suggester/maven.go
@@ -1,0 +1,75 @@
+package suggest
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"deps.dev/util/resolve"
+	"deps.dev/util/semver"
+)
+
+type MavenSuggester struct{}
+
+// Suggest returns the latest version based on the given Maven requirement version.
+// If there is no newer version available, req will be returned.
+// For a version range requirement,
+//   - the greatest version matching the constraint is assumed when deciding whether the
+//     update is a major update or not.
+//   - if the latest version does not satisfy the constraint, this version is returned;
+//     otherwise, the original version range requirement is returned.
+func (ms *MavenSuggester) Suggest(ctx context.Context, client resolve.Client, req resolve.RequirementVersion, opts SuggestOptions) (resolve.RequirementVersion, error) {
+	versions, err := client.Versions(ctx, req.PackageKey)
+	if err != nil {
+		return resolve.RequirementVersion{}, fmt.Errorf("requesting versions of Maven package %s: %w", req.Name, err)
+	}
+	semvers := make([]*semver.Version, 0, len(versions))
+	for _, ver := range versions {
+		v, err := semver.Maven.Parse(ver.Version)
+		if err != nil {
+			log.Printf("parsing Maven version %s: %v", v, err)
+			continue
+		}
+		semvers = append(semvers, v)
+	}
+
+	constraint, err := semver.Maven.ParseConstraint(req.Version)
+	if err != nil {
+		return resolve.RequirementVersion{}, fmt.Errorf("parsing Maven constraint %s: %w", req.Version, err)
+	}
+
+	var current *semver.Version
+	if constraint.IsSimple() {
+		// Constraint is a simple version string, so can be parsed to a single version.
+		current, err = semver.Maven.Parse(req.Version)
+		if err != nil {
+			return resolve.RequirementVersion{}, fmt.Errorf("parsing Maven version %s: %w", req.Version, err)
+		}
+	} else {
+		// Guess the latest version statisfying the constraint is being used
+		for _, v := range semvers {
+			if constraint.MatchVersion(v) && current.Compare(v) < 0 {
+				current = v
+			}
+		}
+	}
+
+	var newReq *semver.Version
+	for _, v := range semvers {
+		if v.Compare(newReq) < 0 {
+			// Skip versions smaller than the current requirement
+			continue
+		}
+		if _, diff := v.Difference(current); diff == semver.DiffMajor && opts.NoMajorUpdates {
+			continue
+		}
+		newReq = v
+	}
+	if constraint.IsSimple() || !constraint.MatchVersion(newReq) {
+		// For version range requirement, update the requirement if the
+		// new requirement does not satisfy the constraint.
+		req.Version = newReq.String()
+	}
+
+	return req, nil
+}

--- a/internal/remediation/suggester/maven_test.go
+++ b/internal/remediation/suggester/maven_test.go
@@ -1,0 +1,72 @@
+package suggest
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"deps.dev/util/resolve"
+)
+
+func TestMavenSuggest(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	lc := resolve.NewLocalClient()
+	suggester, err := GetSuggester(resolve.Maven)
+	if err != nil {
+		t.Fatalf("fail to get Maven suggester")
+	}
+
+	pk := resolve.PackageKey{
+		System: resolve.Maven,
+		Name:   "abc:xyz",
+	}
+	for _, version := range []string{"1.0.0", "1.0.1", "1.1.0", "1.2.3", "2.0.0", "2.2.2", "2.3.4"} {
+		lc.AddVersion(resolve.Version{
+			VersionKey: resolve.VersionKey{
+				PackageKey:  pk,
+				VersionType: resolve.Concrete,
+				Version:     version,
+			}}, nil)
+	}
+
+	tests := []struct {
+		requirement string
+		options     SuggestOptions
+		want        string
+	}{
+		{"1.0.0", SuggestOptions{}, "2.3.4"},
+		// No major updates allowed
+		{"1.0.0", SuggestOptions{NoMajorUpdates: true}, "1.2.3"},
+		// Version range requirement is not outdated
+		{"[1.0.0,)", SuggestOptions{}, "[1.0.0,)"},
+		{"[2.0.0, 2.3.4]", SuggestOptions{}, "[2.0.0, 2.3.4]"},
+		// Version range requirement is outdated
+		{"[2.0.0, 2.3.4)", SuggestOptions{}, "2.3.4"},
+		{"[2.0.0, 2.2.2]", SuggestOptions{}, "2.3.4"},
+		// Version range requirement is outdated but latest version is a major update
+		{"[1.0.0,2.0.0)", SuggestOptions{}, "2.3.4"},
+		{"[1.0.0,2.0.0)", SuggestOptions{NoMajorUpdates: true}, "[1.0.0,2.0.0)"},
+	}
+	for _, test := range tests {
+		vk := resolve.VersionKey{
+			PackageKey:  pk,
+			VersionType: resolve.Requirement,
+			Version:     test.requirement,
+		}
+		want := resolve.RequirementVersion{
+			VersionKey: resolve.VersionKey{
+				PackageKey:  pk,
+				VersionType: resolve.Requirement,
+				Version:     test.want,
+			},
+		}
+		got, err := suggester.Suggest(ctx, lc, resolve.RequirementVersion{VersionKey: vk}, test.options)
+		if err != nil {
+			t.Fatalf("fail to suggest a new version for %v: %v", vk, err)
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("suggest new version for %v with options %v got %s want %s", vk, test.options, got, want)
+		}
+	}
+}

--- a/internal/remediation/suggester/suggest.go
+++ b/internal/remediation/suggester/suggest.go
@@ -1,0 +1,31 @@
+package suggest
+
+import (
+	"context"
+	"fmt"
+
+	"deps.dev/util/resolve"
+)
+
+type SuggestOptions struct {
+	NoMajorUpdates bool
+}
+
+// A VersionSuggester provides an ecosystem-specific method for 'suggesting'
+// the latest version of a dependency based on the given options.
+type VersionSuggester interface {
+	Suggest(ctx context.Context, client resolve.Client, req resolve.RequirementVersion, opts SuggestOptions) (resolve.RequirementVersion, error)
+}
+
+func GetSuggester(system resolve.System) (VersionSuggester, error) {
+	switch system {
+	case resolve.Maven:
+		return &MavenSuggester{}, nil
+	case resolve.NPM:
+		return nil, fmt.Errorf("npm not yet supported")
+	case resolve.UnknownSystem:
+		return nil, fmt.Errorf("unknown system")
+	default:
+		return nil, fmt.Errorf("unsupported ecosystem: %v", system)
+	}
+}


### PR DESCRIPTION
This PR adds the implementation for Maven version suggester:
 - The latest version of the specified package is returned based on the given options.
 - A version range requirement will be replaced to the latest version if this version does not satisfy the constraint.
 - Major updates can be ignored with option `NoMajorUpdates` set to true.