### PR TITLE
Fix snapshot for test

### DIFF
--- a/cmd/osv-scanner/__snapshots__/update_test.snap
+++ b/cmd/osv-scanner/__snapshots__/update_test.snap
@@ -34,7 +34,7 @@ Warning: `update` exists as both a subcommand of OSV-Scanner and as a file on th
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.17.0</version>
+      <version>2.17.1</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Jackson core released a new version that automated updates is now updating to, updating the fixtures to keep the tests passing.