### PR TITLE
Remove busybox from alpine SBOM

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,8 @@ To run tests:
 ./scripts/run_tests.sh
 ```
 
+To get consistent test results, please run with `GOTOOLCHAIN=go<go version in go.mod>`.
+
 By default, tests that require additional dependencies beyond the go toolchain are skipped.
 Enable these tests by setting the env variable `TEST_ACCEPTANCE=true`.
 

--- a/cmd/osv-scanner/__snapshots__/main_test.snap
+++ b/cmd/osv-scanner/__snapshots__/main_test.snap
@@ -219,7 +219,7 @@ Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
 [TestRun/Scan_locks-many - 1]
 Scanning dir ./fixtures/locks-many
 Scanned <rootdir>/fixtures/locks-many/Gemfile.lock file and found 1 package
-Scanned <rootdir>/fixtures/locks-many/alpine.cdx.xml as CycloneDX SBOM and found 15 packages
+Scanned <rootdir>/fixtures/locks-many/alpine.cdx.xml as CycloneDX SBOM and found 14 packages
 Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
 Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
 Scanned <rootdir>/fixtures/locks-many/yarn.lock file and found 1 package
@@ -248,7 +248,7 @@ Attempted to scan lockfile but failed: <rootdir>/fixtures/locks-many-with-invali
 
 [TestRun/folder_of_supported_sbom_with_vulns - 1]
 Scanning dir ./fixtures/sbom-insecure/
-Scanned <rootdir>/fixtures/sbom-insecure/alpine.cdx.xml as CycloneDX SBOM and found 15 packages
+Scanned <rootdir>/fixtures/sbom-insecure/alpine.cdx.xml as CycloneDX SBOM and found 14 packages
 Scanned <rootdir>/fixtures/sbom-insecure/postgres-stretch.cdx.xml as CycloneDX SBOM and found 136 packages
 +-------------------------------------+------+-----------+--------------------------------+------------------------------------+-------------------------------------------------+
 | OSV URL                             | CVSS | ECOSYSTEM | PACKAGE                        | VERSION                            | SOURCE                                          |
@@ -371,7 +371,7 @@ No issues found
 ---
 
 [TestRun/one_specific_supported_sbom_with_vulns - 1]
-Scanned <rootdir>/fixtures/sbom-insecure/alpine.cdx.xml as CycloneDX SBOM and found 15 packages
+Scanned <rootdir>/fixtures/sbom-insecure/alpine.cdx.xml as CycloneDX SBOM and found 14 packages
 +--------------------------------+------+-----------+---------+-----------+---------------------------------------+
 | OSV URL                        | CVSS | ECOSYSTEM | PACKAGE | VERSION   | SOURCE                                |
 +--------------------------------+------+-----------+---------+-----------+---------------------------------------+
@@ -760,7 +760,7 @@ Scanned <rootdir>/fixtures/locks-licenses/package-lock.json file and found 3 pac
 [TestRun_Licenses/No_vulnerabilities_with_license_summary - 1]
 Scanning dir ./fixtures/locks-many
 Scanned <rootdir>/fixtures/locks-many/Gemfile.lock file and found 1 package
-Scanned <rootdir>/fixtures/locks-many/alpine.cdx.xml as CycloneDX SBOM and found 15 packages
+Scanned <rootdir>/fixtures/locks-many/alpine.cdx.xml as CycloneDX SBOM and found 14 packages
 Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
 Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
 Scanned <rootdir>/fixtures/locks-many/yarn.lock file and found 1 package
@@ -772,7 +772,7 @@ Filtered 1 vulnerability from output
 +------------+-------------------------+
 | Apache-2.0 |                       1 |
 | MIT        |                       1 |
-| UNKNOWN    |                      17 |
+| UNKNOWN    |                      16 |
 +------------+-------------------------+
 
 ---
@@ -784,7 +784,7 @@ Filtered 1 vulnerability from output
 [TestRun_Licenses/No_vulnerabilities_with_license_summary_in_markdown - 1]
 Scanning dir ./fixtures/locks-many
 Scanned <rootdir>/fixtures/locks-many/Gemfile.lock file and found 1 package
-Scanned <rootdir>/fixtures/locks-many/alpine.cdx.xml as CycloneDX SBOM and found 15 packages
+Scanned <rootdir>/fixtures/locks-many/alpine.cdx.xml as CycloneDX SBOM and found 14 packages
 Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
 Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
 Scanned <rootdir>/fixtures/locks-many/yarn.lock file and found 1 package
@@ -795,7 +795,7 @@ Filtered 1 vulnerability from output
 | --- | ---:|
 | Apache-2.0 | 1 |
 | MIT | 1 |
-| UNKNOWN | 17 |
+| UNKNOWN | 16 |
 
 ---
 
@@ -1059,7 +1059,7 @@ No package sources found, --help for usage information.
 [TestRun_LocalDatabases/#03 - 1]
 Scanning dir ./fixtures/locks-many
 Scanned <rootdir>/fixtures/locks-many/Gemfile.lock file and found 1 package
-Scanned <rootdir>/fixtures/locks-many/alpine.cdx.xml as CycloneDX SBOM and found 15 packages
+Scanned <rootdir>/fixtures/locks-many/alpine.cdx.xml as CycloneDX SBOM and found 14 packages
 Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
 Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
 Scanned <rootdir>/fixtures/locks-many/yarn.lock file and found 1 package
@@ -1081,7 +1081,7 @@ No issues found
 [TestRun_LocalDatabases/#03 - 3]
 Scanning dir ./fixtures/locks-many
 Scanned <rootdir>/fixtures/locks-many/Gemfile.lock file and found 1 package
-Scanned <rootdir>/fixtures/locks-many/alpine.cdx.xml as CycloneDX SBOM and found 15 packages
+Scanned <rootdir>/fixtures/locks-many/alpine.cdx.xml as CycloneDX SBOM and found 14 packages
 Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
 Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
 Scanned <rootdir>/fixtures/locks-many/yarn.lock file and found 1 package

--- a/cmd/osv-scanner/fixtures/locks-many/alpine.cdx.xml
+++ b/cmd/osv-scanner/fixtures/locks-many/alpine.cdx.xml
@@ -182,38 +182,6 @@
         <property name="syft:location:0:path">/bin/busybox</property>
       </properties>
     </component>
-    <component bom-ref="pkg:apk/alpine/busybox@1.36.1-r27?arch=x86_64&amp;upstream=busybox&amp;distro=alpine-3.17.2&amp;package-id=623d53216342d45e" type="library">
-      <publisher>Sören Tempel &lt;soeren+alpine@soeren-tempel.net&gt;</publisher>
-      <name>busybox</name>
-      <version>1.36.1-r27</version>
-      <description>Size optimized toolbox of many common UNIX utilities</description>
-      <licenses>
-        <license>
-          <id>GPL-2.0-only</id>
-        </license>
-      </licenses>
-      <cpe>cpe:2.3:a:busybox:busybox:1.36.1-r27:*:*:*:*:*:*:*</cpe>
-      <purl>pkg:apk/alpine/busybox@1.36.1-r27?arch=x86_64&amp;upstream=busybox&amp;distro=alpine-3.17.2</purl>
-      <externalReferences>
-        <reference type="distribution">
-          <url>https://busybox.net/</url>
-        </reference>
-      </externalReferences>
-      <properties>
-        <property name="syft:package:foundBy">apkdb-cataloger</property>
-        <property name="syft:package:metadataType">ApkMetadata</property>
-        <property name="syft:package:type">apk</property>
-        <property name="syft:location:0:layerID">sha256:7cd52847ad775a5ddc4b58326cf884beee34544296402c6292ed76474c686d39</property>
-        <property name="syft:location:0:path">/lib/apk/db/installed</property>
-        <property name="syft:metadata:gitCommitOfApkPort">1dbf7a793afae640ea643a055b6dd4f430ac116b</property>
-        <property name="syft:metadata:installedSize">962560</property>
-        <property name="syft:metadata:originPackage">busybox</property>
-        <property name="syft:metadata:provides:0">cmd:busybox=1.36.1-r27</property>
-        <property name="syft:metadata:pullChecksum">Q1NN3sp0yr99btRysqty3nQUrWHaY=</property>
-        <property name="syft:metadata:pullDependencies:0">so:libc.musl-x86_64.so.1</property>
-        <property name="syft:metadata:size">509600</property>
-      </properties>
-    </component>
     <component bom-ref="pkg:apk/alpine/busybox-binsh@1.36.1-r27?arch=x86_64&amp;upstream=busybox&amp;distro=alpine-3.17.2&amp;package-id=256fc96b4a8c4da8" type="library">
       <publisher>Sören Tempel &lt;soeren+alpine@soeren-tempel.net&gt;</publisher>
       <name>busybox-binsh</name>

--- a/cmd/osv-scanner/fixtures/sbom-insecure/alpine.cdx.xml
+++ b/cmd/osv-scanner/fixtures/sbom-insecure/alpine.cdx.xml
@@ -182,38 +182,6 @@
         <property name="syft:location:0:path">/bin/busybox</property>
       </properties>
     </component>
-    <component bom-ref="pkg:apk/alpine/busybox@1.36.1-r27?arch=x86_64&amp;upstream=busybox&amp;distro=alpine-3.17.2&amp;package-id=623d53216342d45e" type="library">
-      <publisher>Sören Tempel &lt;soeren+alpine@soeren-tempel.net&gt;</publisher>
-      <name>busybox</name>
-      <version>1.36.1-r27</version>
-      <description>Size optimized toolbox of many common UNIX utilities</description>
-      <licenses>
-        <license>
-          <id>GPL-2.0-only</id>
-        </license>
-      </licenses>
-      <cpe>cpe:2.3:a:busybox:busybox:1.36.1-r27:*:*:*:*:*:*:*</cpe>
-      <purl>pkg:apk/alpine/busybox@1.36.1-r27?arch=x86_64&amp;upstream=busybox&amp;distro=alpine-3.17.2</purl>
-      <externalReferences>
-        <reference type="distribution">
-          <url>https://busybox.net/</url>
-        </reference>
-      </externalReferences>
-      <properties>
-        <property name="syft:package:foundBy">apkdb-cataloger</property>
-        <property name="syft:package:metadataType">ApkMetadata</property>
-        <property name="syft:package:type">apk</property>
-        <property name="syft:location:0:layerID">sha256:7cd52847ad775a5ddc4b58326cf884beee34544296402c6292ed76474c686d39</property>
-        <property name="syft:location:0:path">/lib/apk/db/installed</property>
-        <property name="syft:metadata:gitCommitOfApkPort">1dbf7a793afae640ea643a055b6dd4f430ac116b</property>
-        <property name="syft:metadata:installedSize">962560</property>
-        <property name="syft:metadata:originPackage">busybox</property>
-        <property name="syft:metadata:provides:0">cmd:busybox=1.36.1-r27</property>
-        <property name="syft:metadata:pullChecksum">Q1NN3sp0yr99btRysqty3nQUrWHaY=</property>
-        <property name="syft:metadata:pullDependencies:0">so:libc.musl-x86_64.so.1</property>
-        <property name="syft:metadata:size">509600</property>
-      </properties>
-    </component>
     <component bom-ref="pkg:apk/alpine/busybox-binsh@1.36.1-r27?arch=x86_64&amp;upstream=busybox&amp;distro=alpine-3.17.2&amp;package-id=256fc96b4a8c4da8" type="library">
       <publisher>Sören Tempel &lt;soeren+alpine@soeren-tempel.net&gt;</publisher>
       <name>busybox-binsh</name>


### PR DESCRIPTION
Remove busybox from alpine SBOM to get a more consistent unit test.