### PR TITLE
Disable all unimportant vulnerabilities

### DIFF
--- a/cmd/osv-scanner/__snapshots__/main_test.snap
+++ b/cmd/osv-scanner/__snapshots__/main_test.snap
@@ -133,6 +133,7 @@ Loaded filter from: <rootdir>/fixtures/go-project/osv-scanner.toml
 | https://osv.dev/GO-2024-2609 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod |
 | https://osv.dev/GO-2024-2610 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod |
 | https://osv.dev/GO-2024-2687 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod |
+| https://osv.dev/GO-2024-2824 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod |
 +------------------------------+------+-----------+---------+---------+----------------------------+
 
 ---
@@ -430,6 +431,7 @@ Scanned <rootdir>/fixtures/call-analysis-go-project/go.mod file and found 4 pack
 | https://osv.dev/GO-2024-2598        |      | Go        | stdlib                      | 1.19    | fixtures/call-analysis-go-project/go.mod |
 | https://osv.dev/GO-2024-2599        |      | Go        | stdlib                      | 1.19    | fixtures/call-analysis-go-project/go.mod |
 | https://osv.dev/GO-2024-2687        |      | Go        | stdlib                      | 1.19    | fixtures/call-analysis-go-project/go.mod |
+| https://osv.dev/GO-2024-2824        |      | Go        | stdlib                      | 1.19    | fixtures/call-analysis-go-project/go.mod |
 +-------------------------------------+------+-----------+-----------------------------+---------+------------------------------------------+
 | Uncalled vulnerabilities            |      |           |                             |         |                                          |
 +-------------------------------------+------+-----------+-----------------------------+---------+------------------------------------------+

--- a/cmd/osv-scanner/__snapshots__/main_test.snap
+++ b/cmd/osv-scanner/__snapshots__/main_test.snap
@@ -133,7 +133,6 @@ Loaded filter from: <rootdir>/fixtures/go-project/osv-scanner.toml
 | https://osv.dev/GO-2024-2609 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod |
 | https://osv.dev/GO-2024-2610 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod |
 | https://osv.dev/GO-2024-2687 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod |
-| https://osv.dev/GO-2024-2824 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod |
 +------------------------------+------+-----------+---------+---------+----------------------------+
 
 ---
@@ -431,7 +430,6 @@ Scanned <rootdir>/fixtures/call-analysis-go-project/go.mod file and found 4 pack
 | https://osv.dev/GO-2024-2598        |      | Go        | stdlib                      | 1.19    | fixtures/call-analysis-go-project/go.mod |
 | https://osv.dev/GO-2024-2599        |      | Go        | stdlib                      | 1.19    | fixtures/call-analysis-go-project/go.mod |
 | https://osv.dev/GO-2024-2687        |      | Go        | stdlib                      | 1.19    | fixtures/call-analysis-go-project/go.mod |
-| https://osv.dev/GO-2024-2824        |      | Go        | stdlib                      | 1.19    | fixtures/call-analysis-go-project/go.mod |
 +-------------------------------------+------+-----------+-----------------------------+---------+------------------------------------------+
 | Uncalled vulnerabilities            |      |           |                             |         |                                          |
 +-------------------------------------+------+-----------+-----------------------------+---------+------------------------------------------+

--- a/internal/sourceanalysis/__snapshots__/integration_test.snap
+++ b/internal/sourceanalysis/__snapshots__/integration_test.snap
@@ -124,7 +124,7 @@
           "position": {
             "filename": "\u003cAny value\u003e",
             "offset": -1,
-            "line": 844,
+            "line": 839,
             "column": 21
           }
         },
@@ -133,38 +133,62 @@
           "version": "v1.19.0",
           "package": "net/http",
           "function": "Read",
