### PR TITLE
refactor: encapsulate getting the working directory in a helper function

### DIFF
--- a/internal/output/githubannotation.go
+++ b/internal/output/githubannotation.go
@@ -3,8 +3,6 @@ package output
 import (
 	"fmt"
 	"io"
-	"log"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -43,10 +41,7 @@ func PrintGHAnnotationReport(vulnResult *models.VulnerabilityResults, outputWrit
 
 	// TODO: Also support last affected
 	groupFixedVersions := GroupFixedVersions(flattened)
-	workingDir, err := os.Getwd()
-	if err != nil {
-		log.Panicf("can't get working dir: %v", err)
-	}
+	workingDir := mustGetWorkingDirectory()
 
 	for _, source := range vulnResult.Results {
 		// TODO: Support docker images

--- a/internal/output/result.go
+++ b/internal/output/result.go
@@ -2,6 +2,8 @@ package output
 
 import (
 	"encoding/json"
+	"log"
+	"os"
 	"slices"
 	"strings"
 
@@ -61,6 +63,16 @@ func (pss *pkgSourceSet) UnmarshalJSON(data []byte) error {
 	}
 
 	return nil
+}
+
+// mustGetWorkingDirectory panics if it can't get the working directory
+func mustGetWorkingDirectory() string {
+	dir, err := os.Getwd()
+	if err != nil {
+		log.Panicf("can't get working dir: %v", err)
+	}
+
+	return dir
 }
 
 // groupFixedVersions builds the fixed versions for each ID Group, with keys formatted like so:

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -3,9 +3,7 @@ package output
 import (
 	"fmt"
 	"io"
-	"log"
 	"math"
-	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -88,11 +86,8 @@ type tbInnerResponse struct {
 
 func tableBuilderInner(vulnResult *models.VulnerabilityResults, addStyling bool, calledVulns bool) []tbInnerResponse {
 	allOutputRows := []tbInnerResponse{}
-	// Working directory used to simplify path
-	workingDir, err := os.Getwd()
-	if err != nil {
-		log.Panicf("can't get working dir: %v", err)
-	}
+	workingDir := mustGetWorkingDirectory()
+
 	for _, sourceRes := range vulnResult.Results {
 		for _, pkg := range sourceRes.Packages {
 			source := sourceRes.Source
@@ -217,10 +212,7 @@ func licenseSummaryTableBuilder(outputTable table.Writer, vulnResult *models.Vul
 
 func licenseViolationsTableBuilder(outputTable table.Writer, vulnResult *models.VulnerabilityResults) table.Writer {
 	outputTable.AppendHeader(table.Row{"License Violation", "Ecosystem", "Package", "Version", "Source"})
-	workingDir, err := os.Getwd()
-	if err != nil {
-		log.Panicf("can't get working dir: %v", err)
-	}
+	workingDir := mustGetWorkingDirectory()
 	for _, pkgSource := range vulnResult.Results {
 		for _, pkg := range pkgSource.Packages {
 			if len(pkg.LicenseViolations) == 0 {


### PR DESCRIPTION
This "improves" our coverage artificially since the unhappy path is not coverable and this reduces us from three uncoverable lines to one.

I think this is worth doing as it feels more representative especially since we're panicking meaning we consider this a very unlikely and "on fire" situation, so we're hiding that within a particular function whose name makes that clear a la `regexp.MustCompile`