### PR TITLE
chore: don't ignore `fixtures` directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,4 @@
 /osv-scanner
 /coverage.out
 /coverage.html
-fixtures/
 *.tar


### PR DESCRIPTION
I mistakenly added this in #693