-          "receiver": "*body",
+          "receiver": "bodyLocked",
           "position": {
             "filename": "\u003cAny value\u003e",
             "offset": -1,
-            "line": 836,
+            "line": 1038,
+            "column": 24
+          }
+        },
+        {
+          "module": "stdlib",
+          "version": "v1.19.0",
+          "package": "io",
+          "function": "copyBuffer",
+          "position": {
+            "filename": "\u003cAny value\u003e",
+            "offset": -1,
+            "line": 430,
             "column": 21
           }
         },
         {
           "module": "stdlib",
           "version": "v1.19.0",
-          "package": "bufio",
-          "function": "fill",
-          "receiver": "*Reader",
+          "package": "io",
+          "function": "Copy",
           "position": {
             "filename": "\u003cAny value\u003e",
             "offset": -1,
-            "line": 110,
-            "column": 22
+            "line": 389,
+            "column": 19
           }
         },
         {
           "module": "stdlib",
           "version": "v1.19.0",
-          "package": "bufio",
-          "function": "Peek",
-          "receiver": "*Reader",
+          "package": "net/http",
+          "function": "Close",
+          "receiver": "*body",
           "position": {
             "filename": "\u003cAny value\u003e",
             "offset": -1,
-            "line": 148,
-            "column": 9
+            "line": 1002,
+            "column": 19
+          }
+        },
+        {
+          "module": "stdlib",
+          "version": "v1.19.0",
+          "package": "net/http",
+          "function": "finishRequest",
+          "receiver": "*response",
+          "position": {
+            "filename": "\u003cAny value\u003e",
+            "offset": -1,
+            "line": 1670,
+            "column": 17
           }
         },
         {
@@ -176,8 +200,8 @@
           "position": {
             "filename": "\u003cAny value\u003e",
             "offset": -1,
-            "line": 2076,
-            "column": 27
+            "line": 2015,
+            "column": 18
           }
         },
         {
@@ -189,7 +213,7 @@
           "position": {
             "filename": "\u003cAny value\u003e",
             "offset": -1,
-            "line": 3290,
+            "line": 3086,
             "column": 3
           }
         },
@@ -202,7 +226,7 @@
           "position": {
             "filename": "\u003cAny value\u003e",
             "offset": -1,
-            "line": 3187,
+            "line": 2985,
             "column": 18
           }
         },
@@ -214,7 +238,7 @@
           "position": {
             "filename": "\u003cAny value\u003e",
             "offset": -1,
-            "line": 3445,
+            "line": 3239,
             "column": 30
           }
         },

--- a/internal/sourceanalysis/__snapshots__/integration_test.snap
+++ b/internal/sourceanalysis/__snapshots__/integration_test.snap
@@ -124,7 +124,7 @@
           "position": {
             "filename": "\u003cAny value\u003e",
             "offset": -1,
-            "line": 839,
+            "line": 844,
             "column": 21
           }
         },
@@ -133,62 +133,38 @@
           "version": "v1.19.0",
           "package": "net/http",
           "function": "Read",
-          "receiver": "bodyLocked",
+          "receiver": "*body",
           "position": {
             "filename": "\u003cAny value\u003e",
             "offset": -1,
-            "line": 1038,
-            "column": 24
-          }
-        },
-        {
-          "module": "stdlib",
-          "version": "v1.19.0",
-          "package": "io",
-          "function": "copyBuffer",
-          "position": {
-            "filename": "\u003cAny value\u003e",
-            "offset": -1,
-            "line": 430,
+            "line": 836,
             "column": 21
           }
         },
         {
           "module": "stdlib",
           "version": "v1.19.0",
-          "package": "io",
-          "function": "Copy",
+          "package": "bufio",
+          "function": "fill",
+          "receiver": "*Reader",
           "position": {
             "filename": "\u003cAny value\u003e",
             "offset": -1,
-            "line": 389,
-            "column": 19
+            "line": 110,
+            "column": 22
           }
         },
         {
           "module": "stdlib",
           "version": "v1.19.0",
-          "package": "net/http",
-          "function": "Close",
-          "receiver": "*body",
+          "package": "bufio",
+          "function": "Peek",
+          "receiver": "*Reader",
           "position": {
             "filename": "\u003cAny value\u003e",
             "offset": -1,
-            "line": 1002,
-            "column": 19
-          }
-        },
-        {
-          "module": "stdlib",
-          "version": "v1.19.0",
-          "package": "net/http",
-          "function": "finishRequest",
-          "receiver": "*response",
-          "position": {
-            "filename": "\u003cAny value\u003e",
-            "offset": -1,
-            "line": 1670,
-            "column": 17
+            "line": 148,
+            "column": 9
           }
         },
         {
@@ -200,8 +176,8 @@
           "position": {
             "filename": "\u003cAny value\u003e",
             "offset": -1,
-            "line": 2015,
-            "column": 18
+            "line": 2076,
+            "column": 27
           }
         },
         {
@@ -213,7 +189,7 @@
           "position": {
             "filename": "\u003cAny value\u003e",
             "offset": -1,
-            "line": 3086,
+            "line": 3290,
             "column": 3
           }
         },
@@ -226,7 +202,7 @@
           "position": {
             "filename": "\u003cAny value\u003e",
             "offset": -1,
-            "line": 2985,
+            "line": 3187,
             "column": 18
           }
         },
