### PR TITLE
GR: Add npm ManifestIO tests & minor fixes

### DIFF
--- a/cmd/osv-scanner/fix_test.go
+++ b/cmd/osv-scanner/fix_test.go
@@ -30,7 +30,7 @@ func matchFile(t *testing.T, file string) {
 	if err != nil {
 		t.Fatalf("could not read test file: %v", err)
 	}
-	testutility.NewSnapshot().WithWindowsReplacements(map[string]string{"\r\n": "\n"}).MatchText(t, string(b))
+	testutility.NewSnapshot().WithCRLFReplacement().MatchText(t, string(b))
 }
 
 func TestRun_Fix(t *testing.T) {

--- a/internal/resolution/manifest/__snapshots__/npm_test.snap
+++ b/internal/resolution/manifest/__snapshots__/npm_test.snap
@@ -1,0 +1,31 @@
+
+[TestNpmWrite - 1]
+{
+  "name": "npm-manifest",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "cliui": "npm:@isaacs/cliui@^9.0.0",
+    "jquery": "~0.0.1",
+    "lodash": "^4.17.21",
+    "string-width": "^7.1.0",
+    "string-width-aliased": "npm:string-width@^6.1.0"
+  },
+  "devDependencies": {
+    "eslint": "*"
+  },
+  "optionalDependencies": {
+    "glob": "^1.0.0"
+  },
+  "peerDependencies": {
+    "@babel/core": "^7.24.0"
+  }
+}
+
+---

--- a/internal/resolution/manifest/fixtures/npm-workspaces/package.json
+++ b/internal/resolution/manifest/fixtures/npm-workspaces/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "npm-workspace-test",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "workspaces": [
+    "z",
+    "ws/*"
+  ],
+  "devDependencies": {
+    "jquery": "^3.7.1",
+    "jquery-real": "npm:jquery@^3.7.1"
+  },
+  "dependencies": {
+    "@workspace/ugh": "*"
+  }
+}

--- a/internal/resolution/manifest/fixtures/npm-workspaces/ws/jquery/package.json
+++ b/internal/resolution/manifest/fixtures/npm-workspaces/ws/jquery/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "jquery",
+  "version": "3.7.1",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "semver": "^7.6.0"
+  }
+}

--- a/internal/resolution/manifest/fixtures/npm-workspaces/ws/ugh/package.json
+++ b/internal/resolution/manifest/fixtures/npm-workspaces/ws/ugh/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@workspace/ugh",
+  "version": "0.0.1",
+  "description": "",
+  "main": "index.js",
+  "devDependencies": {
+    "jquery": "*",
+    "semver": "^6.3.1"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/internal/resolution/manifest/fixtures/npm-workspaces/z/package.json
+++ b/internal/resolution/manifest/fixtures/npm-workspaces/z/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "z-z-z",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@workspace/ugh": "*",
+    "semver": "^5.7.2"
+  }
+}

--- a/internal/resolution/manifest/fixtures/package.json
+++ b/internal/resolution/manifest/fixtures/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "npm-manifest",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "cliui": "npm:@isaacs/cliui@^8.0.2",
+    "jquery": "latest",
+    "lodash": "4.17.17",
+    "string-width": "^5.1.2",
+    "string-width-aliased": "npm:string-width@^4.2.3"
+  },
+  "devDependencies": {
+    "eslint": "^8.57.0"
+  },
+  "optionalDependencies": {
+    "glob": "^10.3.10"
+  },
+  "peerDependencies": {
+    "@babel/core": "^7.24.0"
+  }
+}

--- a/internal/resolution/manifest/maven_test.go
+++ b/internal/resolution/manifest/maven_test.go
@@ -41,6 +41,7 @@ func TestMavenRead(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to open file: %v", err)
 	}
+	defer df.Close()
 
 	mavenIO := MavenManifestIO{}
 	got, err := mavenIO.Read(df)
