### PR TITLE
Fix snapshots and alpine version

### DIFF
--- a/cmd/osv-scanner/__snapshots__/main_test.snap
+++ b/cmd/osv-scanner/__snapshots__/main_test.snap
@@ -222,9 +222,8 @@ Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
 Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
 Scanned <rootdir>/fixtures/locks-many/yarn.lock file and found 1 package
 Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
-CVE-2022-48174 has been filtered out because: Test manifest file (alpine.cdx.xml)
 GHSA-whgm-jr23-g3j9 and 1 alias have been filtered out because: Test manifest file
-Filtered 2 vulnerabilities from output
+Filtered 1 vulnerability from output
 No issues found
 
 ---
@@ -252,7 +251,6 @@ Scanned <rootdir>/fixtures/sbom-insecure/postgres-stretch.cdx.xml as CycloneDX S
 +-------------------------------------+------+-----------+--------------------------------+------------------------------------+-------------------------------------------------+
 | OSV URL                             | CVSS | ECOSYSTEM | PACKAGE                        | VERSION                            | SOURCE                                          |
 +-------------------------------------+------+-----------+--------------------------------+------------------------------------+-------------------------------------------------+
-| https://osv.dev/CVE-2022-48174      | 9.8  | Alpine    | busybox                        | 1.35.0-r29                         | fixtures/sbom-insecure/alpine.cdx.xml           |
 | https://osv.dev/CVE-2022-37434      | 9.8  | Alpine    | zlib                           | 1.2.10-r2                          | fixtures/sbom-insecure/alpine.cdx.xml           |
 | https://osv.dev/DLA-3022-1          |      | Debian    | dpkg                           | 1.18.25                            | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/GHSA-v95c-p5hm-xq8f | 6.0  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
@@ -371,12 +369,11 @@ No issues found
 
 [TestRun/one_specific_supported_sbom_with_vulns - 1]
 Scanned <rootdir>/fixtures/sbom-insecure/alpine.cdx.xml as CycloneDX SBOM and found 15 packages
-+--------------------------------+------+-----------+---------+------------+---------------------------------------+
-| OSV URL                        | CVSS | ECOSYSTEM | PACKAGE | VERSION    | SOURCE                                |
-+--------------------------------+------+-----------+---------+------------+---------------------------------------+
-| https://osv.dev/CVE-2022-48174 | 9.8  | Alpine    | busybox | 1.35.0-r29 | fixtures/sbom-insecure/alpine.cdx.xml |
-| https://osv.dev/CVE-2022-37434 | 9.8  | Alpine    | zlib    | 1.2.10-r2  | fixtures/sbom-insecure/alpine.cdx.xml |
-+--------------------------------+------+-----------+---------+------------+---------------------------------------+
++--------------------------------+------+-----------+---------+-----------+---------------------------------------+
+| OSV URL                        | CVSS | ECOSYSTEM | PACKAGE | VERSION   | SOURCE                                |
++--------------------------------+------+-----------+---------+-----------+---------------------------------------+
+| https://osv.dev/CVE-2022-37434 | 9.8  | Alpine    | zlib    | 1.2.10-r2 | fixtures/sbom-insecure/alpine.cdx.xml |
++--------------------------------+------+-----------+---------+-----------+---------------------------------------+
 
 ---
 
@@ -762,9 +759,8 @@ Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
 Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
 Scanned <rootdir>/fixtures/locks-many/yarn.lock file and found 1 package
 Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
-CVE-2022-48174 has been filtered out because: Test manifest file (alpine.cdx.xml)
 GHSA-whgm-jr23-g3j9 and 1 alias have been filtered out because: Test manifest file
-Filtered 2 vulnerabilities from output
+Filtered 1 vulnerability from output
 +------------+-------------------------+
 | LICENSE    | NO. OF PACKAGE VERSIONS |
 +------------+-------------------------+
@@ -787,9 +783,8 @@ Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
 Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
 Scanned <rootdir>/fixtures/locks-many/yarn.lock file and found 1 package
 Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
-CVE-2022-48174 has been filtered out because: Test manifest file (alpine.cdx.xml)
 GHSA-whgm-jr23-g3j9 and 1 alias have been filtered out because: Test manifest file
-Filtered 2 vulnerabilities from output
+Filtered 1 vulnerability from output
 | License | No. of package versions |
 | --- | ---:|
 | Apache-2.0 | 1 |

