### PR TITLE
Follow up PR851 mark acceptance on image tests

### DIFF
--- a/internal/image/image_test.go
+++ b/internal/image/image_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestScanImage(t *testing.T) {
+	testutility.SkipIfNotAcceptanceTesting(t, "Not consistent on MacOS/Windows")
 	t.Parallel()
 
 	type args struct {

--- a/internal/image/image_test.go
+++ b/internal/image/image_test.go
@@ -11,8 +11,8 @@ import (
 )
 
 func TestScanImage(t *testing.T) {
-	testutility.SkipIfNotAcceptanceTesting(t, "Not consistent on MacOS/Windows")
 	t.Parallel()
+	testutility.SkipIfNotAcceptanceTesting(t, "Not consistent on MacOS/Windows")
 
 	type args struct {
 		imagePath string

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -2,6 +2,8 @@
 
 set -e
 
-scripts/build_test_images.sh
+if [ "$TEST_ACCEPTANCE" = true ]; then
+    scripts/build_test_images.sh
+fi
 
 go test ./... -coverpkg=./... -coverprofile coverage.out


### PR DESCRIPTION
https://github.com/google/osv-scanner/pull/851#issuecomment-1987566176

@G-Rath this the vibe?

Marked the tests in the file edited in previous PR as and acceptance. 

Flagged the additional image build script added in that PR as only called during acceptance testing too (optional can remove)