### PR TITLE
test: include groups when describing package details

### DIFF
--- a/pkg/lockfile/helpers_test.go
+++ b/pkg/lockfile/helpers_test.go
@@ -42,7 +42,13 @@ func packageToString(pkg lockfile.PackageDetails) string {
 		commit = "<no commit>"
 	}
 
-	return fmt.Sprintf("%s@%s (%s, %s)", pkg.Name, pkg.Version, pkg.Ecosystem, commit)
+	groups := strings.Join(pkg.DepGroups, ", ")
+
+	if groups == "" {
+		groups = "<no groups>"
+	}
+
+	return fmt.Sprintf("%s@%s (%s, %s, %s)", pkg.Name, pkg.Version, pkg.Ecosystem, commit, groups)
 }
 
 func hasPackage(t *testing.T, packages []lockfile.PackageDetails, pkg lockfile.PackageDetails) bool {


### PR DESCRIPTION
Ran into this while working on other stuff - currently if two packages are the same except for their groups, the failure message doesn't indicate that which is confusing