### PR TITLE
refactor: enable `revive/indent-error-flow`

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -66,6 +66,8 @@ linters-settings:
     rules:
       - name: increment-decrement
         disabled: true
+      - name: indent-error-flow
+        disabled: false
   nlreturn:
     # Size of the block (including return statement that is still "OK")
     # so no return split required.

--- a/internal/customgitignore/walk_up_to_root.go
+++ b/internal/customgitignore/walk_up_to_root.go
@@ -171,16 +171,16 @@ func readIgnoreFilesFromParents(fs billy.Filesystem, pathRel string, pathGitRoot
 	if pathAbs == pathGitRoot {
 		// Don't recurse any further
 		return ps, nil
-	} else {
-		// continue recursing up tree
-		newPs, err = readIgnoreFilesFromParents(fs, pathRel, pathGitRoot)
-		if err != nil {
-			return ps, err
-		}
-		ps = append(ps, newPs...)
-
-		return ps, nil
 	}
+
+	// continue recursing up tree
+	newPs, err = readIgnoreFilesFromParents(fs, pathRel, pathGitRoot)
+	if err != nil {
+		return ps, err
+	}
+	ps = append(ps, newPs...)
+
+	return ps, nil
 }
 
 // returns the path of the root of this repo (ie with the .git dir in it)

--- a/internal/image/extractor.go
+++ b/internal/image/extractor.go
@@ -101,10 +101,11 @@ func (f ImageFile) Open(openPath string) (lockfile.NestedDepFile, error) {
 	// use path instead of filepath, because container is always in Unix paths (for now)
 	if path.IsAbs(openPath) {
 		return OpenLayerFile(openPath, f.layer)
-	} else {
-		absPath := path.Join(f.path, openPath)
-		return OpenLayerFile(absPath, f.layer)
 	}
+
+	absPath := path.Join(f.path, openPath)
+
+	return OpenLayerFile(absPath, f.layer)
 }
 
 func (f ImageFile) Path() string {

--- a/internal/output/identifiers.go
+++ b/internal/output/identifiers.go
@@ -44,7 +44,7 @@ func idSort(a, b string, prefixOrd func(string) int) int {
 		return -1
 	} else if prefixAOrd < prefixBOrd {
 		return 1
-	} else {
-		return strings.Compare(a, b)
 	}
+
+	return strings.Compare(a, b)
 }

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -168,9 +168,9 @@ func licenseTableBuilder(outputTable table.Writer, vulnResult *models.Vulnerabil
 		return licenseSummaryTableBuilder(outputTable, vulnResult)
 	} else if len(licenseConfig.Allowlist) > 0 {
 		return licenseViolationsTableBuilder(outputTable, vulnResult)
-	} else {
-		return outputTable
 	}
+
+	return outputTable
 }
 
 func licenseSummaryTableBuilder(outputTable table.Writer, vulnResult *models.VulnerabilityResults) table.Writer {

--- a/internal/sbom/cyclonedx.go
+++ b/internal/sbom/cyclonedx.go
@@ -103,9 +103,9 @@ func (c *CycloneDX) GetPackages(r io.ReadSeeker, callback func(Identifier) error
 		if err == nil {
 			if bom.BOMFormat == "CycloneDX" || strings.HasPrefix(bom.XMLNS, "http://cyclonedx.org/schema/bom") {
 				return c.enumeratePackages(&bom, callback)
-			} else {
-				err = errors.New("invalid BOMFormat")
 			}
+
+			err = errors.New("invalid BOMFormat")
 		}
 
 		errs = append(errs, fmt.Errorf("failed trying %s: %w", formatType.name, err))

--- a/internal/thirdparty/ar/reader.go
+++ b/internal/thirdparty/ar/reader.go
@@ -118,10 +118,11 @@ func (rd *Reader) skipUnread() error {
 	if seeker, ok := rd.r.(io.Seeker); ok {
 		_, err := seeker.Seek(bytesToSkip, io.SeekCurrent)
 		return err
-	} else {
-		_, err := io.CopyN(io.Discard, rd.r, bytesToSkip)
-		return err
 	}
+
+	_, err := io.CopyN(io.Discard, rd.r, bytesToSkip)
+
+	return err
 }
 
 func (rd *Reader) readHeader() (*Header, error) {

--- a/pkg/osv/osv.go
+++ b/pkg/osv/osv.go
@@ -132,17 +132,17 @@ func MakePkgRequest(pkgDetails lockfile.PackageDetails) *Query {
 			},
 			Commit: pkgDetails.Commit,
 		}
-	} else {
-		return &Query{
-			Version: pkgDetails.Version,
-			Package: Package{
-				Name:      pkgDetails.Name,
-				Ecosystem: string(pkgDetails.Ecosystem),
-			},
-			Metadata: models.Metadata{
-				DepGroups: pkgDetails.DepGroups,
-			},
-		}
+	}
+
+	return &Query{
+		Version: pkgDetails.Version,
+		Package: Package{
+			Name:      pkgDetails.Name,
+			Ecosystem: string(pkgDetails.Ecosystem),
+		},
+		Metadata: models.Metadata{
+			DepGroups: pkgDetails.DepGroups,
+		},
 	}
 }
 

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -932,9 +932,9 @@ func DoScan(actions ScannerActions, r reporter.Reporter) (models.VulnerabilityRe
 		if (!vuln || onlyUncalledVuln) && !licenseViolation {
 			// There is no error.
 			return results, nil
-		} else {
-			return results, VulnerabilitiesFoundErr
 		}
+
+		return results, VulnerabilitiesFoundErr
 	}
 
 	return results, nil


### PR DESCRIPTION
This enables the [`indent-error-flow`](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#indent-error-flow) rule from `revive`, which flags redundant `else` statements.

---

It turns out that by configuring `revive`, we actually inadvertently disabled all of its rules, and there are a few we're failing on that I think are worth re-enabling - this is one of them