### PR TITLE
ci: downgrade codecov action to v3

### DIFF
--- a/.github/workflows/test-action/action.yml
+++ b/.github/workflows/test-action/action.yml
@@ -24,4 +24,4 @@ runs:
         TEST_ACCEPTANCE: true
       run: ./scripts/run_tests.sh
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@54bcd8715eee62d40e33596ef5e8f0f48dbbccab # v4.1.0
+      uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3.1.6


### PR DESCRIPTION
It seems that v4 is having some teething problems - coverage is no longer being uploaded due to the lack of a token, and it seems like at least some people are getting 500s even when they do provide a token (https://github.com/codecov/codecov-action/issues/1248).

Let's start by downgrading to a known working version, and go from there.

Relates to #784

Before: 

<img width="1009" alt="image" src="https://github.com/google/osv-scanner/assets/3151613/24e6556f-0c94-4c4a-9269-cd59188f303f">

After:

<img width="1334" alt="image" src="https://github.com/google/osv-scanner/assets/3151613/3e5bd689-0daf-410e-814c-62facf3ef50c">
