### PR TITLE
GR: Parse paths in npmrc auth fields correctly

### DIFF
--- a/internal/resolution/datasource/__snapshots__/npmrc_test.snap
+++ b/internal/resolution/datasource/__snapshots__/npmrc_test.snap
@@ -8,7 +8,7 @@ null
 ---
 
 [TestNpmrcRegistryOverriding - 3]
-https://general.global.registry.com/@general%2Fpkg
+https://general.global.registry.com/@general%2fpkg
 ---
 
 [TestNpmrcRegistryOverriding - 4]
@@ -16,7 +16,7 @@ null
 ---
 
 [TestNpmrcRegistryOverriding - 5]
-https://global.registry.com/@global%2Fpkg
+https://global.registry.com/@global%2fpkg
 ---
 
 [TestNpmrcRegistryOverriding - 6]
@@ -24,7 +24,7 @@ null
 ---
 
 [TestNpmrcRegistryOverriding - 7]
-https://user.registry.com/@user%2Fpkg
+https://user.registry.com/@user%2fpkg
 ---
 
 [TestNpmrcRegistryOverriding - 8]
@@ -32,7 +32,7 @@ null
 ---
 
 [TestNpmrcRegistryOverriding - 9]
-https://project.registry.com/@project%2Fpkg
+https://project.registry.com/@project%2fpkg
 ---
 
 [TestNpmrcRegistryOverriding - 10]
@@ -48,7 +48,7 @@ null
 ---
 
 [TestNpmrcRegistryOverriding - 13]
-https://general.user.registry.com/@general%2Fpkg
+https://general.user.registry.com/@general%2fpkg
 ---
 
 [TestNpmrcRegistryOverriding - 14]
@@ -56,7 +56,7 @@ null
 ---
 
 [TestNpmrcRegistryOverriding - 15]
-https://global.registry.com/@global%2Fpkg
+https://global.registry.com/@global%2fpkg
 ---
 
 [TestNpmrcRegistryOverriding - 16]
@@ -64,7 +64,7 @@ null
 ---
 
 [TestNpmrcRegistryOverriding - 17]
-https://user.registry.com/@user%2Fpkg
+https://user.registry.com/@user%2fpkg
 ---
 
 [TestNpmrcRegistryOverriding - 18]
@@ -72,7 +72,7 @@ null
 ---
 
 [TestNpmrcRegistryOverriding - 19]
-https://project.registry.com/@project%2Fpkg
+https://project.registry.com/@project%2fpkg
 ---
 
 [TestNpmrcRegistryOverriding - 20]
@@ -88,7 +88,7 @@ null
 ---
 
 [TestNpmrcRegistryOverriding - 23]
-https://general.project.registry.com/@general%2Fpkg
+https://general.project.registry.com/@general%2fpkg
 ---
 
 [TestNpmrcRegistryOverriding - 24]
@@ -96,7 +96,7 @@ null
 ---
 
 [TestNpmrcRegistryOverriding - 25]
-https://global.registry.com/@global%2Fpkg
+https://global.registry.com/@global%2fpkg
 ---
 
 [TestNpmrcRegistryOverriding - 26]
@@ -104,7 +104,7 @@ null
 ---
 
 [TestNpmrcRegistryOverriding - 27]
-https://user.registry.com/@user%2Fpkg
+https://user.registry.com/@user%2fpkg
 ---
 
 [TestNpmrcRegistryOverriding - 28]
@@ -112,7 +112,7 @@ null
 ---
 
 [TestNpmrcRegistryOverriding - 29]
-https://project.registry.com/@project%2Fpkg
+https://project.registry.com/@project%2fpkg
 ---
 
 [TestNpmrcRegistryOverriding - 30]
@@ -128,7 +128,7 @@ null
 ---
 
 [TestNpmrcRegistryOverriding - 33]
-https://general.project.registry.com/@general%2Fpkg
+https://general.project.registry.com/@general%2fpkg
 ---
 
 [TestNpmrcRegistryOverriding - 34]
@@ -136,7 +136,7 @@ null
 ---
 
 [TestNpmrcRegistryOverriding - 35]
-https://global.registry.com/@global%2Fpkg
+https://global.registry.com/@global%2fpkg
 ---
 
 [TestNpmrcRegistryOverriding - 36]
@@ -144,7 +144,7 @@ null
 ---
 
 [TestNpmrcRegistryOverriding - 37]
