### PR TITLE
Update tests to support go version changes

### DIFF
--- a/internal/sourceanalysis/__snapshots__/integration_test.snap
+++ b/internal/sourceanalysis/__snapshots__/integration_test.snap
@@ -111,7 +111,7 @@
           "position": {
             "filename": "\u003cAny value\u003e",
             "offset": -1,
-            "line": 97,
+            "line": -1,
             "column": 26
           }
         },
@@ -124,7 +124,7 @@
           "position": {
             "filename": "\u003cAny value\u003e",
             "offset": -1,
-            "line": 839,
+            "line": -1,
             "column": 21
           }
         },
@@ -137,7 +137,7 @@
           "position": {
             "filename": "\u003cAny value\u003e",
             "offset": -1,
-            "line": 1038,
+            "line": -1,
             "column": 24
           }
         },
@@ -149,7 +149,7 @@
           "position": {
             "filename": "\u003cAny value\u003e",
             "offset": -1,
-            "line": 430,
+            "line": -1,
             "column": 21
           }
         },
@@ -161,7 +161,7 @@
           "position": {
             "filename": "\u003cAny value\u003e",
             "offset": -1,
-            "line": 389,
+            "line": -1,
             "column": 19
           }
         },
@@ -174,7 +174,7 @@
           "position": {
             "filename": "\u003cAny value\u003e",
             "offset": -1,
-            "line": 1002,
+            "line": -1,
             "column": 19
           }
         },
@@ -187,7 +187,7 @@
           "position": {
             "filename": "\u003cAny value\u003e",
             "offset": -1,
-            "line": 1670,
+            "line": -1,
             "column": 17
           }
         },
@@ -200,7 +200,7 @@
           "position": {
             "filename": "\u003cAny value\u003e",
             "offset": -1,
-            "line": 2015,
+            "line": -1,
             "column": 18
           }
         },
@@ -213,7 +213,7 @@
           "position": {
             "filename": "\u003cAny value\u003e",
             "offset": -1,
-            "line": 3086,
+            "line": -1,
             "column": 3
           }
         },
@@ -226,7 +226,7 @@
           "position": {
             "filename": "\u003cAny value\u003e",
             "offset": -1,
-            "line": 2985,
+            "line": -1,
             "column": 18
           }
         },
@@ -238,7 +238,7 @@
           "position": {
             "filename": "\u003cAny value\u003e",
             "offset": -1,
-            "line": 3239,
+            "line": -1,
             "column": 30
           }
         },
@@ -249,7 +249,7 @@
           "position": {
             "filename": "\u003cAny value\u003e",
             "offset": -1,
-            "line": 19,
+            "line": -1,
             "column": 28
           }
         }

--- a/internal/sourceanalysis/integration_test.go
+++ b/internal/sourceanalysis/integration_test.go
@@ -57,6 +57,7 @@ func Test_runGovulncheck(t *testing.T) {
 	for _, traceItem := range res["GO-2023-2382"][2].Trace {
 		traceItem.Position.Filename = "<Any value>"
 		traceItem.Position.Offset = -1
+		traceItem.Position.Line = -1 // This number differs between go versions
 	}
 
 	testutility.NewSnapshot().MatchJSON(t, res)


### PR DESCRIPTION
Using a different Go version changes where the affected line is in the stdlib, so let's just set it to -1 to make it easier for local development with newer go versions