### PR TITLE
Update base docker image for golang 1.21.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.21-alpine3.19@sha256:1c2e4747a1b15fe65c8317bca9bd91611b29fe7c8b65009b9edbee7653e62614 AS builder
+FROM golang:1.21-alpine3.19@sha256:599a9bb95e8b9bb61522609b850c90977ceadbe5e973fa51e814e5c4fa9d5667 AS builder
 
 WORKDIR /src
 COPY ./go.mod ./go.sum ./

--- a/action.dockerfile
+++ b/action.dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.21-alpine3.19@sha256:1c2e4747a1b15fe65c8317bca9bd91611b29fe7c8b65009b9edbee7653e62614
+FROM golang:1.21-alpine3.19@sha256:599a9bb95e8b9bb61522609b850c90977ceadbe5e973fa51e814e5c4fa9d5667
 
 RUN mkdir /src
 WORKDIR /src


### PR DESCRIPTION
The base docker images are pinned to go 1.21. With 8fd553a, this breaks the GitHub reusable workflows. This PR pins the images to [the official 1.21.11 one](https://hub.docker.com/layers/library/golang/1.21.11-alpine3.19/images/sha256-6c5f76c897971f1b6ff0e447941440889016b18805812660a83b5275e862298d?context=explore). This should fix the issue.