@@ -209,6 +210,7 @@ func TestMavenWrite(t *testing.T) {
 	if err != nil {
 		t.Fatalf("fail to open file: %v", err)
 	}
+	defer df.Close()
 
 	depProfileTwoMgmt.AddAttr(dep.MavenArtifactType, "pom")
 	depProfileTwoMgmt.AddAttr(dep.Scope, "import")
@@ -277,5 +279,5 @@ func TestMavenWrite(t *testing.T) {
 	if err := mavenIO.Write(df, buf, changes); err != nil {
 		t.Fatalf("unable to update Maven pom.xml: %v", err)
 	}
-	testutility.NewSnapshot().WithWindowsReplacements(map[string]string{"\r\n": "\n"}).MatchText(t, buf.String())
+	testutility.NewSnapshot().WithCRLFReplacement().MatchText(t, buf.String())
 }

--- a/internal/resolution/manifest/npm.go
+++ b/internal/resolution/manifest/npm.go
@@ -22,13 +22,13 @@ type PackageJSON struct {
 	Version string `json:"version"`
 	// TODO: yarn allows workspaces to be a object OR a list:
 	// https://classic.yarnpkg.com/blog/2018/02/15/nohoist/
-	Workspaces      []string          `json:"workspaces"`
-	Dependencies    map[string]string `json:"dependencies"`
-	DevDependencies map[string]string `json:"devDependencies"`
+	Workspaces           []string          `json:"workspaces"`
+	Dependencies         map[string]string `json:"dependencies"`
+	DevDependencies      map[string]string `json:"devDependencies"`
+	OptionalDependencies map[string]string `json:"optionalDependencies"`
 
 	// These fields are currently only used when parsing package-lock.json
-	OptionalDependencies map[string]string `json:"optionalDependencies"`
-	PeerDependencies     map[string]string `json:"peerDependencies"`
+	PeerDependencies map[string]string `json:"peerDependencies"`
 	// BundleDependencies   []string          `json:"bundleDependencies"`
 }
 
@@ -79,50 +79,74 @@ func (rw NpmManifestIO) Read(f lockfile.DepFile) (Manifest, error) {
 		}
 		manif.LocalManifests = append(manif.LocalManifests, m)
 		workspaceNames[m.Root.Name] = struct{}{}
-		// TODO: Workspaces can potentially have name collisions with real packages
-		// The OverrideClient will always pick the local manifest, even in indirect dependencies.
-		// These workspace names probably need some unique identifier assigned to them...
-		// (what does npm actually do in this situation?)
+	}
+
+	isWorkspace := func(req resolve.RequirementVersion) bool {
+		if req.Type.HasAttr(dep.KnownAs) {
+			// "alias": "npm:pkg@*" seems to always take the real 'pkg',
+			// even if there's a workspace with the same name.
+			return false
+		}
+		_, ok := workspaceNames[req.Name]
+
+		return ok
 	}
 
 	workspaceReqVers := make(map[resolve.PackageKey]resolve.RequirementVersion)
 
