### PR TITLE
fix: ensure that npm dependencies retain their "production" grouping

### DIFF
--- a/pkg/lockfile/fixtures/npm/same-package-different-groups.v1.json
+++ b/pkg/lockfile/fixtures/npm/same-package-different-groups.v1.json
@@ -1,0 +1,81 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha512-Ajr4IcMXq/2QmMkEmSvxqfLN5zGmJ92gHXAeOXq1OekoH2rfDNsgdDoL2f7QaRCy7G/E6TpxBVdRuNraMztGHw==",
+      "dev": true,
+      "requires": {
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
+      }
+    },
+    "eslint": {
+      "version": "1.2.3",
+      "dev": true,
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha512-Ajr4IcMXq/2QmMkEmSvxqfLN5zGmJ92gHXAeOXq1OekoH2rfDNsgdDoL2f7QaRCy7G/E6TpxBVdRuNraMztGHw==",
+          "dev": true,
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          },
+          "dependencies": {
+            "ajv": {
+              "version": "5.5.2",
+              "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+              "integrity": "sha512-Ajr4IcMXq/2QmMkEmSvxqfLN5zGmJ92gHXAeOXq1OekoH2rfDNsgdDoL2f7QaRCy7G/E6TpxBVdRuNraMztGHw==",
+              "optional": true,
+              "requires": {
+                "co": "^4.6.0",
+                "fast-deep-equal": "^1.0.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.3.0"
+              }
+            }
+          }
+        }
+      }
+    },
+    "table": {
+      "version": "1.0.0",
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha512-Ajr4IcMXq/2QmMkEmSvxqfLN5zGmJ92gHXAeOXq1OekoH2rfDNsgdDoL2f7QaRCy7G/E6TpxBVdRuNraMztGHw==",
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          },
+          "dependencies": {
+            "ajv": {
+              "version": "5.5.2",
+              "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+              "integrity": "sha512-Ajr4IcMXq/2QmMkEmSvxqfLN5zGmJ92gHXAeOXq1OekoH2rfDNsgdDoL2f7QaRCy7G/E6TpxBVdRuNraMztGHw==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "co": "^4.6.0",
+                "fast-deep-equal": "^1.0.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.3.0"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/pkg/lockfile/fixtures/npm/same-package-different-groups.v2.json
+++ b/pkg/lockfile/fixtures/npm/same-package-different-groups.v2.json
@@ -1,0 +1,78 @@
+{
+  "name": "my-library",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {},
+      "devDependencies": {}
+    },
+    "node_modules/ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha512-Ajr4IcMXq/2QmMkEmSvxqfLN5zGmJ92gHXAeOXq1OekoH2rfDNsgdDoL2f7QaRCy7G/E6TpxBVdRuNraMztGHw==",
+      "dev": true,
+      "dependencies": {
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "1.2.3",
+      "dev": true
+    },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha512-Ajr4IcMXq/2QmMkEmSvxqfLN5zGmJ92gHXAeOXq1OekoH2rfDNsgdDoL2f7QaRCy7G/E6TpxBVdRuNraMztGHw==",
+      "dev": true,
+      "dependencies": {
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
+      }
+    },
+    "node_modules/eslint/node_modules/ajv/node_modules/ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha512-Ajr4IcMXq/2QmMkEmSvxqfLN5zGmJ92gHXAeOXq1OekoH2rfDNsgdDoL2f7QaRCy7G/E6TpxBVdRuNraMztGHw==",
+      "optional": true,
+      "dependencies": {
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
+      }
+    },
+    "node_modules/table": {
+      "version": "1.0.0"
+    },
+    "node_modules/table/node_modules/ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha512-Ajr4IcMXq/2QmMkEmSvxqfLN5zGmJ92gHXAeOXq1OekoH2rfDNsgdDoL2f7QaRCy7G/E6TpxBVdRuNraMztGHw==",
+      "dependencies": {
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
+      }
+    },
+    "node_modules/table/node_modules/ajv/node_modules/ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha512-Ajr4IcMXq/2QmMkEmSvxqfLN5zGmJ92gHXAeOXq1OekoH2rfDNsgdDoL2f7QaRCy7G/E6TpxBVdRuNraMztGHw==",
+      "devOptional": true,
+      "dependencies": {
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
+      }
+    }
+  },
+  "dependencies": {}
+}

