### PR TITLE
✨ Adding a flag to stop execution after dependency parsing

### DIFF
--- a/cmd/osv-scanner/__snapshots__/main_test.snap
+++ b/cmd/osv-scanner/__snapshots__/main_test.snap
@@ -1593,6 +1593,42 @@ Warning: `scan` exists as both a subcommand of OSV-Scanner and as a file on the 
 
 ---
 
+[TestRun_SubCommands/scan_with_only_package_being_returned - 1]
+{
+  "results": [
+    {
+      "source": {
+        "path": "<rootdir>/fixtures/locks-one-with-nested/yarn.lock",
+        "type": "lockfile"
+      },
+      "packages": [
+        {
+          "package": {
+            "name": "balanced-match",
+            "version": "1.0.2",
+            "ecosystem": "npm"
+          }
+        }
+      ]
+    }
+  ],
+  "experimental_config": {
+    "licenses": {
+      "summary": false,
+      "allowlist": null
+    }
+  }
+}
+
+---
+
+[TestRun_SubCommands/scan_with_only_package_being_returned - 2]
+Warning: `scan` exists as both a subcommand of OSV-Scanner and as a file on the filesystem. `scan` is assumed to be a subcommand here. If you intended for `scan` to be an argument to `scan`, you must specify `scan scan` in your command line.
+Scanning dir ./fixtures/locks-one-with-nested
+Scanned <rootdir>/fixtures/locks-one-with-nested/yarn.lock file and found 1 package
+
+---
+
 [TestRun_SubCommands/with_no_subcommand - 1]
 Scanning dir ./fixtures/locks-many/composer.lock
 Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -717,6 +717,11 @@ func TestRun_SubCommands(t *testing.T) {
 			args: []string{"", "scan", "--recursive", "./fixtures/locks-one-with-nested"},
 			exit: 0,
 		},
+		{
+			name: "scan with only package being returned",
+			args: []string{"", "scan", "--experimental-only-packages", "--experimental-all-packages", "--format=json", "./fixtures/locks-one-with-nested"},
+			exit: 0,
+		},
 		// TODO: add tests for other future subcommands
 	}
 	for _, tt := range tests {

--- a/cmd/osv-scanner/scan/main.go
+++ b/cmd/osv-scanner/scan/main.go
@@ -132,6 +132,10 @@ func Command(stdout, stderr io.Writer, r *reporter.Reporter) *cli.Command {
 				TakesFile: true,
 				Hidden:    true,
 			},
+			&cli.BoolFlag{
+				Name:  "experimental-only-packages",
+				Usage: "only report packages without running any additional logic",
+			},
 		},
 		ArgsUsage: "[directory1 directory2...]",
 		Action: func(c *cli.Context) error {
@@ -222,6 +226,7 @@ func action(context *cli.Context, stdout, stderr io.Writer) (reporter.Reporter, 
 			ScanLicensesSummary:   context.Bool("experimental-licenses-summary"),
 			ScanLicensesAllowlist: context.StringSlice("experimental-licenses"),
 			ScanOCIImage:          context.String("experimental-oci-image"),
+			OnlyPackages:          context.Bool("experimental-only-packages"),
 		},
 	}, r)
 

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -53,6 +53,7 @@ type ExperimentalScannerActions struct {
 	ScanLicensesSummary   bool
 	ScanLicensesAllowlist []string
 	ScanOCIImage          string
+	OnlyPackages          bool
 
 	LocalDBPath string
 }
@@ -833,6 +834,11 @@ func DoScan(actions ScannerActions, r reporter.Reporter) (models.VulnerabilityRe
 	}
 
 	overrideGoVersion(r, filteredScannedPackages, &configManager)
+
+	if actions.OnlyPackages {
+		vulnerabilityResults := buildVulnerabilityResults(r, filteredScannedPackages, nil, [][]models.License{}, actions)
+		return vulnerabilityResults, nil
+	}
 
 	vulnsResp, err := makeRequest(r, filteredScannedPackages, actions.CompareLocally, actions.CompareOffline, actions.LocalDBPath)
 	if err != nil {

--- a/pkg/osvscanner/vulnerability_result.go
+++ b/pkg/osvscanner/vulnerability_result.go
@@ -54,7 +54,7 @@ func buildVulnerabilityResults(
 
 		pkg.DepGroups = rawPkg.DepGroups
 
-		if len(vulnsResp.Results[i].Vulns) > 0 {
+		if vulnsResp != nil && len(vulnsResp.Results[i].Vulns) > 0 {
 			includePackage = true
 			pkg.Vulnerabilities = vulnsResp.Results[i].Vulns
 			pkg.Groups = grouper.Group(grouper.ConvertVulnerabilityToIDAliases(pkg.Vulnerabilities))


### PR DESCRIPTION
## About this PR

This PR adds a simple experimental flag to stops the execution of osv-scanner after having extracted dependencies from the lockfiles.

Adding this will let us use osv-scanner to extract dependencies from lockfiles, but continue to use our internal tools to detect vulnerabilties from them.

It is the first step for us to export packages in the CycloneDX format.