### PR TITLE
test: update snapshots and exit codes

### DIFF
--- a/cmd/osv-scanner/__snapshots__/main_test.snap
+++ b/cmd/osv-scanner/__snapshots__/main_test.snap
@@ -226,7 +226,12 @@ Scanned <rootdir>/fixtures/locks-many/yarn.lock file and found 1 package
 Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
 GHSA-whgm-jr23-g3j9 and 1 alias have been filtered out because: Test manifest file
 Filtered 1 vulnerability from output
-No issues found
++--------------------------------+------+-----------+---------+------------+------------------------------------+
+| OSV URL                        | CVSS | ECOSYSTEM | PACKAGE | VERSION    | SOURCE                             |
++--------------------------------+------+-----------+---------+------------+------------------------------------+
+| https://osv.dev/CVE-2023-42364 | 5.5  | Alpine    | busybox | 1.36.1-r27 | fixtures/locks-many/alpine.cdx.xml |
+| https://osv.dev/CVE-2023-42365 | 5.5  | Alpine    | busybox | 1.36.1-r27 | fixtures/locks-many/alpine.cdx.xml |
++--------------------------------+------+-----------+---------+------------+------------------------------------+
 
 ---
 
@@ -253,6 +258,8 @@ Scanned <rootdir>/fixtures/sbom-insecure/postgres-stretch.cdx.xml as CycloneDX S
 +-------------------------------------+------+-----------+--------------------------------+------------------------------------+-------------------------------------------------+
 | OSV URL                             | CVSS | ECOSYSTEM | PACKAGE                        | VERSION                            | SOURCE                                          |
 +-------------------------------------+------+-----------+--------------------------------+------------------------------------+-------------------------------------------------+
+| https://osv.dev/CVE-2023-42364      | 5.5  | Alpine    | busybox                        | 1.36.1-r27                         | fixtures/sbom-insecure/alpine.cdx.xml           |
+| https://osv.dev/CVE-2023-42365      | 5.5  | Alpine    | busybox                        | 1.36.1-r27                         | fixtures/sbom-insecure/alpine.cdx.xml           |
 | https://osv.dev/CVE-2018-25032      | 7.5  | Alpine    | zlib                           | 1.2.10-r0                          | fixtures/sbom-insecure/alpine.cdx.xml           |
 | https://osv.dev/CVE-2022-37434      | 9.8  | Alpine    | zlib                           | 1.2.10-r0                          | fixtures/sbom-insecure/alpine.cdx.xml           |
 | https://osv.dev/DLA-3022-1          |      | Debian    | dpkg                           | 1.18.25                            | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
@@ -372,12 +379,14 @@ No issues found
 
 [TestRun/one_specific_supported_sbom_with_vulns - 1]
 Scanned <rootdir>/fixtures/sbom-insecure/alpine.cdx.xml as CycloneDX SBOM and found 15 packages
-+--------------------------------+------+-----------+---------+-----------+---------------------------------------+
-| OSV URL                        | CVSS | ECOSYSTEM | PACKAGE | VERSION   | SOURCE                                |
-+--------------------------------+------+-----------+---------+-----------+---------------------------------------+
-| https://osv.dev/CVE-2018-25032 | 7.5  | Alpine    | zlib    | 1.2.10-r0 | fixtures/sbom-insecure/alpine.cdx.xml |
-| https://osv.dev/CVE-2022-37434 | 9.8  | Alpine    | zlib    | 1.2.10-r0 | fixtures/sbom-insecure/alpine.cdx.xml |
-+--------------------------------+------+-----------+---------+-----------+---------------------------------------+
++--------------------------------+------+-----------+---------+------------+---------------------------------------+
+| OSV URL                        | CVSS | ECOSYSTEM | PACKAGE | VERSION    | SOURCE                                |
++--------------------------------+------+-----------+---------+------------+---------------------------------------+
+| https://osv.dev/CVE-2023-42364 | 5.5  | Alpine    | busybox | 1.36.1-r27 | fixtures/sbom-insecure/alpine.cdx.xml |
+| https://osv.dev/CVE-2023-42365 | 5.5  | Alpine    | busybox | 1.36.1-r27 | fixtures/sbom-insecure/alpine.cdx.xml |
+| https://osv.dev/CVE-2018-25032 | 7.5  | Alpine    | zlib    | 1.2.10-r0  | fixtures/sbom-insecure/alpine.cdx.xml |
+| https://osv.dev/CVE-2022-37434 | 9.8  | Alpine    | zlib    | 1.2.10-r0  | fixtures/sbom-insecure/alpine.cdx.xml |
++--------------------------------+------+-----------+---------+------------+---------------------------------------+
 
 ---
 
@@ -767,6 +776,12 @@ Scanned <rootdir>/fixtures/locks-many/yarn.lock file and found 1 package
 Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
 GHSA-whgm-jr23-g3j9 and 1 alias have been filtered out because: Test manifest file
 Filtered 1 vulnerability from output
++--------------------------------+------+-----------+---------+------------+------------------------------------+
+| OSV URL                        | CVSS | ECOSYSTEM | PACKAGE | VERSION    | SOURCE                             |
++--------------------------------+------+-----------+---------+------------+------------------------------------+
+| https://osv.dev/CVE-2023-42364 | 5.5  | Alpine    | busybox | 1.36.1-r27 | fixtures/locks-many/alpine.cdx.xml |
+| https://osv.dev/CVE-2023-42365 | 5.5  | Alpine    | busybox | 1.36.1-r27 | fixtures/locks-many/alpine.cdx.xml |
++--------------------------------+------+-----------+---------+------------+------------------------------------+
 +------------+-------------------------+
 | LICENSE    | NO. OF PACKAGE VERSIONS |
 +------------+-------------------------+
@@ -791,6 +806,10 @@ Scanned <rootdir>/fixtures/locks-many/yarn.lock file and found 1 package
 Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
 GHSA-whgm-jr23-g3j9 and 1 alias have been filtered out because: Test manifest file
 Filtered 1 vulnerability from output
+| OSV URL | CVSS | Ecosystem | Package | Version | Source |
+| --- | --- | --- | --- | --- | --- |
+| https://osv.dev/CVE-2023-42364 | 5.5 | Alpine | busybox | 1.36.1-r27 | fixtures/locks-many/alpine.cdx.xml |
+| https://osv.dev/CVE-2023-42365 | 5.5 | Alpine | busybox | 1.36.1-r27 | fixtures/locks-many/alpine.cdx.xml |
 | License | No. of package versions |
 | --- | ---:|
 | Apache-2.0 | 1 |

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -176,7 +176,7 @@ func TestRun(t *testing.T) {
 		{
 			name: "Scan locks-many",
 			args: []string{"", "./fixtures/locks-many"},
-			exit: 0,
+			exit: 1,
 		},
 		// all supported lockfiles in the directory should be checked
 		{
@@ -576,12 +576,12 @@ func TestRun_Licenses(t *testing.T) {
 		{
 			name: "No vulnerabilities with license summary",
 			args: []string{"", "--experimental-licenses-summary", "./fixtures/locks-many"},
-			exit: 0,
+			exit: 1,
 		},
 		{
 			name: "No vulnerabilities with license summary in markdown",
 			args: []string{"", "--experimental-licenses-summary", "--format=markdown", "./fixtures/locks-many"},
-			exit: 0,
+			exit: 1,
 		},
 		{
 			name: "Vulnerabilities and license summary",


### PR DESCRIPTION
Someone that knows these tests better should double check that these changes in exit codes mean they're no longer covering what they were meant to