--- a/pkg/lockfile/parse-npm-lock-v1_test.go
+++ b/pkg/lockfile/parse-npm-lock-v1_test.go
@@ -445,28 +445,7 @@ func TestParseNpmLock_v1_SamePackageDifferentGroups(t *testing.T) {
 			Version:   "5.5.2",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
-			DepGroups: nil,
-		},
-		{
-			Name:      "ajv",
-			Version:   "5.5.2",
-			Ecosystem: lockfile.NpmEcosystem,
-			CompareAs: lockfile.NpmEcosystem,
-			DepGroups: []string{"dev"},
-		},
-		{
-			Name:      "ajv",
-			Version:   "5.5.2",
-			Ecosystem: lockfile.NpmEcosystem,
-			CompareAs: lockfile.NpmEcosystem,
-			DepGroups: []string{"optional"},
-		},
-		{
-			Name:      "ajv",
-			Version:   "5.5.2",
-			Ecosystem: lockfile.NpmEcosystem,
-			CompareAs: lockfile.NpmEcosystem,
-			DepGroups: []string{"dev", "optional"},
+			DepGroups: []string{},
 		},
 	})
 }

--- a/pkg/lockfile/parse-npm-lock-v1_test.go
+++ b/pkg/lockfile/parse-npm-lock-v1_test.go
@@ -415,3 +415,58 @@ func TestParseNpmLock_v1_OptionalPackage(t *testing.T) {
 		},
 	})
 }
+
+func TestParseNpmLock_v1_SamePackageDifferentGroups(t *testing.T) {
+	t.Parallel()
+
+	packages, err := lockfile.ParseNpmLock("fixtures/npm/same-package-different-groups.v1.json")
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	expectPackages(t, packages, []lockfile.PackageDetails{
+		{
+			Name:      "eslint",
+			Version:   "1.2.3",
+			Ecosystem: lockfile.NpmEcosystem,
+			CompareAs: lockfile.NpmEcosystem,
+			DepGroups: []string{"dev"},
+		},
+		{
+			Name:      "table",
+			Version:   "1.0.0",
+			Ecosystem: lockfile.NpmEcosystem,
+			CompareAs: lockfile.NpmEcosystem,
+			DepGroups: nil,
+		},
+		{
+			Name:      "ajv",
+			Version:   "5.5.2",
+			Ecosystem: lockfile.NpmEcosystem,
+			CompareAs: lockfile.NpmEcosystem,
+			DepGroups: nil,
+		},
+		{
+			Name:      "ajv",
+			Version:   "5.5.2",
+			Ecosystem: lockfile.NpmEcosystem,
+			CompareAs: lockfile.NpmEcosystem,
+			DepGroups: []string{"dev"},
+		},
+		{
+			Name:      "ajv",
+			Version:   "5.5.2",
+			Ecosystem: lockfile.NpmEcosystem,
+			CompareAs: lockfile.NpmEcosystem,
+			DepGroups: []string{"optional"},
+		},
+		{
+			Name:      "ajv",
+			Version:   "5.5.2",
+			Ecosystem: lockfile.NpmEcosystem,
+			CompareAs: lockfile.NpmEcosystem,
+			DepGroups: []string{"dev", "optional"},
+		},
+	})
+}

