### PR TITLE
Remove version from the binary name.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -135,11 +135,11 @@ docker_manifests:
 
 archives:
   - format: binary
-    name_template: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    name_template: "{{ .Binary }}_{{ .Os }}_{{ .Arch }}"
     builds:
       - osv-scanner
 checksum:
-  name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
+  name_template: "{{ .ProjectName }}_SHA256SUMS"
   algorithm: sha256
 release:
   draft: true


### PR DESCRIPTION
Removing redundant versioning for cleaner binary names.