### PR TITLE
ci: harden workflow permissions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -23,11 +23,14 @@ on:
   merge_group:
     branches: [main]
 
-permissions:
-  contents: read # to fetch code (actions/checkout)
+# Restrict jobs in this workflow to have no permissions by default; permissions
+# should be granted per job as needed using a dedicated `permissions` block
+permissions: {}
 
 jobs:
   format:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
     name: prettier
     runs-on: ubuntu-latest
     steps:
@@ -38,6 +41,8 @@ jobs:
       - name: Run lint action
         uses: ./.github/workflows/format-action
   lint:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
     name: golangci-lint
     runs-on: ubuntu-latest
     steps:
@@ -53,6 +58,8 @@ jobs:
       - name: Run lint action
         uses: ./.github/workflows/lint-action
   prepare_test_image_fixtures:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -66,6 +73,8 @@ jobs:
           path: internal/image/fixtures/*.tar
           retention-days: 1
   tests:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
     needs:
       - prepare_test_image_fixtures
     name: Run unit tests

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,7 +20,9 @@ on:
   merge_group:
     branches: [main]
 
-permissions: read-all
+# Restrict jobs in this workflow to have no permissions by default; permissions
+# should be granted per job as needed using a dedicated `permissions` block
+permissions: {}
 
 jobs:
   analyze:

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -5,10 +5,9 @@ on:
     tags:
       - "*" # triggers only if push new tag version, like `v0.8.4`
 
-permissions:
-  contents: read # to fetch code (actions/checkout)
-  # Require writing security events to upload SARIF file to security tab
-  security-events: write
+# Restrict jobs in this workflow to have no permissions by default; permissions
+# should be granted per job as needed using a dedicated `permissions` block
+permissions: {}
 
 jobs:
   goreleaser:

--- a/.github/workflows/link-check-on-push.yml
+++ b/.github/workflows/link-check-on-push.yml
@@ -1,10 +1,15 @@
 name: Check links on push
 
 on: push
-permissions: # added using https://github.com/step-security/secure-repo
-  contents: read
+
+# Restrict jobs in this workflow to have no permissions by default; permissions
+# should be granted per job as needed using a dedicated `permissions` block
+permissions: {}
+
 jobs:
   markdown-link-check:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -3,10 +3,15 @@ name: Check markdown links on schedule
 on:
   schedule:
     - cron: "45 22 * * 1,4"
-permissions: # added using https://github.com/step-security/secure-repo
-  contents: read
+
+# Restrict jobs in this workflow to have no permissions by default; permissions
+# should be granted per job as needed using a dedicated `permissions` block
+permissions: {}
+
 jobs:
   markdown-link-check:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/osv-scanner-reusable-pr.yml
+++ b/.github/workflows/osv-scanner-reusable-pr.yml
@@ -14,9 +14,9 @@
 
 name: OSV-Scanner PR scanning reusable
 
-permissions:
-  contents: read
-  security-events: write
+# Restrict jobs in this workflow to have no permissions by default; permissions
+# should be granted per job as needed using a dedicated `permissions` block
+permissions: {}
 
 on:
   workflow_call:
@@ -44,6 +44,9 @@ on:
 
 jobs:
   scan-pr:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+      security-events: write # for uploading SARIF files
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/osv-scanner-reusable.yml
+++ b/.github/workflows/osv-scanner-reusable.yml
@@ -14,9 +14,9 @@
 
 name: OSV-Scanner scanning reusable
 
-permissions:
-  contents: read
-  security-events: write
+# Restrict jobs in this workflow to have no permissions by default; permissions
+# should be granted per job as needed using a dedicated `permissions` block
+permissions: {}
 
 on:
   workflow_call:
@@ -49,6 +49,9 @@ on:
 
 jobs:
   osv-scan:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+      security-events: write # for uploading SARIF files
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/osv-scanner-unified-action.yml
+++ b/.github/workflows/osv-scanner-unified-action.yml
@@ -24,14 +24,15 @@ on:
   push:
     branches: ["main"]
 
-permissions:
-  # Require writing security events to upload SARIF file to security tab
-  security-events: write
-  # Read commit contents
-  contents: read
+# Restrict jobs in this workflow to have no permissions by default; permissions
+# should be granted per job as needed using a dedicated `permissions` block
+permissions: {}
 
 jobs:
   scan-scheduled:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+      security-events: write # for uploading SARIF files
     if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
     uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@staging"
     with:
@@ -41,6 +42,9 @@ jobs:
         ./
         ./docs/
   scan-pr:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+      security-events: write # for uploading SARIF files
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
     uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@staging"
     with:

--- a/.github/workflows/prerelease-check.yml
+++ b/.github/workflows/prerelease-check.yml
@@ -12,13 +12,15 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: read # to fetch code (actions/checkout)
-  # Require writing security events to upload SARIF file to security tab
-  security-events: write
+# Restrict jobs in this workflow to have no permissions by default; permissions
+# should be granted per job as needed using a dedicated `permissions` block
+permissions: {}
 
 jobs:
   osv-scan:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+      security-events: write # for uploading SARIF files
     uses: ./.github/workflows/osv-scanner-reusable.yml
     with:
       # Only scan the top level go.mod file without recursively scanning directories since
@@ -28,6 +30,8 @@ jobs:
         ./
 
   format:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
     name: prettier
     runs-on: ubuntu-latest
     steps:
@@ -38,6 +42,8 @@ jobs:
       - name: Run lint action
         uses: ./.github/workflows/format-action
   lint:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
     name: golangci-lint
     runs-on: ubuntu-latest
     steps:
@@ -54,6 +60,8 @@ jobs:
       - name: Run lint action
         uses: ./.github/workflows/lint-action
   prepare_test_image_fixtures:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -67,6 +75,8 @@ jobs:
           path: internal/image/fixtures/*.tar
           retention-days: 1
   tests:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
     name: Run unit tests
     needs:
       - prepare_test_image_fixtures
@@ -93,6 +103,8 @@ jobs:
       - name: Run test action
         uses: ./.github/workflows/test-action
   release-helper:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
     runs-on: ubuntu-latest
     needs:
       - format

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -14,8 +14,9 @@ on:
   push:
     branches: ["main"]
 
-# Declare default permissions as read only.
-permissions: read-all
+# Restrict jobs in this workflow to have no permissions by default; permissions
+# should be granted per job as needed using a dedicated `permissions` block
+permissions: {}
 
 jobs:
   analysis:


### PR DESCRIPTION
This hardens the workflow permissions so that jobs only have the permissions they need - it's unclear to me from the docs if scorecard currently understands this is the most secure approach (as its docs to me imply it it thinks `permissions: read-all` is best), but that's a scorecard problem.

In doing this, we do harden the permissions of a few jobs that were getting permissions they don't actually need.