### PR TITLE
Added a switch for using cached local db in test to improve speed

### DIFF
--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -62,7 +62,7 @@ func normalizeRootDirectory(t *testing.T, str string) string {
 	return strings.ReplaceAll(str, cwd, "<rootdir>")
 }
 
-// normalizeRootDirectory attempts to replace references to the temp directory
+// normalizeTempDirectory attempts to replace references to the temp directory
 // with "<tempdir>", to ensure tests pass across different OSs
 func normalizeTempDirectory(t *testing.T, str string) string {
 	t.Helper()
@@ -508,8 +508,19 @@ func TestRun_LocalDatabases(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			testDir, cleanupTestDir := createTestDir(t)
-			defer cleanupTestDir()
+			var testDir string
+			var cleanupTestDir func()
+
+			if os.Getenv("TEST_ACCEPTANCE") != "true" {
+				testDir = filepath.Join(os.TempDir(), "osv-scanner-test-0")
+				err := os.MkdirAll(testDir, 0777)
+				if err != nil {
+					t.Fatalf("could not create test directory: %v", err)
+				}
+			} else {
+				testDir, cleanupTestDir = createTestDir(t)
+				defer cleanupTestDir()
+			}
 
 			old := tt.args
 

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -523,16 +523,13 @@ func TestRun_LocalDatabases(t *testing.T) {
 		},
 	}
 
-	var testDir string
-	var cleanupTestDir func()
-
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
 			if os.Getenv("TEST_ACCEPTANCE") == "true" {
-				testDir, cleanupTestDir = createTestDir(t)
+				testDir, cleanupTestDir := createTestDir(t)
 				defer cleanupTestDir()
 				old := tt.args
 				tt.args = []string{"", "--experimental-local-db-path", testDir}

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -528,7 +528,7 @@ func TestRun_LocalDatabases(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			if os.Getenv("TEST_ACCEPTANCE") == "true" {
+			if testutility.AcceptanceTestOn() {
 				testDir, cleanupTestDir := createTestDir(t)
 				defer cleanupTestDir()
 				old := tt.args

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -503,16 +503,19 @@ func TestRun_LocalDatabases(t *testing.T) {
 			exit: 0,
 		},
 	}
+
+	var testDir string
+	var cleanupTestDir func()
+	if os.Getenv("TEST_ACCEPTANCE") != "true" {
+		testDir = filepath.Join(os.TempDir(), "osv-scanner-test-0")
+	}
+
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			var testDir string
-			var cleanupTestDir func()
-
-			if os.Getenv("TEST_ACCEPTANCE") != "true" {
-				testDir = filepath.Join(os.TempDir(), "osv-scanner-test-0")
+			if testDir != "" {
 				err := os.MkdirAll(testDir, 0777)
 				if err != nil {
 					t.Fatalf("could not create test directory: %v", err)

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -528,7 +528,7 @@ func TestRun_LocalDatabases(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			if testutility.AcceptanceTestOn() {
+			if testutility.IsAcceptanceTest() {
 				testDir, cleanupTestDir := createTestDir(t)
 				defer cleanupTestDir()
 				old := tt.args

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -62,6 +62,24 @@ func normalizeRootDirectory(t *testing.T, str string) string {
 	return strings.ReplaceAll(str, cwd, "<rootdir>")
 }
 
+// normalizeUserCacheDirectory attempts to replace references to the current working
+// directory with "<tempdir>", in order to reduce the noise of the cmp diff
+func normalizeUserCacheDirectory(t *testing.T, str string) string {
+	t.Helper()
+
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		t.Errorf("could not get user cache (%v) - results and diff might be inaccurate!", err)
+	}
+
+	cacheDir = normalizeFilePaths(t, cacheDir)
+
+	// file uris with Windows end up with three slashes, so we normalize that too
+	str = strings.ReplaceAll(str, "file:///"+cacheDir, "file://<tempdir>")
+
+	return strings.ReplaceAll(str, cacheDir, "<tempdir>")
+}
+
 // normalizeTempDirectory attempts to replace references to the temp directory
 // with "<tempdir>", to ensure tests pass across different OSs
 func normalizeTempDirectory(t *testing.T, str string) string {
@@ -95,6 +113,7 @@ func normalizeStdStream(t *testing.T, std *bytes.Buffer) string {
 		normalizeFilePaths,
 		normalizeRootDirectory,
 		normalizeTempDirectory,
+		normalizeUserCacheDirectory,
 		normalizeErrors,
 	} {
 		str = normalizer(t, str)
@@ -506,29 +525,19 @@ func TestRun_LocalDatabases(t *testing.T) {
 
 	var testDir string
 	var cleanupTestDir func()
-	if os.Getenv("TEST_ACCEPTANCE") != "true" {
-		testDir = filepath.Join(os.TempDir(), "osv-scanner-test-0")
-	}
 
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			if testDir != "" {
-				err := os.MkdirAll(testDir, 0777)
-				if err != nil {
-					t.Fatalf("could not create test directory: %v", err)
-				}
-			} else {
+			if os.Getenv("TEST_ACCEPTANCE") == "true" {
 				testDir, cleanupTestDir = createTestDir(t)
 				defer cleanupTestDir()
+				old := tt.args
+				tt.args = []string{"", "--experimental-local-db-path", testDir}
+				tt.args = append(tt.args, old[1:]...)
 			}
-
-			old := tt.args
-
-			tt.args = []string{"", "--experimental-local-db-path", testDir}
-			tt.args = append(tt.args, old[1:]...)
 
 			// run each test twice since they should provide the same output,
 			// and the second run should be fast as the db is already available

--- a/internal/local/check.go
+++ b/internal/local/check.go
@@ -73,10 +73,10 @@ func setupLocalDBDirectory(localDBPath string) (string, error) {
 		}
 	}
 
-	err = os.MkdirAll(path.Join(localDBPath, "osv-scanner"), 0750)
-
+	altPath := path.Join(localDBPath, "osv-scanner")
+	err = os.MkdirAll(altPath, 0750)
 	if err == nil {
-		return path.Join(localDBPath, "osv-scanner"), nil
+		return altPath, nil
 	}
 
 	// if we're implicitly picking a path, try the temp directory before giving up

--- a/internal/sourceanalysis/rust_test.go
+++ b/internal/sourceanalysis/rust_test.go
@@ -65,7 +65,7 @@ func Test_functionsFromDWARF(t *testing.T) {
 }
 
 func Test_rustBuildSource(t *testing.T) {
-	testutility.AcceptanceTests(t, "Requires rust toolchain to be installed")
+	testutility.SkipIfNotAcceptanceTesting(t, "Requires rust toolchain to be installed")
 	t.Parallel()
 
 	workingDir, err := os.Getwd()

--- a/internal/testutility/utility.go
+++ b/internal/testutility/utility.go
@@ -37,10 +37,7 @@ func Skip(t *testing.T, args ...any) {
 // Access to environment variable that toggles acceptance testing execution paths
 // Acceptance testing is "On" only when var set to "true"
 func AcceptanceTestOn() bool {
-	if os.Getenv("TEST_ACCEPTANCE") == "true" {
-		return true
-	}
-	return false
+	return os.Getenv("TEST_ACCEPTANCE") == "true"
 }
 
 // AcceptanceTests marks this test function as a extended that require additional dependencies

--- a/internal/testutility/utility.go
+++ b/internal/testutility/utility.go
@@ -34,11 +34,20 @@ func Skip(t *testing.T, args ...any) {
 	snaps.Skip(t, args...)
 }
 
+// Access to environment variable that toggles acceptance testing execution paths
+// Acceptance testing is "On" only when var set to "true"
+func AcceptanceTestOn() bool {
+	if os.Getenv("TEST_ACCEPTANCE") == "true" {
+		return true
+	}
+	return false
+}
+
 // AcceptanceTests marks this test function as a extended that require additional dependencies
 // automatically skipped unless running in a CI environment
-func AcceptanceTests(t *testing.T, reason string) {
+func SkipIfNotAcceptanceTesting(t *testing.T, reason string) {
 	t.Helper()
-	if os.Getenv("TEST_ACCEPTANCE") != "true" {
+	if !AcceptanceTestOn() {
 		Skip(t, "Skipping extended test: ", reason)
 	}
 }

--- a/internal/testutility/utility.go
+++ b/internal/testutility/utility.go
@@ -36,7 +36,7 @@ func Skip(t *testing.T, args ...any) {
 
 // Access to environment variable that toggles acceptance testing execution paths
 // Acceptance testing is "On" only when var set to "true"
-func AcceptanceTestOn() bool {
+func IsAcceptanceTest() bool {
 	return os.Getenv("TEST_ACCEPTANCE") == "true"
 }
 
@@ -44,7 +44,7 @@ func AcceptanceTestOn() bool {
 // automatically skipped unless running in a CI environment
 func SkipIfNotAcceptanceTesting(t *testing.T, reason string) {
 	t.Helper()
-	if !AcceptanceTestOn() {
+	if !IsAcceptanceTest() {
 		Skip(t, "Skipping extended test: ", reason)
 	}
 }


### PR DESCRIPTION
regarding : https://github.com/google/osv-scanner/issues/741

As discussed with google team, moving to using cached local db when not running acceptance tests.