--- a/pkg/lockfile/parse-npm-lock-v1_test.go
+++ b/pkg/lockfile/parse-npm-lock-v1_test.go
@@ -438,7 +438,6 @@ func TestParseNpmLock_v1_SamePackageDifferentGroups(t *testing.T) {
 			Version:   "1.0.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
-			DepGroups: nil,
 		},
 		{
 			Name:      "ajv",

--- a/pkg/lockfile/parse-npm-lock-v1_test.go
+++ b/pkg/lockfile/parse-npm-lock-v1_test.go
@@ -188,6 +188,7 @@ func TestParseNpmLock_v1_NestedDependenciesDup(t *testing.T) {
 		Version:   "6.1.0",
 		Ecosystem: lockfile.NpmEcosystem,
 		CompareAs: lockfile.NpmEcosystem,
+		DepGroups: []string{},
 	})
 
 	expectPackage(t, packages, lockfile.PackageDetails{
@@ -195,6 +196,7 @@ func TestParseNpmLock_v1_NestedDependenciesDup(t *testing.T) {
 		Version:   "5.5.0",
 		Ecosystem: lockfile.NpmEcosystem,
 		CompareAs: lockfile.NpmEcosystem,
+		DepGroups: []string{},
 	})
 
 	expectPackage(t, packages, lockfile.PackageDetails{
@@ -202,6 +204,7 @@ func TestParseNpmLock_v1_NestedDependenciesDup(t *testing.T) {
 		Version:   "2.0.0",
 		Ecosystem: lockfile.NpmEcosystem,
 		CompareAs: lockfile.NpmEcosystem,
+		DepGroups: []string{},
 	})
 }
 

--- a/pkg/lockfile/parse-npm-lock-v1_test.go
+++ b/pkg/lockfile/parse-npm-lock-v1_test.go
@@ -188,7 +188,6 @@ func TestParseNpmLock_v1_NestedDependenciesDup(t *testing.T) {
 		Version:   "6.1.0",
 		Ecosystem: lockfile.NpmEcosystem,
 		CompareAs: lockfile.NpmEcosystem,
-		DepGroups: []string{},
 	})
 
 	expectPackage(t, packages, lockfile.PackageDetails{
@@ -196,7 +195,6 @@ func TestParseNpmLock_v1_NestedDependenciesDup(t *testing.T) {
 		Version:   "5.5.0",
 		Ecosystem: lockfile.NpmEcosystem,
 		CompareAs: lockfile.NpmEcosystem,
-		DepGroups: []string{},
 	})
 
 	expectPackage(t, packages, lockfile.PackageDetails{
@@ -204,7 +202,6 @@ func TestParseNpmLock_v1_NestedDependenciesDup(t *testing.T) {
 		Version:   "2.0.0",
 		Ecosystem: lockfile.NpmEcosystem,
 		CompareAs: lockfile.NpmEcosystem,
-		DepGroups: []string{},
 	})
 }
 
@@ -448,7 +445,6 @@ func TestParseNpmLock_v1_SamePackageDifferentGroups(t *testing.T) {
 			Version:   "5.5.2",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
-			DepGroups: []string{},
 		},
 	})
 }

--- a/pkg/lockfile/parse-npm-lock-v2_test.go
+++ b/pkg/lockfile/parse-npm-lock-v2_test.go
@@ -409,3 +409,58 @@ func TestParseNpmLock_v2_OptionalPackage(t *testing.T) {
 		},
 	})
 }
+
+func TestParseNpmLock_v2_SamePackageDifferentGroups(t *testing.T) {
+	t.Parallel()
+
+	packages, err := lockfile.ParseNpmLock("fixtures/npm/same-package-different-groups.v2.json")
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	expectPackages(t, packages, []lockfile.PackageDetails{
+		{
+			Name:      "eslint",
+			Version:   "1.2.3",
+			Ecosystem: lockfile.NpmEcosystem,
+			CompareAs: lockfile.NpmEcosystem,
+			DepGroups: []string{"dev"},
+		},
+		{
+			Name:      "table",
+			Version:   "1.0.0",
+			Ecosystem: lockfile.NpmEcosystem,
+			CompareAs: lockfile.NpmEcosystem,
+			DepGroups: nil,
+		},
+		{
+			Name:      "ajv",
+			Version:   "5.5.2",
+			Ecosystem: lockfile.NpmEcosystem,
+			CompareAs: lockfile.NpmEcosystem,
+			DepGroups: nil,
+		},
+		{
+			Name:      "ajv",
+			Version:   "5.5.2",
+			Ecosystem: lockfile.NpmEcosystem,
+			CompareAs: lockfile.NpmEcosystem,
+			DepGroups: []string{"dev"},
+		},
+		{
+			Name:      "ajv",
+			Version:   "5.5.2",
+			Ecosystem: lockfile.NpmEcosystem,
+			CompareAs: lockfile.NpmEcosystem,
+			DepGroups: []string{"optional"},
+		},
+		{
+			Name:      "ajv",
+			Version:   "5.5.2",
+			Ecosystem: lockfile.NpmEcosystem,
+			CompareAs: lockfile.NpmEcosystem,
+			DepGroups: []string{"dev", "optional"},
+		},
+	})
+}

