### PR TITLE
fix: use errgroup to avoid hydration deadlock scenario

### DIFF
--- a/pkg/osv/osv.go
+++ b/pkg/osv/osv.go
@@ -288,13 +288,12 @@ func HydrateWithClient(resp *BatchedResponse, client *http.Client) (*HydratedBat
 
 			go func(id string, batchIdx int, resultIdx int) {
 				vuln, err := GetWithClient(id, client)
+				rateLimiter.Release(1)
 				if err != nil {
 					errChan <- err
 				} else {
 					hydrated.Results[batchIdx].Vulns[resultIdx] = *vuln
 				}
-
-				rateLimiter.Release(1)
 			}(vuln.ID, batchIdx, resultIdx)
 		}
 	}

--- a/pkg/osv/osv.go
+++ b/pkg/osv/osv.go
@@ -287,7 +287,7 @@ func HydrateWithClient(resp *BatchedResponse, client *http.Client) (*HydratedBat
 				// exit early if another hydration request has already failed
 				// results are thrown away later, so avoid needless work
 				if ctx.Err() != nil {
-					return nil
+					return nil //nolint:nilerr // this value doesn't matter to errgroup.Wait()
 				}
 				vuln, err := GetWithClient(id, client)
 				if err != nil {

--- a/pkg/osv/osv.go
+++ b/pkg/osv/osv.go
@@ -6,14 +6,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"math/rand"
 	"net/http"
 	"time"
 
 	"github.com/google/osv-scanner/pkg/lockfile"
 	"github.com/google/osv-scanner/pkg/models"
-	"golang.org/x/sync/semaphore"
+
+	"golang.org/x/sync/errgroup"
 )
 
 const (
@@ -269,7 +269,6 @@ func Hydrate(resp *BatchedResponse) (*HydratedBatchedResponse, error) {
 // Vulnerability details using the provided http client.
 func HydrateWithClient(resp *BatchedResponse, client *http.Client) (*HydratedBatchedResponse, error) {
 	hydrated := HydratedBatchedResponse{}
-	ctx := context.TODO()
 	// Preallocate the array to avoid slice reallocations when inserting later
 	hydrated.Results = make([]Response, len(resp.Results))
 	for idx := range hydrated.Results {
@@ -277,39 +276,31 @@ func HydrateWithClient(resp *BatchedResponse, client *http.Client) (*HydratedBat
 			make([]models.Vulnerability, len(resp.Results[idx].Vulns))
 	}
 
-	errChan := make(chan error)
-	rateLimiter := semaphore.NewWeighted(maxConcurrentRequests)
-
+	g, ctx := errgroup.WithContext(context.TODO())
+	g.SetLimit(maxConcurrentRequests)
 	for batchIdx, response := range resp.Results {
 		for resultIdx, vuln := range response.Vulns {
-			if err := rateLimiter.Acquire(ctx, 1); err != nil {
-				log.Panicf("Failed to acquire semaphore: %v", err)
-			}
-
-			go func(id string, batchIdx int, resultIdx int) {
-				vuln, err := GetWithClient(id, client)
-				rateLimiter.Release(1)
-				if err != nil {
-					errChan <- err
-				} else {
-					hydrated.Results[batchIdx].Vulns[resultIdx] = *vuln
+			id := vuln.ID
+			batchIdx := batchIdx
+			resultIdx := resultIdx
+			g.Go(func() error {
+				// exit early if another hydration request has already failed
+				// results are thrown away later, so avoid needless work
+				if ctx.Err() != nil {
+					return nil
 				}
-			}(vuln.ID, batchIdx, resultIdx)
+				vuln, err := GetWithClient(id, client)
+				if err != nil {
+					return err
+				}
+				hydrated.Results[batchIdx].Vulns[resultIdx] = *vuln
+
+				return nil
+			})
 		}
 	}
 
-	// Close error channel when all semaphores are released
-	go func() {
-		if err := rateLimiter.Acquire(ctx, maxConcurrentRequests); err != nil {
-			log.Panicf("Failed to acquire semaphore: %v", err)
-		}
-		// Always close the error channel
-		close(errChan)
-	}()
-
-	// Range will exit when channel is closed.
-	// Channel will be closed when all semaphores are freed.
-	for err := range errChan {
+	if err := g.Wait(); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
The existing code tried to do what `errgroup` does, limit concurrency and return the first error if present, but had a deadlock scenario.

Fixes #1077 