### PR TITLE
Downgrade go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/osv-scanner
 
-go 1.21.5
+go 1.21.8
 
 require (
 	deps.dev/api/v3alpha v0.0.0-20240214003419-1729b6244a2d

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/osv-scanner
 
-go 1.22.0
+go 1.21.5
 
 require (
 	deps.dev/api/v3alpha v0.0.0-20240214003419-1729b6244a2d

--- a/internal/sourceanalysis/__snapshots__/integration_test.snap
+++ b/internal/sourceanalysis/__snapshots__/integration_test.snap
@@ -124,7 +124,7 @@
           "position": {
             "filename": "\u003cAny value\u003e",
             "offset": -1,
-            "line": 840,
+            "line": 839,
             "column": 21
           }
         },
@@ -137,7 +137,7 @@
           "position": {
             "filename": "\u003cAny value\u003e",
             "offset": -1,
-            "line": 1039,
+            "line": 1038,
             "column": 24
           }
         },
@@ -149,7 +149,7 @@
           "position": {
             "filename": "\u003cAny value\u003e",
             "offset": -1,
-            "line": 429,
+            "line": 430,
             "column": 21
           }
         },
@@ -161,7 +161,7 @@
           "position": {
             "filename": "\u003cAny value\u003e",
             "offset": -1,
-            "line": 388,
+            "line": 389,
             "column": 19
           }
         },
@@ -174,7 +174,7 @@
           "position": {
             "filename": "\u003cAny value\u003e",
             "offset": -1,
-            "line": 1003,
+            "line": 1002,
             "column": 19
           }
         },
@@ -187,7 +187,7 @@
           "position": {
             "filename": "\u003cAny value\u003e",
             "offset": -1,
-            "line": 1675,
+            "line": 1670,
             "column": 17
           }
         },
@@ -200,7 +200,7 @@
           "position": {
             "filename": "\u003cAny value\u003e",
             "offset": -1,
-            "line": 2045,
+            "line": 2015,
             "column": 18
           }
         },
@@ -213,7 +213,7 @@
           "position": {
             "filename": "\u003cAny value\u003e",
             "offset": -1,
-            "line": 3285,
+            "line": 3086,
             "column": 3
           }
         },
@@ -226,7 +226,7 @@
           "position": {
             "filename": "\u003cAny value\u003e",
             "offset": -1,
-            "line": 3184,
+            "line": 2985,
             "column": 18
           }
         },
@@ -238,7 +238,7 @@
           "position": {
             "filename": "\u003cAny value\u003e",
             "offset": -1,
-            "line": 3438,
+            "line": 3239,
             "column": 30
           }
         },


### PR DESCRIPTION
It was accidentally updated to 1.22.0 with renovatebot 2 weeks ago. We need a way to prevent this from happening. 