### PR TITLE
test: clean and sort snapshots

### DIFF
--- a/internal/image/testmain_test.go
+++ b/internal/image/testmain_test.go
@@ -1,0 +1,16 @@
+package image_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/google/osv-scanner/internal/testutility"
+)
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+
+	testutility.CleanSnapshots(m)
+
+	os.Exit(code)
+}

--- a/internal/resolution/datasource/__snapshots__/npmrc_test.snap
+++ b/internal/resolution/datasource/__snapshots__/npmrc_test.snap
@@ -1,4 +1,52 @@
 
+[TestNpmrcNoRegistries - 1]
+https://registry.npmjs.org/@test%2Fpackage/1.2.3
+---
+
+[TestNpmrcNoRegistries - 2]
+null
+---
+
+[TestNpmrcRegistryAuth - 1]
+https://registry1.test.com/foo
+---
+
+[TestNpmrcRegistryAuth - 2]
+[
+  "Basic bXVjaDphdXRoCg=="
+]
+---
+
+[TestNpmrcRegistryAuth - 3]
+https://registry1.test.com/@test0%2Fbar
+---
+
+[TestNpmrcRegistryAuth - 4]
+[
+  "Basic bXVjaDphdXRoCg=="
+]
+---
+
+[TestNpmrcRegistryAuth - 5]
+https://registry2.test.com/@test1%2Fbaz
+---
+
+[TestNpmrcRegistryAuth - 6]
+[
+  "Bearer c3VjaCB0b2tlbgo="
+]
+---
+
+[TestNpmrcRegistryAuth - 7]
+https://sub.registry2.test.com/@test2%2Ftest
+---
+
+[TestNpmrcRegistryAuth - 8]
+[
+  "Basic dXNlcjp3b3cK"
+]
+---
+
 [TestNpmrcRegistryOverriding - 1]
 https://global.registry.com/pkg
 ---
@@ -156,53 +204,5 @@ https://project.registry.com/@project%2Fpkg
 ---
 
 [TestNpmrcRegistryOverriding - 40]
-null
----
-
-[TestNpmrcRegistryAuth - 1]
-https://registry1.test.com/foo
----
-
-[TestNpmrcRegistryAuth - 2]
-[
-  "Basic bXVjaDphdXRoCg=="
-]
----
-
-[TestNpmrcRegistryAuth - 3]
-https://registry1.test.com/@test0%2Fbar
----
-
-[TestNpmrcRegistryAuth - 4]
-[
-  "Basic bXVjaDphdXRoCg=="
-]
----
-
-[TestNpmrcRegistryAuth - 5]
-https://registry2.test.com/@test1%2Fbaz
----
-
-[TestNpmrcRegistryAuth - 6]
-[
-  "Bearer c3VjaCB0b2tlbgo="
-]
----
-
-[TestNpmrcRegistryAuth - 7]
-https://sub.registry2.test.com/@test2%2Ftest
----
-
-[TestNpmrcRegistryAuth - 8]
-[
-  "Basic dXNlcjp3b3cK"
-]
----
-
-[TestNpmrcNoRegistries - 1]
-https://registry.npmjs.org/@test%2Fpackage/1.2.3
----
-
-[TestNpmrcNoRegistries - 2]
 null
 ---

--- a/internal/resolution/datasource/testmain_test.go
+++ b/internal/resolution/datasource/testmain_test.go
@@ -1,0 +1,16 @@
+package datasource_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/google/osv-scanner/internal/testutility"
+)
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+
+	testutility.CleanSnapshots(m)
+
+	os.Exit(code)
+}

--- a/internal/resolution/lockfile/testmain_test.go
+++ b/internal/resolution/lockfile/testmain_test.go
@@ -1,0 +1,16 @@
+package lockfile_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/google/osv-scanner/internal/testutility"
+)
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+
+	testutility.CleanSnapshots(m)
+
+	os.Exit(code)
+}

--- a/internal/resolution/manifest/testmain_test.go
+++ b/internal/resolution/manifest/testmain_test.go
@@ -1,0 +1,16 @@
+package manifest_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/google/osv-scanner/internal/testutility"
+)
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+
+	testutility.CleanSnapshots(m)
+
+	os.Exit(code)
+}


### PR DESCRIPTION
While doing #902 I realised we've got a couple of packages using snapshots but not cleaning them up afterwards - this changes that; I've also opened #903 adding a script to check all packages using snapshots are cleaning them.