--- a/cmd/osv-scanner/fixtures/locks-many/alpine.cdx.xml
+++ b/cmd/osv-scanner/fixtures/locks-many/alpine.cdx.xml
@@ -182,18 +182,18 @@
         <property name="syft:location:0:path">/bin/busybox</property>
       </properties>
     </component>
-    <component bom-ref="pkg:apk/alpine/busybox@1.35.0-r29?arch=x86_64&amp;upstream=busybox&amp;distro=alpine-3.17.2&amp;package-id=623d53216342d45e" type="library">
+    <component bom-ref="pkg:apk/alpine/busybox@1.36.1-r27?arch=x86_64&amp;upstream=busybox&amp;distro=alpine-3.17.2&amp;package-id=623d53216342d45e" type="library">
       <publisher>Sören Tempel &lt;soeren+alpine@soeren-tempel.net&gt;</publisher>
       <name>busybox</name>
-      <version>1.35.0-r29</version>
+      <version>1.36.1-r27</version>
       <description>Size optimized toolbox of many common UNIX utilities</description>
       <licenses>
         <license>
           <id>GPL-2.0-only</id>
         </license>
       </licenses>
-      <cpe>cpe:2.3:a:busybox:busybox:1.35.0-r29:*:*:*:*:*:*:*</cpe>
-      <purl>pkg:apk/alpine/busybox@1.35.0-r29?arch=x86_64&amp;upstream=busybox&amp;distro=alpine-3.17.2</purl>
+      <cpe>cpe:2.3:a:busybox:busybox:1.36.1-r27:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:apk/alpine/busybox@1.36.1-r27?arch=x86_64&amp;upstream=busybox&amp;distro=alpine-3.17.2</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://busybox.net/</url>
@@ -208,24 +208,24 @@
         <property name="syft:metadata:gitCommitOfApkPort">1dbf7a793afae640ea643a055b6dd4f430ac116b</property>
         <property name="syft:metadata:installedSize">962560</property>
         <property name="syft:metadata:originPackage">busybox</property>
-        <property name="syft:metadata:provides:0">cmd:busybox=1.35.0-r29</property>
+        <property name="syft:metadata:provides:0">cmd:busybox=1.36.1-r27</property>
         <property name="syft:metadata:pullChecksum">Q1NN3sp0yr99btRysqty3nQUrWHaY=</property>
         <property name="syft:metadata:pullDependencies:0">so:libc.musl-x86_64.so.1</property>
         <property name="syft:metadata:size">509600</property>
       </properties>
     </component>
-    <component bom-ref="pkg:apk/alpine/busybox-binsh@1.35.0-r29?arch=x86_64&amp;upstream=busybox&amp;distro=alpine-3.17.2&amp;package-id=256fc96b4a8c4da8" type="library">
+    <component bom-ref="pkg:apk/alpine/busybox-binsh@1.36.1-r27?arch=x86_64&amp;upstream=busybox&amp;distro=alpine-3.17.2&amp;package-id=256fc96b4a8c4da8" type="library">
       <publisher>Sören Tempel &lt;soeren+alpine@soeren-tempel.net&gt;</publisher>
       <name>busybox-binsh</name>
-      <version>1.35.0-r29</version>
+      <version>1.36.1-r27</version>
       <description>busybox ash /bin/sh</description>
       <licenses>
         <license>
           <id>GPL-2.0-only</id>
         </license>
       </licenses>
-      <cpe>cpe:2.3:a:busybox-binsh:busybox-binsh:1.35.0-r29:*:*:*:*:*:*:*</cpe>
-      <purl>pkg:apk/alpine/busybox-binsh@1.35.0-r29?arch=x86_64&amp;upstream=busybox&amp;distro=alpine-3.17.2</purl>
+      <cpe>cpe:2.3:a:busybox-binsh:busybox-binsh:1.36.1-r27:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:apk/alpine/busybox-binsh@1.36.1-r27?arch=x86_64&amp;upstream=busybox&amp;distro=alpine-3.17.2</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://busybox.net/</url>
@@ -235,20 +235,20 @@
         <property name="syft:package:foundBy">apkdb-cataloger</property>
         <property name="syft:package:metadataType">ApkMetadata</property>
         <property name="syft:package:type">apk</property>
