### PR TITLE
ci: don't fail if codecov errors when uploading

### DIFF
--- a/.github/workflows/test-action/action.yml
+++ b/.github/workflows/test-action/action.yml
@@ -35,4 +35,4 @@ runs:
       uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0
       with:
         token: ${{ inputs.codecov_token }}
-        fail_ci_if_error: true
+        fail_ci_if_error: false


### PR DESCRIPTION
Codecov has been just too flakey to have as a requirement for landing changes, so for the time being we're going to ignore if uploading fails