### PR TITLE
Guided Remediation: Compute Dev dependencies in in-place parsing

### DIFF
--- a/internal/remediation/in_place.go
+++ b/internal/remediation/in_place.go
@@ -275,7 +275,7 @@ func inPlaceVulnsNodes(cl client.VulnerabilityClient, graph *resolve.Graph) (inP
 			resVuln := resolution.ResolutionVuln{
 				Vulnerability: vuln,
 				ProblemChains: slices.Clone(chains),
-				DevOnly:       false, // TODO: parse & compute from lockfile
+				DevOnly:       !slices.ContainsFunc(chains, func(dc resolution.DependencyChain) bool { return !resolution.ChainIsDev(dc, nil) }),
 			}
 			idx := slices.IndexFunc(result.vkVulns[vk], func(rv resolution.ResolutionVuln) bool { return rv.Vulnerability.ID == resVuln.Vulnerability.ID })
 			if idx >= 0 {

--- a/internal/resolution/resolve.go
+++ b/internal/resolution/resolve.go
@@ -139,7 +139,7 @@ func (res *ResolutionResult) computeVulns(ctx context.Context, cl client.Resolut
 			} else {
 				rv.NonProblemChains = append(rv.NonProblemChains, chain)
 			}
-			rv.DevOnly = rv.DevOnly && ChainIsDev(chain, res.Manifest)
+			rv.DevOnly = rv.DevOnly && ChainIsDev(chain, res.Manifest.Groups)
 		}
 		if len(rv.ProblemChains) == 0 {
 			// There has to be at least one problem chain for the vulnerability to appear.


### PR DESCRIPTION
I've used the `dep.Dev` type in the in-place parsed graph to flag dev dependencies.
Ideally, I'd also be able to do the same with the relock graph, it's just that the npm resolver does not resolve any dev dependencies