### PR TITLE
ci: don't try to upload code coverage on macOS

### DIFF
--- a/.github/workflows/test-action/action.yml
+++ b/.github/workflows/test-action/action.yml
@@ -29,6 +29,9 @@ runs:
         TEST_ACCEPTANCE: true
       run: ./scripts/run_tests.sh
     - name: Upload coverage to Codecov
+      # codecov is currently being flakey on macOS
+      # https://github.com/codecov/codecov-action/issues/1416
+      if: ${{ runner.os != 'macOS' }}
       uses: codecov/codecov-action@125fc84a9a348dbcf27191600683ec096ec9021c # v4.4.1
       with:
         token: ${{ inputs.codecov_token }}


### PR DESCRIPTION
This keeps failing on macOS, so let's skip it for now