-        <property name="syft:cpe23">cpe:2.3:a:busybox-binsh:busybox_binsh:1.35.0-r29:*:*:*:*:*:*:*</property>
-        <property name="syft:cpe23">cpe:2.3:a:busybox_binsh:busybox-binsh:1.35.0-r29:*:*:*:*:*:*:*</property>
-        <property name="syft:cpe23">cpe:2.3:a:busybox_binsh:busybox_binsh:1.35.0-r29:*:*:*:*:*:*:*</property>
-        <property name="syft:cpe23">cpe:2.3:a:busybox:busybox-binsh:1.35.0-r29:*:*:*:*:*:*:*</property>
-        <property name="syft:cpe23">cpe:2.3:a:busybox:busybox_binsh:1.35.0-r29:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:busybox-binsh:busybox_binsh:1.36.1-r27:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:busybox_binsh:busybox-binsh:1.36.1-r27:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:busybox_binsh:busybox_binsh:1.36.1-r27:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:busybox:busybox-binsh:1.36.1-r27:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:busybox:busybox_binsh:1.36.1-r27:*:*:*:*:*:*:*</property>
         <property name="syft:location:0:layerID">sha256:7cd52847ad775a5ddc4b58326cf884beee34544296402c6292ed76474c686d39</property>
         <property name="syft:location:0:path">/lib/apk/db/installed</property>
         <property name="syft:metadata:gitCommitOfApkPort">1dbf7a793afae640ea643a055b6dd4f430ac116b</property>
         <property name="syft:metadata:installedSize">8192</property>
         <property name="syft:metadata:originPackage">busybox</property>
         <property name="syft:metadata:provides:0">/bin/sh</property>
-        <property name="syft:metadata:provides:1">cmd:sh=1.35.0-r29</property>
+        <property name="syft:metadata:provides:1">cmd:sh=1.36.1-r27</property>
         <property name="syft:metadata:pullChecksum">Q1miWwyhWKXVEiRYLhmArV1TKMs6A=</property>
-        <property name="syft:metadata:pullDependencies:0">busybox=1.35.0-r29</property>
+        <property name="syft:metadata:pullDependencies:0">busybox=1.36.1-r27</property>
         <property name="syft:metadata:size">1547</property>
       </properties>
     </component>
@@ -510,18 +510,18 @@
         <property name="syft:metadata:size">37687</property>
       </properties>
     </component>
-    <component bom-ref="pkg:apk/alpine/ssl_client@1.35.0-r29?arch=x86_64&amp;upstream=busybox&amp;distro=alpine-3.17.2&amp;package-id=b15247aafcd4a647" type="library">
+    <component bom-ref="pkg:apk/alpine/ssl_client@1.36.1-r27?arch=x86_64&amp;upstream=busybox&amp;distro=alpine-3.17.2&amp;package-id=b15247aafcd4a647" type="library">
       <publisher>Sören Tempel &lt;soeren+alpine@soeren-tempel.net&gt;</publisher>
       <name>ssl_client</name>
-      <version>1.35.0-r29</version>
+      <version>1.36.1-r27</version>
       <description>EXternal ssl_client for busybox wget</description>
       <licenses>
         <license>
           <id>GPL-2.0-only</id>
         </license>
       </licenses>
-      <cpe>cpe:2.3:a:ssl-client:ssl-client:1.35.0-r29:*:*:*:*:*:*:*</cpe>
-      <purl>pkg:apk/alpine/ssl_client@1.35.0-r29?arch=x86_64&amp;upstream=busybox&amp;distro=alpine-3.17.2</purl>
+      <cpe>cpe:2.3:a:ssl-client:ssl-client:1.36.1-r27:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:apk/alpine/ssl_client@1.36.1-r27?arch=x86_64&amp;upstream=busybox&amp;distro=alpine-3.17.2</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://busybox.net/</url>
@@ -531,17 +531,17 @@
         <property name="syft:package:foundBy">apkdb-cataloger</property>
         <property name="syft:package:metadataType">ApkMetadata</property>
         <property name="syft:package:type">apk</property>
