### PR TITLE
Select a version that actually exists

### DIFF
--- a/cmd/osv-scanner/__snapshots__/main_test.snap
+++ b/cmd/osv-scanner/__snapshots__/main_test.snap
@@ -251,7 +251,8 @@ Scanned <rootdir>/fixtures/sbom-insecure/postgres-stretch.cdx.xml as CycloneDX S
 +-------------------------------------+------+-----------+--------------------------------+------------------------------------+-------------------------------------------------+
 | OSV URL                             | CVSS | ECOSYSTEM | PACKAGE                        | VERSION                            | SOURCE                                          |
 +-------------------------------------+------+-----------+--------------------------------+------------------------------------+-------------------------------------------------+
-| https://osv.dev/CVE-2022-37434      | 9.8  | Alpine    | zlib                           | 1.2.10-r2                          | fixtures/sbom-insecure/alpine.cdx.xml           |
+| https://osv.dev/CVE-2018-25032      | 7.5  | Alpine    | zlib                           | 1.2.10-r0                          | fixtures/sbom-insecure/alpine.cdx.xml           |
+| https://osv.dev/CVE-2022-37434      | 9.8  | Alpine    | zlib                           | 1.2.10-r0                          | fixtures/sbom-insecure/alpine.cdx.xml           |
 | https://osv.dev/DLA-3022-1          |      | Debian    | dpkg                           | 1.18.25                            | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/GHSA-v95c-p5hm-xq8f | 6.0  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/GO-2022-0274        |      |           |                                |                                    |                                                 |
@@ -372,7 +373,8 @@ Scanned <rootdir>/fixtures/sbom-insecure/alpine.cdx.xml as CycloneDX SBOM and fo
 +--------------------------------+------+-----------+---------+-----------+---------------------------------------+
 | OSV URL                        | CVSS | ECOSYSTEM | PACKAGE | VERSION   | SOURCE                                |
 +--------------------------------+------+-----------+---------+-----------+---------------------------------------+
-| https://osv.dev/CVE-2022-37434 | 9.8  | Alpine    | zlib    | 1.2.10-r2 | fixtures/sbom-insecure/alpine.cdx.xml |
+| https://osv.dev/CVE-2018-25032 | 7.5  | Alpine    | zlib    | 1.2.10-r0 | fixtures/sbom-insecure/alpine.cdx.xml |
+| https://osv.dev/CVE-2022-37434 | 9.8  | Alpine    | zlib    | 1.2.10-r0 | fixtures/sbom-insecure/alpine.cdx.xml |
 +--------------------------------+------+-----------+---------+-----------+---------------------------------------+
 
 ---

--- a/cmd/osv-scanner/fixtures/sbom-insecure/alpine.cdx.xml
+++ b/cmd/osv-scanner/fixtures/sbom-insecure/alpine.cdx.xml
@@ -549,18 +549,18 @@
         <property name="syft:metadata:size">4929</property>
       </properties>
     </component>
-    <component bom-ref="pkg:apk/alpine/zlib@1.2.13-r0?arch=x86_64&amp;upstream=zlib&amp;distro=alpine-3.17.2&amp;package-id=94014313cfcd2b71" type="library">
+    <component bom-ref="pkg:apk/alpine/zlib@1.2.10-r0?arch=x86_64&amp;upstream=zlib&amp;distro=alpine-3.17.2&amp;package-id=94014313cfcd2b71" type="library">
       <publisher>Natanael Copa &lt;ncopa@alpinelinux.org&gt;</publisher>
       <name>zlib</name>
-      <version>1.2.13-r0</version>
+      <version>1.2.10-r0</version>
       <description>A compression/decompression Library</description>
       <licenses>
         <license>
           <id>Zlib</id>
         </license>
       </licenses>
-      <cpe>cpe:2.3:a:zlib:zlib:1.2.13-r0:*:*:*:*:*:*:*</cpe>
-      <purl>pkg:apk/alpine/zlib@1.2.10-r2?arch=x86_64&amp;upstream=zlib&amp;distro=alpine-3.17.2</purl>
+      <cpe>cpe:2.3:a:zlib:zlib:1.2.10-r0:*:*:*:*:*:*:*</cpe>
+      <purl>pkg:apk/alpine/zlib@1.2.10-r0?arch=x86_64&amp;upstream=zlib&amp;distro=alpine-3.17.2</purl>
       <externalReferences>
         <reference type="distribution">
           <url>https://zlib.net/</url>


### PR DESCRIPTION
The version of zlib (in the purl) seems to be randomly selected for testing purposes (1.2.10-r2), as it doesn't match the rest of the SBOM. The problem is that a particular version never existed, and only showed up because it was incorrectly enumerated in osv.dev. 

Now that the version enumeration has been fixed it causes different results to show up in the testing snapshot. 

This PR makes all the version numbers for zlib in the SBOM consistent, and sets it to `1.2.10-r0` which actually exists. (And the snapshot will not change when the fixed alpine enumeration moves to production.)