### PR TITLE
Add new line to filtered out vulns

### DIFF
--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -725,7 +725,7 @@ func filterPackageVulns(r reporter.Reporter, pkgVulns models.PackageVulns, confi
 		for _, vuln := range pkgVulns.Vulnerabilities {
 			if isUnimportant(pkgVulns.Package.Ecosystem, vuln.Affected) {
 				unimportantCount++
-				r.Verbosef("%s has been filtered out due to its unimportance.", vuln.ID)
+				r.Verbosef("%s has been filtered out due to its unimportance.\n", vuln.ID)
 
 				continue
 			}
@@ -736,7 +736,7 @@ func filterPackageVulns(r reporter.Reporter, pkgVulns models.PackageVulns, confi
 		}
 
 		if unimportantCount > 0 {
-			r.Infof("%d unimportant vulnerabilities have been filtered out.", unimportantCount)
+			r.Infof("%d unimportant vulnerabilities have been filtered out.\n", unimportantCount)
 		}
 	}
 


### PR DESCRIPTION
These logs weren't adding a new line, causing all of them to be printed in one big line.

I wonder if we can add a lint for this, seems to happen pretty often to everyone using the reporter.