### PR TITLE
ci: upgrade Codecov to v4

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -109,3 +109,5 @@ jobs:
           check-latest: true
       - name: Run test action
         uses: ./.github/workflows/test-action
+        with:
+          codecov_token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/prerelease-check.yml
+++ b/.github/workflows/prerelease-check.yml
@@ -102,6 +102,8 @@ jobs:
           check-latest: true
       - name: Run test action
         uses: ./.github/workflows/test-action
+        with:
+          codecov_token: ${{ secrets.CODECOV_TOKEN }}
   release-helper:
     permissions:
       contents: read # to fetch code (actions/checkout)

--- a/.github/workflows/test-action/action.yml
+++ b/.github/workflows/test-action/action.yml
@@ -15,6 +15,11 @@
 name: test
 description: "Runs go tests"
 
+inputs:
+  codecov_token:
+    description: "Token for uploading coverage reports to Codecov"
+    required: true
+
 runs:
   using: composite
   steps:
@@ -24,4 +29,7 @@ runs:
         TEST_ACCEPTANCE: true
       run: ./scripts/run_tests.sh
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3.1.6
+      uses: codecov/codecov-action@84508663e988701840491b86de86b666e8a86bed # v4.3.0
+      with:
+        token: ${{ inputs.CODECOV_TOKEN }}
+        fail_ci_if_error: true


### PR DESCRIPTION
This will hopefully resolve the issues we're having with the v3 action, but requires the `CODECOV_TOKEN` secret to be configured per [this document](https://docs.codecov.com/docs/adding-the-codecov-token) which needs to be done by someone with repository permissions to set secrets.