-https://user.registry.com/@user%2Fpkg
+https://user.registry.com/@user%2fpkg
 ---
 
 [TestNpmrcRegistryOverriding - 38]
@@ -152,7 +152,7 @@ null
 ---
 
 [TestNpmrcRegistryOverriding - 39]
-https://project.registry.com/@project%2Fpkg
+https://project.registry.com/@project%2fpkg
 ---
 
 [TestNpmrcRegistryOverriding - 40]
@@ -170,7 +170,7 @@ https://registry1.test.com/foo
 ---
 
 [TestNpmrcRegistryAuth - 3]
-https://registry1.test.com/@test0%2Fbar
+https://registry1.test.com/@test0%2fbar
 ---
 
 [TestNpmrcRegistryAuth - 4]
@@ -180,7 +180,7 @@ https://registry1.test.com/@test0%2Fbar
 ---
 
 [TestNpmrcRegistryAuth - 5]
-https://registry2.test.com/@test1%2Fbaz
+https://registry2.test.com/@test1%2fbaz
 ---
 
 [TestNpmrcRegistryAuth - 6]
@@ -190,7 +190,7 @@ https://registry2.test.com/@test1%2Fbaz
 ---
 
 [TestNpmrcRegistryAuth - 7]
-https://sub.registry2.test.com/@test2%2Ftest
+https://sub.registry2.test.com/@test2%2ftest
 ---
 
 [TestNpmrcRegistryAuth - 8]
@@ -200,7 +200,7 @@ https://sub.registry2.test.com/@test2%2Ftest
 ---
 
 [TestNpmrcNoRegistries - 1]
-https://registry.npmjs.org/@test%2Fpackage/1.2.3
+https://registry.npmjs.org/@test%2fpackage/1.2.3
 ---
 
 [TestNpmrcNoRegistries - 2]

--- a/internal/resolution/datasource/npm_registry_cache.go
+++ b/internal/resolution/datasource/npm_registry_cache.go
@@ -8,9 +8,9 @@ import (
 )
 
 type npmRegistryCache struct {
-	Timestamp    *time.Time
-	Details      map[string]npmRegistryPackageDetails
-	RegistryURLs map[string]string
+	Timestamp *time.Time
+	Details   map[string]npmRegistryPackageDetails
+	ScopeURLs map[string]string
 }
 
 func (c *NpmRegistryAPIClient) GobEncode() ([]byte, error) {
@@ -23,15 +23,13 @@ func (c *NpmRegistryAPIClient) GobEncode() ([]byte, error) {
 	}
 
 	cache := npmRegistryCache{
-		Timestamp:    c.cacheTimestamp,
-		Details:      c.details,
-		RegistryURLs: make(map[string]string),
+		Timestamp: c.cacheTimestamp,
+		Details:   c.details,
+		ScopeURLs: make(map[string]string),
 	}
 
 	// store the registry URL for each scope (but not the auth info)
-	for scope, reg := range c.registries {
-		cache.RegistryURLs[scope] = reg.URL
-	}
+	cache.ScopeURLs = c.registries.ScopeURLs
 
 	return gobMarshal(&cache)
 }
@@ -58,7 +56,7 @@ func (c *NpmRegistryAPIClient) GobDecode(b []byte) error {
 			scope, _, _ = strings.Cut(pkg, "/")
 		}
 
-		return cache.RegistryURLs[scope] != c.registries[scope].URL
+		return cache.ScopeURLs[scope] != c.registries.ScopeURLs[scope]
 	})
 
 	c.cacheTimestamp = cache.Timestamp