@@ -238,7 +214,7 @@
           "position": {
             "filename": "\u003cAny value\u003e",
             "offset": -1,
-            "line": 3239,
+            "line": 3445,
             "column": 30
           }
         },

--- a/pkg/osvscanner/__snapshots__/osvscanner_internal_test.snap
+++ b/pkg/osvscanner/__snapshots__/osvscanner_internal_test.snap
@@ -1499,81 +1499,6 @@
           },
           "vulnerabilities": [
             {
-              "modified": "2023-03-09T21:20:44Z",
-              "published": "2023-02-17T14:00:02Z",
-              "schema_version": "1.4.0",
-              "id": "GHSA-vvpx-j8f3-3w6h",
-              "aliases": [
-                "CVE-2022-41723"
-              ],
-              "summary": "Uncontrolled Resource Consumption",
-              "details": "A maliciously crafted HTTP/2 stream could cause excessive CPU consumption in the HPACK decoder, sufficient to cause a denial of service from a small number of small requests.",
-              "affected": [
-                {
-                  "package": {
-                    "ecosystem": "Go",
-                    "name": "golang.org/x/net",
-                    "purl": "pkg:golang/golang.org/x/net"
-                  },
-                  "ranges": [
-                    {
-                      "type": "SEMVER",
-                      "events": [
-                        {
-                          "introduced": "0"
-                        },
-                        {
-                          "fixed": "0.7.0"
-                        }
-                      ]
-                    }
-                  ],
-                  "database_specific": {
-                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2023/02/GHSA-vvpx-j8f3-3w6h/GHSA-vvpx-j8f3-3w6h.json"
-                  }
-                }
-              ],
-              "references": [
-                {
-                  "type": "ADVISORY",
-                  "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-41723"
-                },
-                {
-                  "type": "WEB",
-                  "url": "https://go.dev/cl/468135"
-                },
-                {
-                  "type": "WEB",
-                  "url": "https://go.dev/cl/468295"
-                },
-                {
-                  "type": "WEB",
-                  "url": "https://go.dev/issue/57855"
-                },
-                {
-                  "type": "WEB",
-                  "url": "https://groups.google.com/g/golang-announce/c/V0aBFqaFs_E"
-                },
-                {
-                  "type": "WEB",
-                  "url": "https://pkg.go.dev/vuln/GO-2023-1571"
-                },
-                {
-                  "type": "WEB",
-                  "url": "https://vuln.go.dev/ID/GO-2023-1571.json"
-                }
-              ],
-              "database_specific": {
-                "cwe_ids": [
-                  "CWE-400"
-                ],
-                "github_reviewed": true,
-                "github_reviewed_at": "2023-02-17T14:00:02Z",
-                "nvd_published_at": "2023-02-28T18:15:00Z",
-                "severity": "HIGH"
-              }
-            },
-            {
               "modified": "2023-02-22T20:13:12Z",
               "published": "2023-02-16T22:31:36Z",
               "schema_version": "1.4.0",
@@ -1618,7 +1543,8 @@
                       {
                         "path": "net/http"
                       }
-                    ]
+                    ],
+                    "urgency": "low"
                   }
                 },
                 {

--- a/pkg/osvscanner/__snapshots__/osvscanner_internal_test.snap
+++ b/pkg/osvscanner/__snapshots__/osvscanner_internal_test.snap
@@ -1487,6 +1487,112 @@
   "results": [
     {
       "source": {
+        "path": "fixtures/filter/some/configs/a/",
+        "type": "lockfile"
+      },
+      "packages": [
+        {
+          "package": {
+            "name": "chromium",
+            "version": "73.0.3683.75-1",
+            "ecosystem": "Debian:10"
+          },
+          "vulnerabilities": [
+            {
+              "modified": "2024-05-03T03:16:29Z",
+              "published": "2024-04-17T08:15:10Z",
+              "id": "CVE-2024-3847",
+              "details": "Insufficient policy enforcement in WebUI in Google Chrome prior to 124.0.6367.60 allowed a remote attacker to bypass content security policy via a crafted HTML page. (Chromium security severity: Low)",
+              "affected": [
+                {
+                  "package": {
+                    "ecosystem": "Debian:10",
+                    "name": "chromium"
+                  },
+                  "ranges": [
+                    {
+                      "type": "ECOSYSTEM",
+                      "events": [
+                        {
+                          "introduced": "0"
+                        }
+                      ]
+                    }
+                  ],
+                  "ecosystem_specific": {
+                    "urgency": "low"
+                  }
+                },
+                {
+                  "package": {
+                    "ecosystem": "Debian:11",
+                    "name": "chromium"
+                  },
+                  "ranges": [
+                    {
+                      "type": "ECOSYSTEM",
+                      "events": [
+                        {
+                          "introduced": "0"
+                        }
+                      ]
+                    }
+                  ],
+                  "ecosystem_specific": {
+                    "urgency": "low"
+                  }
+                }
+              ],
+              "references": [
+                {
+                  "type": "ARTICLE",
+                  "url": "https://chromereleases.googleblog.com/2024/04/stable-channel-update-for-desktop_16.html"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://issues.chromium.org/issues/328690293"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/CWIVXXSVO5VB3NAZVFJ7CWVBN6W2735T/"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/IDLUD644WEWGOFKMZWC2K7Z4CQOKQYR7/"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/M4PCXKCOVBUUU6GOSN46DCPI4HMER3PJ/"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/PCWPUBGTBNT4EW32YNZMRIPB3Y4R6XL6/"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UOC3HLIZCGMIJLJ6LME5UWUUIFLXEGRN/"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/WEP5NJUWMDRLDQUKU4LFDUHF5PCYAPIO/"
+                }
+              ]
+            }
+          ],
+          "groups": [
+            {
+              "ids": [
+                "CVE-2024-3847"
+              ],
+              "aliases": null,
+              "max_severity": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "source": {
         "path": "fixtures/filter/some/configs/b/",
         "type": "lockfile"
       },
@@ -1498,6 +1604,84 @@
             "ecosystem": "Go"
           },
           "vulnerabilities": [
+            {
+              "modified": "2023-03-09T21:20:44Z",
+              "published": "2023-02-17T14:00:02Z",
+              "schema_version": "1.4.0",
+              "id": "GHSA-vvpx-j8f3-3w6h",
+              "aliases": [
+                "CVE-2022-41723"
+              ],
+              "summary": "Uncontrolled Resource Consumption",
+              "details": "A maliciously crafted HTTP/2 stream could cause excessive CPU consumption in the HPACK decoder, sufficient to cause a denial of service from a small number of small requests.",
+              "affected": [
+                {
+                  "package": {
+                    "ecosystem": "Go",
+                    "name": "golang.org/x/net",
+                    "purl": "pkg:golang/golang.org/x/net"
+                  },
+                  "ranges": [
+                    {
+                      "type": "SEMVER",
+                      "events": [
+                        {
+                          "introduced": "0"
+                        },
+                        {
+                          "fixed": "0.7.0"
+                        }
+                      ]
+                    }
+                  ],
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2023/02/GHSA-vvpx-j8f3-3w6h/GHSA-vvpx-j8f3-3w6h.json"
+                  },
+                  "ecosystem_specific": {
+                    "urgency": "unimportant"
+                  }
+                }
+              ],
+              "references": [
+                {
+                  "type": "ADVISORY",
+                  "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-41723"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://go.dev/cl/468135"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://go.dev/cl/468295"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://go.dev/issue/57855"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://groups.google.com/g/golang-announce/c/V0aBFqaFs_E"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://pkg.go.dev/vuln/GO-2023-1571"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://vuln.go.dev/ID/GO-2023-1571.json"
+                }
+              ],
+              "database_specific": {
+                "cwe_ids": [
+                  "CWE-400"
+                ],
+                "github_reviewed": true,
+                "github_reviewed_at": "2023-02-17T14:00:02Z",
+                "nvd_published_at": "2023-02-28T18:15:00Z",
+                "severity": "HIGH"
+              }
+            },
             {
               "modified": "2023-02-22T20:13:12Z",
               "published": "2023-02-16T22:31:36Z",

--- a/pkg/osvscanner/fixtures/filter/some/input.json
+++ b/pkg/osvscanner/fixtures/filter/some/input.json
@@ -8,6 +8,159 @@
       "packages": [
         {
           "package": {
+            "name": "unixodbc",
+            "version": "2.3.11-2",
+            "ecosystem": "Debian:10"
+          },
+          "vulnerabilities": [
+            {
+              "id": "CVE-2024-1013",
+              "details": "An out-of-bounds stack write flaw was found in unixODBC on 64-bit architectures where the caller has 4 bytes and callee writes 8 bytes. This issue may go unnoticed on little-endian architectures, while big-endian architectures can be broken.",
+              "affected": [
+                {
+                  "package": {
+                    "name": "unixodbc",
+                    "ecosystem": "Debian:10"
+                  },
+                  "ranges": [
+                    {
+                      "type": "ECOSYSTEM",
+                      "events": [
+                        {
+                          "introduced": "0"
+                        }
+                      ]
+                    }
+                  ],
+                  "ecosystem_specific": {
+                    "urgency": "unimportant"
+                  }
+                }
+              ],
+              "references": [
+                {
+                  "type": "REPORT",
+                  "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2260823"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://access.redhat.com/security/cve/CVE-2024-1013"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/lurcher/unixODBC/pull/157"
+                }
+              ],
+              "modified": "2024-03-18T12:38:25Z",
+              "published": "2024-03-18T11:15:09Z"
+            }
+          ],
+          "groups": [
+            {
+              "ids": [
+                "CVE-2024-1013"
+              ]
+            }
+          ]
+        },
+        {
+          "package": {
+            "name": "chromium",
+            "version": "73.0.3683.75-1",
+            "ecosystem": "Debian:10"
+          },
+          "vulnerabilities": [
+            {
+              "id": "CVE-2024-3847",
+              "details": "Insufficient policy enforcement in WebUI in Google Chrome prior to 124.0.6367.60 allowed a remote attacker to bypass content security policy via a crafted HTML page. (Chromium security severity: Low)",
+              "affected": [
+                {
+                  "package": {
+                    "name": "chromium",
+                    "ecosystem": "Debian:10"
+                  },
+                  "ranges": [
+                    {
+                      "type": "ECOSYSTEM",
+                      "events": [
+                        {
+                          "introduced": "0"
+                        }
+                      ]
+                    }
+                  ],
+                  "ecosystem_specific": {
+                    "urgency": "low"
+                  }
+                },
+                {
+                  "package": {
+                    "name": "chromium",
+                    "ecosystem": "Debian:11"
+                  },
+                  "ranges": [
+                    {
+                      "type": "ECOSYSTEM",
+                      "events": [
+                        {
+                          "introduced": "0"
+                        }
+                      ]
+                    }
+                  ],
+                  "ecosystem_specific": {
+                    "urgency": "low"
+                  }
+                }
+              ],
+              "references": [
+                {
+                  "type": "ARTICLE",
+                  "url": "https://chromereleases.googleblog.com/2024/04/stable-channel-update-for-desktop_16.html"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://issues.chromium.org/issues/328690293"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/CWIVXXSVO5VB3NAZVFJ7CWVBN6W2735T/"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/IDLUD644WEWGOFKMZWC2K7Z4CQOKQYR7/"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/M4PCXKCOVBUUU6GOSN46DCPI4HMER3PJ/"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/PCWPUBGTBNT4EW32YNZMRIPB3Y4R6XL6/"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UOC3HLIZCGMIJLJ6LME5UWUUIFLXEGRN/"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/WEP5NJUWMDRLDQUKU4LFDUHF5PCYAPIO/"
+                }
+              ],
+              "modified": "2024-05-03T03:16:29Z",
+              "published": "2024-04-17T08:15:10Z"
+            }
+          ],
+          "groups": [
+            {
+              "ids": [
+                "CVE-2024-3847"
+              ]
+            }
+          ]
+        },
+        {
+          "package": {
             "name": "remove_dir_all",
             "version": "0.5.3",
             "ecosystem": "crates.io"

--- a/pkg/osvscanner/fixtures/filter/some/input.json
+++ b/pkg/osvscanner/fixtures/filter/some/input.json
@@ -717,6 +717,9 @@
                   ],
                   "database_specific": {
                     "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2023/02/GHSA-vvpx-j8f3-3w6h/GHSA-vvpx-j8f3-3w6h.json"
+                  },
+                  "ecosystem_specific": {
+                    "urgency": "unimportant"
                   }
                 }
               ],
@@ -806,7 +809,8 @@
                       {
                         "path": "net/http"
                       }
-                    ]
+                    ],
+                    "urgency": "low"
                   }
                 },
                 {

--- a/pkg/osvscanner/fixtures/filter/some/want.json
+++ b/pkg/osvscanner/fixtures/filter/some/want.json
@@ -14,81 +14,6 @@
           },
           "vulnerabilities": [
             {
-              "modified": "2023-03-09T21:20:44Z",
-              "published": "2023-02-17T14:00:02Z",
-              "schema_version": "1.4.0",
-              "id": "GHSA-vvpx-j8f3-3w6h",
-              "aliases": [
-                "CVE-2022-41723"
-              ],
-              "summary": "Uncontrolled Resource Consumption",
-              "details": "A maliciously crafted HTTP/2 stream could cause excessive CPU consumption in the HPACK decoder, sufficient to cause a denial of service from a small number of small requests.",
-              "affected": [
-                {
-                  "package": {
-                    "ecosystem": "Go",
-                    "name": "golang.org/x/net",
-                    "purl": "pkg:golang/golang.org/x/net"
-                  },
-                  "ranges": [
-                    {
-                      "type": "SEMVER",
-                      "events": [
-                        {
-                          "introduced": "0"
-                        },
-                        {
-                          "fixed": "0.7.0"
-                        }
-                      ]
-                    }
-                  ],
-                  "database_specific": {
-                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2023/02/GHSA-vvpx-j8f3-3w6h/GHSA-vvpx-j8f3-3w6h.json"
-                  }
-                }
-              ],
-              "references": [
-                {
-                  "type": "ADVISORY",
-                  "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-41723"
-                },
-                {
-                  "type": "WEB",
-                  "url": "https://go.dev/cl/468135"
-                },
-                {
-                  "type": "WEB",
-                  "url": "https://go.dev/cl/468295"
-                },
-                {
-                  "type": "WEB",
-                  "url": "https://go.dev/issue/57855"
-                },
-                {
-                  "type": "WEB",
-                  "url": "https://groups.google.com/g/golang-announce/c/V0aBFqaFs_E"
-                },
-                {
-                  "type": "WEB",
-                  "url": "https://pkg.go.dev/vuln/GO-2023-1571"
-                },
-                {
-                  "type": "WEB",
-                  "url": "https://vuln.go.dev/ID/GO-2023-1571.json"
-                }
-              ],
-              "database_specific": {
-                "cwe_ids": [
-                  "CWE-400"
-                ],
-                "github_reviewed": true,
-                "github_reviewed_at": "2023-02-17T14:00:02Z",
-                "nvd_published_at": "2023-02-28T18:15:00Z",
-                "severity": "HIGH"
-              }
-            },
-            {
               "modified": "2023-02-22T20:13:12Z",
               "published": "2023-02-16T22:31:36Z",
               "schema_version": "1.4.0",
@@ -133,7 +58,8 @@
                       {
                         "path": "net/http"
                       }
-                    ]
+                    ],
+                    "urgency": "low"
                   }
                 },
                 {

--- a/pkg/osvscanner/fixtures/filter/some/want.json
+++ b/pkg/osvscanner/fixtures/filter/some/want.json
@@ -2,6 +2,112 @@
   "results": [
     {
       "source": {
+        "path": "fixtures/filter/some/configs/a/",
+        "type": "lockfile"
+      },
+      "packages": [
+        {
+          "package": {
+            "name": "chromium",
+            "version": "73.0.3683.75-1",
+            "ecosystem": "Debian:10"
+          },
+          "vulnerabilities": [
+            {
+              "modified": "2024-05-03T03:16:29Z",
+              "published": "2024-04-17T08:15:10Z",
+              "id": "CVE-2024-3847",
+              "details": "Insufficient policy enforcement in WebUI in Google Chrome prior to 124.0.6367.60 allowed a remote attacker to bypass content security policy via a crafted HTML page. (Chromium security severity: Low)",
+              "affected": [
+                {
+                  "package": {
+                    "ecosystem": "Debian:10",
+                    "name": "chromium"
+                  },
+                  "ranges": [
+                    {
+                      "type": "ECOSYSTEM",
+                      "events": [
+                        {
+                          "introduced": "0"
+                        }
+                      ]
+                    }
+                  ],
+                  "ecosystem_specific": {
+                    "urgency": "low"
+                  }
+                },
+                {
+                  "package": {
+                    "ecosystem": "Debian:11",
+                    "name": "chromium"
+                  },
+                  "ranges": [
+                    {
+                      "type": "ECOSYSTEM",
+                      "events": [
+                        {
+                          "introduced": "0"
+                        }
+                      ]
+                    }
+                  ],
+                  "ecosystem_specific": {
+                    "urgency": "low"
+                  }
+                }
+              ],
+              "references": [
+                {
+                  "type": "ARTICLE",
+                  "url": "https://chromereleases.googleblog.com/2024/04/stable-channel-update-for-desktop_16.html"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://issues.chromium.org/issues/328690293"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/CWIVXXSVO5VB3NAZVFJ7CWVBN6W2735T/"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/IDLUD644WEWGOFKMZWC2K7Z4CQOKQYR7/"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/M4PCXKCOVBUUU6GOSN46DCPI4HMER3PJ/"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/PCWPUBGTBNT4EW32YNZMRIPB3Y4R6XL6/"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UOC3HLIZCGMIJLJ6LME5UWUUIFLXEGRN/"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/WEP5NJUWMDRLDQUKU4LFDUHF5PCYAPIO/"
+                }
+              ]
+            }
+          ],
+          "groups": [
+            {
+              "ids": [
+                "CVE-2024-3847"
+              ],
+              "aliases": null,
+              "max_severity": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "source": {
         "path": "fixtures/filter/some/configs/b/",
         "type": "lockfile"
       },
@@ -13,6 +119,81 @@
             "ecosystem": "Go"
           },
           "vulnerabilities": [
+            {
+              "modified": "2023-03-09T21:20:44Z",
+              "published": "2023-02-17T14:00:02Z",
+              "schema_version": "1.4.0",
+              "id": "GHSA-vvpx-j8f3-3w6h",
+              "aliases": [
+                "CVE-2022-41723"
+              ],
+              "summary": "Uncontrolled Resource Consumption",
+              "details": "A maliciously crafted HTTP/2 stream could cause excessive CPU consumption in the HPACK decoder, sufficient to cause a denial of service from a small number of small requests.",
+              "affected": [
+                {
+                  "package": {
+                    "ecosystem": "Go",
+                    "name": "golang.org/x/net",
+                    "purl": "pkg:golang/golang.org/x/net"
+                  },
+                  "ranges": [
+                    {
+                      "type": "SEMVER",
+                      "events": [
+                        {
+                          "introduced": "0"
+                        },
+                        {
+                          "fixed": "0.7.0"
+                        }
+                      ]
+                    }
+                  ],
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2023/02/GHSA-vvpx-j8f3-3w6h/GHSA-vvpx-j8f3-3w6h.json"
+                  }
+                }
+              ],
+              "references": [
+                {
+                  "type": "ADVISORY",
+                  "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-41723"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://go.dev/cl/468135"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://go.dev/cl/468295"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://go.dev/issue/57855"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://groups.google.com/g/golang-announce/c/V0aBFqaFs_E"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://pkg.go.dev/vuln/GO-2023-1571"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://vuln.go.dev/ID/GO-2023-1571.json"
+                }
+              ],
+              "database_specific": {
+                "cwe_ids": [
+                  "CWE-400"
+                ],
+                "github_reviewed": true,
+                "github_reviewed_at": "2023-02-17T14:00:02Z",
+                "nvd_published_at": "2023-02-28T18:15:00Z",
+                "severity": "HIGH"
+              }
+            },
             {
               "modified": "2023-02-22T20:13:12Z",
               "published": "2023-02-16T22:31:36Z",

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -701,6 +701,7 @@ func isUnimportant(affectedPackages []models.Affected) bool {
 			return true
 		}
 	}
+
 	return false
 }
 

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -671,7 +671,8 @@ func filterPackageVulns(r reporter.Reporter, pkgVulns models.PackageVulns, confi
 	var newVulns []models.Vulnerability
 	if len(newGroups) > 0 { // If there are no groups left then there would be no vulnerabilities.
 		for _, vuln := range pkgVulns.Vulnerabilities {
-			if isUnimportant(vuln.Affected) {
+			// Checks if a Debian vulnerability is unimportant. Debian ecosystems may be listed with a version number, such as 'Debian:10'.
+			if strings.HasPrefix(pkgVulns.Package.Ecosystem, string(models.EcosystemDebian)) && isUnimportant(vuln.Affected) {
 				continue
 			}
 
@@ -692,11 +693,6 @@ func filterPackageVulns(r reporter.Reporter, pkgVulns models.PackageVulns, confi
 // Details: https://security-team.debian.org/security_tracker.html#severity-levels
 func isUnimportant(affectedPackages []models.Affected) bool {
 	for _, affected := range affectedPackages {
-		// Only checks Debian packages. Affected package ecosystems may be listed as "Debian:10"
-		if !strings.HasPrefix(string(affected.Package.Ecosystem), string(models.EcosystemDebian)) {
-			continue
-		}
-
 		if affected.EcosystemSpecific["urgency"] == "unimportant" {
 			return true
 		}

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -670,8 +670,11 @@ func filterPackageVulns(r reporter.Reporter, pkgVulns models.PackageVulns, confi
 
 	var newVulns []models.Vulnerability
 	if len(newGroups) > 0 { // If there are no groups left then there would be no vulnerabilities.
+		unimportantCount := 0
 		for _, vuln := range pkgVulns.Vulnerabilities {
 			if isUnimportant(pkgVulns.Package.Ecosystem, vuln.Affected) {
+				unimportantCount++
+				r.Verbosef("%s has been filtered out due to its unimportance.", vuln.ID)
 				continue
 			}
 
@@ -679,6 +682,7 @@ func filterPackageVulns(r reporter.Reporter, pkgVulns models.PackageVulns, confi
 				newVulns = append(newVulns, vuln)
 			}
 		}
+		r.Infof("%d unimportant vulnerabilities have been filtered out.", unimportantCount)
 	}
 
 	// Passed by value. We don't want to alter the original PackageVulns.

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -671,7 +671,15 @@ func filterPackageVulns(r reporter.Reporter, pkgVulns models.PackageVulns, confi
 	var newVulns []models.Vulnerability
 	if len(newGroups) > 0 { // If there are no groups left then there would be no vulnerabilities.
 		for _, vuln := range pkgVulns.Vulnerabilities {
-			if _, filtered := ignoredVulns[vuln.ID]; !filtered {
+			unimportant := false
+			for _, affected := range vuln.Affected {
+				if affected.EcosystemSpecific["urgency"] == "unimportant" {
+					unimportant = true
+					break
+				}
+			}
+
+			if _, filtered := ignoredVulns[vuln.ID]; !filtered && !unimportant {
 				newVulns = append(newVulns, vuln)
 			}
 		}

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -671,8 +671,7 @@ func filterPackageVulns(r reporter.Reporter, pkgVulns models.PackageVulns, confi
 	var newVulns []models.Vulnerability
 	if len(newGroups) > 0 { // If there are no groups left then there would be no vulnerabilities.
 		for _, vuln := range pkgVulns.Vulnerabilities {
-			// Checks if a Debian vulnerability is unimportant. Debian ecosystems may be listed with a version number, such as 'Debian:10'.
-			if strings.HasPrefix(pkgVulns.Package.Ecosystem, string(models.EcosystemDebian)) && isUnimportant(vuln.Affected) {
+			if isUnimportant(pkgVulns.Package.Ecosystem, vuln.Affected) {
 				continue
 			}
 
@@ -689,9 +688,14 @@ func filterPackageVulns(r reporter.Reporter, pkgVulns models.PackageVulns, confi
 	return pkgVulns
 }
 
-// isUnimportant returns if a Debian vulnerability is unimportant
-// Details: https://security-team.debian.org/security_tracker.html#severity-levels
-func isUnimportant(affectedPackages []models.Affected) bool {
+// isUnimportant checks if a Debian vulnerability is tagged with an "unimportant" urgency tag
+// Urgency levels are defined here: https://security-team.debian.org/security_tracker.html#severity-levels
+func isUnimportant(ecosystem string, affectedPackages []models.Affected) bool {
+	// Debian ecosystems may be listed with a version number, such as "Debian:10".
+	if !strings.HasPrefix(ecosystem, string(models.EcosystemDebian)) {
+		return false
+	}
+
 	for _, affected := range affectedPackages {
 		if affected.EcosystemSpecific["urgency"] == "unimportant" {
 			return true

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -675,6 +675,7 @@ func filterPackageVulns(r reporter.Reporter, pkgVulns models.PackageVulns, confi
 			if isUnimportant(pkgVulns.Package.Ecosystem, vuln.Affected) {
 				unimportantCount++
 				r.Verbosef("%s has been filtered out due to its unimportance.", vuln.ID)
+
 				continue
 			}
 
@@ -682,7 +683,10 @@ func filterPackageVulns(r reporter.Reporter, pkgVulns models.PackageVulns, confi
 				newVulns = append(newVulns, vuln)
 			}
 		}
-		r.Infof("%d unimportant vulnerabilities have been filtered out.", unimportantCount)
+
+		if unimportantCount > 0 {
+			r.Infof("%d unimportant vulnerabilities have been filtered out.", unimportantCount)
+		}
 	}
 
 	// Passed by value. We don't want to alter the original PackageVulns.

--- a/pkg/osvscanner/osvscanner_internal_test.go
+++ b/pkg/osvscanner/osvscanner_internal_test.go
@@ -33,7 +33,7 @@ func Test_filterResults(t *testing.T) {
 		{
 			name: "filter_partially",
 			path: "fixtures/filter/some",
-			want: 10,
+			want: 11,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
osv.dev integrates Debian security tracker data into existing CVE entries, filtering out unimportant vulnerabilities.
![image](https://github.com/google/osv-scanner/assets/39108850/14e00974-fa2c-47d7-a526-e3ab06009cf1)
