### PR TITLE
chore: only extract versions from packages in the generator ecosystem

### DIFF
--- a/scripts/generators/GenerateMavenVersions.java
+++ b/scripts/generators/GenerateMavenVersions.java
@@ -94,6 +94,10 @@ public class GenerateMavenVersions {
     osvs.forEach(osv -> osv.getJSONArray("affected").forEach(aff -> {
       JSONObject affected = (JSONObject) aff;
 
+      if(affected.getJSONObject("package").getString("ecosystem").equals("Maven")) {
+        return;
+      }
+
       String pkgName = affected.getJSONObject("package").getString("name");
 
       if(!affected.has("versions")) {

--- a/scripts/generators/generate-cran-versions.R
+++ b/scripts/generators/generate-cran-versions.R
@@ -24,6 +24,10 @@ extract_packages_with_versions <- function(osvs) {
 
   for (osv in osvs) {
     for (affected in osv$affected) {
+      if (affected$package$ecosystem != "CRAN") {
+        next
+      }
+
       package <- affected$package$name
 
       if (!(package %in% names(result))) {

--- a/scripts/generators/generate-debian-versions.py
+++ b/scripts/generators/generate-debian-versions.py
@@ -47,6 +47,9 @@ def extract_packages_with_versions(osvs):
 
   for osv in osvs:
     for affected in osv['affected']:
+      if not affected['package']['ecosystem'].startswith('Debian'):
+        continue
+
       package = affected['package']['name']
 
       if package not in dict:

--- a/scripts/generators/generate-packagist-versions.php
+++ b/scripts/generators/generate-packagist-versions.php
@@ -79,6 +79,10 @@ function fetchPackageVersions(): array
 
   foreach ($osvs as $osv) {
     foreach ($osv['affected'] as $affected) {
+      if ($affected['package']['ecosystem'] !== 'Packagist') {
+        continue;
+      }
+
       $package = $affected['package']['name'];
 
       if (!isset($packages[$package])) {

--- a/scripts/generators/generate-pypi-versions.py
+++ b/scripts/generators/generate-pypi-versions.py
@@ -40,6 +40,9 @@ def extract_packages_with_versions(osvs):
 
   for osv in osvs:
     for affected in osv['affected']:
+      if affected['package']['ecosystem'] != 'PyPI':
+        continue
+
       package = affected['package']['name']
 
       if package not in dict:


### PR DESCRIPTION
Cherry-picked from https://github.com/G-Rath/osv-detector/pull/241

---

Currently the generators assume that all packages in an OSV are for their respective ecosystem which since they download ecosystem-specific databases is _mostly_ true, but there are a few OSVs that are for packages that exist across more than one ecosystem.

This has not been a problem up until now because either the versions in such OSVs happen to be compatible with native ecosystem version parser or we're skipping invalid versions for legacy reasons, but now GHSA-5844-q3fc-56rh exists which has versions that are invalid in Ruby.