-        <property name="syft:cpe23">cpe:2.3:a:ssl-client:ssl_client:1.35.0-r29:*:*:*:*:*:*:*</property>
-        <property name="syft:cpe23">cpe:2.3:a:ssl_client:ssl-client:1.35.0-r29:*:*:*:*:*:*:*</property>
-        <property name="syft:cpe23">cpe:2.3:a:ssl_client:ssl_client:1.35.0-r29:*:*:*:*:*:*:*</property>
-        <property name="syft:cpe23">cpe:2.3:a:ssl:ssl-client:1.35.0-r29:*:*:*:*:*:*:*</property>
-        <property name="syft:cpe23">cpe:2.3:a:ssl:ssl_client:1.35.0-r29:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:ssl-client:ssl_client:1.36.1-r27:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:ssl_client:ssl-client:1.36.1-r27:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:ssl_client:ssl_client:1.36.1-r27:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:ssl:ssl-client:1.36.1-r27:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:ssl:ssl_client:1.36.1-r27:*:*:*:*:*:*:*</property>
         <property name="syft:location:0:layerID">sha256:7cd52847ad775a5ddc4b58326cf884beee34544296402c6292ed76474c686d39</property>
         <property name="syft:location:0:path">/lib/apk/db/installed</property>
         <property name="syft:metadata:gitCommitOfApkPort">1dbf7a793afae640ea643a055b6dd4f430ac116b</property>
         <property name="syft:metadata:installedSize">28672</property>
         <property name="syft:metadata:originPackage">busybox</property>
-        <property name="syft:metadata:provides:0">cmd:ssl_client=1.35.0-r29</property>
+        <property name="syft:metadata:provides:0">cmd:ssl_client=1.36.1-r27</property>
         <property name="syft:metadata:pullChecksum">Q1QuqZjeP6XG85I29tOiCWofL8Cj0=</property>
         <property name="syft:metadata:pullDependencies:0">so:libc.musl-x86_64.so.1</property>
         <property name="syft:metadata:pullDependencies:1">so:libcrypto.so.3</property>

--- a/cmd/osv-scanner/fixtures/sbom-insecure/alpine.cdx.xml
+++ b/cmd/osv-scanner/fixtures/sbom-insecure/alpine.cdx.xml
@@ -182,18 +182,18 @@
         <property name="syft:location:0:path">/bin/busybox</property>
       </properties>
     </component>
-    <component bom-ref="pkg:apk/alpine/busybox@1.35.0-r29?arch=x86_64&amp;upstream=busybox&amp;distro=alpine-3.17.2&amp;package-id=623d53216342d45e" type="library">
+    <component bom-ref="pkg:apk/alpine/busybox@1.36.1-r27?arch=x86_64&amp;upstream=busybox&amp;distro=alpine-3.17.2&amp;package-id=623d53216342d45e" type="library">
       <publisher>Sören Tempel &lt;soeren+alpine@soeren-tempel.net&gt;</publisher>
       <name>busybox</name>
-      <version>1.35.0-r29</version>
+      <version>1.36.1-r27</version>
       <description>Size optimized toolbox of many common UNIX utilities</description>
       <licenses>
         <license>
           <id>GPL-2.0-only</id>
         </license>
       </licenses>
-      <cpe>cpe:2.3:a:busybox:busybox:1.35.0-r29:*:*:*:*:*:*:*</cpe>
-      <purl>pkg:apk/alpine/busybox@1.35.0-r29?arch=x86_64&amp;upstream=busybox&amp;distro=alpine-3.17.2</purl>
+      <cpe>cpe:2.3:a:busybox:busybox:1.36.1-r27:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:apk/alpine/busybox@1.36.1-r27?arch=x86_64&amp;upstream=busybox&amp;distro=alpine-3.17.2</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://busybox.net/</url>
@@ -208,24 +208,24 @@
         <property name="syft:metadata:gitCommitOfApkPort">1dbf7a793afae640ea643a055b6dd4f430ac116b</property>
         <property name="syft:metadata:installedSize">962560</property>
         <property name="syft:metadata:originPackage">busybox</property>
-        <property name="syft:metadata:provides:0">cmd:busybox=1.35.0-r29</property>
+        <property name="syft:metadata:provides:0">cmd:busybox=1.36.1-r27</property>
         <property name="syft:metadata:pullChecksum">Q1NN3sp0yr99btRysqty3nQUrWHaY=</property>
         <property name="syft:metadata:pullDependencies:0">so:libc.musl-x86_64.so.1</property>
         <property name="syft:metadata:size">509600</property>
       </properties>
     </component>
