### PR TITLE
Update snapshots

### DIFF
--- a/cmd/osv-scanner/__snapshots__/main_test.snap
+++ b/cmd/osv-scanner/__snapshots__/main_test.snap
@@ -225,7 +225,11 @@ Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
 CVE-2022-48174 has been filtered out because: Test manifest file (alpine.cdx.xml)
 GHSA-whgm-jr23-g3j9 and 1 alias have been filtered out because: Test manifest file
 Filtered 2 vulnerabilities from output
-No issues found
++--------------------------------+------+-----------+---------+------------+------------------------------------+
+| OSV URL                        | CVSS | ECOSYSTEM | PACKAGE | VERSION    | SOURCE                             |
++--------------------------------+------+-----------+---------+------------+------------------------------------+
+| https://osv.dev/CVE-2023-42366 | 5.5  | Alpine    | busybox | 1.35.0-r29 | fixtures/locks-many/alpine.cdx.xml |
++--------------------------------+------+-----------+---------+------------+------------------------------------+
 
 ---
 
@@ -253,6 +257,7 @@ Scanned <rootdir>/fixtures/sbom-insecure/postgres-stretch.cdx.xml as CycloneDX S
 | OSV URL                             | CVSS | ECOSYSTEM | PACKAGE                        | VERSION                            | SOURCE                                          |
 +-------------------------------------+------+-----------+--------------------------------+------------------------------------+-------------------------------------------------+
 | https://osv.dev/CVE-2022-48174      | 9.8  | Alpine    | busybox                        | 1.35.0-r29                         | fixtures/sbom-insecure/alpine.cdx.xml           |
+| https://osv.dev/CVE-2023-42366      | 5.5  | Alpine    | busybox                        | 1.35.0-r29                         | fixtures/sbom-insecure/alpine.cdx.xml           |
 | https://osv.dev/CVE-2022-37434      | 9.8  | Alpine    | zlib                           | 1.2.10-r2                          | fixtures/sbom-insecure/alpine.cdx.xml           |
 | https://osv.dev/DLA-3022-1          |      | Debian    | dpkg                           | 1.18.25                            | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/GHSA-v95c-p5hm-xq8f | 6.0  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
@@ -375,6 +380,7 @@ Scanned <rootdir>/fixtures/sbom-insecure/alpine.cdx.xml as CycloneDX SBOM and fo
 | OSV URL                        | CVSS | ECOSYSTEM | PACKAGE | VERSION    | SOURCE                                |
 +--------------------------------+------+-----------+---------+------------+---------------------------------------+
 | https://osv.dev/CVE-2022-48174 | 9.8  | Alpine    | busybox | 1.35.0-r29 | fixtures/sbom-insecure/alpine.cdx.xml |
+| https://osv.dev/CVE-2023-42366 | 5.5  | Alpine    | busybox | 1.35.0-r29 | fixtures/sbom-insecure/alpine.cdx.xml |
 | https://osv.dev/CVE-2022-37434 | 9.8  | Alpine    | zlib    | 1.2.10-r2  | fixtures/sbom-insecure/alpine.cdx.xml |
 +--------------------------------+------+-----------+---------+------------+---------------------------------------+
 
@@ -765,6 +771,11 @@ Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
 CVE-2022-48174 has been filtered out because: Test manifest file (alpine.cdx.xml)
 GHSA-whgm-jr23-g3j9 and 1 alias have been filtered out because: Test manifest file
 Filtered 2 vulnerabilities from output
++--------------------------------+------+-----------+---------+------------+------------------------------------+
+| OSV URL                        | CVSS | ECOSYSTEM | PACKAGE | VERSION    | SOURCE                             |
++--------------------------------+------+-----------+---------+------------+------------------------------------+
+| https://osv.dev/CVE-2023-42366 | 5.5  | Alpine    | busybox | 1.35.0-r29 | fixtures/locks-many/alpine.cdx.xml |
++--------------------------------+------+-----------+---------+------------+------------------------------------+
 +------------+-------------------------+
 | LICENSE    | NO. OF PACKAGE VERSIONS |
 +------------+-------------------------+
@@ -790,6 +801,9 @@ Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
 CVE-2022-48174 has been filtered out because: Test manifest file (alpine.cdx.xml)
 GHSA-whgm-jr23-g3j9 and 1 alias have been filtered out because: Test manifest file
 Filtered 2 vulnerabilities from output
+| OSV URL | CVSS | Ecosystem | Package | Version | Source |
+| --- | --- | --- | --- | --- | --- |
+| https://osv.dev/CVE-2023-42366 | 5.5 | Alpine | busybox | 1.35.0-r29 | fixtures/locks-many/alpine.cdx.xml |
 | License | No. of package versions |
 | --- | ---:|
 | Apache-2.0 | 1 |

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -176,7 +176,7 @@ func TestRun(t *testing.T) {
 		{
 			name: "Scan locks-many",
 			args: []string{"", "./fixtures/locks-many"},
-			exit: 0,
+			exit: 1,
 		},
 		// all supported lockfiles in the directory should be checked
 		{
@@ -576,12 +576,12 @@ func TestRun_Licenses(t *testing.T) {
 		{
 			name: "No vulnerabilities with license summary",
 			args: []string{"", "--experimental-licenses-summary", "./fixtures/locks-many"},
-			exit: 0,
+			exit: 1,
 		},
 		{
 			name: "No vulnerabilities with license summary in markdown",
 			args: []string{"", "--experimental-licenses-summary", "--format=markdown", "./fixtures/locks-many"},
-			exit: 0,
+			exit: 1,
 		},
 		{
 			name: "Vulnerabilities and license summary",


### PR DESCRIPTION
Currently tests are broken due to a new vulnerability in test fixtures. This PR aims to fix these failures by updating the snapshots