--- a/internal/resolution/datasource/npm_registry_cache.go
+++ b/internal/resolution/datasource/npm_registry_cache.go
@@ -8,9 +8,9 @@ import (
 )
 
 type npmRegistryCache struct {
-	Timestamp *time.Time
-	Details   map[string]npmRegistryPackageDetails
-	ScopeURLs map[string]string
+	Timestamp *time.Time                           // Timestamp of when this cache was made
+	Details   map[string]npmRegistryPackageDetails // For a package name, the versions & their dependencies, and the list of tags
+	ScopeURLs map[string]string                    // The URL of the registry used for a given package @scope. Used to invalidate cache if registry has changed.
 }
 
 func (c *NpmRegistryAPIClient) GobEncode() ([]byte, error) {

--- a/internal/resolution/datasource/npm_registry_test.go
+++ b/internal/resolution/datasource/npm_registry_test.go
@@ -27,7 +27,7 @@ func TestNpmRegistryClient(t *testing.T) {
 
 	srv2 := testutility.NewMockHTTPServer(t)
 	srv2.SetAuthorization(t, "Bearer "+authToken)
-	srv2.SetResponseFromFile(t, "/@fake-registry%2Fa", "./fixtures/npm_registry/@fake-registry-a.json")
+	srv2.SetResponseFromFile(t, "/@fake-registry%2fa", "./fixtures/npm_registry/@fake-registry-a.json")
 
 	npmrcFile := createTempNpmrc(t, ".npmrc")
 	writeToNpmrc(t, npmrcFile,

--- a/internal/resolution/datasource/npmrc.go
+++ b/internal/resolution/datasource/npmrc.go
@@ -164,11 +164,20 @@ type npmRegistryInfo struct {
 	authInfo *npmRegistryAuthInfo
 }
 
+// urlPathEscapeLower is url.PathEscape but with lowercase letters in hex codes (matching npm's behaviour)
+// e.g. "@reg/pkg" -> "@reg%2fpkg"
+func urlPathEscapeLower(s string) string {
+	escaped := url.PathEscape(s)
+
+	re := cachedregexp.MustCompile(`%[0-9A-F]{2}`)
+	return re.ReplaceAllStringFunc(escaped, strings.ToLower)
+}
+
 // create the http request to the registry api
 // urlComponents should be (package) or (package, version)
 func (info npmRegistryInfo) buildRequest(ctx context.Context, urlComponents ...string) (*http.Request, error) {
 	for i := range urlComponents {
-		urlComponents[i] = url.PathEscape(urlComponents[i])
+		urlComponents[i] = urlPathEscapeLower(urlComponents[i])
 	}
 	reqURL, err := url.JoinPath(info.URL, urlComponents...)
 	if err != nil {

--- a/internal/resolution/datasource/npmrc.go
+++ b/internal/resolution/datasource/npmrc.go
@@ -136,6 +136,7 @@ type npmRegistryAuthInfo struct {
 	auth      string
 	username  string
 	password  string
+	// TODO: certfile, keyfile
 }
 
 func (authInfo npmRegistryAuthInfo) AddToHeader(header http.Header) {
@@ -151,6 +152,7 @@ func (authInfo npmRegistryAuthInfo) AddToHeader(header http.Header) {
 		b, err := base64.StdEncoding.DecodeString(authInfo.password)
 		if err != nil {
 			// TODO: mimic the behaviour of node's Buffer.from(s, 'base64').toString()
+			// e.g. ignore invalid characters, stop parsing after first '=', just never throw an error
 			panic(fmt.Sprintf("Unable to decode registry password: %v", err))
 		}
 		authBytes = append(authBytes, b...)
@@ -214,8 +216,8 @@ func urlPathEscapeLower(s string) string {
 }
 
 type NpmRegistryConfig struct {
-	ScopeURLs map[string]string // map of @scope to registry
-	RegOpts   NpmRegistryAuthOpts
+	ScopeURLs map[string]string   // map of @scope to registry URL
+	RegOpts   NpmRegistryAuthOpts // the full key-value pairs of relevant npmrc config options.
 }
 
 func LoadNpmRegistryConfig(workdir string) (NpmRegistryConfig, error) {

--- a/internal/resolution/datasource/npmrc.go
+++ b/internal/resolution/datasource/npmrc.go
@@ -138,7 +138,7 @@ type npmRegistryAuthInfo struct {
 	password  string
 }
 
-func (authInfo npmRegistryAuthInfo) addAuth(header http.Header) {
+func (authInfo npmRegistryAuthInfo) AddToHeader(header http.Header) {
 	switch {
 	case authInfo.authToken != "":
 		header.Set("Authorization", "Bearer "+authInfo.authToken)
@@ -150,7 +150,7 @@ func (authInfo npmRegistryAuthInfo) addAuth(header http.Header) {
 		authBytes := []byte(authInfo.username + ":")
 		b, err := base64.StdEncoding.DecodeString(authInfo.password)
 		if err != nil {
-			// TODO: npm seems to actually be quite lenient with invalid encodings
+			// TODO: mimic the behaviour of node's Buffer.from(s, 'base64').toString()
 			panic(fmt.Sprintf("Unable to decode registry password: %v", err))
 		}
 		authBytes = append(authBytes, b...)
@@ -159,46 +159,69 @@ func (authInfo npmRegistryAuthInfo) addAuth(header http.Header) {
 	}
 }
 
-type npmRegistryInfo struct {
-	URL      string
-	authInfo *npmRegistryAuthInfo
+// Implementation of npm registry auth matching, adapted from npm-registry-fetch
+// https://github.com/npm/npm-registry-fetch/blob/237d33b45396caa00add61e0549cf09fbf9deb4f/lib/auth.js
+type NpmRegistryAuthOpts map[string]string
+
+var npmAuthFields = [...]string{":_authToken", ":_auth", ":username", ":_password"} // reference of the relevant config key suffixes
+
+func (opts NpmRegistryAuthOpts) getRegAuth(regKey string) (npmRegistryAuthInfo, bool) {
+	if token, ok := opts[regKey+":_authToken"]; ok {
+		return npmRegistryAuthInfo{authToken: token}, true
+	}
+	if auth, ok := opts[regKey+":_auth"]; ok {
+		return npmRegistryAuthInfo{auth: auth}, true
+	}
+	if user, ok := opts[regKey+":username"]; ok {
+		if pass, ok := opts[regKey+":_password"]; ok {
+			return npmRegistryAuthInfo{username: user, password: pass}, true
+		}
+	}
+	// TODO: certfile / keyfile
+
+	return npmRegistryAuthInfo{}, false
+}
+
+func (opts NpmRegistryAuthOpts) GetAuth(uri string) npmRegistryAuthInfo {
+	parsed, err := url.Parse(uri)
+	if err != nil {
+		return npmRegistryAuthInfo{}
+	}
+	regKey := "//" + parsed.Host + parsed.EscapedPath()
+	for regKey != "//" {
+		if authInfo, ok := opts.getRegAuth(regKey); ok {
+			return authInfo
+		}
+
+		// can be either //host/some/path/:_auth or //host/some/path:_auth
+		// walk up by removing EITHER what's after the slash OR the slash itself
+		var found bool
+		if regKey, found = strings.CutSuffix(regKey, "/"); !found {
+			regKey = regKey[:strings.LastIndex(regKey, "/")+1]
+		}
+	}
+
+	return npmRegistryAuthInfo{}
 }
 
 // urlPathEscapeLower is url.PathEscape but with lowercase letters in hex codes (matching npm's behaviour)
 // e.g. "@reg/pkg" -> "@reg%2fpkg"
 func urlPathEscapeLower(s string) string {
 	escaped := url.PathEscape(s)
-
 	re := cachedregexp.MustCompile(`%[0-9A-F]{2}`)
+
 	return re.ReplaceAllStringFunc(escaped, strings.ToLower)
 }
 
-// create the http request to the registry api
-// urlComponents should be (package) or (package, version)
-func (info npmRegistryInfo) buildRequest(ctx context.Context, urlComponents ...string) (*http.Request, error) {
-	for i := range urlComponents {
-		urlComponents[i] = urlPathEscapeLower(urlComponents[i])
-	}
-	reqURL, err := url.JoinPath(info.URL, urlComponents...)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
-	if err != nil {
-		return nil, err
-	}
-	info.authInfo.addAuth(req.Header)
-
-	return req, nil
+type NpmRegistryConfig struct {
+	ScopeURLs map[string]string // map of @scope to registry
+	RegOpts   NpmRegistryAuthOpts
 }
-
-type NpmRegistryConfig map[string]npmRegistryInfo
 
 func LoadNpmRegistryConfig(workdir string) (NpmRegistryConfig, error) {
 	npmrc, err := loadNpmrc(workdir)
 	if err != nil {
-		return nil, err
+		return NpmRegistryConfig{}, err
 	}
 
 	return parseNpmRegistryInfo(npmrc), nil
@@ -216,81 +239,56 @@ func (r NpmRegistryConfig) BuildRequest(ctx context.Context, urlComponents ...st
 	if strings.HasPrefix(pkg, "@") {
 		scope, _, _ = strings.Cut(pkg, "/")
 	}
-	info, ok := r[scope]
+	baseURL, ok := r.ScopeURLs[scope]
 	if !ok {
 		// no specific rules for this scope, use the default scope
-		info = r[""]
+		baseURL = r.ScopeURLs[""]
 	}
 
-	return info.buildRequest(ctx, urlComponents...)
+	for i := range urlComponents {
+		urlComponents[i] = urlPathEscapeLower(urlComponents[i])
+	}
+	reqURL, err := url.JoinPath(baseURL, urlComponents...)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	r.RegOpts.GetAuth(reqURL).AddToHeader(req.Header)
+
+	return req, nil
 }
 
 func parseNpmRegistryInfo(npmrc npmrcConfig) NpmRegistryConfig {
-	infos := make(NpmRegistryConfig)               // map of @scope to info
-	auths := make(map[string]*npmRegistryAuthInfo) // map of host url to auth
-
-	getOrCreateAuth := func(host string) *npmRegistryAuthInfo {
-		host, _ = strings.CutSuffix(host, "/")
-		if authInfo, ok := auths[host]; ok {
-			return authInfo
-		}
-		auths[host] = &npmRegistryAuthInfo{}
-
-		return auths[host]
+	config := NpmRegistryConfig{
+		ScopeURLs: map[string]string{"": "https://registry.npmjs.org/"}, // set the default registry
+		RegOpts:   make(NpmRegistryAuthOpts),
 	}
-
-	makeRegistryInfo := func(fullURL string) npmRegistryInfo {
-		u, err := url.Parse(fullURL)
-		if err != nil {
-			panic(fmt.Sprintf("Error parsing url %s: %v", fullURL, err))
-		}
-
-		return npmRegistryInfo{
-			URL:      fullURL,
-			authInfo: getOrCreateAuth(u.Host),
-		}
-	}
-
-	// set the default registry
-	infos[""] = makeRegistryInfo("https://registry.npmjs.org")
-	// Regexes for matching the scope/host in npmrc keys
-	var (
-		urlRegex       = cachedregexp.MustCompile(`^(@.*):registry$`)
-		authTokenRegex = cachedregexp.MustCompile(`^//(.*):_authToken$`)
-		authRegex      = cachedregexp.MustCompile(`^//(.*):_auth$`)
-		usernameRegex  = cachedregexp.MustCompile(`^//(.*):username$`)
-		passwordRegex  = cachedregexp.MustCompile(`^//(.*):_password$`)
-	)
 
 	for _, k := range npmrc.Keys() {
 		name := k.Name()
 		value := os.ExpandEnv(k.String())
 		// TODO: npm config replaces only ${VAR}, not $VAR
 		// and if VAR is unset, it will leave the string as "${VAR}"
-		switch {
-		case name == "registry":
-			infos[""] = makeRegistryInfo(value)
-		case urlRegex.MatchString(name):
-			scope := urlRegex.FindStringSubmatch(name)[1]
-			infos[scope] = makeRegistryInfo(value)
-		case authTokenRegex.MatchString(name):
-			u := authTokenRegex.FindStringSubmatch(name)[1]
-			info := getOrCreateAuth(u)
-			info.authToken = value
-		case authRegex.MatchString(name):
-			u := authRegex.FindStringSubmatch(name)[1]
-			info := getOrCreateAuth(u)
-			info.auth = value
-		case usernameRegex.MatchString(name):
-			u := usernameRegex.FindStringSubmatch(name)[1]
-			info := getOrCreateAuth(u)
-			info.username = value
-		case passwordRegex.MatchString(name):
-			u := passwordRegex.FindStringSubmatch(name)[1]
-			info := getOrCreateAuth(u)
-			info.password = value
+
+		if name == "registry" {
+			config.ScopeURLs[""] = value
+			continue
+		}
+		if scope, ok := strings.CutSuffix(name, ":registry"); ok {
+			config.ScopeURLs[scope] = value
+			continue
+		}
+		for _, f := range npmAuthFields {
+			if strings.HasSuffix(name, f) {
+				config.RegOpts[name] = value
+			}
 		}
 	}
 
-	return infos
+	return config
 }

--- a/internal/resolution/datasource/npmrc_test.go
+++ b/internal/resolution/datasource/npmrc_test.go
@@ -185,7 +185,7 @@ func TestNpmRegistryAuthOpts(t *testing.T) {
 			opts: datasource.NpmRegistryAuthOpts{
 				"//my.custom.registry/here/:_authToken": "c0ffee",
 				"//my.custom.registry/here/:token":      "nope",
-				"//my.custom.registry/:_authToken":      "c0ffee",
+				"//my.custom.registry/:_authToken":      "7ea",
 				"//my.custom.registry/:token":           "nope",
 			},
 			requestURL: "https://my.custom.registry/here//foo/-/foo.tgz",

--- a/internal/resolution/datasource/npmrc_test.go
+++ b/internal/resolution/datasource/npmrc_test.go
@@ -2,7 +2,9 @@ package datasource_test
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -80,7 +82,7 @@ func TestNpmrcNoRegistries(t *testing.T) {
 		t.Fatalf("could not parse npmrc: %v", err)
 	}
 
-	if nRegs := len(config); nRegs != 1 {
+	if nRegs := len(config.ScopeURLs); nRegs != 1 {
 		t.Errorf("expected 1 npm registry, got %v", nRegs)
 	}
 
@@ -153,4 +155,142 @@ func TestNpmrcRegistryOverriding(t *testing.T) {
 	// override global/user/project in environment variable
 	t.Setenv("NPM_CONFIG_REGISTRY", "https://environ.registry.com")
 	check(t, npmrcFiles)
+}
+
+func TestNpmRegistryAuthOpts(t *testing.T) {
+	t.Parallel()
+	b64enc := func(s string) string {
+		t.Helper()
+		return base64.StdEncoding.EncodeToString([]byte(s))
+	}
+	tests := []struct {
+		name       string
+		opts       datasource.NpmRegistryAuthOpts
+		requestURL string
+		wantAuth   string
+	}{
+		// Auth tests adapted from npm-registry-fetch
+		// https://github.com/npm/npm-registry-fetch/blob/237d33b45396caa00add61e0549cf09fbf9deb4f/test/auth.js
+		{
+			name: "basic auth",
+			opts: datasource.NpmRegistryAuthOpts{
+				"//my.custom.registry/here/:username":  "user",
+				"//my.custom.registry/here/:_password": b64enc("pass"),
+			},
+			requestURL: "https://my.custom.registry/here/",
+			wantAuth:   "Basic " + b64enc("user:pass"),
+		},
+		{
+			name: "token auth",
+			opts: datasource.NpmRegistryAuthOpts{
+				"//my.custom.registry/here/:_authToken": "c0ffee",
+				"//my.custom.registry/here/:token":      "nope",
+				"//my.custom.registry/:_authToken":      "c0ffee",
+				"//my.custom.registry/:token":           "nope",
+			},
+			requestURL: "https://my.custom.registry/here//foo/-/foo.tgz",
+			wantAuth:   "Bearer c0ffee",
+		},
+		{
+			name: "_auth auth",
+			opts: datasource.NpmRegistryAuthOpts{
+				"//my.custom.registry/:_auth":      "decafbad",
+				"//my.custom.registry/here/:_auth": "c0ffee",
+			},
+			requestURL: "https://my.custom.registry/here//asdf/foo/bard/baz",
+			wantAuth:   "Basic c0ffee",
+		},
+		{
+			name: "_auth username:pass auth",
+			opts: datasource.NpmRegistryAuthOpts{
+				"//my.custom.registry/here/:_auth": b64enc("foo:bar"),
+			},
+			requestURL: "https://my.custom.registry/here/",
+			wantAuth:   "Basic " + b64enc("foo:bar"),
+		},
+		{
+			name: "ignore user/pass when _auth is set",
+			opts: datasource.NpmRegistryAuthOpts{
+				"//registry/:_auth":     b64enc("not:foobar"),
+				"//registry/:username":  "foo",
+				"//registry/:_password": b64enc("bar"),
+			},
+			requestURL: "http://registry/pkg/-/pkg-1.2.3.tgz",
+			wantAuth:   "Basic " + b64enc("not:foobar"),
+		},
+		{
+			name: "different hosts for uri vs registry",
+			opts: datasource.NpmRegistryAuthOpts{
+				"//my.custom.registry/here/:_authToken": "c0ffee",
+				"//my.custom.registry/here/:token":      "nope",
+			},
+			requestURL: "https://some.other.host/",
+			wantAuth:   "",
+		},
+		{
+			name: "do not be thrown by other weird configs",
+			opts: datasource.NpmRegistryAuthOpts{
+				"@asdf:_authToken":                 "does this work?",
+				"//registry.npmjs.org:_authToken":  "do not share this",
+				"_authToken":                       "definitely do not share this, either",
+				"//localhost:15443:_authToken":     "wrong",
+				"//localhost:15443/foo:_authToken": "correct bearer token",
+				"//localhost:_authToken":           "not this one",
+				"//other-registry:_authToken":      "this should not be used",
+				"@asdf:registry":                   "https://other-registry/",
+			},
+			requestURL: "http://localhost:15443/foo/@asdf/bar/-/bar-1.2.3.tgz",
+			wantAuth:   "Bearer correct bearer token",
+		},
+		// Some extra tests, based on experimentation with npm config
+		{
+			name: "exact package path uri",
+			opts: datasource.NpmRegistryAuthOpts{
+				"//custom.registry/:_authToken":         "less specific match",
+				"//custom.registry/package:_authToken":  "exact match",
+				"//custom.registry/package/:_authToken": "no match trailing slash",
+			},
+			requestURL: "http://custom.registry/package",
+			wantAuth:   "Bearer exact match",
+		},
+		{
+			name: "percent-encoding case-sensitivity",
+			opts: datasource.NpmRegistryAuthOpts{
+				"//custom.registry/:_authToken":                 "expected",
+				"//custom.registry/@scope%2Fpackage:_authToken": "bad config",
+			},
+			requestURL: "http://custom.registry/@scope%2fpackage",
+			wantAuth:   "Bearer expected",
+		},
+		{
+			name: "require both user and pass",
+			opts: datasource.NpmRegistryAuthOpts{
+				"//custom.registry/:_authToken":  "fallback",
+				"//custom.registry/foo:username": "user",
+			},
+			requestURL: "https://custom.registry/foo/bar",
+			wantAuth:   "Bearer fallback",
+		},
+		{
+			name: "don't inherit username",
+			opts: datasource.NpmRegistryAuthOpts{
+				"//custom.registry/:_authToken":       "fallback",
+				"//custom.registry/foo:username":      "user",
+				"//custom.registry/foo/bar:_password": b64enc("pass"),
+			},
+			requestURL: "https://custom.registry/foo/bar/baz",
+			wantAuth:   "Bearer fallback",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			header := make(http.Header)
+			tt.opts.GetAuth(tt.requestURL).AddToHeader(header)
+			if got := header.Get("Authorization"); got != tt.wantAuth {
+				t.Errorf("authorization header got = \"%s\", want \"%s\"", got, tt.wantAuth)
+			}
+		})
+	}
 }

--- a/internal/resolution/lockfile/npm_test.go
+++ b/internal/resolution/lockfile/npm_test.go
@@ -152,8 +152,8 @@ func TestNpmWrite(t *testing.T) {
 
 	// Set up mock npm registry
 	srv := testutility.NewMockHTTPServer(t)
-	srv.SetResponseFromFile(t, "/@fake-registry%2Fa/1.2.4", "./fixtures/npm_registry/@fake-registry-a-1.2.4.json")
-	srv.SetResponseFromFile(t, "/@fake-registry%2Fa/2.3.5", "./fixtures/npm_registry/@fake-registry-a-2.3.5.json")
+	srv.SetResponseFromFile(t, "/@fake-registry%2fa/1.2.4", "./fixtures/npm_registry/@fake-registry-a-1.2.4.json")
+	srv.SetResponseFromFile(t, "/@fake-registry%2fa/2.3.5", "./fixtures/npm_registry/@fake-registry-a-2.3.5.json")
 
 	// Copy package-lock.json to temporary directory
 	dir := testutility.CreateTestDir(t)

--- a/internal/testutility/mock_http.go
+++ b/internal/testutility/mock_http.go
@@ -62,13 +62,9 @@ func (m *MockHTTPServer) SetAuthorization(t *testing.T, auth string) {
 
 // ServeHTTP is the http.Handler for the underlying httptest.Server.
 func (m *MockHTTPServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	path := r.URL.RawPath
-	if path == "" {
-		path = r.URL.Path
-	}
 	m.mu.Lock()
 	wantAuth := m.authorization
-	resp, ok := m.response[strings.TrimPrefix(path, "/")]
+	resp, ok := m.response[strings.TrimPrefix(r.URL.EscapedPath(), "/")]
 	m.mu.Unlock()
 
 	if wantAuth != "" && r.Header.Get("Authorization") != wantAuth {


### PR DESCRIPTION
Should fix #899 
Changed the npmrc parsing logic when using `--data-source=native` so that specifying registries with paths (e.g. `//my.registry/package/path:_authToken`) will now correctly add the authorization headers.

Used [npm-registry-fetch](https://github.com/npm/npm-registry-fetch/tree/main) as reference.