-    <component bom-ref="pkg:apk/alpine/busybox-binsh@1.35.0-r29?arch=x86_64&amp;upstream=busybox&amp;distro=alpine-3.17.2&amp;package-id=256fc96b4a8c4da8" type="library">
+    <component bom-ref="pkg:apk/alpine/busybox-binsh@1.36.1-r27?arch=x86_64&amp;upstream=busybox&amp;distro=alpine-3.17.2&amp;package-id=256fc96b4a8c4da8" type="library">
       <publisher>Sören Tempel &lt;soeren+alpine@soeren-tempel.net&gt;</publisher>
       <name>busybox-binsh</name>
-      <version>1.35.0-r29</version>
+      <version>1.36.1-r27</version>
       <description>busybox ash /bin/sh</description>
       <licenses>
         <license>
           <id>GPL-2.0-only</id>
         </license>
       </licenses>
-      <cpe>cpe:2.3:a:busybox-binsh:busybox-binsh:1.35.0-r29:*:*:*:*:*:*:*</cpe>
-      <purl>pkg:apk/alpine/busybox-binsh@1.35.0-r29?arch=x86_64&amp;upstream=busybox&amp;distro=alpine-3.17.2</purl>
+      <cpe>cpe:2.3:a:busybox-binsh:busybox-binsh:1.36.1-r27:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:apk/alpine/busybox-binsh@1.36.1-r27?arch=x86_64&amp;upstream=busybox&amp;distro=alpine-3.17.2</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://busybox.net/</url>
@@ -235,20 +235,20 @@
         <property name="syft:package:foundBy">apkdb-cataloger</property>
         <property name="syft:package:metadataType">ApkMetadata</property>
         <property name="syft:package:type">apk</property>
-        <property name="syft:cpe23">cpe:2.3:a:busybox-binsh:busybox_binsh:1.35.0-r29:*:*:*:*:*:*:*</property>
-        <property name="syft:cpe23">cpe:2.3:a:busybox_binsh:busybox-binsh:1.35.0-r29:*:*:*:*:*:*:*</property>
-        <property name="syft:cpe23">cpe:2.3:a:busybox_binsh:busybox_binsh:1.35.0-r29:*:*:*:*:*:*:*</property>
-        <property name="syft:cpe23">cpe:2.3:a:busybox:busybox-binsh:1.35.0-r29:*:*:*:*:*:*:*</property>
-        <property name="syft:cpe23">cpe:2.3:a:busybox:busybox_binsh:1.35.0-r29:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:busybox-binsh:busybox_binsh:1.36.1-r27:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:busybox_binsh:busybox-binsh:1.36.1-r27:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:busybox_binsh:busybox_binsh:1.36.1-r27:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:busybox:busybox-binsh:1.36.1-r27:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:busybox:busybox_binsh:1.36.1-r27:*:*:*:*:*:*:*</property>
         <property name="syft:location:0:layerID">sha256:7cd52847ad775a5ddc4b58326cf884beee34544296402c6292ed76474c686d39</property>
         <property name="syft:location:0:path">/lib/apk/db/installed</property>
         <property name="syft:metadata:gitCommitOfApkPort">1dbf7a793afae640ea643a055b6dd4f430ac116b</property>
         <property name="syft:metadata:installedSize">8192</property>
         <property name="syft:metadata:originPackage">busybox</property>
         <property name="syft:metadata:provides:0">/bin/sh</property>
-        <property name="syft:metadata:provides:1">cmd:sh=1.35.0-r29</property>
+        <property name="syft:metadata:provides:1">cmd:sh=1.36.1-r27</property>
         <property name="syft:metadata:pullChecksum">Q1miWwyhWKXVEiRYLhmArV1TKMs6A=</property>
-        <property name="syft:metadata:pullDependencies:0">busybox=1.35.0-r29</property>
+        <property name="syft:metadata:pullDependencies:0">busybox=1.36.1-r27</property>
         <property name="syft:metadata:size">1547</property>
       </properties>
     </component>
@@ -510,18 +510,18 @@
         <property name="syft:metadata:size">37687</property>
       </properties>
     </component>
