### PR TITLE
 GR: Support filtering on alias IDs

### DIFF
--- a/internal/remediation/remediation.go
+++ b/internal/remediation/remediation.go
@@ -21,11 +21,11 @@ type RemediationOptions struct {
 }
 
 func (opts RemediationOptions) MatchVuln(v resolution.ResolutionVuln) bool {
-	if slices.Contains(opts.IgnoreVulns, v.Vulnerability.ID) {
+	if opts.matchID(v, opts.IgnoreVulns) {
 		return false
 	}
 
-	if len(opts.ExplicitVulns) > 0 && !slices.Contains(opts.ExplicitVulns, v.Vulnerability.ID) {
+	if len(opts.ExplicitVulns) > 0 && !opts.matchID(v, opts.ExplicitVulns) {
 		return false
 	}
 
@@ -34,6 +34,20 @@ func (opts RemediationOptions) MatchVuln(v resolution.ResolutionVuln) bool {
 	}
 
 	return opts.matchSeverity(v) && opts.matchDepth(v)
+}
+
+func (opts RemediationOptions) matchID(v resolution.ResolutionVuln, ids []string) bool {
+	if slices.Contains(ids, v.Vulnerability.ID) {
+		return true
+	}
+
+	for _, id := range v.Vulnerability.Aliases {
+		if slices.Contains(ids, id) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (opts RemediationOptions) matchSeverity(v resolution.ResolutionVuln) bool {

--- a/internal/remediation/remediation_test.go
+++ b/internal/remediation/remediation_test.go
@@ -12,7 +12,7 @@ import (
 func TestMatchVuln(t *testing.T) {
 	t.Parallel()
 	var (
-		// ID: VULN-001, Dev: false, Severity: 6.6, Depth: 3
+		// ID: VULN-001, Dev: false, Severity: 6.6, Depth: 3, Aliases: CVE-111, OSV-2
 		vuln1 = resolution.ResolutionVuln{
 			Vulnerability: models.Vulnerability{
 				ID: "VULN-001",
@@ -20,6 +20,7 @@ func TestMatchVuln(t *testing.T) {
 					{Type: models.SeverityCVSSV3, Score: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:H"}, // 6.6
 					{Type: models.SeverityCVSSV2, Score: "AV:L/AC:L/Au:S/C:P/I:P/A:C"},                   // 5.7
 				},
+				Aliases: []string{"CVE-111", "OSV-2"},
 			},
 			DevOnly: false,
 			ProblemChains: []resolution.DependencyChain{{
@@ -173,6 +174,26 @@ func TestMatchVuln(t *testing.T) {
 				ExplicitVulns: []string{"VULN-002"},
 			},
 			want: true,
+		},
+		{
+			name: "accept explicit ID in alias",
+			vuln: vuln1,
+			opt: remediation.RemediationOptions{
+				DevDeps:       true,
+				MaxDepth:      -1,
+				ExplicitVulns: []string{"CVE-111"},
+			},
+			want: true,
+		},
+		{
+			name: "reject excluded ID in alias",
+			vuln: vuln1,
+			opt: remediation.RemediationOptions{
+				DevDeps:     true,
+				MaxDepth:    -1,
+				IgnoreVulns: []string{"OSV-2"},
+			},
+			want: false,
 		},
 	}
 


### PR DESCRIPTION
Check the vuln's aliases when using the `--vulns` or `--ignore-vulns` flag.
Closes #922 