### PR TITLE
make Maven parent path relative on current project

### DIFF
--- a/internal/resolution/manifest/fixtures/parent/grandparent/pom.xml
+++ b/internal/resolution/manifest/fixtures/parent/grandparent/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.grandparent</groupId>
+  <artifactId>grandparent-pom</artifactId>
+  <version>1.1.1</version>
+
+  <name>my-app</name>
+  <!-- FIXME change it to the project's website -->
+  <url>http://www.example.com</url>
+
+  <packaging>pom</packaging>
+
+  <parent>
+    <groupId>org.upstream</groupId>
+    <artifactId>parent-pom</artifactId>
+    <version>1.2.3</version>
+  </parent>
+
+</project>

--- a/internal/resolution/manifest/fixtures/parent/pom.xml
+++ b/internal/resolution/manifest/fixtures/parent/pom.xml
@@ -15,9 +15,10 @@
   <packaging>pom</packaging>
 
   <parent>
-    <groupId>org.upstream</groupId>
-    <artifactId>parent-pom</artifactId>
-    <version>1.2.3</version>
+    <groupId>org.grandparent</groupId>
+    <artifactId>grandparentparent-pom</artifactId>
+    <version>1.1.1</version>
+    <relativePath>./grandparent</relativePath>
   </parent>
 
   <properties>


### PR DESCRIPTION
Previously, the path is always relative to the provided path to `pom.xml`, however, this path should be relative to the current parent path.

Also we observe that sometimes `pom.xml` is omitted in `</relativePath>` so when this happens, we manually append `pom.xml` to file path.