### PR TITLE
Fix rust call analysis by explicitly disabling stripping of debug info

### DIFF
--- a/internal/sourceanalysis/rust.go
+++ b/internal/sourceanalysis/rust.go
@@ -27,7 +27,7 @@ const (
 	// - lto (Enable full link time optimisation, this allows unused dynamic dispatch calls to be optimised out)
 	// - codegen-units=1 (Build everything in one codegen unit, increases build time but enables more optimisations
 	//                  and make libraries only generate one object file)
-	RustFlagsEnv     = "RUSTFLAGS=-C opt-level=3 -C debuginfo=1 -C embed-bitcode=yes -C lto -C codegen-units=1"
+	RustFlagsEnv     = "RUSTFLAGS=-C opt-level=3 -C debuginfo=1 -C embed-bitcode=yes -C lto -C codegen-units=1 -C strip=none"
 	RustLibExtension = ".rcgu.o/"
 )
 


### PR DESCRIPTION
Latest rust version (1.77) implemented stripping release binaries by default. This makes the call analysis stop working, so explicitly disable the stripping behaviour when building for analysis.

https://blog.rust-lang.org/2024/03/21/Rust-1.77.0.html#enable-strip-in-release-profiles-by-default