### PR TITLE
perf: optimize string formatting and update linting

### DIFF
--- a/.github/workflows/lint-action/action.yml
+++ b/.github/workflows/lint-action/action.yml
@@ -22,6 +22,6 @@ runs:
       uses: golangci/golangci-lint-action@3cfe3a4abbb849e10058ce4af15d205b6da42804 # v4.0.0
       with:
         # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-        version: v1.55.2
+        version: v1.56.2
         # https://github.com/golangci/golangci-lint-action/issues/135
         skip-pkg-cache: true

--- a/cmd/osv-scanner/fix/main.go
+++ b/cmd/osv-scanner/fix/main.go
@@ -1,6 +1,7 @@
 package fix
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -85,11 +86,11 @@ func Command(stdout, stderr io.Writer, r *reporter.Reporter) *cli.Command {
 					switch s {
 					case "in-place":
 						if !ctx.IsSet("lockfile") {
-							return fmt.Errorf("in-place strategy requires lockfile")
+							return errors.New("in-place strategy requires lockfile")
 						}
 					case "relock":
 						if !ctx.IsSet("manifest") {
-							return fmt.Errorf("relock strategy requires manifest file")
+							return errors.New("relock strategy requires manifest file")
 						}
 					default:
 						return fmt.Errorf("unsupported strategy \"%s\" - must be one of: in-place, relock", s)
@@ -158,11 +159,11 @@ func Command(stdout, stderr io.Writer, r *reporter.Reporter) *cli.Command {
 func action(ctx *cli.Context, stdout, stderr io.Writer) (reporter.Reporter, error) {
 	// The Action on strategy isn't run when using the default values. Check if the manifest is set.
 	if ctx.Bool("non-interactive") && ctx.String("strategy") == "relock" && !ctx.IsSet("manifest") {
-		return nil, fmt.Errorf("relock strategy requires manifest file")
+		return nil, errors.New("relock strategy requires manifest file")
 	}
 
 	if !ctx.IsSet("manifest") && !ctx.IsSet("lockfile") {
-		return nil, fmt.Errorf("manifest or lockfile is required")
+		return nil, errors.New("manifest or lockfile is required")
 	}
 
 	opts := osvFixOptions{

--- a/cmd/osv-scanner/scan/main.go
+++ b/cmd/osv-scanner/scan/main.go
@@ -48,7 +48,7 @@ func Command(stdout, stderr io.Writer, r *reporter.Reporter) *cli.Command {
 			&cli.StringFlag{
 				Name:    "format",
 				Aliases: []string{"f"},
-				Usage:   fmt.Sprintf("sets the output format; value can be: %s", strings.Join(reporter.Format(), ", ")),
+				Usage:   "sets the output format; value can be: " + strings.Join(reporter.Format(), ", "),
 				Value:   "table",
 				Action: func(context *cli.Context, s string) error {
 					if slices.Contains(reporter.Format(), s) {
@@ -98,7 +98,7 @@ func Command(stdout, stderr io.Writer, r *reporter.Reporter) *cli.Command {
 			},
 			&cli.StringFlag{
 				Name:  "verbosity",
-				Usage: fmt.Sprintf("specify the level of information that should be provided during runtime; value can be: %s", strings.Join(reporter.VerbosityLevels(), ", ")),
+				Usage: "specify the level of information that should be provided during runtime; value can be: " + strings.Join(reporter.VerbosityLevels(), ", "),
 				Value: "info",
 			},
 			&cli.BoolFlag{

--- a/cmd/osv-scanner/scan/main.go
+++ b/cmd/osv-scanner/scan/main.go
@@ -169,13 +169,13 @@ func action(context *cli.Context, stdout, stderr io.Writer) (reporter.Reporter, 
 	}
 
 	if context.Bool("experimental-licenses-summary") && context.IsSet("experimental-licenses") {
-		return nil, fmt.Errorf("--experimental-licenses-summary and --experimental-licenses flags cannot be set")
+		return nil, errors.New("--experimental-licenses-summary and --experimental-licenses flags cannot be set")
 	}
 	allowlist := context.StringSlice("experimental-licenses")
 	if context.IsSet("experimental-licenses") {
 		if len(allowlist) == 0 ||
 			(len(allowlist) == 1 && allowlist[0] == "") {
-			return nil, fmt.Errorf("--experimental-licenses requires at least one value")
+			return nil, errors.New("--experimental-licenses requires at least one value")
 		}
 		if unrecognized := spdx.Unrecognized(allowlist); len(unrecognized) > 0 {
 			return nil, fmt.Errorf("--experimental-licenses requires comma-separated spdx licenses. The following license(s) are not recognized as spdx: %s", strings.Join(unrecognized, ","))

--- a/internal/image/image.go
+++ b/internal/image/image.go
@@ -153,7 +153,7 @@ func loadImage(imagePath string) (Image, error) {
 				numBytes, err := io.Copy(f, io.LimitReader(tarReader, fileReadLimit))
 				if numBytes >= fileReadLimit || errors.Is(err, io.EOF) {
 					f.Close()
-					return Image{}, fmt.Errorf("file exceeds read limit (potential decompression bomb attack)")
+					return Image{}, errors.New("file exceeds read limit (potential decompression bomb attack)")
 				}
 				if err != nil {
 					f.Close()

--- a/internal/local/check.go
+++ b/internal/local/check.go
@@ -1,6 +1,7 @@
 package local
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -129,7 +130,7 @@ func MakeRequest(r reporter.Reporter, query osv.BatchedQuery, offline bool, loca
 		if pkg.Ecosystem == "" {
 			if pkg.Commit == "" {
 				// The only time this can happen should be when someone passes in their own OSV-Scanner-Results file.
-				return nil, fmt.Errorf("ecosystem is empty and there is no commit hash")
+				return nil, errors.New("ecosystem is empty and there is no commit hash")
 			}
 
 			// Is a commit based query, skip local scanning

--- a/internal/local/zip.go
+++ b/internal/local/zip.go
@@ -68,7 +68,7 @@ func fetchRemoteArchiveCRC32CHash(url string) (uint32, error) {
 		}
 	}
 
-	return 0, fmt.Errorf("could not find crc32c= checksum")
+	return 0, errors.New("could not find crc32c= checksum")
 }
 
 func fetchLocalArchiveCRC32CHash(data []byte) uint32 {

--- a/internal/output/githubannotation.go
+++ b/internal/output/githubannotation.go
@@ -23,7 +23,7 @@ func createSourceRemediationTable(source models.PackageSource, groupFixedVersion
 
 			vulnIDs := []string{}
 			for _, id := range group.IDs {
-				vulnIDs = append(vulnIDs, fmt.Sprintf("https://osv.dev/%s", id))
+				vulnIDs = append(vulnIDs, "https://osv.dev/"+id)
 			}
 			remediationTable.AppendRow(table.Row{
 				pv.Package.Name,

--- a/internal/remediation/suggest/suggest.go
+++ b/internal/remediation/suggest/suggest.go
@@ -2,6 +2,7 @@ package suggest
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"deps.dev/util/resolve"
@@ -28,9 +29,9 @@ func GetSuggester(system resolve.System) (PatchSuggester, error) {
 	case resolve.Maven:
 		return &MavenSuggester{}, nil
 	case resolve.NPM:
-		return nil, fmt.Errorf("npm not yet supported")
+		return nil, errors.New("npm not yet supported")
 	case resolve.UnknownSystem:
-		return nil, fmt.Errorf("unknown system")
+		return nil, errors.New("unknown system")
 	default:
 		return nil, fmt.Errorf("unsupported ecosystem: %v", system)
 	}

--- a/internal/resolution/manifest/maven.go
+++ b/internal/resolution/manifest/maven.go
@@ -309,7 +309,7 @@ func (MavenManifestIO) Write(df lockfile.DepFile, w io.Writer, patch ManifestPat
 
 				properties, ok := patch.EcosystemSpecific.(MavenPropertyPatches)
 				if !ok {
-					return fmt.Errorf("cannot convert ecosystem specific information to Maven properties")
+					return errors.New("cannot convert ecosystem specific information to Maven properties")
 				}
 				// Then we update the project by passing the innerXML and name spaces are not passed.
 				if err := updateProject(enc, rawProj.InnerXML, "", "", patches, properties); err != nil {

--- a/internal/semantic/version-pypi.go
+++ b/internal/semantic/version-pypi.go
@@ -94,7 +94,7 @@ func normalizePyPILegacyPart(part string) string {
 		return fmt.Sprintf("%08s", part)
 	}
 
-	return fmt.Sprintf("*%s", part)
+	return "*" + part
 }
 
 func parsePyPIVersionParts(str string) (parts []string) {
@@ -191,7 +191,7 @@ func (pv PyPIVersion) preIndex() int {
 		}
 	}
 
-	panic(fmt.Sprintf("unknown prefix %s", pv.pre.letter))
+	panic("unknown prefix " + pv.pre.letter)
 }
 
 // Checks if this PyPIVersion should apply a sort trick when comparing pre,

--- a/internal/sourceanalysis/go.go
+++ b/internal/sourceanalysis/go.go
@@ -137,7 +137,7 @@ func runGovulncheck(moddir string, vulns []models.Vulnerability, goVersion strin
 	cmd := scan.Command(context.Background(), "-db", dbdirURL.String(), "-C", moddir, "-json", "./...")
 	var b bytes.Buffer
 	cmd.Stdout = &b
-	cmd.Env = append(os.Environ(), fmt.Sprintf("GOVERSION=go%s", goVersion))
+	cmd.Env = append(os.Environ(), "GOVERSION=go"+goVersion)
 	if err := cmd.Start(); err != nil {
 		return nil, err
 	}

--- a/internal/sourceanalysis/rust.go
+++ b/internal/sourceanalysis/rust.go
@@ -265,7 +265,7 @@ func rustBuildSource(r reporter.Reporter, source models.SourceInfo) ([]string, e
 		fileSplit := strings.Split(string(file), ": ")
 		if len(fileSplit) != 2 {
 			// TODO: this can probably be fixed with more effort
-			return nil, fmt.Errorf("file path contains ': ', which is unsupported")
+			return nil, errors.New("file path contains ': ', which is unsupported")
 		}
 		resultBinaryPaths = append(resultBinaryPaths, fileSplit[0])
 	}

--- a/internal/thirdparty/ar/reader.go
+++ b/internal/thirdparty/ar/reader.go
@@ -24,7 +24,7 @@ package ar
 
 import (
 	"bytes"
-	"fmt"
+	"errors"
 	"io"
 	"strconv"
 	"strings"
@@ -80,7 +80,7 @@ func NewReader(r io.Reader) (*Reader, error) {
 	_, _ = io.CopyN(&sigBuf, r, 8) // Discard global header
 
 	if sigBuf.String() != ArSignature {
-		return nil, fmt.Errorf("not an rlib archive")
+		return nil, errors.New("not an rlib archive")
 	}
 
 	return &Reader{r: r}, nil

--- a/pkg/lockfile/extract.go
+++ b/pkg/lockfile/extract.go
@@ -11,7 +11,7 @@ var lockfileExtractors = map[string]Extractor{}
 
 func registerExtractor(name string, extractor Extractor) {
 	if _, ok := lockfileExtractors[name]; ok {
-		panic(fmt.Sprintf("an extractor is already registered as %s", name))
+		panic("an extractor is already registered as" + name)
 	}
 
 	lockfileExtractors[name] = extractor

--- a/pkg/lockfile/extract_test.go
+++ b/pkg/lockfile/extract_test.go
@@ -2,7 +2,6 @@ package lockfile_test
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -17,7 +16,7 @@ type TestDepFile struct {
 }
 
 func (f TestDepFile) Open(_ string) (lockfile.NestedDepFile, error) {
-	return TestDepFile{}, fmt.Errorf("file opening is not supported")
+	return TestDepFile{}, errors.New("file opening is not supported")
 }
 
 func (f TestDepFile) Path() string { return f.path }

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -718,7 +718,7 @@ func DoScan(actions ScannerActions, r reporter.Reporter) (models.VulnerabilityRe
 		actions.SkipGit = true
 
 		if len(actions.ScanLicensesAllowlist) > 0 || actions.ScanLicensesSummary {
-			return models.VulnerabilityResults{}, fmt.Errorf("cannot retrieve licenses locally")
+			return models.VulnerabilityResults{}, errors.New("cannot retrieve licenses locally")
 		}
 	}
 

--- a/scripts/run_lints.sh
+++ b/scripts/run_lints.sh
@@ -2,4 +2,4 @@
 
 set -ex
 
-go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.2 run ./... --max-same-issues 0
+go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.2 run ./... --max-same-issues 0


### PR DESCRIPTION
I'm kind of on the fence about this - I actually ran the [`perfsprint` benchmarks locally](https://github.com/catenacyber/perfsprint) and these changes are indeed faster, but they're really in the hotpath; at the same time though we're not importing anything new for this and it could one day catch a use on the hotpath so I'm not sure about disabling it either.

Happy to hear what others think