### PR TITLE
Add warning to the default docker container scanning method

### DIFF
--- a/cmd/osv-scanner/scan/main.go
+++ b/cmd/osv-scanner/scan/main.go
@@ -25,7 +25,7 @@ func Command(stdout, stderr io.Writer, r *reporter.Reporter) *cli.Command {
 			&cli.StringSliceFlag{
 				Name:      "docker",
 				Aliases:   []string{"D"},
-				Usage:     "scan docker image with this name",
+				Usage:     "scan docker image with this name. Warning: Only run this on a trusted container image, as it runs the container image to retrieve the package versions",
 				TakesFile: false,
 			},
 			&cli.StringSliceFlag{
@@ -130,7 +130,6 @@ func Command(stdout, stderr io.Writer, r *reporter.Reporter) *cli.Command {
 				Name:      "experimental-oci-image",
 				Usage:     "scan an exported *docker* container image archive (exported using `docker save` command) file",
 				TakesFile: true,
-				Hidden:    true,
 			},
 		},
 		ArgsUsage: "[directory1 directory2...]",

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -94,6 +94,9 @@ Requires `docker` to be installed and the tool to have permission calling it.
 
 This currently does not scan the filesystem of the Docker container, and has various other limitations. Follow [this issue](https://github.com/google/osv-scanner/issues/64) for updates on container scanning!
 
+{: .warning }
+Only run this on a trusted container image, as it runs the container image to retrieve the package versions.
+
 ### Example
 
 ```bash


### PR DESCRIPTION
Not deprecating this yet, as there are still a few questions to work out before making the new container scanning flag public. 

Mainly: 
- Add support for OCI images?
- Replace current docker flag?