### PR TITLE
Refactoring `manifest.Read()` for Maven

### DIFF
--- a/internal/remediation/suggest/maven.go
+++ b/internal/remediation/suggest/maven.go
@@ -195,6 +195,7 @@ func originalRequirement(patch manifest.DependencyPatch, origReqs []manifest.Dep
 			return d.Version, d.Origin
 		}
 	}
+
 	return "", ""
 }
 

--- a/internal/remediation/suggest/maven.go
+++ b/internal/remediation/suggest/maven.go
@@ -68,27 +68,8 @@ func (ms *MavenSuggester) Suggest(ctx context.Context, client resolve.Client, mf
 			continue
 		}
 
-		//depOrigin, _ := req.Type.GetAttr(dep.MavenDependencyOrigin)
-		//if strings.HasPrefix(depOrigin, manifest.OriginProfile) {
-		// Dependency management is not indicated in property origin.
-		//	depOrigin, _ = strings.CutSuffix(depOrigin, "@"+manifest.OriginManagement)
-		//} else {
-		// Properties are defined either universally or in a profile. For property
-		// origin not starting with 'profile', this is an universal property.
-		//	depOrigin = ""
-		//}
-
 		for name, value := range patches {
-			// A dependency in a profile may contain properties from this profile or
-			// properties universally defined. We need to figure out the origin of these
-			// properties. If a property is defined both universally and in the profile,
-			// we use the profile's origin.
 			propertyOrigin := ""
-			//for _, p := range specific.Properties {
-			//	if p.Name == name && p.Origin != "" && p.Origin == depOrigin {
-			//		propertyOrigin = depOrigin
-			//	}
-			//}
 			if _, ok := propertyPatches[propertyOrigin]; !ok {
 				propertyPatches[propertyOrigin] = make(map[string]string)
 			}

--- a/internal/remediation/suggest/maven_test.go
+++ b/internal/remediation/suggest/maven_test.go
@@ -201,37 +201,51 @@ func TestSuggest(t *testing.T) {
 				{Property: maven.Property{Name: "no.update.minor", Value: "9"}},
 				{Property: maven.Property{Name: "def.version", Value: "2.3.4"}, Origin: "profile@profile-one"},
 			},
-			OriginalRequirements: map[string]map[maven.DependencyKey]maven.String{
-				"parent": {
-					{GroupID: "com.mycompany.app", ArtifactID: "parent-pom"}: "1.0.0",
+			OriginalRequirements: []manifest.DependencyWithOrigin{
+				{
+					Dependency: maven.Dependency{GroupID: "com.mycompany.app", ArtifactID: "parent-pom", Version: "1.0.0"},
+					Origin:     manifest.OriginParent,
 				},
-				"": {
-					{GroupID: "junit", ArtifactID: "junit", Type: "jar"}:                    "${junit.version}",
-					{GroupID: "org.example", ArtifactID: "abc", Type: "jar"}:                "1.0.1",
-					{GroupID: "org.example", ArtifactID: "no-updates", Type: "jar"}:         "9.9.9",
-					{GroupID: "org.example", ArtifactID: "property", Type: "jar"}:           "${property.version}",
-					{GroupID: "org.example", ArtifactID: "property-no-update", Type: "jar"}: "1.${no.update.minor}",
-					{GroupID: "org.example", ArtifactID: "same-property", Type: "jar"}:      "${property.version}",
-					{GroupID: "org.example", ArtifactID: "another-property", Type: "jar"}:   "${property.version}",
-
-					{GroupID: "org.", ArtifactID: "abc", Type: "jar"}:        "1.2.3",
-					{GroupID: "org.profile", ArtifactID: "def", Type: "jar"}: "${def.version}",
+				{
+					Dependency: maven.Dependency{GroupID: "junit", ArtifactID: "junit", Version: "${junit.version}", Scope: "test"},
 				},
-				"management": {
-					{GroupID: "org.example", ArtifactID: "xyz", Type: "jar"}: "2.0.0",
-
-					{GroupID: "org.import", ArtifactID: "import", Type: "pom"}: "1.0.0",
-					{GroupID: "org.import", ArtifactID: "xyz", Type: "pom"}:    "6.6.6",
+				{
+					Dependency: maven.Dependency{GroupID: "org.example", ArtifactID: "abc", Version: "1.0.1"},
 				},
-				"profile@profile-one": {
-					{GroupID: "org.profile", ArtifactID: "abc", Type: "jar"}: "1.2.3",
-					{GroupID: "org.profile", ArtifactID: "def", Type: "jar"}: "${def.version}",
+				{
+					Dependency: maven.Dependency{GroupID: "org.example", ArtifactID: "no-updates", Version: "9.9.9"},
 				},
-				"profile@profile-two@management": {
-					{GroupID: "org.import", ArtifactID: "xyz", Type: "pom"}: "6.6.6",
+				{
+					Dependency: maven.Dependency{GroupID: "org.example", ArtifactID: "property", Version: "${property.version}"},
 				},
-				"plugin@org.plugin:plugin": {
-					{GroupID: "org.dep", ArtifactID: "plugin-dep", Type: "jar"}: "2.3.3",
+				{
+					Dependency: maven.Dependency{GroupID: "org.example", ArtifactID: "property-no-update", Version: "1.${no.update.minor}"},
+				},
+				{
+					Dependency: maven.Dependency{GroupID: "org.example", ArtifactID: "same-property", Version: "${property.version}"},
+				},
+				{
+					Dependency: maven.Dependency{GroupID: "org.example", ArtifactID: "another-property", Version: "${property.version}"},
+				},
+				{
+					Dependency: maven.Dependency{GroupID: "org.example", ArtifactID: "xyz", Version: "2.0.0"},
+					Origin:     manifest.OriginManagement,
+				},
+				{
+					Dependency: maven.Dependency{GroupID: "org.profile", ArtifactID: "abc", Version: "1.2.3"},
+					Origin:     "profile@profile-one",
+				},
+				{
+					Dependency: maven.Dependency{GroupID: "org.profile", ArtifactID: "def", Version: "${def.version}"},
+					Origin:     "profile@profile-one",
+				},
+				{
+					Dependency: maven.Dependency{GroupID: "org.import", ArtifactID: "xyz", Version: "6.6.6", Scope: "import", Type: "pom"},
+					Origin:     "profile@profile-two@management",
+				},
+				{
+					Dependency: maven.Dependency{GroupID: "org.dep", ArtifactID: "plugin-dep", Version: "2.3.3"},
+					Origin:     "plugin@org.plugin:plugin",
 				},
 			},
 			RequirementsForUpdates: []resolve.RequirementVersion{

--- a/internal/remediation/suggest/maven_test.go
+++ b/internal/remediation/suggest/maven_test.go
@@ -196,134 +196,34 @@ func TestSuggest(t *testing.T) {
 			mavenReqKey(t, "org.import:xyz", "", ""): {"import"},
 		},
 		EcosystemSpecific: manifest.MavenManifestSpecific{
-			BaseProject: maven.Project{
-				ProjectKey: maven.ProjectKey{
-					GroupID:    "com.mycompany.app",
-					ArtifactID: "my-app",
-					Version:    "1.0",
+			Properties: []manifest.PropertyWithOrigin{
+				{Property: maven.Property{Name: "project.build.sourceEncoding", Value: "UTF-8"}},
+				{Property: maven.Property{Name: "maven.compiler.source", Value: "1.7"}},
+				{Property: maven.Property{Name: "maven.compiler.target", Value: "1.7"}},
+				{Property: maven.Property{Name: "junit.version", Value: "4.12"}},
+				{Property: maven.Property{Name: "def.version", Value: "2.3.4"}, Origin: "profile@profile-one"},
+			},
+			OriginalRequirements: map[string]map[maven.DependencyKey]maven.String{
+				"": {
+					{GroupID: "junit", ArtifactID: "junit", Type: "jar"}:     "${junit.version}",
+					{GroupID: "org.example", ArtifactID: "abc", Type: "jar"}: "1.0.1",
+					{GroupID: "org.profile", ArtifactID: "abc", Type: "jar"}: "1.2.3",
+					{GroupID: "org.profile", ArtifactID: "def", Type: "jar"}: "${def.version}",
 				},
-				Parent: maven.Parent{
-					ProjectKey: maven.ProjectKey{
-						GroupID:    "com.mycompany.app",
-						ArtifactID: "parent-pom",
-						Version:    "1.0.0",
-					},
-					//	RelativePath: "./parent/pom.xml",
+				"management": {
+					{GroupID: "org.example", ArtifactID: "xyz", Type: "jar"}:   "2.0.0",
+					{GroupID: "org.import", ArtifactID: "import", Type: "pom"}: "1.0.0",
+					{GroupID: "org.import", ArtifactID: "xyz", Type: "pom"}:    "6.6.6",
 				},
-				Properties: maven.Properties{
-					Properties: []maven.Property{
-						{Name: "project.build.sourceEncoding", Value: "UTF-8"},
-						{Name: "maven.compiler.source", Value: "1.7"},
-						{Name: "maven.compiler.target", Value: "1.7"},
-						{Name: "junit.version", Value: "4.12"},
-					},
+				"profile@profile-one": {
+					{GroupID: "org.profile", ArtifactID: "abc", Type: "jar"}: "1.2.3",
+					{GroupID: "org.profile", ArtifactID: "def", Type: "jar"}: "${def.version}",
 				},
-				Dependencies: []maven.Dependency{
-					{
-						GroupID:    "junit",
-						ArtifactID: "junit",
-						Version:    "${junit.version}",
-						Scope:      "test",
-					},
-					{
-						GroupID:    "org.example",
-						ArtifactID: "abc",
-						Version:    "1.0.1",
-					},
-					{
-						GroupID:    "org.example",
-						ArtifactID: "no-updates",
-						Version:    "9.9.9",
-					},
-					{
-						GroupID:    "org.example",
-						ArtifactID: "property",
-						Version:    "${property.version}",
-					},
-					{
-						GroupID:    "org.example",
-						ArtifactID: "same-property",
-						Version:    "${property.version}",
-					},
-					{
-						GroupID:    "org.example",
-						ArtifactID: "another-property",
-						Version:    "${property.version}",
-					},
-					{
-						GroupID:    "org.example",
-						ArtifactID: "property-no-update",
-						Version:    "1.${no.update.minor}",
-					},
+				"profile@profile-two@management": {
+					{GroupID: "org.import", ArtifactID: "xyz", Type: "pom"}: "6.6.6",
 				},
-				DependencyManagement: maven.DependencyManagement{
-					Dependencies: []maven.Dependency{
-						{
-							GroupID:    "org.example",
-							ArtifactID: "xyz",
-							Version:    "2.0.0",
-						},
-						{
-							GroupID:    "org.import",
-							ArtifactID: "import",
-							Version:    "1.0.0",
-							Type:       "pom",
-							Scope:      "import",
-						},
-					},
-				},
-				Profiles: []maven.Profile{
-					{
-						ID: "profile-one",
-						Properties: maven.Properties{
-							Properties: []maven.Property{
-								{Name: "def.version", Value: "2.3.4"},
-							},
-						},
-						Dependencies: []maven.Dependency{{
-							GroupID:    "org.profile",
-							ArtifactID: "abc",
-							Version:    "1.2.3",
-						}, {
-							GroupID:    "org.profile",
-							ArtifactID: "def",
-							Version:    "${def.version}",
-						}},
-					},
-					{
-						ID: "profile-two",
-						DependencyManagement: maven.DependencyManagement{
-							Dependencies: []maven.Dependency{
-								{
-									GroupID:    "org.import",
-									ArtifactID: "xyz",
-									Version:    "6.6.6",
-									Scope:      "import",
-									Type:       "pom",
-								},
-							},
-						},
-					},
-				},
-				Build: maven.Build{
-					PluginManagement: maven.PluginManagement{
-						Plugins: []maven.Plugin{
-							{
-								ProjectKey: maven.ProjectKey{
-									GroupID:    "org.plugin",
-									ArtifactID: "plugin",
-									Version:    "1.0.0",
-								},
-								Dependencies: []maven.Dependency{
-									{
-										GroupID:    "org.dep",
-										ArtifactID: "plugin-dep",
-										Version:    "2.3.3",
-									},
-								},
-							},
-						},
-					},
+				"plugin@org.plugin:plugin": {
+					{GroupID: "org.dep", ArtifactID: "plugin-dep", Type: "jar"}: "2.3.3",
 				},
 			},
 			RequirementsForUpdates: []resolve.RequirementVersion{

--- a/internal/remediation/suggest/maven_test.go
+++ b/internal/remediation/suggest/maven_test.go
@@ -197,21 +197,29 @@ func TestSuggest(t *testing.T) {
 		},
 		EcosystemSpecific: manifest.MavenManifestSpecific{
 			Properties: []manifest.PropertyWithOrigin{
-				{Property: maven.Property{Name: "project.build.sourceEncoding", Value: "UTF-8"}},
-				{Property: maven.Property{Name: "maven.compiler.source", Value: "1.7"}},
-				{Property: maven.Property{Name: "maven.compiler.target", Value: "1.7"}},
-				{Property: maven.Property{Name: "junit.version", Value: "4.12"}},
+				{Property: maven.Property{Name: "property.version", Value: "1.0.0"}},
+				{Property: maven.Property{Name: "no.update.minor", Value: "9"}},
 				{Property: maven.Property{Name: "def.version", Value: "2.3.4"}, Origin: "profile@profile-one"},
 			},
 			OriginalRequirements: map[string]map[maven.DependencyKey]maven.String{
+				"parent": {
+					{GroupID: "com.mycompany.app", ArtifactID: "parent-pom"}: "1.0.0",
+				},
 				"": {
-					{GroupID: "junit", ArtifactID: "junit", Type: "jar"}:     "${junit.version}",
-					{GroupID: "org.example", ArtifactID: "abc", Type: "jar"}: "1.0.1",
-					{GroupID: "org.profile", ArtifactID: "abc", Type: "jar"}: "1.2.3",
+					{GroupID: "junit", ArtifactID: "junit", Type: "jar"}:                    "${junit.version}",
+					{GroupID: "org.example", ArtifactID: "abc", Type: "jar"}:                "1.0.1",
+					{GroupID: "org.example", ArtifactID: "no-updates", Type: "jar"}:         "9.9.9",
+					{GroupID: "org.example", ArtifactID: "property", Type: "jar"}:           "${property.version}",
+					{GroupID: "org.example", ArtifactID: "property-no-update", Type: "jar"}: "1.${no.update.minor}",
+					{GroupID: "org.example", ArtifactID: "same-property", Type: "jar"}:      "${property.version}",
+					{GroupID: "org.example", ArtifactID: "another-property", Type: "jar"}:   "${property.version}",
+
+					{GroupID: "org.", ArtifactID: "abc", Type: "jar"}:        "1.2.3",
 					{GroupID: "org.profile", ArtifactID: "def", Type: "jar"}: "${def.version}",
 				},
 				"management": {
-					{GroupID: "org.example", ArtifactID: "xyz", Type: "jar"}:   "2.0.0",
+					{GroupID: "org.example", ArtifactID: "xyz", Type: "jar"}: "2.0.0",
+
 					{GroupID: "org.import", ArtifactID: "import", Type: "pom"}: "1.0.0",
 					{GroupID: "org.import", ArtifactID: "xyz", Type: "pom"}:    "6.6.6",
 				},

--- a/internal/resolution/manifest/maven.go
+++ b/internal/resolution/manifest/maven.go
@@ -30,6 +30,7 @@ func mavenRequirementKey(requirement resolve.RequirementVersion) RequirementKey 
 	// Maven dependencies must have unique groupId:artifactId:type:classifier.
 	artifactType, _ := requirement.Type.GetAttr(dep.MavenArtifactType)
 	classifier, _ := requirement.Type.GetAttr(dep.MavenClassifier)
+
 	return RequirementKey{
 		PackageKey: requirement.PackageKey,
 		EcosystemSpecific: struct{ ArtifactType, Classifier string }{
@@ -190,11 +191,12 @@ func buildPropertiesWithOrigins(project maven.Project) []PropertyWithOrigin {
 			})
 		}
 	}
+
 	return properties
 }
 
 func buildOriginalRequirements(project maven.Project) []DependencyWithOrigin {
-	var dependencies []DependencyWithOrigin
+	var dependencies []DependencyWithOrigin //nolint:prealloc
 	if project.Parent.GroupID != "" && project.Parent.ArtifactID != "" {
 		dependencies = append(dependencies, DependencyWithOrigin{
 			Dependency: maven.Dependency{
@@ -236,6 +238,7 @@ func buildOriginalRequirements(project maven.Project) []DependencyWithOrigin {
 			})
 		}
 	}
+
 	return dependencies
 }
 

--- a/internal/resolution/manifest/maven.go
+++ b/internal/resolution/manifest/maven.go
@@ -96,7 +96,7 @@ func (m MavenManifestIO) Read(df lockfile.DepFile) (Manifest, error) {
 	if err := m.mergeParents(ctx, &project, project.Parent, 1, df.Path(), true); err != nil {
 		return Manifest{}, fmt.Errorf("failed to merge parents: %w", err)
 	}
-	
+
 	// For dependency management imports, the dependencies that imports
 	// dependencies from other projects will be replaced by the imported
 	// dependencies, so add them to requirements first.

--- a/internal/resolution/manifest/maven.go
+++ b/internal/resolution/manifest/maven.go
@@ -51,9 +51,8 @@ func NewMavenManifestIO() MavenManifestIO {
 }
 
 type MavenManifestSpecific struct {
-	Properties []maven.Property
-	//RequirementsWithProperties []resolve.RequirementVersion
-	//RequirementsFromOtherPOMs  []resolve.RequirementVersion // Requirements that we cannot modify directly
+	Properties  []maven.Property
+	BaseProject maven.Project
 }
 
 // TODO: handle profiles (activation and interpolation)
@@ -64,6 +63,7 @@ func (m MavenManifestIO) Read(df lockfile.DepFile) (Manifest, error) {
 	if err := xml.NewDecoder(df).Decode(&project); err != nil {
 		return Manifest{}, fmt.Errorf("failed to unmarshal project: %w", err)
 	}
+	baseProject := project
 
 	// Merging parents data by parsing local parent pom.xml or fetching from upstream.
 	if err := m.mergeParents(ctx, &project, project.Parent, 1, df.Path(), true); err != nil {
@@ -137,7 +137,8 @@ func (m MavenManifestIO) Read(df lockfile.DepFile) (Manifest, error) {
 		Requirements: requirements,
 		Groups:       groups,
 		EcosystemSpecific: MavenManifestSpecific{
-			Properties: properties,
+			Properties:  properties,
+			BaseProject: baseProject,
 		},
 	}, nil
 }

--- a/internal/resolution/manifest/maven_test.go
+++ b/internal/resolution/manifest/maven_test.go
@@ -187,45 +187,12 @@ func TestMavenRead(t *testing.T) {
 				VersionKey: resolve.VersionKey{
 					PackageKey: resolve.PackageKey{
 						System: resolve.Maven,
-						Name:   "org.profile:abc",
-					},
-					VersionType: resolve.Requirement,
-					Version:     "1.2.3",
-				},
-				Type: depProfileOne,
-			},
-			{
-				VersionKey: resolve.VersionKey{
-					PackageKey: resolve.PackageKey{
-						System: resolve.Maven,
-						Name:   "org.profile:def",
-					},
-					VersionType: resolve.Requirement,
-					Version:     "${def.version}",
-				},
-				Type: depProfileOne,
-			},
-			{
-				VersionKey: resolve.VersionKey{
-					PackageKey: resolve.PackageKey{
-						System: resolve.Maven,
 						Name:   "org.import:xyz",
 					},
 					VersionType: resolve.Requirement,
 					Version:     "6.6.6",
 				},
-				Type: depProfileTwoMgmt,
-			},
-			{
-				VersionKey: resolve.VersionKey{
-					PackageKey: resolve.PackageKey{
-						System: resolve.Maven,
-						Name:   "org.dep:plugin-dep",
-					},
-					VersionType: resolve.Requirement,
-					Version:     "2.3.3",
-				},
-				Type: depPlugin,
+				Type: depMgmt,
 			},
 		},
 		Groups: map[manifest.RequirementKey][]string{
@@ -233,108 +200,15 @@ func TestMavenRead(t *testing.T) {
 			mavenReqKey(t, "org.import:xyz", "pom", ""): {"import"},
 		},
 		EcosystemSpecific: manifest.MavenManifestSpecific{
-			Properties: []manifest.PropertyWithOrigin{
-				{Property: maven.Property{Name: "bbb.artifact", Value: "bbb"}},
-				{Property: maven.Property{Name: "bbb.version", Value: "2.2.2"}},
-				{Property: maven.Property{Name: "aaa.version", Value: "1.1.1"}},
-
-				{Property: maven.Property{Name: "project.build.sourceEncoding", Value: "UTF-8"}},
-				{Property: maven.Property{Name: "maven.compiler.source", Value: "1.7"}},
-				{Property: maven.Property{Name: "maven.compiler.target", Value: "1.7"}},
-				{Property: maven.Property{Name: "junit.version", Value: "4.12"}},
-				{Property: maven.Property{Name: "def.version", Value: "2.3.4"}, Origin: "profile@profile-one"},
-			},
-			RequirementsWithProperties: []resolve.RequirementVersion{
-				{
-					VersionKey: resolve.VersionKey{
-						PackageKey: resolve.PackageKey{
-							System: resolve.Maven,
-							Name:   "junit:junit",
-						},
-						VersionType: resolve.Requirement,
-						Version:     "${junit.version}",
-					},
-					// Type: dep.NewType(dep.Test), test scope is ignored to make resolution work.
-				},
-				{
-					VersionKey: resolve.VersionKey{
-						PackageKey: resolve.PackageKey{
-							System: resolve.Maven,
-							Name:   "org.profile:def",
-						},
-						VersionType: resolve.Requirement,
-						Version:     "${def.version}",
-					},
-					Type: depProfileOne,
-				},
-				{
-					VersionKey: resolve.VersionKey{
-						PackageKey: resolve.PackageKey{
-							System: resolve.Maven,
-							Name:   "org.example:aaa",
-						},
-						VersionType: resolve.Requirement,
-						Version:     "${aaa.version}",
-					},
-					Type: depParentMgmt,
-				},
-				{
-					VersionKey: resolve.VersionKey{
-						PackageKey: resolve.PackageKey{
-							System: resolve.Maven,
-							Name:   "org.example:${bbb.artifact}",
-						},
-						VersionType: resolve.Requirement,
-						Version:     "${bbb.version}",
-					},
-					Type: depParentUpstreamMgmt,
-				},
-				{
-					VersionKey: resolve.VersionKey{
-						PackageKey: resolve.PackageKey{
-							System: resolve.Maven,
-							Name:   "org.example:ccc",
-						},
-						VersionType: resolve.Requirement,
-						Version:     "${ccc.version}",
-					},
-					Type: depImport,
-				},
-			},
-			RequirementsFromOtherPOMs: []resolve.RequirementVersion{
-				{
-					VersionKey: resolve.VersionKey{
-						PackageKey: resolve.PackageKey{
-							System: resolve.Maven,
-							Name:   "org.example:aaa",
-						},
-						VersionType: resolve.Requirement,
-						Version:     "1.1.1",
-					},
-					Type: depParentMgmt,
-				},
-				{
-					VersionKey: resolve.VersionKey{
-						PackageKey: resolve.PackageKey{
-							System: resolve.Maven,
-							Name:   "org.example:bbb",
-						},
-						VersionType: resolve.Requirement,
-						Version:     "2.2.2",
-					},
-					Type: depParentUpstreamMgmt,
-				},
-				{
-					VersionKey: resolve.VersionKey{
-						PackageKey: resolve.PackageKey{
-							System: resolve.Maven,
-							Name:   "org.example:ccc",
-						},
-						VersionType: resolve.Requirement,
-						Version:     "3.3.3",
-					},
-					Type: depImport,
-				},
+			Properties: []maven.Property{
+				{Name: "bbb.artifact", Value: "bbb"},
+				{Name: "bbb.version", Value: "2.2.2"},
+				{Name: "aaa.version", Value: "1.1.1"},
+				{Name: "project.build.sourceEncoding", Value: "UTF-8"},
+				{Name: "maven.compiler.source", Value: "1.7"},
+				{Name: "maven.compiler.target", Value: "1.7"},
+				{Name: "junit.version", Value: "4.12"},
+				{Name: "def.version", Value: "2.3.4"},
 			},
 		},
 	}

--- a/internal/resolution/manifest/maven_test.go
+++ b/internal/resolution/manifest/maven_test.go
@@ -216,30 +216,40 @@ func TestMavenRead(t *testing.T) {
 				{Property: maven.Property{Name: "junit.version", Value: "4.12"}},
 				{Property: maven.Property{Name: "def.version", Value: "2.3.4"}, Origin: "profile@profile-one"},
 			},
-			OriginalRequirements: map[string]map[maven.DependencyKey]maven.String{
-				"parent": {
-					{GroupID: "org.parent", ArtifactID: "parent-pom"}: "1.1.1",
+			OriginalRequirements: []manifest.DependencyWithOrigin{
+				{
+					Dependency: maven.Dependency{GroupID: "org.parent", ArtifactID: "parent-pom", Version: "1.1.1"},
+					Origin:     manifest.OriginParent,
 				},
-				"": {
-					{GroupID: "junit", ArtifactID: "junit", Type: "jar"}:     "${junit.version}",
-					{GroupID: "org.example", ArtifactID: "abc", Type: "jar"}: "1.0.1",
-					{GroupID: "org.profile", ArtifactID: "abc", Type: "jar"}: "1.2.3",
-					{GroupID: "org.profile", ArtifactID: "def", Type: "jar"}: "${def.version}",
+				{
+					Dependency: maven.Dependency{GroupID: "junit", ArtifactID: "junit", Version: "${junit.version}", Scope: "test"},
 				},
-				"management": {
-					{GroupID: "org.example", ArtifactID: "xyz", Type: "jar"}:   "2.0.0",
-					{GroupID: "org.import", ArtifactID: "import", Type: "pom"}: "1.0.0",
-					{GroupID: "org.import", ArtifactID: "xyz", Type: "pom"}:    "6.6.6",
+				{
+					Dependency: maven.Dependency{GroupID: "org.example", ArtifactID: "abc", Version: "1.0.1"},
 				},
-				"profile@profile-one": {
-					{GroupID: "org.profile", ArtifactID: "abc", Type: "jar"}: "1.2.3",
-					{GroupID: "org.profile", ArtifactID: "def", Type: "jar"}: "${def.version}",
+				{
+					Dependency: maven.Dependency{GroupID: "org.example", ArtifactID: "xyz", Version: "2.0.0"},
+					Origin:     manifest.OriginManagement,
 				},
-				"profile@profile-two@management": {
-					{GroupID: "org.import", ArtifactID: "xyz", Type: "pom"}: "6.6.6",
+				{
+					Dependency: maven.Dependency{GroupID: "org.import", ArtifactID: "import", Version: "1.0.0", Scope: "import", Type: "pom"},
+					Origin:     manifest.OriginManagement,
 				},
-				"plugin@org.plugin:plugin": {
-					{GroupID: "org.dep", ArtifactID: "plugin-dep", Type: "jar"}: "2.3.3",
+				{
+					Dependency: maven.Dependency{GroupID: "org.profile", ArtifactID: "abc", Version: "1.2.3"},
+					Origin:     "profile@profile-one",
+				},
+				{
+					Dependency: maven.Dependency{GroupID: "org.profile", ArtifactID: "def", Version: "${def.version}"},
+					Origin:     "profile@profile-one",
+				},
+				{
+					Dependency: maven.Dependency{GroupID: "org.import", ArtifactID: "xyz", Version: "6.6.6", Scope: "import", Type: "pom"},
+					Origin:     "profile@profile-two@management",
+				},
+				{
+					Dependency: maven.Dependency{GroupID: "org.dep", ArtifactID: "plugin-dep", Version: "2.3.3"},
+					Origin:     "plugin@org.plugin:plugin",
 				},
 			},
 			RequirementsForUpdates: []resolve.RequirementVersion{

--- a/internal/resolution/manifest/maven_test.go
+++ b/internal/resolution/manifest/maven_test.go
@@ -11,7 +11,6 @@ import (
 	"deps.dev/util/maven"
 	"deps.dev/util/resolve"
 	"deps.dev/util/resolve/dep"
-	"fmt"
 	"github.com/google/osv-scanner/internal/resolution/datasource"
 	"github.com/google/osv-scanner/internal/resolution/manifest"
 	"github.com/google/osv-scanner/internal/testutility"
@@ -384,7 +383,6 @@ func TestMavenRead(t *testing.T) {
 			},
 		},
 	}
-	fmt.Println(len(got.Requirements))
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("Maven manifest mismatch:\ngot %v\nwant %v\n", got, want)
 	}

--- a/internal/resolution/manifest/maven_test.go
+++ b/internal/resolution/manifest/maven_test.go
@@ -187,17 +187,52 @@ func TestMavenRead(t *testing.T) {
 				VersionKey: resolve.VersionKey{
 					PackageKey: resolve.PackageKey{
 						System: resolve.Maven,
-						Name:   "org.import:xyz",
+						Name:   "org.example:aaa",
 					},
 					VersionType: resolve.Requirement,
-					Version:     "6.6.6",
+					Version:     "1.1.1",
 				},
 				Type: depMgmt,
 			},
+			{
+				VersionKey: resolve.VersionKey{
+					PackageKey: resolve.PackageKey{
+						System: resolve.Maven,
+						Name:   "org.example:bbb",
+					},
+					VersionType: resolve.Requirement,
+					Version:     "2.2.2",
+				},
+				Type: depMgmt,
+			},
+			{
+				VersionKey: resolve.VersionKey{
+					PackageKey: resolve.PackageKey{
+						System: resolve.Maven,
+						Name:   "org.example:ccc",
+					},
+					VersionType: resolve.Requirement,
+					Version:     "3.3.3",
+				},
+				Type: depMgmt,
+			},
+			/*
+				{
+					VersionKey: resolve.VersionKey{
+						PackageKey: resolve.PackageKey{
+							System: resolve.Maven,
+							Name:   "org.import:xyz",
+						},
+						VersionType: resolve.Requirement,
+						Version:     "6.6.6",
+					},
+					Type: depMgmt,
+				},
+			*/
 		},
 		Groups: map[manifest.RequirementKey][]string{
-			mavenReqKey(t, "junit:junit", "", ""):       {"test"},
-			mavenReqKey(t, "org.import:xyz", "pom", ""): {"import"},
+			mavenReqKey(t, "junit:junit", "", ""): {"test"},
+			//	mavenReqKey(t, "org.import:xyz", "pom", ""): {"import"},
 		},
 		EcosystemSpecific: manifest.MavenManifestSpecific{
 			Properties: []maven.Property{
@@ -208,7 +243,114 @@ func TestMavenRead(t *testing.T) {
 				{Name: "maven.compiler.source", Value: "1.7"},
 				{Name: "maven.compiler.target", Value: "1.7"},
 				{Name: "junit.version", Value: "4.12"},
-				{Name: "def.version", Value: "2.3.4"},
+				//{Name: "def.version", Value: "2.3.4"},
+			},
+			BaseProject: maven.Project{
+				Name: "my-app",
+				URL:  "http://www.example.com",
+				ProjectKey: maven.ProjectKey{
+					GroupID:    "com.mycompany.app",
+					ArtifactID: "my-app",
+					Version:    "1.0",
+				},
+				Parent: maven.Parent{
+					ProjectKey: maven.ProjectKey{
+						GroupID:    "org.parent",
+						ArtifactID: "parent-pom",
+						Version:    "1.1.1",
+					},
+					RelativePath: "./parent/pom.xml",
+				},
+				Properties: maven.Properties{
+					Properties: []maven.Property{
+						{Name: "project.build.sourceEncoding", Value: "UTF-8"},
+						{Name: "maven.compiler.source", Value: "1.7"},
+						{Name: "maven.compiler.target", Value: "1.7"},
+						{Name: "junit.version", Value: "4.12"},
+					},
+				},
+				Dependencies: []maven.Dependency{
+					{
+						GroupID:    "junit",
+						ArtifactID: "junit",
+						Version:    "${junit.version}",
+						Scope:      "test",
+					},
+					{
+						GroupID:    "org.example",
+						ArtifactID: "abc",
+						Version:    "1.0.1",
+					},
+				},
+				DependencyManagement: maven.DependencyManagement{
+					Dependencies: []maven.Dependency{
+						{
+							GroupID:    "org.example",
+							ArtifactID: "xyz",
+							Version:    "2.0.0",
+						},
+						{
+							GroupID:    "org.import",
+							ArtifactID: "import",
+							Version:    "1.0.0",
+							Type:       "pom",
+							Scope:      "import",
+						},
+					},
+				},
+				Profiles: []maven.Profile{
+					{
+						ID: "profile-one",
+						Properties: maven.Properties{
+							Properties: []maven.Property{
+								{Name: "def.version", Value: "2.3.4"},
+							},
+						},
+						Dependencies: []maven.Dependency{{
+							GroupID:    "org.profile",
+							ArtifactID: "abc",
+							Version:    "1.2.3",
+						}, {
+							GroupID:    "org.profile",
+							ArtifactID: "def",
+							Version:    "${def.version}",
+						}},
+					},
+					{
+						ID: "profile-two",
+						DependencyManagement: maven.DependencyManagement{
+							Dependencies: []maven.Dependency{
+								{
+									GroupID:    "org.import",
+									ArtifactID: "xyz",
+									Version:    "6.6.6",
+									Scope:      "import",
+									Type:       "pom",
+								},
+							},
+						},
+					},
+				},
+				Build: maven.Build{
+					PluginManagement: maven.PluginManagement{
+						Plugins: []maven.Plugin{
+							{
+								ProjectKey: maven.ProjectKey{
+									GroupID:    "org.plugin",
+									ArtifactID: "plugin",
+									Version:    "1.0.0",
+								},
+								Dependencies: []maven.Dependency{
+									{
+										GroupID:    "org.dep",
+										ArtifactID: "plugin-dep",
+										Version:    "2.3.3",
+									},
+								},
+							},
+						},
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
The current design of Maven manifest reading has some problems:
 - requirements that are not useful for resolution are also included
 - requirement origins mess the dependency resolution as well

To address the issues above, in this PR:
 - requirements returned are only those ones needed for dependency resolution
 - passing Maven dependencies with origins so we can look up their original requirement
 - passing requirements that are needed for updates only individually

However there are still known issues for this implementation:
 - profiles are not yet fully supported (pending deps.dev changes)
 - original requirements may not be found for dependencies with placeholders in their names