### PR TITLE
Automated Updates: add a simple Maven registry API client

### DIFF
--- a/internal/resolution/datasource/maven_registry.go
+++ b/internal/resolution/datasource/maven_registry.go
@@ -1,0 +1,54 @@
+package datasource
+
+import (
+	"context"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"deps.dev/util/maven"
+)
+
+const MavenCentral = "https://repo.maven.apache.org/maven2"
+
+type MavenRegistryAPIClient struct {
+	Registry string // Base URL of the registry that we are making requests
+}
+
+func NewMavenRegistryAPIClient() (*MavenRegistryAPIClient, error) {
+	return &MavenRegistryAPIClient{
+		Registry: MavenCentral,
+	}, nil
+}
+
+func (m *MavenRegistryAPIClient) GetProject(ctx context.Context, groupID, artifactID, version string) (maven.Project, error) {
+	url, err := url.JoinPath(m.Registry, strings.ReplaceAll(groupID, ".", "/"), artifactID, version, fmt.Sprintf("%s-%s.pom", artifactID, version))
+	if err != nil {
+		return maven.Project{}, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return maven.Project{}, err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return maven.Project{}, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return maven.Project{}, errors.New(resp.Status)
+	}
+
+	var proj maven.Project
+	if err := xml.NewDecoder(resp.Body).Decode(&proj); err != nil {
+		return maven.Project{}, err
+	}
+
+	return proj, nil
+}

--- a/internal/resolution/datasource/maven_test.go
+++ b/internal/resolution/datasource/maven_test.go
@@ -1,0 +1,75 @@
+package datasource
+
+import (
+	"context"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+
+	"deps.dev/util/maven"
+)
+
+type fakeMavenRegistry struct {
+	mu         sync.Mutex
+	repository map[string]string // path -> response
+}
+
+func (f *fakeMavenRegistry) setResponse(path, response string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.repository == nil {
+		f.repository = make(map[string]string)
+	}
+	f.repository[path] = response
+}
+
+func (f *fakeMavenRegistry) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	f.mu.Lock()
+	resp, ok := f.repository[strings.TrimPrefix(r.URL.Path, "/")]
+	f.mu.Unlock()
+	if !ok {
+		w.WriteHeader(http.StatusNotFound)
+		resp = "not found"
+	}
+	if _, err := io.WriteString(w, resp); err != nil {
+		log.Fatalf("WriteString: %v", err)
+	}
+}
+
+func TestGetProject(t *testing.T) {
+	t.Parallel()
+
+	fakeMaven := &fakeMavenRegistry{}
+	srv := httptest.NewServer(fakeMaven)
+	defer srv.Close()
+	client := &MavenRegistryAPIClient{
+		Registry: srv.URL,
+	}
+
+	fakeMaven.setResponse("org/example/x.y.z/1.0.0/x.y.z-1.0.0.pom", `
+	<project>
+	  <groupId>org.example</groupId>
+	  <artifactId>x.y.z</artifactId>
+	  <version>1.0.0</version>
+	</project>
+	`)
+	got, err := client.GetProject(context.Background(), "org.example", "x.y.z", "1.0.0")
+	if err != nil {
+		t.Fatalf("failed to get Maven project %s:%s verion %s: %v", "org.example", "x.y.z", "1.0.0", err)
+	}
+	want := maven.Project{
+		ProjectKey: maven.ProjectKey{
+			GroupID:    "org.example",
+			ArtifactID: "x.y.z",
+			Version:    "1.0.0",
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("GetProject(%s, %s, %s):\ngot %v\nwant %v\n", "org.example", "x.y.z", "1.0.0", got, want)
+	}
+}


### PR DESCRIPTION
This PR adds a simple Maven registry API client which sends requests to Maven Central Repository.

For now, this client can only be used to fetch a Maven project. We are able to extend the client to fetch other data (versions, dependencies, etc) in the future.