--- a/pkg/lockfile/parse-npm-lock-v2_test.go
+++ b/pkg/lockfile/parse-npm-lock-v2_test.go
@@ -184,14 +184,12 @@ func TestParseNpmLock_v2_NestedDependenciesDup(t *testing.T) {
 			Version:   "6.1.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
-			DepGroups: []string{},
 		},
 		{
 			Name:      "supports-color",
 			Version:   "2.0.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
-			DepGroups: []string{},
 		},
 	})
 }
@@ -440,7 +438,6 @@ func TestParseNpmLock_v2_SamePackageDifferentGroups(t *testing.T) {
 			Version:   "5.5.2",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
-			DepGroups: []string{},
 		},
 	})
 }

--- a/pkg/lockfile/parse-npm-lock-v2_test.go
+++ b/pkg/lockfile/parse-npm-lock-v2_test.go
@@ -184,12 +184,14 @@ func TestParseNpmLock_v2_NestedDependenciesDup(t *testing.T) {
 			Version:   "6.1.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
+			DepGroups: []string{},
 		},
 		{
 			Name:      "supports-color",
 			Version:   "2.0.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
+			DepGroups: []string{},
 		},
 	})
 }

--- a/pkg/lockfile/parse-npm-lock-v2_test.go
+++ b/pkg/lockfile/parse-npm-lock-v2_test.go
@@ -432,35 +432,13 @@ func TestParseNpmLock_v2_SamePackageDifferentGroups(t *testing.T) {
 			Version:   "1.0.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
-			DepGroups: nil,
 		},
 		{
 			Name:      "ajv",
 			Version:   "5.5.2",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
-			DepGroups: nil,
-		},
-		{
-			Name:      "ajv",
-			Version:   "5.5.2",
-			Ecosystem: lockfile.NpmEcosystem,
-			CompareAs: lockfile.NpmEcosystem,
-			DepGroups: []string{"dev"},
-		},
-		{
-			Name:      "ajv",
-			Version:   "5.5.2",
-			Ecosystem: lockfile.NpmEcosystem,
-			CompareAs: lockfile.NpmEcosystem,
-			DepGroups: []string{"optional"},
-		},
-		{
-			Name:      "ajv",
-			Version:   "5.5.2",
-			Ecosystem: lockfile.NpmEcosystem,
-			CompareAs: lockfile.NpmEcosystem,
-			DepGroups: []string{"dev", "optional"},
+			DepGroups: []string{},
 		},
 	})
 }

--- a/pkg/lockfile/parse-npm-lock.go
+++ b/pkg/lockfile/parse-npm-lock.go
@@ -83,15 +83,15 @@ func (pdm npmPackageDetailsMap) add(key string, details PackageDetails) {
 	pdm[key] = details
 }
 
