### PR TITLE
test: make `createTestDir` a general test utility

### DIFF
--- a/cmd/osv-scanner/fix_test.go
+++ b/cmd/osv-scanner/fix_test.go
@@ -68,7 +68,7 @@ func TestRun_Fix(t *testing.T) {
 			}
 
 			// fix action overwrites files, copy them to a temporary directory
-			testDir, cleanupTestDir := createTestDir(t)
+			testDir, cleanupTestDir := testutility.CreateTestDir(t)
 			defer cleanupTestDir()
 
 			var lockfile, manifest string

--- a/cmd/osv-scanner/fix_test.go
+++ b/cmd/osv-scanner/fix_test.go
@@ -68,8 +68,7 @@ func TestRun_Fix(t *testing.T) {
 			}
 
 			// fix action overwrites files, copy them to a temporary directory
-			testDir, cleanupTestDir := testutility.CreateTestDir(t)
-			defer cleanupTestDir()
+			testDir := testutility.CreateTestDir(t)
 
 			var lockfile, manifest string
 			if tt.lockfile != "" {

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -15,19 +15,6 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func createTestDir(t *testing.T) (string, func()) {
-	t.Helper()
-
-	p, err := os.MkdirTemp("", "osv-scanner-test-*")
-	if err != nil {
-		t.Fatalf("could not create test directory: %v", err)
-	}
-
-	return p, func() {
-		_ = os.RemoveAll(p)
-	}
-}
-
 type cliTestCase struct {
 	name string
 	args []string
@@ -529,7 +516,7 @@ func TestRun_LocalDatabases(t *testing.T) {
 			t.Parallel()
 
 			if testutility.IsAcceptanceTest() {
-				testDir, cleanupTestDir := createTestDir(t)
+				testDir, cleanupTestDir := testutility.CreateTestDir(t)
 				defer cleanupTestDir()
 				old := tt.args
 				tt.args = []string{"", "--experimental-local-db-path", testDir}

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -516,8 +516,7 @@ func TestRun_LocalDatabases(t *testing.T) {
 			t.Parallel()
 
 			if testutility.IsAcceptanceTest() {
-				testDir, cleanupTestDir := testutility.CreateTestDir(t)
-				defer cleanupTestDir()
+				testDir := testutility.CreateTestDir(t)
 				old := tt.args
 				tt.args = []string{"", "--experimental-local-db-path", testDir}
 				tt.args = append(tt.args, old[1:]...)

--- a/internal/local/zip_test.go
+++ b/internal/local/zip_test.go
@@ -17,21 +17,9 @@ import (
 	"testing"
 
 	"github.com/google/osv-scanner/internal/local"
+	"github.com/google/osv-scanner/internal/testutility"
 	"github.com/google/osv-scanner/pkg/models"
 )
-
-func createTestDir(t *testing.T) (string, func()) {
-	t.Helper()
-
-	p, err := os.MkdirTemp("", "osv-scanner-test-*")
-	if err != nil {
-		t.Fatal("could not create test directory")
-	}
-
-	return p, func() {
-		_ = os.RemoveAll(p)
-	}
-}
 
 func expectDBToHaveOSVs(
 	t *testing.T,
@@ -149,7 +137,7 @@ func determineStoredAtPath(dbBasePath, name string) string {
 func TestNewZippedDB_Offline_WithoutCache(t *testing.T) {
 	t.Parallel()
 
-	testDir, cleanupTestDir := createTestDir(t)
+	testDir, cleanupTestDir := testutility.CreateTestDir(t)
 	defer cleanupTestDir()
 
 	ts, cleanupTestServer := createZipServer(t, func(w http.ResponseWriter, r *http.Request) {
@@ -175,7 +163,7 @@ func TestNewZippedDB_Offline_WithCache(t *testing.T) {
 		{ID: "GHSA-5"},
 	}
 
-	testDir, cleanupTestDir := createTestDir(t)
+	testDir, cleanupTestDir := testutility.CreateTestDir(t)
 	defer cleanupTestDir()
 
 	ts, cleanupTestServer := createZipServer(t, func(w http.ResponseWriter, r *http.Request) {
@@ -203,7 +191,7 @@ func TestNewZippedDB_Offline_WithCache(t *testing.T) {
 func TestNewZippedDB_BadZip(t *testing.T) {
 	t.Parallel()
 
-	testDir, cleanupTestDir := createTestDir(t)
+	testDir, cleanupTestDir := testutility.CreateTestDir(t)
 	defer cleanupTestDir()
 
 	ts, cleanupTestServer := createZipServer(t, func(w http.ResponseWriter, r *http.Request) {
@@ -221,7 +209,7 @@ func TestNewZippedDB_BadZip(t *testing.T) {
 func TestNewZippedDB_UnsupportedProtocol(t *testing.T) {
 	t.Parallel()
 
-	testDir, cleanupTestDir := createTestDir(t)
+	testDir, cleanupTestDir := testutility.CreateTestDir(t)
 	defer cleanupTestDir()
 
 	_, err := local.NewZippedDB(testDir, "my-db", "file://hello-world", false)
@@ -242,7 +230,7 @@ func TestNewZippedDB_Online_WithoutCache(t *testing.T) {
 		{ID: "GHSA-5"},
 	}
 
-	testDir, cleanupTestDir := createTestDir(t)
+	testDir, cleanupTestDir := testutility.CreateTestDir(t)
 	defer cleanupTestDir()
 
 	ts, cleanupTestServer := createZipServer(t, func(w http.ResponseWriter, r *http.Request) {
@@ -276,7 +264,7 @@ func TestNewZippedDB_Online_WithoutCacheAndNoHashHeader(t *testing.T) {
 		{ID: "GHSA-5"},
 	}
 
-	testDir, cleanupTestDir := createTestDir(t)
+	testDir, cleanupTestDir := testutility.CreateTestDir(t)
 	defer cleanupTestDir()
 
 	ts, cleanupTestServer := createZipServer(t, func(w http.ResponseWriter, r *http.Request) {
@@ -308,7 +296,7 @@ func TestNewZippedDB_Online_WithSameCache(t *testing.T) {
 		{ID: "GHSA-3"},
 	}
 
-	testDir, cleanupTestDir := createTestDir(t)
+	testDir, cleanupTestDir := testutility.CreateTestDir(t)
 	defer cleanupTestDir()
 
 	cache := zipOSVs(t, map[string]models.Vulnerability{
@@ -350,7 +338,7 @@ func TestNewZippedDB_Online_WithDifferentCache(t *testing.T) {
 		{ID: "GHSA-5"},
 	}
 
-	testDir, cleanupTestDir := createTestDir(t)
+	testDir, cleanupTestDir := testutility.CreateTestDir(t)
 	defer cleanupTestDir()
 
 	ts, cleanupTestServer := createZipServer(t, func(w http.ResponseWriter, r *http.Request) {
@@ -382,7 +370,7 @@ func TestNewZippedDB_Online_WithDifferentCache(t *testing.T) {
 func TestNewZippedDB_Online_WithCacheButNoHashHeader(t *testing.T) {
 	t.Parallel()
 
-	testDir, cleanupTestDir := createTestDir(t)
+	testDir, cleanupTestDir := testutility.CreateTestDir(t)
 	defer cleanupTestDir()
 
 	ts, cleanupTestServer := createZipServer(t, func(w http.ResponseWriter, r *http.Request) {
@@ -418,7 +406,7 @@ func TestNewZippedDB_Online_WithBadCache(t *testing.T) {
 		{ID: "GHSA-3"},
 	}
 
-	testDir, cleanupTestDir := createTestDir(t)
+	testDir, cleanupTestDir := testutility.CreateTestDir(t)
 	defer cleanupTestDir()
 
 	ts, cleanupTestServer := createZipServer(t, func(w http.ResponseWriter, r *http.Request) {
@@ -446,7 +434,7 @@ func TestNewZippedDB_FileChecks(t *testing.T) {
 
 	osvs := []models.Vulnerability{{ID: "GHSA-1234"}, {ID: "GHSA-4321"}}
 
-	testDir, cleanupTestDir := createTestDir(t)
+	testDir, cleanupTestDir := testutility.CreateTestDir(t)
 	defer cleanupTestDir()
 
 	ts, cleanupTestServer := createZipServer(t, func(w http.ResponseWriter, r *http.Request) {

--- a/internal/local/zip_test.go
+++ b/internal/local/zip_test.go
@@ -137,8 +137,7 @@ func determineStoredAtPath(dbBasePath, name string) string {
 func TestNewZippedDB_Offline_WithoutCache(t *testing.T) {
 	t.Parallel()
 
-	testDir, cleanupTestDir := testutility.CreateTestDir(t)
-	defer cleanupTestDir()
+	testDir := testutility.CreateTestDir(t)
 
 	ts, cleanupTestServer := createZipServer(t, func(w http.ResponseWriter, r *http.Request) {
 		t.Errorf("a server request was made when running offline")
@@ -163,8 +162,7 @@ func TestNewZippedDB_Offline_WithCache(t *testing.T) {
 		{ID: "GHSA-5"},
 	}
 
-	testDir, cleanupTestDir := testutility.CreateTestDir(t)
-	defer cleanupTestDir()
+	testDir := testutility.CreateTestDir(t)
 
 	ts, cleanupTestServer := createZipServer(t, func(w http.ResponseWriter, r *http.Request) {
 		t.Errorf("a server request was made when running offline")
@@ -191,8 +189,7 @@ func TestNewZippedDB_Offline_WithCache(t *testing.T) {
 func TestNewZippedDB_BadZip(t *testing.T) {
 	t.Parallel()
 
-	testDir, cleanupTestDir := testutility.CreateTestDir(t)
-	defer cleanupTestDir()
+	testDir := testutility.CreateTestDir(t)
 
 	ts, cleanupTestServer := createZipServer(t, func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte("this is not a zip"))
@@ -209,8 +206,7 @@ func TestNewZippedDB_BadZip(t *testing.T) {
 func TestNewZippedDB_UnsupportedProtocol(t *testing.T) {
 	t.Parallel()
 
-	testDir, cleanupTestDir := testutility.CreateTestDir(t)
-	defer cleanupTestDir()
+	testDir := testutility.CreateTestDir(t)
 
 	_, err := local.NewZippedDB(testDir, "my-db", "file://hello-world", false)
 
@@ -230,8 +226,7 @@ func TestNewZippedDB_Online_WithoutCache(t *testing.T) {
 		{ID: "GHSA-5"},
 	}
 
-	testDir, cleanupTestDir := testutility.CreateTestDir(t)
-	defer cleanupTestDir()
+	testDir := testutility.CreateTestDir(t)
 
 	ts, cleanupTestServer := createZipServer(t, func(w http.ResponseWriter, r *http.Request) {
 		_, _ = writeOSVsZip(t, w, map[string]models.Vulnerability{
@@ -264,8 +259,7 @@ func TestNewZippedDB_Online_WithoutCacheAndNoHashHeader(t *testing.T) {
 		{ID: "GHSA-5"},
 	}
 
-	testDir, cleanupTestDir := testutility.CreateTestDir(t)
-	defer cleanupTestDir()
+	testDir := testutility.CreateTestDir(t)
 
 	ts, cleanupTestServer := createZipServer(t, func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write(zipOSVs(t, map[string]models.Vulnerability{
@@ -296,8 +290,7 @@ func TestNewZippedDB_Online_WithSameCache(t *testing.T) {
 		{ID: "GHSA-3"},
 	}
 
-	testDir, cleanupTestDir := testutility.CreateTestDir(t)
-	defer cleanupTestDir()
+	testDir := testutility.CreateTestDir(t)
 
 	cache := zipOSVs(t, map[string]models.Vulnerability{
 		"GHSA-1.json": {ID: "GHSA-1"},
@@ -338,8 +331,7 @@ func TestNewZippedDB_Online_WithDifferentCache(t *testing.T) {
 		{ID: "GHSA-5"},
 	}
 
-	testDir, cleanupTestDir := testutility.CreateTestDir(t)
-	defer cleanupTestDir()
+	testDir := testutility.CreateTestDir(t)
 
 	ts, cleanupTestServer := createZipServer(t, func(w http.ResponseWriter, r *http.Request) {
 		_, _ = writeOSVsZip(t, w, map[string]models.Vulnerability{
@@ -370,8 +362,7 @@ func TestNewZippedDB_Online_WithDifferentCache(t *testing.T) {
 func TestNewZippedDB_Online_WithCacheButNoHashHeader(t *testing.T) {
 	t.Parallel()
 
-	testDir, cleanupTestDir := testutility.CreateTestDir(t)
-	defer cleanupTestDir()
+	testDir := testutility.CreateTestDir(t)
 
 	ts, cleanupTestServer := createZipServer(t, func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write(zipOSVs(t, map[string]models.Vulnerability{
@@ -406,8 +397,7 @@ func TestNewZippedDB_Online_WithBadCache(t *testing.T) {
 		{ID: "GHSA-3"},
 	}
 
-	testDir, cleanupTestDir := testutility.CreateTestDir(t)
-	defer cleanupTestDir()
+	testDir := testutility.CreateTestDir(t)
 
 	ts, cleanupTestServer := createZipServer(t, func(w http.ResponseWriter, r *http.Request) {
 		_, _ = writeOSVsZip(t, w, map[string]models.Vulnerability{
@@ -434,8 +424,7 @@ func TestNewZippedDB_FileChecks(t *testing.T) {
 
 	osvs := []models.Vulnerability{{ID: "GHSA-1234"}, {ID: "GHSA-4321"}}
 
-	testDir, cleanupTestDir := testutility.CreateTestDir(t)
-	defer cleanupTestDir()
+	testDir := testutility.CreateTestDir(t)
 
 	ts, cleanupTestServer := createZipServer(t, func(w http.ResponseWriter, r *http.Request) {
 		_, _ = writeOSVsZip(t, w, map[string]models.Vulnerability{

--- a/internal/testutility/utility.go
+++ b/internal/testutility/utility.go
@@ -59,8 +59,9 @@ func ValueIfOnWindows(win, or string) string {
 }
 
 // CreateTestDir makes a temporary directory for use in testing that involves
-// writing and reading files from disk - make sure to call the cleanup function!
-func CreateTestDir(t *testing.T) (string, func()) {
+// writing and reading files from disk, which is automatically cleaned up
+// when testing finishes
+func CreateTestDir(t *testing.T) string {
 	t.Helper()
 
 	p, err := os.MkdirTemp("", "osv-scanner-test-*")
@@ -68,7 +69,10 @@ func CreateTestDir(t *testing.T) (string, func()) {
 		t.Fatalf("could not create test directory: %v", err)
 	}
 
-	return p, func() {
+	// ensure the test directory is removed when we're done testing
+	t.Cleanup(func() {
 		_ = os.RemoveAll(p)
-	}
+	})
+
+	return p
 }

--- a/internal/testutility/utility.go
+++ b/internal/testutility/utility.go
@@ -57,3 +57,18 @@ func ValueIfOnWindows(win, or string) string {
 
 	return or
 }
+
+// CreateTestDir makes a temporary directory for use in testing that involves
+// writing and reading files from disk - make sure to call the cleanup function!
+func CreateTestDir(t *testing.T) (string, func()) {
+	t.Helper()
+
+	p, err := os.MkdirTemp("", "osv-scanner-test-*")
+	if err != nil {
+		t.Fatalf("could not create test directory: %v", err)
+	}
+
+	return p, func() {
+		_ = os.RemoveAll(p)
+	}
+}


### PR DESCRIPTION
We've already got this duplicated in two places, and I have need for it in an upcoming PR and @robramsaynz should be using it in #797 so let's move this into `testutility`