+	// empirically, the dev version takes precedence over optional, which takes precedence over regular, if they conflict.
 	for pkg, ver := range packagejson.Dependencies {
-		dep := rw.makeNPMReqVer(pkg, ver)
-		if _, ok := workspaceNames[pkg]; ok {
+		req := rw.makeNPMReqVer(pkg, ver)
+		if isWorkspace(req) {
 			// workspaces seem to always be evaluated separately
-			workspaceReqVers[dep.PackageKey] = dep
+			workspaceReqVers[req.PackageKey] = req
 			continue
 		}
-		manif.Requirements = append(manif.Requirements, dep)
+		manif.Requirements = append(manif.Requirements, req)
 	}
 
-	for pkg, ver := range packagejson.DevDependencies {
-		dep := rw.makeNPMReqVer(pkg, ver)
-		if _, ok := workspaceNames[pkg]; ok {
+	for pkg, ver := range packagejson.OptionalDependencies {
+		req := rw.makeNPMReqVer(pkg, ver)
+		req.Type.AddAttr(dep.Opt, "")
+		if isWorkspace(req) {
 			// workspaces seem to always be evaluated separately
-			workspaceReqVers[dep.PackageKey] = dep
+			workspaceReqVers[req.PackageKey] = req
 			continue
 		}
 		if idx := slices.IndexFunc(manif.Requirements, func(imp resolve.RequirementVersion) bool {
-			return imp.PackageKey == dep.PackageKey
+			return imp.PackageKey == req.PackageKey
+		}); idx != -1 {
+			manif.Requirements[idx] = req
+		} else {
+			manif.Requirements = append(manif.Requirements, req)
+		}
+		manif.Groups[req.PackageKey] = []string{"optional"}
+	}
+
+	for pkg, ver := range packagejson.DevDependencies {
+		req := rw.makeNPMReqVer(pkg, ver)
+		if isWorkspace(req) {
+			// workspaces seem to always be evaluated separately
+			workspaceReqVers[req.PackageKey] = req
+			continue
+		}
+		if idx := slices.IndexFunc(manif.Requirements, func(imp resolve.RequirementVersion) bool {
+			return imp.PackageKey == req.PackageKey
 		}); idx != -1 {
 			// In newer versions of npm, having a package in both the `dependencies` and `devDependencies`
 			// makes it treated as ONLY a devDependency (using the devDependency version)
 			// npm v6 and below seems to do the opposite and there's no easy way of seeing the npm version :/
-			manif.Requirements[idx] = dep
+			manif.Requirements[idx] = req
 		} else {
-			manif.Requirements = append(manif.Requirements, dep)
+			manif.Requirements = append(manif.Requirements, req)
 		}
-		manif.Groups[dep.PackageKey] = []string{"dev"}
+		manif.Groups[req.PackageKey] = []string{"dev"}
 	}
 
-	slices.SortFunc(manif.Requirements, func(a, b resolve.RequirementVersion) int {
-		return a.VersionKey.Compare(b.VersionKey)
-	})
+	resolve.SortDependencies(manif.Requirements)
 
 	// resolve workspaces after regular requirements
-	for _, m := range manif.LocalManifests {
+	for i, m := range manif.LocalManifests {
 		imp, ok := workspaceReqVers[m.Root.PackageKey]
 		if !ok { // The workspace isn't directly used by the root package, add it as a 'requirement' anyway so it's resolved
 			imp = resolve.RequirementVersion{
@@ -134,7 +158,21 @@ func (rw NpmManifestIO) Read(f lockfile.DepFile) (Manifest, error) {
 				},
 			}
 		}
+		// Add an extra identifier to the workspace package names so name collisions don't overwrite indirect dependencies
+		imp.Name += ":workspace"
+		manif.LocalManifests[i].Root.Name = imp.Name
 		manif.Requirements = append(manif.Requirements, imp)
+		// replace the workspace's sibling requirements
+		for j, req := range m.Requirements {
+			if isWorkspace(req) {
+				manif.LocalManifests[i].Requirements[j].Name = req.Name + ":workspace"
+				if g, ok := m.Groups[req.PackageKey]; ok {
+					newPK := manif.LocalManifests[i].Requirements[j].PackageKey
+					manif.LocalManifests[i].Groups[newPK] = g
+					delete(manif.LocalManifests[i].Groups, req.PackageKey)
+				}
+			}
+		}
 	}
 
 	return manif, nil
@@ -200,15 +238,31 @@ func (NpmManifestIO) Write(r lockfile.DepFile, w io.Writer, patch ManifestPatch)
 			newVer = fmt.Sprintf("npm:%s@%s", name, newVer)
 			name = knownAs
 		}
-		// Don't currently know whether a package is a dependency or devDependency, check both.
+		// Don't know what kind of dependency this is, so check them all.
+		// Check them in dev -> optional -> prod because that's the order npm seems to use when they conflict.
 		// Check devDependency first because npm>=7 uses only the devDependency if it exists in both.
+		alreadyMatched := false
 		depStr := "devDependencies." + name
-		matchedDev := false
 		if res := gjson.Get(manif, depStr); res.Exists() {
 			if res.Str != origVer {
-				panic("Original dependency does not match package.json")
+				panic("original dependency version does not match what is in package.json")
 			}
-			matchedDev = true
+			alreadyMatched = true
+			manif, err = sjson.Set(manif, depStr, newVer)
+			if err != nil {
+				return err
+			}
+		}
+
+		depStr = "optionalDependencies." + name
+		if res := gjson.Get(manif, depStr); res.Exists() {
+			if res.Str != origVer {
+				if alreadyMatched {
+					continue
+				}
+				panic("original dependency version does not match what is in package.json")
+			}
+			alreadyMatched = true
 			manif, err = sjson.Set(manif, depStr, newVer)
 			if err != nil {
 				return err
@@ -218,12 +272,10 @@ func (NpmManifestIO) Write(r lockfile.DepFile, w io.Writer, patch ManifestPatch)
 		depStr = "dependencies." + name
 		if res := gjson.Get(manif, depStr); res.Exists() {
 			if res.Str != origVer {
-				if matchedDev {
-					// devDependency was fine, but not the non-dev dependency had a different original version.
-					// Ignore the problem - npm>=7 doesn't use the non-dev version anyway.
+				if alreadyMatched {
 					continue
 				}
-				panic("Original dependency does not match package.json")
+				panic("original dependency version does not match what is in package.json")
 			}
 			manif, err = sjson.Set(manif, depStr, newVer)
 			if err != nil {

--- a/internal/resolution/manifest/npm.go
+++ b/internal/resolution/manifest/npm.go
@@ -113,9 +113,10 @@ func (rw NpmManifestIO) Read(f lockfile.DepFile) (Manifest, error) {
 			workspaceReqVers[req.PackageKey] = req
 			continue
 		}
-		if idx := slices.IndexFunc(manif.Requirements, func(imp resolve.RequirementVersion) bool {
+		idx := slices.IndexFunc(manif.Requirements, func(imp resolve.RequirementVersion) bool {
 			return imp.PackageKey == req.PackageKey
-		}); idx != -1 {
+		})
+		if idx != -1 {
 			manif.Requirements[idx] = req
 		} else {
 			manif.Requirements = append(manif.Requirements, req)
@@ -130,9 +131,10 @@ func (rw NpmManifestIO) Read(f lockfile.DepFile) (Manifest, error) {
 			workspaceReqVers[req.PackageKey] = req
 			continue
 		}
-		if idx := slices.IndexFunc(manif.Requirements, func(imp resolve.RequirementVersion) bool {
+		idx := slices.IndexFunc(manif.Requirements, func(imp resolve.RequirementVersion) bool {
 			return imp.PackageKey == req.PackageKey
-		}); idx != -1 {
+		})
+		if idx != -1 {
 			// In newer versions of npm, having a package in both the `dependencies` and `devDependencies`
 			// makes it treated as ONLY a devDependency (using the devDependency version)
 			// npm v6 and below seems to do the opposite and there's no easy way of seeing the npm version :/

--- a/internal/resolution/manifest/npm_test.go
+++ b/internal/resolution/manifest/npm_test.go
@@ -1,0 +1,274 @@
+package manifest_test
+
+import (
+	"bytes"
+	"reflect"
+	"strings"
+	"testing"
+
+	"deps.dev/util/resolve"
+	"deps.dev/util/resolve/dep"
+	"github.com/google/osv-scanner/internal/resolution/manifest"
+	"github.com/google/osv-scanner/internal/testutility"
+	"github.com/google/osv-scanner/pkg/lockfile"
+)
+
+func aliasType(aliasedName string) dep.Type {
+	t := dep.NewType()
+	t.AddAttr(dep.KnownAs, aliasedName)
+
+	return t
+}
+
+func npmVK(name, version string, versionType resolve.VersionType) resolve.VersionKey {
+	return resolve.VersionKey{
+		PackageKey: resolve.PackageKey{
+			System: resolve.NPM,
+			Name:   name,
+		},
+		Version:     version,
+		VersionType: versionType,
+	}
+}
+
+func TestNpmRead(t *testing.T) {
+	t.Parallel()
+
+	df, err := lockfile.OpenLocalDepFile("./fixtures/package.json")
+	if err != nil {
+		t.Fatalf("failed to open file: %v", err)
+	}
+	defer df.Close()
+
+	npmIO := manifest.NpmManifestIO{}
+	got, err := npmIO.Read(df)
+	if err != nil {
+		t.Fatalf("failed to read file: %v", err)
+	}
+	if !strings.HasSuffix(got.FilePath, "package.json") {
+		t.Errorf("manifest file path %v does not have package.json", got.FilePath)
+	}
+	got.FilePath = ""
+
+	want := manifest.Manifest{
+		Root: resolve.Version{
+			VersionKey: npmVK("npm-manifest", "1.0.0", resolve.Concrete),
+		},
+		// npm dependencies should resolve in alphabetical order, regardless of type
+		Requirements: []resolve.RequirementVersion{
+			// TODO: @babel/core peerDependency currently not resolved
+			{
+				Type:       aliasType("cliui"), // sorts on aliased name, not real package name
+				VersionKey: npmVK("@isaacs/cliui", "^8.0.2", resolve.Requirement),
+			},
+			{
+				// Type: dep.NewType(dep.Dev), devDependencies treated as prod to make resolution work
+				VersionKey: npmVK("eslint", "^8.57.0", resolve.Requirement),
+			},
+			{
+				Type:       dep.NewType(dep.Opt),
+				VersionKey: npmVK("glob", "^10.3.10", resolve.Requirement),
+			},
+			{
+				VersionKey: npmVK("jquery", "latest", resolve.Requirement),
+			},
+			{
+				VersionKey: npmVK("lodash", "4.17.17", resolve.Requirement),
+			},
+			{
+				VersionKey: npmVK("string-width", "^5.1.2", resolve.Requirement),
+			},
+			{
+				Type:       aliasType("string-width-aliased"),
+				VersionKey: npmVK("string-width", "^4.2.3", resolve.Requirement),
+			},
+		},
+		Groups: map[resolve.PackageKey][]string{
+			{System: resolve.NPM, Name: "eslint"}: {"dev"},
+			{System: resolve.NPM, Name: "glob"}:   {"optional"},
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("npm manifest mismatch:\ngot %v\nwant %v\n", got, want)
+	}
+}
+
+func TestNpmWorkspaceRead(t *testing.T) {
+	t.Parallel()
+
+	df, err := lockfile.OpenLocalDepFile("./fixtures/npm-workspaces/package.json")
+	if err != nil {
+		t.Fatalf("failed to open file: %v", err)
+	}
+	defer df.Close()
+
+	npmIO := manifest.NpmManifestIO{}
+	got, err := npmIO.Read(df)
+	if err != nil {
+		t.Fatalf("failed to read file: %v", err)
+	}
+	if !strings.HasSuffix(got.FilePath, "package.json") {
+		t.Errorf("manifest file path %v does not have package.json", got.FilePath)
+	}
+	got.FilePath = ""
+	for i, local := range got.LocalManifests {
+		if !strings.HasSuffix(local.FilePath, "package.json") {
+			t.Errorf("local manifest file path %v does not have package.json", local.FilePath)
+		}
+		got.LocalManifests[i].FilePath = ""
+	}
+
+	want := manifest.Manifest{
+		Root: resolve.Version{
+			VersionKey: npmVK("npm-workspace-test", "1.0.0", resolve.Concrete),
+		},
+		Requirements: []resolve.RequirementVersion{
+			// root dependencies always before workspace
+			{
+				Type:       aliasType("jquery-real"),
+				VersionKey: npmVK("jquery", "^3.7.1", resolve.Requirement),
+			},
+			// workspaces in path order
+			{
+				VersionKey: npmVK("jquery:workspace", "^3.7.1", resolve.Requirement),
+			},
+			{
+				VersionKey: npmVK("@workspace/ugh:workspace", "*", resolve.Requirement),
+			},
+			{
+				VersionKey: npmVK("z-z-z:workspace", "*", resolve.Requirement),
+			},
+		},
+		Groups: map[resolve.PackageKey][]string{
+			{System: resolve.NPM, Name: "jquery"}: {"dev"},
+			// excludes workspace dev dependency
+		},
+		LocalManifests: []manifest.Manifest{
+			{
+				Root: resolve.Version{
+					VersionKey: npmVK("jquery:workspace", "3.7.1", resolve.Concrete),
+				},
+				Requirements: []resolve.RequirementVersion{
+					{
+						VersionKey: npmVK("semver", "^7.6.0", resolve.Requirement),
+					},
+				},
+				Groups: map[resolve.PackageKey][]string{},
+			},
+			{
+				Root: resolve.Version{
+					VersionKey: npmVK("@workspace/ugh:workspace", "0.0.1", resolve.Concrete),
+				},
+				Requirements: []resolve.RequirementVersion{
+					{
+						VersionKey: npmVK("jquery:workspace", "*", resolve.Requirement),
+					},
+					{
+						VersionKey: npmVK("semver", "^6.3.1", resolve.Requirement),
+					},
+				},
+				Groups: map[resolve.PackageKey][]string{
+					{System: resolve.NPM, Name: "jquery:workspace"}: {"dev"},
+					{System: resolve.NPM, Name: "semver"}:           {"dev"},
+				},
+			},
+			{
+				Root: resolve.Version{
+					VersionKey: npmVK("z-z-z:workspace", "1.0.0", resolve.Concrete),
+				},
+				Requirements: []resolve.RequirementVersion{
+					{
+						VersionKey: npmVK("@workspace/ugh:workspace", "*", resolve.Requirement),
+					},
+					{
+						VersionKey: npmVK("semver", "^5.7.2", resolve.Requirement),
+					},
+				},
+				Groups: map[resolve.PackageKey][]string{},
+			},
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("npm manifest mismatch:\ngot  %v\nwant %v\n", got, want)
+	}
+}
+
+func TestNpmWrite(t *testing.T) {
+	t.Parallel()
+
+	df, err := lockfile.OpenLocalDepFile("./fixtures/package.json")
+	if err != nil {
+		t.Fatalf("failed to open file: %v", err)
+	}
+	defer df.Close()
+
+	changes := manifest.ManifestPatch{
+		Deps: []manifest.DependencyPatch{
+			{
+				Pkg: resolve.PackageKey{
+					System: resolve.NPM,
+					Name:   "lodash",
+				},
+				OrigRequire: "4.17.17",
+				NewRequire:  "^4.17.21",
+			},
+			{
+				Pkg: resolve.PackageKey{
+					System: resolve.NPM,
+					Name:   "eslint",
+				},
+				OrigRequire: "^8.57.0",
+				NewRequire:  "*",
+			},
+			{
+				Pkg: resolve.PackageKey{
+					System: resolve.NPM,
+					Name:   "glob",
+				},
+				OrigRequire: "^10.3.10",
+				NewRequire:  "^1.0.0",
+			},
+			{
+				Pkg: resolve.PackageKey{
+					System: resolve.NPM,
+					Name:   "jquery",
+				},
+				OrigRequire: "latest",
+				NewRequire:  "~0.0.1",
+			},
+			{
+				Pkg: resolve.PackageKey{
+					System: resolve.NPM,
+					Name:   "@isaacs/cliui",
+				},
+				Type:        aliasType("cliui"),
+				OrigRequire: "^8.0.2",
+				NewRequire:  "^9.0.0",
+			},
+			{
+				Pkg: resolve.PackageKey{
+					System: resolve.NPM,
+					Name:   "string-width",
+				},
+				OrigRequire: "^5.1.2",
+				NewRequire:  "^7.1.0",
+			},
+			{
+				Pkg: resolve.PackageKey{
+					System: resolve.NPM,
+					Name:   "string-width",
+				},
+				Type:        aliasType("string-width-aliased"),
+				OrigRequire: "^4.2.3",
+				NewRequire:  "^6.1.0",
+			},
+		},
+	}
+
+	buf := new(bytes.Buffer)
+	npmIO := manifest.NpmManifestIO{}
+	if err := npmIO.Write(df, buf, changes); err != nil {
+		t.Fatalf("unable to update npm package.json: %v", err)
+	}
+	testutility.NewSnapshot().WithCRLFReplacement().MatchText(t, buf.String())
+}

--- a/internal/testutility/snapshot.go
+++ b/internal/testutility/snapshot.go
@@ -24,6 +24,14 @@ func (s Snapshot) WithWindowsReplacements(replacements map[string]string) Snapsh
 	return s
 }
 
+// WithCRLFReplacement adds a Windows replacement for "\r\n" to "\n".
+// This should be called after WithWindowsReplacements if used together.
+func (s Snapshot) WithCRLFReplacement() Snapshot {
+	s.windowsReplacements["\r\n"] = "\n"
+
+	return s
+}
+
 // MatchJSON asserts the existing snapshot matches what was gotten in the test,
 // after being marshalled as JSON
 func (s Snapshot) MatchJSON(t *testing.T, got any) {


### PR DESCRIPTION
Slowly adding tests to the guided remediation code.
This adds tests for the npm ManifestIO, and fixed a few things I found when writing them:
- The ordering of the found dependencies was slightly incorrect in some cases.
- `optionalDependencies` weren't being included in relock/relax
- Workspace dependencies were overriding real npm registry dependencies with the same name beyond the scope of the workspace.

Also made a `WithCRLFReplacement()` test snapshot helper for `\r\n` -> `\n` conversion on Windows.