-func mergePkgDetailsMap(m1 map[string]PackageDetails, m2 map[string]PackageDetails) map[string]PackageDetails {
-	details := map[string]PackageDetails{}
+func mergePkgDetailsMap(m1 npmPackageDetailsMap, m2 npmPackageDetailsMap) map[string]PackageDetails {
+	details := npmPackageDetailsMap{}
 
 	for name, detail := range m1 {
-		details[name] = detail
+		details.add(name, detail)
 	}
 
 	for name, detail := range m2 {
-		details[name] = detail
+		details.add(name, detail)
 	}
 
 	return details

--- a/pkg/lockfile/parse-npm-lock.go
+++ b/pkg/lockfile/parse-npm-lock.go
@@ -63,6 +63,10 @@ func (dep NpmLockDependency) depGroups() []string {
 	return nil
 }
 
+func npmPkgKey(name string, version string, dev bool, optional bool) string {
+	return fmt.Sprintf("%s@%s@%t+%t", name, version, dev, optional)
+}
+
 func parseNpmLockDependencies(dependencies map[string]NpmLockDependency) map[string]PackageDetails {
 	details := map[string]PackageDetails{}
 
@@ -98,7 +102,12 @@ func parseNpmLockDependencies(dependencies map[string]NpmLockDependency) map[str
 			}
 		}
 
-		details[name+"@"+version] = PackageDetails{
+		details[npmPkgKey(
+			name,
+			version,
+			detail.Dev,
+			detail.Optional,
+		)] = PackageDetails{
 			Name:      name,
 			Version:   finalVersion,
 			Ecosystem: NpmEcosystem,
@@ -159,7 +168,12 @@ func parseNpmLockPackages(packages map[string]NpmLockPackage) map[string]Package
 			finalVersion = commit
 		}
 
-		details[finalName+"@"+finalVersion] = PackageDetails{
+		details[npmPkgKey(
+			finalName,
+			finalVersion,
+			detail.DevOptional || detail.Dev,
+			detail.DevOptional || detail.Optional,
+		)] = PackageDetails{
 			Name:      finalName,
 			Version:   detail.Version,
 			Ecosystem: NpmEcosystem,

--- a/pkg/lockfile/parse-npm-lock.go
+++ b/pkg/lockfile/parse-npm-lock.go
@@ -83,18 +83,10 @@ func (pdm npmPackageDetailsMap) add(key string, details PackageDetails) {
 	pdm[key] = details
 }
 
-func mergePkgDetailsMap(m1 npmPackageDetailsMap, m2 npmPackageDetailsMap) map[string]PackageDetails {
-	details := npmPackageDetailsMap{}
-
-	for name, detail := range m1 {
-		details.add(name, detail)
+func (pdm npmPackageDetailsMap) merge(m npmPackageDetailsMap) {
+	for key, details := range m {
+		pdm.add(key, details)
 	}
-
-	for name, detail := range m2 {
-		details.add(name, detail)
-	}
-
-	return details
 }
 
 func (dep NpmLockDependency) depGroups() []string {
@@ -116,7 +108,7 @@ func parseNpmLockDependencies(dependencies map[string]NpmLockDependency) map[str
 
 	for name, detail := range dependencies {
 		if detail.Dependencies != nil {
-			maps.Copy(details, parseNpmLockDependencies(detail.Dependencies))
+			details.merge(parseNpmLockDependencies(detail.Dependencies))
 		}
 
 		version := detail.Version

--- a/pkg/lockfile/parse-npm-lock.go
+++ b/pkg/lockfile/parse-npm-lock.go
@@ -68,7 +68,7 @@ func npmPkgKey(name string, version string, dev bool, optional bool) string {
 }
 
 func parseNpmLockDependencies(dependencies map[string]NpmLockDependency) map[string]PackageDetails {
-	details := map[string]PackageDetails{}
+	details := npmPackageDetailsMap{}
 
 	for name, detail := range dependencies {
 		if detail.Dependencies != nil {
@@ -102,19 +102,22 @@ func parseNpmLockDependencies(dependencies map[string]NpmLockDependency) map[str
 			}
 		}
 
-		details[npmPkgKey(
-			name,
-			version,
-			detail.Dev,
-			detail.Optional,
-		)] = PackageDetails{
-			Name:      name,
-			Version:   finalVersion,
-			Ecosystem: NpmEcosystem,
-			CompareAs: NpmEcosystem,
-			Commit:    commit,
-			DepGroups: detail.depGroups(),
-		}
+		details.add(
+			npmPkgKey(
+				name,
+				version,
+				detail.Dev,
+				detail.Optional,
+			),
+			PackageDetails{
+				Name:      name,
+				Version:   finalVersion,
+				Ecosystem: NpmEcosystem,
+				CompareAs: NpmEcosystem,
+				Commit:    commit,
+				DepGroups: detail.depGroups(),
+			},
+		)
 	}
 
 	return details
@@ -145,8 +148,14 @@ func (pkg NpmLockPackage) depGroups() []string {
 	return nil
 }
 
+type npmPackageDetailsMap map[string]PackageDetails
+
+func (pdm npmPackageDetailsMap) add(key string, details PackageDetails) {
+	pdm[key] = details
+}
+
 func parseNpmLockPackages(packages map[string]NpmLockPackage) map[string]PackageDetails {
-	details := map[string]PackageDetails{}
+	details := npmPackageDetailsMap{}
 
 	for namePath, detail := range packages {
 		if namePath == "" {
@@ -168,19 +177,22 @@ func parseNpmLockPackages(packages map[string]NpmLockPackage) map[string]Package
 			finalVersion = commit
 		}
 
-		details[npmPkgKey(
-			finalName,
-			finalVersion,
-			detail.DevOptional || detail.Dev,
-			detail.DevOptional || detail.Optional,
-		)] = PackageDetails{
-			Name:      finalName,
-			Version:   detail.Version,
-			Ecosystem: NpmEcosystem,
-			CompareAs: NpmEcosystem,
-			Commit:    commit,
-			DepGroups: detail.depGroups(),
-		}
+		details.add(
+			npmPkgKey(
+				finalName,
+				finalVersion,
+				detail.DevOptional || detail.Dev,
+				detail.DevOptional || detail.Optional,
+			),
+			PackageDetails{
+				Name:      finalName,
+				Version:   detail.Version,
+				Ecosystem: NpmEcosystem,
+				CompareAs: NpmEcosystem,
+				Commit:    commit,
+				DepGroups: detail.depGroups(),
+			},
+		)
 	}
 
 	return details

--- a/pkg/lockfile/parse-npm-lock.go
+++ b/pkg/lockfile/parse-npm-lock.go
@@ -83,12 +83,6 @@ func (pdm npmPackageDetailsMap) add(key string, details PackageDetails) {
 	pdm[key] = details
 }
 
-func (pdm npmPackageDetailsMap) merge(m npmPackageDetailsMap) {
-	for key, details := range m {
-		pdm.add(key, details)
-	}
-}
-
 func (dep NpmLockDependency) depGroups() []string {
 	if dep.Dev && dep.Optional {
 		return []string{"dev", "optional"}
@@ -108,7 +102,7 @@ func parseNpmLockDependencies(dependencies map[string]NpmLockDependency) map[str
 
 	for name, detail := range dependencies {
 		if detail.Dependencies != nil {
-			details.merge(parseNpmLockDependencies(detail.Dependencies))
+			maps.Copy(details, parseNpmLockDependencies(detail.Dependencies))
 		}
 
 		version := detail.Version

--- a/pkg/lockfile/parse-npm-lock.go
+++ b/pkg/lockfile/parse-npm-lock.go
@@ -61,7 +61,7 @@ type npmPackageDetailsMap map[string]PackageDetails
 func mergeNpmDepsGroups(a, b PackageDetails) []string {
 	// if either group includes no groups, then the package is in the "production" group
 	if len(a.DepGroups) == 0 || len(b.DepGroups) == 0 {
-		return []string{}
+		return nil
 	}
 
 	combined := make([]string, 0, len(a.DepGroups)+len(b.DepGroups))

--- a/pkg/lockfile/parse-nuget-lock.go
+++ b/pkg/lockfile/parse-nuget-lock.go
@@ -43,7 +43,9 @@ func parseNuGetLock(lockfile NuGetLockfile) ([]PackageDetails, error) {
 	// its dependencies, there might be different or duplicate dependencies
 	// between frameworks
 	for _, dependencies := range lockfile.Dependencies {
-		maps.Copy(details, parseNuGetLockDependencies(dependencies))
+		for name, detail := range parseNuGetLockDependencies(dependencies) {
+			details[name] = detail
+		}
 	}
 
 	return maps.Values(details), nil


### PR DESCRIPTION
This resolves an inconsistency in the scanner output for npm packages that appear in the same tree multiple times but in different groups; this happens because the table outputter deduplicates on groups on the assumption that a package can only appear in a single group which is incorrect for the NPM ecosystem.

To address this, I've introduced an internal map type that ensures groups are merged when a package is added, with the twist that if either instance of a package being merged is in no groups then that is the result of the merge because implicitly that means an instance of the package is in the "production" group which takes priority over the other groups.

This is something that should most likely be improved on the future, but right now this fix should be good enough to ship since afaik it doesn't impact any other ecosystem and groups are something of a PoC given we can't resolve that information richly enough across all ecosystems yet.

I think this technically could impact `pnpm` as well, but none of our fixtures gave a good indicator and the latest lockfile version doesn't have that information anymore so frankly I'm not worrying about it at this point.

Resolves #924