### PR TITLE
refactor: use `maps` functions instead of custom implementations

### DIFF
--- a/pkg/lockfile/parse-go-lock.go
+++ b/pkg/lockfile/parse-go-lock.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"golang.org/x/exp/maps"
 	"golang.org/x/mod/modfile"
 )
 
@@ -91,7 +92,7 @@ func (e GoLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 		}
 	}
 
-	return pkgDetailsMapToSlice(deduplicatePackages(packages)), nil
+	return maps.Values(deduplicatePackages(packages)), nil
 }
 
 var _ Extractor = GoLockExtractor{}

--- a/pkg/lockfile/parse-maven-lock.go
+++ b/pkg/lockfile/parse-maven-lock.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/google/osv-scanner/internal/cachedregexp"
+	"golang.org/x/exp/maps"
 )
 
 type MavenLockDependency struct {
@@ -150,7 +151,7 @@ func (e MavenLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 		details[finalName] = pkgDetails
 	}
 
-	return pkgDetailsMapToSlice(details), nil
+	return maps.Values(details), nil
 }
 
 var _ Extractor = MavenLockExtractor{}

--- a/pkg/lockfile/parse-npm-lock.go
+++ b/pkg/lockfile/parse-npm-lock.go
@@ -6,6 +6,8 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+
+	"golang.org/x/exp/maps"
 )
 
 type NpmLockDependency struct {
@@ -46,16 +48,6 @@ type NpmLockfile struct {
 }
 
 const NpmEcosystem Ecosystem = "npm"
-
-func pkgDetailsMapToSlice(m map[string]PackageDetails) []PackageDetails {
-	details := make([]PackageDetails, 0, len(m))
-
-	for _, detail := range m {
-		details = append(details, detail)
-	}
-
-	return details
-}
 
 func mergePkgDetailsMap(m1 map[string]PackageDetails, m2 map[string]PackageDetails) map[string]PackageDetails {
 	details := map[string]PackageDetails{}
@@ -217,7 +209,7 @@ func (e NpmLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 		return []PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
 	}
 
-	return pkgDetailsMapToSlice(parseNpmLock(*parsedLockfile)), nil
+	return maps.Values(parseNpmLock(*parsedLockfile)), nil
 }
 
 var _ Extractor = NpmLockExtractor{}

--- a/pkg/lockfile/parse-npm-lock.go
+++ b/pkg/lockfile/parse-npm-lock.go
@@ -49,20 +49,6 @@ type NpmLockfile struct {
 
 const NpmEcosystem Ecosystem = "npm"
 
-func mergePkgDetailsMap(m1 map[string]PackageDetails, m2 map[string]PackageDetails) map[string]PackageDetails {
-	details := map[string]PackageDetails{}
-
-	for name, detail := range m1 {
-		details[name] = detail
-	}
-
-	for name, detail := range m2 {
-		details[name] = detail
-	}
-
-	return details
-}
-
 func (dep NpmLockDependency) depGroups() []string {
 	if dep.Dev && dep.Optional {
 		return []string{"dev", "optional"}
@@ -82,7 +68,7 @@ func parseNpmLockDependencies(dependencies map[string]NpmLockDependency) map[str
 
 	for name, detail := range dependencies {
 		if detail.Dependencies != nil {
-			details = mergePkgDetailsMap(details, parseNpmLockDependencies(detail.Dependencies))
+			maps.Copy(details, parseNpmLockDependencies(detail.Dependencies))
 		}
 
 		version := detail.Version

--- a/pkg/lockfile/parse-nuget-lock.go
+++ b/pkg/lockfile/parse-nuget-lock.go
@@ -43,7 +43,7 @@ func parseNuGetLock(lockfile NuGetLockfile) ([]PackageDetails, error) {
 	// its dependencies, there might be different or duplicate dependencies
 	// between frameworks
 	for _, dependencies := range lockfile.Dependencies {
-		details = mergePkgDetailsMap(details, parseNuGetLockDependencies(dependencies))
+		maps.Copy(details, parseNuGetLockDependencies(dependencies))
 	}
 
 	return maps.Values(details), nil

--- a/pkg/lockfile/parse-nuget-lock.go
+++ b/pkg/lockfile/parse-nuget-lock.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+
+	"golang.org/x/exp/maps"
 )
 
 type NuGetLockPackage struct {
@@ -44,7 +46,7 @@ func parseNuGetLock(lockfile NuGetLockfile) ([]PackageDetails, error) {
 		details = mergePkgDetailsMap(details, parseNuGetLockDependencies(dependencies))
 	}
 
-	return pkgDetailsMapToSlice(details), nil
+	return maps.Values(details), nil
 }
 
 type NuGetLockExtractor struct{}

--- a/pkg/lockfile/parse-pipenv-lock.go
+++ b/pkg/lockfile/parse-pipenv-lock.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+
+	"golang.org/x/exp/maps"
 )
 
 type PipenvPackage struct {
@@ -37,7 +39,7 @@ func (e PipenvLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 	addPkgDetails(details, parsedLockfile.Packages, "")
 	addPkgDetails(details, parsedLockfile.PackagesDev, "dev")
 
-	return pkgDetailsMapToSlice(details), nil
+	return maps.Values(details), nil
 }
 
 func addPkgDetails(details map[string]PackageDetails, packages map[string]PipenvPackage, group string) {

--- a/pkg/lockfile/parse-requirements-txt.go
+++ b/pkg/lockfile/parse-requirements-txt.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/google/osv-scanner/internal/cachedregexp"
+	"golang.org/x/exp/maps"
 )
 
 const PipEcosystem Ecosystem = "PyPI"
@@ -192,7 +193,7 @@ func parseRequirementsTxt(f DepFile, requiredAlready map[string]struct{}) ([]Pac
 		return []PackageDetails{}, fmt.Errorf("error while scanning %s: %w", f.Path(), err)
 	}
 
-	return pkgDetailsMapToSlice(packages), nil
+	return maps.Values(packages), nil
 }
 
 var _ Extractor = RequirementsTxtExtractor{}

--- a/pkg/lockfile/parse.go
+++ b/pkg/lockfile/parse.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"golang.org/x/exp/maps"
 )
 
 func FindParser(pathToLockfile string, parseAs string) (PackageDetailsParser, string) {
@@ -57,20 +59,6 @@ var ErrParserNotFound = errors.New("could not determine parser")
 
 type Packages []PackageDetails
 
-func toSliceOfEcosystems(ecosystemsMap map[Ecosystem]struct{}) []Ecosystem {
-	ecosystems := make([]Ecosystem, 0, len(ecosystemsMap))
-
-	for ecosystem := range ecosystemsMap {
-		if ecosystem == "" {
-			continue
-		}
-
-		ecosystems = append(ecosystems, ecosystem)
-	}
-
-	return ecosystems
-}
-
 func (ps Packages) Ecosystems() []Ecosystem {
 	ecosystems := make(map[Ecosystem]struct{})
 
@@ -78,7 +66,7 @@ func (ps Packages) Ecosystems() []Ecosystem {
 		ecosystems[pkg.Ecosystem] = struct{}{}
 	}
 
-	slicedEcosystems := toSliceOfEcosystems(ecosystems)
+	slicedEcosystems := maps.Keys(ecosystems)
 
 	sort.Slice(slicedEcosystems, func(i, j int) bool {
 		return slicedEcosystems[i] < slicedEcosystems[j]


### PR DESCRIPTION
This replaces some of our custom code for map-based operations with almost-standard-library versions