### PR TITLE
ci: upgrade `golangci/golangci-lint-action` to v5

### DIFF
--- a/.github/workflows/lint-action/action.yml
+++ b/.github/workflows/lint-action/action.yml
@@ -19,9 +19,7 @@ runs:
   using: composite
   steps:
     - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@d6238b002a20823d52840fda27e2d4891c5952dc # v4.0.1
+      uses: golangci/golangci-lint-action@38e1018663fa5173f3968ea0777460d3de38f256 # v5.3.0
       with:
         # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
         version: v1.56.2
-        # https://github.com/golangci/golangci-lint-action/issues/135
-        skip-pkg-cache: true


### PR DESCRIPTION
Cherry-picked from #897

---

We can drop the `skip-pkg-cache` option now as caching has been removed in favor of `actions/setup-go`s caching