### PR TITLE
test: change how snapshot matchers are called and update example name for consistency

### DIFF
--- a/cmd/osv-scanner/__snapshots__/fix_test.snap
+++ b/cmd/osv-scanner/__snapshots__/fix_test.snap
@@ -1,5 +1,22 @@
 
 [TestRun_Fix/fix_non-interactive_in-place_package-lock.json - 1]
+Scanning <tempdir>/package-lock.json...
+Found 7 vulnerabilities matching the filter
+Can fix 2/7 matching vulnerabilities by changing 2 dependencies
+UPGRADED-PACKAGE: concat-stream,1.5.0,1.6.1
+UPGRADED-PACKAGE: hosted-git-info,2.1.4,2.8.9
+REMAINING-VULNS: 5
+UNFIXABLE-VULNS: 5
+Rewriting <tempdir>/package-lock.json...
+
+---
+
+[TestRun_Fix/fix_non-interactive_in-place_package-lock.json - 2]
+Warning: `fix` exists as both a subcommand of OSV-Scanner and as a file on the filesystem. `fix` is assumed to be a subcommand here. If you intended for `fix` to be an argument to `fix`, you must specify `fix fix` in your command line.
+
+---
+
+[TestRun_Fix/fix_non-interactive_in-place_package-lock.json - 3]
 {
   "name": "osv-fix",
   "version": "1.0.0",
@@ -1724,6 +1741,22 @@
 ---
 
 [TestRun_Fix/fix_non-interactive_relock_package.json - 1]
+Resolving <tempdir>/package.json...
+Found 5 vulnerabilities matching the filter
+Can fix 3/5 matching vulnerabilities by changing 1 dependencies
+UPGRADED-PACKAGE: npm-registry-client,6.2.0,^7.5.0
+REMAINING-VULNS: 2
+UNFIXABLE-VULNS: 2
+Rewriting <tempdir>/package.json...
+
+---
+
+[TestRun_Fix/fix_non-interactive_relock_package.json - 2]
+Warning: `fix` exists as both a subcommand of OSV-Scanner and as a file on the filesystem. `fix` is assumed to be a subcommand here. If you intended for `fix` to be an argument to `fix`, you must specify `fix fix` in your command line.
+
+---
+
+[TestRun_Fix/fix_non-interactive_relock_package.json - 3]
 {
   "name": "osv-fix",
   "version": "1.0.0",

--- a/cmd/osv-scanner/__snapshots__/main_test.snap
+++ b/cmd/osv-scanner/__snapshots__/main_test.snap
@@ -414,48 +414,6 @@ No issues found
 
 ---
 
-[TestRunUpdate/update_pom.xml_with_in-place_changes - 1]
-
----
-
-[TestRunUpdate/update_pom.xml_with_in-place_changes - 2]
-Warning: `update` exists as both a subcommand of OSV-Scanner and as a file on the filesystem. `update` is assumed to be a subcommand here. If you intended for `update` to be an argument to `update`, you must specify `update update` in your command line.
-
----
-
-[TestRun_Fix/fix_non-interactive_in-place_package-lock.json - 1]
-Scanning <tempdir>/package-lock.json...
-Found 7 vulnerabilities matching the filter
-Can fix 2/7 matching vulnerabilities by changing 2 dependencies
-UPGRADED-PACKAGE: concat-stream,1.5.0,1.6.1
-UPGRADED-PACKAGE: hosted-git-info,2.1.4,2.8.9
-REMAINING-VULNS: 5
-UNFIXABLE-VULNS: 5
-Rewriting <tempdir>/package-lock.json...
-
----
-
-[TestRun_Fix/fix_non-interactive_in-place_package-lock.json - 2]
-Warning: `fix` exists as both a subcommand of OSV-Scanner and as a file on the filesystem. `fix` is assumed to be a subcommand here. If you intended for `fix` to be an argument to `fix`, you must specify `fix fix` in your command line.
-
----
-
-[TestRun_Fix/fix_non-interactive_relock_package.json - 1]
-Resolving <tempdir>/package.json...
-Found 5 vulnerabilities matching the filter
-Can fix 3/5 matching vulnerabilities by changing 1 dependencies
-UPGRADED-PACKAGE: npm-registry-client,6.2.0,^7.5.0
-REMAINING-VULNS: 2
-UNFIXABLE-VULNS: 2
-Rewriting <tempdir>/package.json...
-
----
-
-[TestRun_Fix/fix_non-interactive_relock_package.json - 2]
-Warning: `fix` exists as both a subcommand of OSV-Scanner and as a file on the filesystem. `fix` is assumed to be a subcommand here. If you intended for `fix` to be an argument to `fix`, you must specify `fix fix` in your command line.
-
----
-
 [TestRun_GithubActions/scanning_osv-scanner_custom_format - 1]
 Scanned <rootdir>/fixtures/locks-insecure/osv-scanner-flutter-deps.json file as a osv-scanner and found 3 packages
 +--------------------------------+------+-----------+----------------------------+----------------------------+-------------------------------------------------------+

--- a/cmd/osv-scanner/__snapshots__/update_test.snap
+++ b/cmd/osv-scanner/__snapshots__/update_test.snap
@@ -1,14 +1,14 @@
 
-[TestRunUpdate/update_pom.xml_with_in-place_changes - 1]
+[TestRun_Update/update_pom.xml_with_in-place_changes - 1]
 
 ---
 
-[TestRunUpdate/update_pom.xml_with_in-place_changes - 2]
+[TestRun_Update/update_pom.xml_with_in-place_changes - 2]
 Warning: `update` exists as both a subcommand of OSV-Scanner and as a file on the filesystem. `update` is assumed to be a subcommand here. If you intended for `update` to be an argument to `update`, you must specify `update update` in your command line.
 
 ---
 
-[TestRunUpdate/update_pom.xml_with_in-place_changes - 3]
+[TestRun_Update/update_pom.xml_with_in-place_changes - 3]
 <?xml version="1.0" encoding="UTF-8"?>
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/cmd/osv-scanner/__snapshots__/update_test.snap
+++ b/cmd/osv-scanner/__snapshots__/update_test.snap
@@ -1,5 +1,14 @@
 
 [TestRunUpdate/update_pom.xml_with_in-place_changes - 1]
+
+---
+
+[TestRunUpdate/update_pom.xml_with_in-place_changes - 2]
+Warning: `update` exists as both a subcommand of OSV-Scanner and as a file on the filesystem. `update` is assumed to be a subcommand here. If you intended for `update` to be an argument to `update`, you must specify `update update` in your command line.
+
+---
+
+[TestRunUpdate/update_pom.xml_with_in-place_changes - 3]
 <?xml version="1.0" encoding="UTF-8"?>
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/cmd/osv-scanner/fix_test.go
+++ b/cmd/osv-scanner/fix_test.go
@@ -80,7 +80,11 @@ func TestRun_Fix(t *testing.T) {
 				tc.args = append(tc.args, "-M", manifest)
 			}
 
-			testCli(t, tc)
+			stdout, stderr := runCli(t, tc)
+
+			testutility.NewSnapshot().MatchText(t, stdout)
+			testutility.NewSnapshot().MatchText(t, stderr)
+
 			if lockfile != "" {
 				matchFile(t, lockfile)
 			}

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -109,21 +109,28 @@ func normalizeStdStream(t *testing.T, std *bytes.Buffer) string {
 	return str
 }
 
-func testCli(t *testing.T, tc cliTestCase) {
+func runCli(t *testing.T, tc cliTestCase) (string, string) {
 	t.Helper()
 
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 
 	ec := run(tc.args, stdout, stderr)
-	// ec := run(tc.args, os.Stdout, os.Stderr)
 
 	if ec != tc.exit {
 		t.Errorf("cli exited with code %d, not %d", ec, tc.exit)
 	}
 
-	testutility.NewSnapshot().MatchText(t, normalizeStdStream(t, stdout))
-	testutility.NewSnapshot().MatchText(t, normalizeStdStream(t, stderr))
+	return normalizeStdStream(t, stdout), normalizeStdStream(t, stderr)
+}
+
+func testCli(t *testing.T, tc cliTestCase) {
+	t.Helper()
+
+	stdout, stderr := runCli(t, tc)
+
+	testutility.NewSnapshot().MatchText(t, stdout)
+	testutility.NewSnapshot().MatchText(t, stderr)
 }
 
 func TestRun(t *testing.T) {

--- a/cmd/osv-scanner/update_test.go
+++ b/cmd/osv-scanner/update_test.go
@@ -44,7 +44,11 @@ func TestRunUpdate(t *testing.T) {
 				tc.args = append(tc.args, "-M", manifest)
 			}
 
-			testCli(t, tc)
+			stdout, stderr := runCli(t, tc)
+
+			testutility.NewSnapshot().MatchText(t, stdout)
+			testutility.NewSnapshot().MatchText(t, stderr)
+
 			if manifest != "" {
 				b, err := os.ReadFile(manifest)
 				if err != nil {

--- a/cmd/osv-scanner/update_test.go
+++ b/cmd/osv-scanner/update_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/osv-scanner/internal/testutility"
 )
 
-func TestRunUpdate(t *testing.T) {
+func TestRun_Update(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name     string

--- a/cmd/osv-scanner/update_test.go
+++ b/cmd/osv-scanner/update_test.go
@@ -54,7 +54,7 @@ func TestRun_Update(t *testing.T) {
 				if err != nil {
 					t.Fatalf("could not read test file: %v", err)
 				}
-				testutility.NewSnapshot().WithWindowsReplacements(map[string]string{"\r\n": "\n"}).MatchText(t, string(b))
+				testutility.NewSnapshot().WithCRLFReplacement().MatchText(t, string(b))
 			}
 		})
 	}


### PR DESCRIPTION
I was very confused on why _most_ snapshots were all going into `main_test.snap` except for a couple, and it turns out the filename is determined by the call stack (literally `go-snaps` looks for the first frame in a `_test.go` file); I couldn't think of a good way `go-snaps` should enable working around this so instead I decided to refactor our helper a bit.

I think its useful to have all the snaps in their relative files like this vs saving a couple of lines especially given the size and that we're already generating a snapshot for each test.

I've also made a couple of other minor tweaks for consistency while I was at it.