### PR TITLE
Highlight supported manifests/lockfiles in Guided Remediation docs

### DIFF
--- a/docs/guided-remediation.md
+++ b/docs/guided-remediation.md
@@ -32,6 +32,7 @@ This tool provides several options to users for how to prioritise and remediate 
 - Modification of package manifest and lockfiles (e.g. `package.json`/`package-lock.json`) to fix vulnerabilities.
 - Different strategies with different risk/reward ratios (e.g. in-place fixes vs relocking).
 
+{: .highlight }
 Currently, only npm `package.json` manifests and `package-lock.json` lockfiles are supported.
 
 {: .note }


### PR DESCRIPTION
Make it more obvious that only npm is supported with a yellow highlight box.