### PR TITLE
fix(renovate): constrain go to 1.21 and do not update golang

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,8 +20,15 @@
     {
       "matchFileNames": [".github/**"],
       "groupName": "workflows"
-    }
+    },
+    {
+      "matchDepTypes": ["golang"],
+      "enabled": false
+    },
   ],
+  "constraints": {
+    "go": "1.21"
+  },
   "ignorePaths": ["**/fixtures/**", "**/fixtures-go/**"],
   "ignoreDeps": ["golang.org/x/vuln"]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -24,7 +24,7 @@
     {
       "matchDepTypes": ["golang"],
       "enabled": false
-    },
+    }
   ],
   "constraints": {
     "go": "1.21"


### PR DESCRIPTION
follow up on https://github.com/google/osv-scanner/pull/833#issue-2160370114