-    <component bom-ref="pkg:apk/alpine/ssl_client@1.35.0-r29?arch=x86_64&amp;upstream=busybox&amp;distro=alpine-3.17.2&amp;package-id=b15247aafcd4a647" type="library">
+    <component bom-ref="pkg:apk/alpine/ssl_client@1.36.1-r27?arch=x86_64&amp;upstream=busybox&amp;distro=alpine-3.17.2&amp;package-id=b15247aafcd4a647" type="library">
       <publisher>Sören Tempel &lt;soeren+alpine@soeren-tempel.net&gt;</publisher>
       <name>ssl_client</name>
-      <version>1.35.0-r29</version>
+      <version>1.36.1-r27</version>
       <description>EXternal ssl_client for busybox wget</description>
       <licenses>
         <license>
           <id>GPL-2.0-only</id>
         </license>
       </licenses>
-      <cpe>cpe:2.3:a:ssl-client:ssl-client:1.35.0-r29:*:*:*:*:*:*:*</cpe>
-      <purl>pkg:apk/alpine/ssl_client@1.35.0-r29?arch=x86_64&amp;upstream=busybox&amp;distro=alpine-3.17.2</purl>
+      <cpe>cpe:2.3:a:ssl-client:ssl-client:1.36.1-r27:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:apk/alpine/ssl_client@1.36.1-r27?arch=x86_64&amp;upstream=busybox&amp;distro=alpine-3.17.2</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://busybox.net/</url>
@@ -531,17 +531,17 @@
         <property name="syft:package:foundBy">apkdb-cataloger</property>
         <property name="syft:package:metadataType">ApkMetadata</property>
         <property name="syft:package:type">apk</property>
-        <property name="syft:cpe23">cpe:2.3:a:ssl-client:ssl_client:1.35.0-r29:*:*:*:*:*:*:*</property>
-        <property name="syft:cpe23">cpe:2.3:a:ssl_client:ssl-client:1.35.0-r29:*:*:*:*:*:*:*</property>
-        <property name="syft:cpe23">cpe:2.3:a:ssl_client:ssl_client:1.35.0-r29:*:*:*:*:*:*:*</property>
-        <property name="syft:cpe23">cpe:2.3:a:ssl:ssl-client:1.35.0-r29:*:*:*:*:*:*:*</property>
-        <property name="syft:cpe23">cpe:2.3:a:ssl:ssl_client:1.35.0-r29:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:ssl-client:ssl_client:1.36.1-r27:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:ssl_client:ssl-client:1.36.1-r27:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:ssl_client:ssl_client:1.36.1-r27:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:ssl:ssl-client:1.36.1-r27:*:*:*:*:*:*:*</property>
+        <property name="syft:cpe23">cpe:2.3:a:ssl:ssl_client:1.36.1-r27:*:*:*:*:*:*:*</property>
         <property name="syft:location:0:layerID">sha256:7cd52847ad775a5ddc4b58326cf884beee34544296402c6292ed76474c686d39</property>
         <property name="syft:location:0:path">/lib/apk/db/installed</property>
         <property name="syft:metadata:gitCommitOfApkPort">1dbf7a793afae640ea643a055b6dd4f430ac116b</property>
         <property name="syft:metadata:installedSize">28672</property>
         <property name="syft:metadata:originPackage">busybox</property>
-        <property name="syft:metadata:provides:0">cmd:ssl_client=1.35.0-r29</property>
+        <property name="syft:metadata:provides:0">cmd:ssl_client=1.36.1-r27</property>
         <property name="syft:metadata:pullChecksum">Q1QuqZjeP6XG85I29tOiCWofL8Cj0=</property>
         <property name="syft:metadata:pullDependencies:0">so:libc.musl-x86_64.so.1</property>
         <property name="syft:metadata:pullDependencies:1">so:libcrypto.so.3</property>


### PR DESCRIPTION
This updates busybox to 1.36.1-r27 to resolve all current vulnerabilities, and then updates the snapshots to match.

This is a bit odd as 1.36.1-r27 doesn't actually exist on the distro this SBOM is created for (alpine 3.17) , where the highest version is 1.35.0-r30. However, as 3.17 is now out of support, no more fixes are being backported for 1.35.0. 

The *ideal(?)* behavior would not show the 3.19/3.20 vulnerabilities on 1.36.1 when scanning Alpine 3.17, but because of distro in purls still being undefined, all alpine advisories are returned. When this is eventually implemented, we should revert this PR. 