### PR TITLE
A failing test, not a nice one though

### DIFF
--- a/cmd/osv-scanner/__snapshots__/main_test.snap
+++ b/cmd/osv-scanner/__snapshots__/main_test.snap
@@ -140,6 +140,24 @@ Loaded filter from: <rootdir>/fixtures/go-project/osv-scanner.toml
 
 ---
 
+[TestRun/PURL_SBOM_case_sensitivity - 1]
+Scanning dir ./fixtures/sbom-insecure/alpine.cdx.xml
+Scanned <rootdir>/fixtures/sbom-insecure/alpine.cdx.xml as CycloneDX SBOM and found 15 packages
+Loaded filter from: <rootdir>/fixtures/sbom-insecure/osv-scanner.toml
+CVE-2022-37434 has been filtered out because: This is a intentionally vulnerable test sbom
+Filtered 1 vulnerability from output
++--------------------------------+------+-----------+---------+------------+---------------------------------------+
+| OSV URL                        | CVSS | ECOSYSTEM | PACKAGE | VERSION    | SOURCE                                |
++--------------------------------+------+-----------+---------+------------+---------------------------------------+
+| https://osv.dev/CVE-2022-48174 | 9.8  | Alpine    | busybox | 1.35.0-r29 | fixtures/sbom-insecure/alpine.cdx.xml |
++--------------------------------+------+-----------+---------+------------+---------------------------------------+
+
+---
+
+[TestRun/PURL_SBOM_case_sensitivity - 2]
+
+---
+
 [TestRun/Sarif_with_vulns - 1]
 {
   "version": "2.1.0",

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -274,6 +274,12 @@ func TestRun(t *testing.T) {
 			args: []string{"", "--verbosity", "info", "--format", "table", "./fixtures/locks-many/composer.lock"},
 			exit: 0,
 		},
+		{ // Currently failing due to forced offline mode to surface bug.
+		  // I guess this will be better as a seperate test tbh
+			name: "PURL SBOM case sensitivity",
+			args: []string{"", "--verbosity", "info", "--experimental-offline", "--format", "table", "./fixtures/sbom-insecure/alpine.cdx.xml"},
+			exit: 1,
+		},
 		// Go project with an overridden go version
 		{
 			name: "Go project with an overridden go version",


### PR DESCRIPTION
Interestingly doesn't fail even when TEST_ACCEPTANCE=true unless its forced offline not just local-db\

I assume this is an artifact of the snapshot structure? it seems that the second tests results are often not recorded.

https://github.com/google/osv-scanner/issues/769