### PR TITLE
ci: setup workflow to run `semantic` tests weekly

### DIFF
--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -1,0 +1,191 @@
+name: Semantic
+
+on:
+  schedule:
+    - cron: "0 0 * * SUN"
+  workflow_dispatch:
+    inputs:
+      filterResults:
+        description: "What comparator results the generators should print"
+        required: false
+        default: "failures"
+        type: choice
+        options:
+          - all
+          - failures
+          - successes
+  pull_request:
+    paths:
+      - ".github/workflows/semantic.yml"
+      - "scripts/generators/**"
+
+# Restrict jobs in this workflow to have no permissions by default; permissions
+# should be granted per job as needed using a dedicated `permissions` block
+permissions: {}
+
+env:
+  VERSION_GENERATOR_PRINT: ${{ inputs.filterResults }}
+
+jobs:
+  generate-debian-versions:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        with:
+          path: /tmp/debian-versions-generator-cache.csv
+          key: ${{ runner.os }}-
+
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
+        with:
+          python-version: "3.10"
+      - run: dpkg --version
+      - run: python3 scripts/generators/generate-debian-versions.py
+      - run: git status
+      - run: stat debian-db.zip
+      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        with:
+          name: generated-versions
+          path: internal/semantic/fixtures/debian-versions-generated.txt
+
+      - uses: actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        with:
+          path: /tmp/debian-versions-generator-cache.csv
+          key: ${{ runner.os }}-${{ hashFiles('debian-db.zip') }}
+
+  generate-packagist-versions:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
+      - uses: shivammathur/setup-php@c665c7a15b5295c2488ac8a87af9cb806cd72198 # v2.30.4
+        with:
+          php-version: "8.2"
+          extensions: zip
+      - run: php scripts/generators/generate-packagist-versions.php
+      - run: git status
+      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        with:
+          name: generated-versions
+          path: internal/semantic/fixtures/packagist-versions-generated.txt
+
+  generate-pypi-versions:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
+        with:
+          python-version: "3.10"
+      - name: setup dependencies
+        run: pip install packaging==21.3
+      - run: python3 scripts/generators/generate-pypi-versions.py
+      - run: git status
+      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        with:
+          name: generated-versions
+          path: internal/semantic/fixtures/pypi-versions-generated.txt
+
+  generate-rubygems-versions:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
+      - uses: ruby/setup-ruby@1198b074305f9356bd56dd4b311757cc0dab2f1c # v1.175.1
+        with:
+          ruby-version: "3.1"
+      - name: setup dependencies
+        run: gem install rubyzip
+      - run: ruby scripts/generators/generate-rubygems-versions.rb
+      - run: git status
+      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        with:
+          name: generated-versions
+          path: internal/semantic/fixtures/rubygems-versions-generated.txt
+
+  generate-maven-versions:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
+        with:
+          java-version: 17
+          distribution: oracle
+      - name: setup dependencies
+        run: |
+          mkdir -p scripts/generators/lib
+          curl https://repo1.maven.org/maven2/org/json/json/20220924/json-20220924.jar \
+            -o scripts/generators/lib/json-20220924.jar
+          curl https://repo1.maven.org/maven2/org/apache/maven/maven-artifact/3.8.5/maven-artifact-3.8.5.jar \
+            -o scripts/generators/lib/maven-artifact-3.8.5.jar
+      - run: java -cp 'scripts/generators/lib/*' scripts/generators/GenerateMavenVersions.java
+      - run: git status
+      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        with:
+          name: generated-versions
+          path: internal/semantic/fixtures/maven-versions-generated.txt
+
+  generate-cran-versions:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
+      - uses: r-lib/actions/setup-r@b7e68d63e51bdf225997973e2add36d551f60f02 # v2.8.7
+        with:
+          r-version: "3.5.3"
+      - run: Rscript scripts/generators/generate-cran-versions.R
+      - run: git status
+      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        with:
+          name: generated-versions
+          path: internal/semantic/fixtures/cran-versions-generated.txt
+
+  test-semantic:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+    runs-on: ubuntu-latest
+    needs:
+      - generate-debian-versions
+      - generate-packagist-versions
+      - generate-pypi-versions
+      - generate-rubygems-versions
+      - generate-maven-versions
+      - generate-cran-versions
+    if: always()
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        with:
+          go-version-file: .go-version
+          cache: true
+
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        with:
+          name: generated-versions
+          path: internal/semantic/fixtures/
+      - run: git status
+      - run: scripts/run_tests.sh


### PR DESCRIPTION
Cherry-pick of https://github.com/G-Rath/osv-detector/pull/182

---

This setups up a dedicated workflow for running the `semantic` test suite using the latest generated fixtures:
  - every sunday
  - whenever a generator or the workflow is changed
  - via a `workflow_dispatch`

This helps ensure high confidence in `semantic` across ecosystems; the workflow also exports the generated files as an artifact which makes it easy to update the committed version of each fixture without requiring the native ecosystem components (i.e. Ruby, Java, R, etc) to be installed.

Note currently this is using v3 of the artifact actions - I'll upgrade to v4 in a follow-up PR, since it will require further work due to them switching to using immutable artifacts.

At some point I'm also keen to explore this for the API side since the logic should be pretty much the same