### PR TITLE
ci: cancel in-progress runs when new changes are pushed

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -23,6 +23,11 @@ on:
   merge_group:
     branches: [main]
 
+concurrency:
+  # Pushing new changes to a branch will cancel any in-progress CI runs
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # Restrict jobs in this workflow to have no permissions by default; permissions
 # should be granted per job as needed using a dedicated `permissions` block
 permissions: {}


### PR DESCRIPTION
This saves a bit of processing power, and also can help Codecov by reducing some of the API calls it makes which impact rate limiting