### PR TITLE
test: use "public" package where possible

### DIFF
--- a/internal/image/image_test.go
+++ b/internal/image/image_test.go
@@ -1,4 +1,4 @@
-package image
+package image_test
 
 import (
 	"errors"
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/google/osv-scanner/internal/image"
 	"github.com/google/osv-scanner/internal/testutility"
 	"github.com/google/osv-scanner/pkg/reporter"
 )
@@ -75,7 +76,7 @@ func TestScanImage(t *testing.T) {
 				t.Fatalf("%s does not exist - have you run scripts/build_test_images.sh?", tt.args.imagePath)
 			}
 
-			got, err := ScanImage(&reporter.VoidReporter{}, tt.args.imagePath)
+			got, err := image.ScanImage(&reporter.VoidReporter{}, tt.args.imagePath)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ScanImage() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/internal/resolution/manifest/maven_test.go
+++ b/internal/resolution/manifest/maven_test.go
@@ -1,4 +1,4 @@
-package manifest
+package manifest_test
 
 import (
 	"bytes"
@@ -11,6 +11,7 @@ import (
 	"deps.dev/util/maven"
 	"deps.dev/util/resolve"
 	"deps.dev/util/resolve/dep"
+	"github.com/google/osv-scanner/internal/resolution/manifest"
 	"github.com/google/osv-scanner/internal/testutility"
 	"github.com/google/osv-scanner/pkg/lockfile"
 )
@@ -43,7 +44,7 @@ func TestMavenRead(t *testing.T) {
 	}
 	defer df.Close()
 
-	mavenIO := MavenManifestIO{}
+	mavenIO := manifest.MavenManifestIO{}
 	got, err := mavenIO.Read(df)
 	if err != nil {
 		t.Fatalf("failed to read file: %v", err)
@@ -56,7 +57,7 @@ func TestMavenRead(t *testing.T) {
 	depProfileTwoMgmt.AddAttr(dep.MavenArtifactType, "pom")
 	depProfileTwoMgmt.AddAttr(dep.Scope, "import")
 
-	want := Manifest{
+	want := manifest.Manifest{
 		Root: resolve.Version{
 			VersionKey: resolve.VersionKey{
 				PackageKey: resolve.PackageKey{
@@ -160,8 +161,8 @@ func TestMavenRead(t *testing.T) {
 			{System: resolve.Maven, Name: "junit:junit"}:    {"test"},
 			{System: resolve.Maven, Name: "org.import:xyz"}: {"import"},
 		},
-		EcosystemSpecific: MavenManifestSpecific{
-			Properties: []PropertyWithOrigin{
+		EcosystemSpecific: manifest.MavenManifestSpecific{
+			Properties: []manifest.PropertyWithOrigin{
 				{Property: maven.Property{Name: "project.build.sourceEncoding", Value: "UTF-8"}},
 				{Property: maven.Property{Name: "maven.compiler.source", Value: "1.7"}},
 				{Property: maven.Property{Name: "maven.compiler.target", Value: "1.7"}},
@@ -215,8 +216,8 @@ func TestMavenWrite(t *testing.T) {
 	depProfileTwoMgmt.AddAttr(dep.MavenArtifactType, "pom")
 	depProfileTwoMgmt.AddAttr(dep.Scope, "import")
 
-	changes := ManifestPatch{
-		Deps: []DependencyPatch{
+	changes := manifest.ManifestPatch{
+		Deps: []manifest.DependencyPatch{
 			{
 				Pkg: resolve.PackageKey{
 					System: resolve.Maven,
@@ -264,7 +265,7 @@ func TestMavenWrite(t *testing.T) {
 				NewRequire: "1.2.0",
 			},
 		},
-		EcosystemSpecific: MavenPropertyPatches{
+		EcosystemSpecific: manifest.MavenPropertyPatches{
 			"": {
 				"junit.version": "4.13.2",
 			},
@@ -275,7 +276,7 @@ func TestMavenWrite(t *testing.T) {
 	}
 
 	buf := new(bytes.Buffer)
-	mavenIO := MavenManifestIO{}
+	mavenIO := manifest.MavenManifestIO{}
 	if err := mavenIO.Write(df, buf, changes); err != nil {
 		t.Fatalf("unable to update Maven pom.xml: %v", err)
 	}

--- a/internal/sourceanalysis/__snapshots__/integration_test.snap
+++ b/internal/sourceanalysis/__snapshots__/integration_test.snap
@@ -1,4 +1,4 @@
-[Test_RunGoVulnCheck - 1]
+[Test_runGovulncheck - 1]
 {
   "GO-2021-0053": [
     {

--- a/internal/sourceanalysis/integration_test.go
+++ b/internal/sourceanalysis/integration_test.go
@@ -13,7 +13,7 @@ import (
 
 var fixturesDir = "integration/fixtures-go"
 
-func Test_RunGoVulnCheck(t *testing.T) {
+func Test_runGovulncheck(t *testing.T) {
 	t.Parallel()
 	entries, err := os.ReadDir(fixturesDir)
 	if err != nil {

--- a/pkg/grouper/grouper_test.go
+++ b/pkg/grouper/grouper_test.go
@@ -1,9 +1,10 @@
-package grouper
+package grouper_test
 
 import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/osv-scanner/pkg/grouper"
 	"github.com/google/osv-scanner/pkg/models"
 )
 
@@ -11,17 +12,17 @@ func TestGroup(t *testing.T) {
 	t.Parallel()
 
 	// Should be grouped by IDs appearing in alias.
-	v1 := IDAliases{
+	v1 := grouper.IDAliases{
 		ID: "CVE-1",
 		Aliases: []string{
 			"FOO-1",
 		},
 	}
-	v2 := IDAliases{
+	v2 := grouper.IDAliases{
 		ID:      "FOO-1",
 		Aliases: []string{},
 	}
-	v3 := IDAliases{
+	v3 := grouper.IDAliases{
 		ID: "FOO-2",
 		Aliases: []string{
 			"FOO-1",
@@ -29,21 +30,21 @@ func TestGroup(t *testing.T) {
 	}
 
 	// Should be grouped by aliases intersecting.
-	v4 := IDAliases{
+	v4 := grouper.IDAliases{
 		ID: "BAR-1",
 		Aliases: []string{
 			"CVE-2",
 			"CVE-3",
 		},
 	}
-	v5 := IDAliases{
+	v5 := grouper.IDAliases{
 		ID: "BAR-2",
 		Aliases: []string{
 			"CVE-3",
 			"CVE-4",
 		},
 	}
-	v6 := IDAliases{
+	v6 := grouper.IDAliases{
 		ID: "BAR-3",
 		Aliases: []string{
 			"CVE-4",
@@ -51,13 +52,13 @@ func TestGroup(t *testing.T) {
 	}
 
 	// Unrelated.
-	v7 := IDAliases{
+	v7 := grouper.IDAliases{
 		ID: "UNRELATED-1",
 		Aliases: []string{
 			"BAR-1337",
 		},
 	}
-	v8 := IDAliases{
+	v8 := grouper.IDAliases{
 		ID: "UNRELATED-2",
 		Aliases: []string{
 			"BAR-1338",
@@ -65,18 +66,18 @@ func TestGroup(t *testing.T) {
 	}
 
 	// Unrelated, empty aliases
-	v9 := IDAliases{
+	v9 := grouper.IDAliases{
 		ID: "UNRELATED-3",
 	}
-	v10 := IDAliases{
+	v10 := grouper.IDAliases{
 		ID: "UNRELATED-4",
 	}
 	for _, tc := range []struct {
-		vulns []IDAliases
+		vulns []grouper.IDAliases
 		want  []models.GroupInfo
 	}{
 		{
-			vulns: []IDAliases{
+			vulns: []grouper.IDAliases{
 				v1, v2, v3, v4, v5, v6, v7, v8,
 			},
 			want: []models.GroupInfo{
@@ -99,7 +100,7 @@ func TestGroup(t *testing.T) {
 			},
 		},
 		{
-			vulns: []IDAliases{
+			vulns: []grouper.IDAliases{
 				v8, v2, v1, v5, v7, v4, v6, v3, v9, v10,
 			},
 			want: []models.GroupInfo{
@@ -130,7 +131,7 @@ func TestGroup(t *testing.T) {
 			},
 		},
 		{
-			vulns: []IDAliases{
+			vulns: []grouper.IDAliases{
 				v9, v10,
 			},
 			want: []models.GroupInfo{
@@ -145,7 +146,7 @@ func TestGroup(t *testing.T) {
 			},
 		},
 	} {
-		grouped := Group(tc.vulns)
+		grouped := grouper.Group(tc.vulns)
 		if diff := cmp.Diff(tc.want, grouped); diff != "" {
 			t.Errorf("GroupedVulns() returned an unexpected result (-want, +got):\n%s", diff)
 		}

--- a/pkg/models/results_test.go
+++ b/pkg/models/results_test.go
@@ -1,43 +1,44 @@
-package models
+package models_test
 
 import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/osv-scanner/pkg/models"
 )
 
 func TestFlatten(t *testing.T) {
 	t.Parallel()
 	// Test case 1: When there are no vulnerabilities
-	vulns := VulnerabilityResults{Results: []PackageSource{}}
-	expectedFlattened := []VulnerabilityFlattened{}
+	vulns := models.VulnerabilityResults{Results: []models.PackageSource{}}
+	expectedFlattened := []models.VulnerabilityFlattened{}
 	flattened := vulns.Flatten()
 	if diff := cmp.Diff(flattened, expectedFlattened); diff != "" {
 		t.Errorf("Flatten() returned unexpected result (-got +want):\n%s", diff)
 	}
 
 	// Test case 2: When there are vulnerabilities
-	group := GroupInfo{IDs: []string{"CVE-2021-1234"}}
-	pkg := PackageVulns{
-		Package:   PackageInfo{Name: "package"},
+	group := models.GroupInfo{IDs: []string{"CVE-2021-1234"}}
+	pkg := models.PackageVulns{
+		Package:   models.PackageInfo{Name: "package"},
 		DepGroups: []string{"dev"},
-		Groups:    []GroupInfo{group},
-		Vulnerabilities: []Vulnerability{
+		Groups:    []models.GroupInfo{group},
+		Vulnerabilities: []models.Vulnerability{
 			{
 				ID: "CVE-2021-1234",
-				Severity: []Severity{
+				Severity: []models.Severity{
 					{
-						Type:  SeverityType("high"),
+						Type:  models.SeverityType("high"),
 						Score: "1",
 					},
 				},
 			},
 		},
-		Licenses: []License{License("MIT")},
+		Licenses: []models.License{models.License("MIT")},
 	}
-	source := PackageSource{Source: SourceInfo{Path: "package"}, Packages: []PackageVulns{pkg}}
-	vulns = VulnerabilityResults{Results: []PackageSource{source}}
-	expectedFlattened = []VulnerabilityFlattened{
+	source := models.PackageSource{Source: models.SourceInfo{Path: "package"}, Packages: []models.PackageVulns{pkg}}
+	vulns = models.VulnerabilityResults{Results: []models.PackageSource{source}}
+	expectedFlattened = []models.VulnerabilityFlattened{
 		{
 			Source:        source.Source,
 			Package:       pkg.Package,
@@ -51,24 +52,24 @@ func TestFlatten(t *testing.T) {
 		t.Errorf("Flatten() returned unexpected result (-got +want):\n%s", diff)
 	}
 
-	// Test case 3: When there are no vulnerabilities and but license violations
-	group = GroupInfo{IDs: []string{"CVE-2021-1234"}}
-	pkg = PackageVulns{
-		Package:           PackageInfo{Name: "package"},
+	// Test case 3: When there are no vulnerabilities and license violations
+	group = models.GroupInfo{IDs: []string{"CVE-2021-1234"}}
+	pkg = models.PackageVulns{
+		Package:           models.PackageInfo{Name: "package"},
 		DepGroups:         []string{"dev"},
-		Groups:            []GroupInfo{group},
-		Licenses:          []License{License("MIT")},
-		LicenseViolations: []License{License("MIT")},
+		Groups:            []models.GroupInfo{group},
+		Licenses:          []models.License{"MIT"},
+		LicenseViolations: []models.License{"MIT"},
 	}
-	source = PackageSource{Source: SourceInfo{Path: "package"}, Packages: []PackageVulns{pkg}}
-	vulns = VulnerabilityResults{Results: []PackageSource{source}}
-	expectedFlattened = []VulnerabilityFlattened{
+	source = models.PackageSource{Source: models.SourceInfo{Path: "package"}, Packages: []models.PackageVulns{pkg}}
+	vulns = models.VulnerabilityResults{Results: []models.PackageSource{source}}
+	expectedFlattened = []models.VulnerabilityFlattened{
 		{
 			Source:            source.Source,
 			Package:           pkg.Package,
 			DepGroups:         []string{"dev"},
-			Licenses:          []License{License("MIT")},
-			LicenseViolations: []License{License("MIT")},
+			Licenses:          []models.License{"MIT"},
+			LicenseViolations: []models.License{"MIT"},
 		},
 	}
 	flattened = vulns.Flatten()
@@ -77,28 +78,28 @@ func TestFlatten(t *testing.T) {
 	}
 
 	// Test case 4: When there are vulnerabilities and license violations
-	group = GroupInfo{IDs: []string{"CVE-2021-1234"}}
-	pkg = PackageVulns{
-		Package:   PackageInfo{Name: "package"},
+	group = models.GroupInfo{IDs: []string{"CVE-2021-1234"}}
+	pkg = models.PackageVulns{
+		Package:   models.PackageInfo{Name: "package"},
 		DepGroups: []string{"dev"},
-		Groups:    []GroupInfo{group},
-		Vulnerabilities: []Vulnerability{
+		Groups:    []models.GroupInfo{group},
+		Vulnerabilities: []models.Vulnerability{
 			{
 				ID: "CVE-2021-1234",
-				Severity: []Severity{
+				Severity: []models.Severity{
 					{
-						Type:  SeverityType("high"),
+						Type:  "high",
 						Score: "1",
 					},
 				},
 			},
 		},
-		Licenses:          []License{License("MIT")},
-		LicenseViolations: []License{License("MIT")},
+		Licenses:          []models.License{"MIT"},
+		LicenseViolations: []models.License{"MIT"},
 	}
-	source = PackageSource{Source: SourceInfo{Path: "package"}, Packages: []PackageVulns{pkg}}
-	vulns = VulnerabilityResults{Results: []PackageSource{source}}
-	expectedFlattened = []VulnerabilityFlattened{
+	source = models.PackageSource{Source: models.SourceInfo{Path: "package"}, Packages: []models.PackageVulns{pkg}}
+	vulns = models.VulnerabilityResults{Results: []models.PackageSource{source}}
+	expectedFlattened = []models.VulnerabilityFlattened{
 		{
 			Source:        source.Source,
 			Package:       pkg.Package,
@@ -110,8 +111,8 @@ func TestFlatten(t *testing.T) {
 			Source:            source.Source,
 			Package:           pkg.Package,
 			DepGroups:         []string{"dev"},
-			Licenses:          []License{License("MIT")},
-			LicenseViolations: []License{License("MIT")},
+			Licenses:          []models.License{"MIT"},
+			LicenseViolations: []models.License{"MIT"},
 		},
 	}
 	flattened = vulns.Flatten()

--- a/pkg/reporter/gh-annotations_reporter_test.go
+++ b/pkg/reporter/gh-annotations_reporter_test.go
@@ -1,16 +1,18 @@
-package reporter
+package reporter_test
 
 import (
 	"bytes"
 	"io"
 	"testing"
+
+	"github.com/google/osv-scanner/pkg/reporter"
 )
 
 func TestGHAnnotationsReporter_Errorf(t *testing.T) {
 	t.Parallel()
 
 	writer := &bytes.Buffer{}
-	r := NewGHAnnotationsReporter(io.Discard, writer, ErrorLevel)
+	r := reporter.NewGHAnnotationsReporter(io.Discard, writer, reporter.ErrorLevel)
 	text := "hello world!"
 
 	r.Errorf(text)
@@ -28,16 +30,16 @@ func TestGHAnnotationsReporter_Warnf(t *testing.T) {
 
 	text := "hello world!"
 	tests := []struct {
-		lvl              VerbosityLevel
+		lvl              reporter.VerbosityLevel
 		expectedPrintout string
 	}{
-		{lvl: WarnLevel, expectedPrintout: text},
-		{lvl: ErrorLevel, expectedPrintout: ""},
+		{lvl: reporter.WarnLevel, expectedPrintout: text},
+		{lvl: reporter.ErrorLevel, expectedPrintout: ""},
 	}
 
 	for _, test := range tests {
 		writer := &bytes.Buffer{}
-		r := NewGHAnnotationsReporter(io.Discard, writer, test.lvl)
+		r := reporter.NewGHAnnotationsReporter(io.Discard, writer, test.lvl)
 
 		r.Warnf(text)
 
@@ -52,16 +54,16 @@ func TestGHAnnotationsReporter_Infof(t *testing.T) {
 
 	text := "hello world!"
 	tests := []struct {
-		lvl              VerbosityLevel
+		lvl              reporter.VerbosityLevel
 		expectedPrintout string
 	}{
-		{lvl: InfoLevel, expectedPrintout: text},
-		{lvl: WarnLevel, expectedPrintout: ""},
+		{lvl: reporter.InfoLevel, expectedPrintout: text},
+		{lvl: reporter.WarnLevel, expectedPrintout: ""},
 	}
 
 	for _, test := range tests {
 		writer := &bytes.Buffer{}
-		r := NewGHAnnotationsReporter(io.Discard, writer, test.lvl)
+		r := reporter.NewGHAnnotationsReporter(io.Discard, writer, test.lvl)
 
 		r.Infof(text)
 
@@ -76,16 +78,16 @@ func TestGHAnnotationsReporter_Verbosef(t *testing.T) {
 
 	text := "hello world!"
 	tests := []struct {
-		lvl              VerbosityLevel
+		lvl              reporter.VerbosityLevel
 		expectedPrintout string
 	}{
-		{lvl: VerboseLevel, expectedPrintout: text},
-		{lvl: InfoLevel, expectedPrintout: ""},
+		{lvl: reporter.VerboseLevel, expectedPrintout: text},
+		{lvl: reporter.InfoLevel, expectedPrintout: ""},
 	}
 
 	for _, test := range tests {
 		writer := &bytes.Buffer{}
-		r := NewGHAnnotationsReporter(io.Discard, writer, test.lvl)
+		r := reporter.NewGHAnnotationsReporter(io.Discard, writer, test.lvl)
 
 		r.Verbosef(text)
 

--- a/pkg/reporter/json_reporter_test.go
+++ b/pkg/reporter/json_reporter_test.go
@@ -1,16 +1,18 @@
-package reporter
+package reporter_test
 
 import (
 	"bytes"
 	"io"
 	"testing"
+
+	"github.com/google/osv-scanner/pkg/reporter"
 )
 
 func TestJSONReporter_Errorf(t *testing.T) {
 	t.Parallel()
 
 	writer := &bytes.Buffer{}
-	r := NewJSONReporter(io.Discard, writer, ErrorLevel)
+	r := reporter.NewJSONReporter(io.Discard, writer, reporter.ErrorLevel)
 	text := "hello world!"
 
 	r.Errorf(text)
@@ -28,16 +30,16 @@ func TestJSONReporter_Warnf(t *testing.T) {
 
 	text := "hello world!"
 	tests := []struct {
-		lvl              VerbosityLevel
+		lvl              reporter.VerbosityLevel
 		expectedPrintout string
 	}{
-		{lvl: WarnLevel, expectedPrintout: text},
-		{lvl: ErrorLevel, expectedPrintout: ""},
+		{lvl: reporter.WarnLevel, expectedPrintout: text},
+		{lvl: reporter.ErrorLevel, expectedPrintout: ""},
 	}
 
 	for _, test := range tests {
 		writer := &bytes.Buffer{}
-		r := NewJSONReporter(io.Discard, writer, test.lvl)
+		r := reporter.NewJSONReporter(io.Discard, writer, test.lvl)
 
 		r.Warnf(text)
 
@@ -52,16 +54,16 @@ func TestJSONReporter_Infof(t *testing.T) {
 
 	text := "hello world!"
 	tests := []struct {
-		lvl              VerbosityLevel
+		lvl              reporter.VerbosityLevel
 		expectedPrintout string
 	}{
-		{lvl: InfoLevel, expectedPrintout: text},
-		{lvl: WarnLevel, expectedPrintout: ""},
+		{lvl: reporter.InfoLevel, expectedPrintout: text},
+		{lvl: reporter.WarnLevel, expectedPrintout: ""},
 	}
 
 	for _, test := range tests {
 		writer := &bytes.Buffer{}
-		r := NewJSONReporter(io.Discard, writer, test.lvl)
+		r := reporter.NewJSONReporter(io.Discard, writer, test.lvl)
 
 		r.Infof(text)
 
@@ -76,16 +78,16 @@ func TestJSONReporter_Verbosef(t *testing.T) {
 
 	text := "hello world!"
 	tests := []struct {
-		lvl              VerbosityLevel
+		lvl              reporter.VerbosityLevel
 		expectedPrintout string
 	}{
-		{lvl: VerboseLevel, expectedPrintout: text},
-		{lvl: InfoLevel, expectedPrintout: ""},
+		{lvl: reporter.VerboseLevel, expectedPrintout: text},
+		{lvl: reporter.InfoLevel, expectedPrintout: ""},
 	}
 
 	for _, test := range tests {
 		writer := &bytes.Buffer{}
-		r := NewJSONReporter(io.Discard, writer, test.lvl)
+		r := reporter.NewJSONReporter(io.Discard, writer, test.lvl)
 
 		r.Verbosef(text)
 

--- a/pkg/reporter/sarif_reporter_test.go
+++ b/pkg/reporter/sarif_reporter_test.go
@@ -1,16 +1,18 @@
-package reporter
+package reporter_test
 
 import (
 	"bytes"
 	"io"
 	"testing"
+
+	"github.com/google/osv-scanner/pkg/reporter"
 )
 
 func TestSarifReporter_Errorf(t *testing.T) {
 	t.Parallel()
 
 	writer := &bytes.Buffer{}
-	r := NewSarifReporter(io.Discard, writer, ErrorLevel)
+	r := reporter.NewSarifReporter(io.Discard, writer, reporter.ErrorLevel)
 	text := "hello world!"
 
 	r.Errorf(text)
@@ -28,16 +30,16 @@ func TestSarifReporter_Warnf(t *testing.T) {
 
 	text := "hello world!"
 	tests := []struct {
-		lvl              VerbosityLevel
+		lvl              reporter.VerbosityLevel
 		expectedPrintout string
 	}{
-		{lvl: WarnLevel, expectedPrintout: text},
-		{lvl: ErrorLevel, expectedPrintout: ""},
+		{lvl: reporter.WarnLevel, expectedPrintout: text},
+		{lvl: reporter.ErrorLevel, expectedPrintout: ""},
 	}
 
 	for _, test := range tests {
 		writer := &bytes.Buffer{}
-		r := NewSarifReporter(io.Discard, writer, test.lvl)
+		r := reporter.NewSarifReporter(io.Discard, writer, test.lvl)
 
 		r.Warnf(text)
 
@@ -52,16 +54,16 @@ func TestSarifReporter_Infof(t *testing.T) {
 
 	text := "hello world!"
 	tests := []struct {
-		lvl              VerbosityLevel
+		lvl              reporter.VerbosityLevel
 		expectedPrintout string
 	}{
-		{lvl: InfoLevel, expectedPrintout: text},
-		{lvl: WarnLevel, expectedPrintout: ""},
+		{lvl: reporter.InfoLevel, expectedPrintout: text},
+		{lvl: reporter.WarnLevel, expectedPrintout: ""},
 	}
 
 	for _, test := range tests {
 		writer := &bytes.Buffer{}
-		r := NewSarifReporter(io.Discard, writer, test.lvl)
+		r := reporter.NewSarifReporter(io.Discard, writer, test.lvl)
 
 		r.Infof(text)
 
@@ -76,16 +78,16 @@ func TestSarifReporter_Verbosef(t *testing.T) {
 
 	text := "hello world!"
 	tests := []struct {
-		lvl              VerbosityLevel
+		lvl              reporter.VerbosityLevel
 		expectedPrintout string
 	}{
-		{lvl: VerboseLevel, expectedPrintout: text},
-		{lvl: InfoLevel, expectedPrintout: ""},
+		{lvl: reporter.VerboseLevel, expectedPrintout: text},
+		{lvl: reporter.InfoLevel, expectedPrintout: ""},
 	}
 
 	for _, test := range tests {
 		writer := &bytes.Buffer{}
-		r := NewSarifReporter(io.Discard, writer, test.lvl)
+		r := reporter.NewSarifReporter(io.Discard, writer, test.lvl)
 
 		r.Verbosef(text)
 

--- a/pkg/reporter/table_reporter_test.go
+++ b/pkg/reporter/table_reporter_test.go
@@ -1,16 +1,18 @@
-package reporter
+package reporter_test
 
 import (
 	"bytes"
 	"io"
 	"testing"
+
+	"github.com/google/osv-scanner/pkg/reporter"
 )
 
 func TestTableReporter_Errorf(t *testing.T) {
 	t.Parallel()
 
 	writer := &bytes.Buffer{}
-	r := NewTableReporter(io.Discard, writer, ErrorLevel, false, 0)
+	r := reporter.NewTableReporter(io.Discard, writer, reporter.ErrorLevel, false, 0)
 	text := "hello world!"
 
 	r.Errorf(text)
@@ -28,16 +30,16 @@ func TestTableReporter_Warnf(t *testing.T) {
 
 	text := "hello world!"
 	tests := []struct {
-		lvl              VerbosityLevel
+		lvl              reporter.VerbosityLevel
 		expectedPrintout string
 	}{
-		{lvl: WarnLevel, expectedPrintout: text},
-		{lvl: ErrorLevel, expectedPrintout: ""},
+		{lvl: reporter.WarnLevel, expectedPrintout: text},
+		{lvl: reporter.ErrorLevel, expectedPrintout: ""},
 	}
 
 	for _, test := range tests {
 		writer := &bytes.Buffer{}
-		r := NewTableReporter(writer, io.Discard, test.lvl, false, 0)
+		r := reporter.NewTableReporter(writer, io.Discard, test.lvl, false, 0)
 
 		r.Warnf(text)
 
@@ -52,16 +54,16 @@ func TestTableReporter_Infof(t *testing.T) {
 
 	text := "hello world!"
 	tests := []struct {
-		lvl              VerbosityLevel
+		lvl              reporter.VerbosityLevel
 		expectedPrintout string
 	}{
-		{lvl: InfoLevel, expectedPrintout: text},
-		{lvl: WarnLevel, expectedPrintout: ""},
+		{lvl: reporter.InfoLevel, expectedPrintout: text},
+		{lvl: reporter.WarnLevel, expectedPrintout: ""},
 	}
 
 	for _, test := range tests {
 		writer := &bytes.Buffer{}
-		r := NewTableReporter(writer, io.Discard, test.lvl, false, 0)
+		r := reporter.NewTableReporter(writer, io.Discard, test.lvl, false, 0)
 
 		r.Infof(text)
 
@@ -76,16 +78,16 @@ func TestTableReporter_Verbosef(t *testing.T) {
 
 	text := "hello world!"
 	tests := []struct {
-		lvl              VerbosityLevel
+		lvl              reporter.VerbosityLevel
 		expectedPrintout string
 	}{
-		{lvl: VerboseLevel, expectedPrintout: text},
-		{lvl: InfoLevel, expectedPrintout: ""},
+		{lvl: reporter.VerboseLevel, expectedPrintout: text},
+		{lvl: reporter.InfoLevel, expectedPrintout: ""},
 	}
 
 	for _, test := range tests {
 		writer := &bytes.Buffer{}
-		r := NewTableReporter(writer, io.Discard, test.lvl, false, 0)
+		r := reporter.NewTableReporter(writer, io.Discard, test.lvl, false, 0)
 
 		r.Verbosef(text)
 


### PR DESCRIPTION
None of these need to be within the same package - `internal/suggestor` could also almost be except its calling a single private function, but more notably it highlighted to me that maybe it should be called something like `suggest` anyway because it's main method is `GetSuggestor` resulting in `suggestor, err := suggestor.GetSuggestor`; happy to do a follow-up PR renaming this if folks agree.