### PR TITLE
fix: restore custom styling to table format

### DIFF
--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -48,15 +48,15 @@ func newTable(outputWriter io.Writer, terminalWidth int) table.Writer {
 	outputTable := table.NewWriter()
 	outputTable.SetOutputMirror(outputWriter)
 
-	outputTable.Style().Options.DoNotColorBordersAndSeparators = true
-	outputTable.Style().Color.Row = text.Colors{text.Reset, text.BgHiBlack}
-	outputTable.Style().Color.RowAlternate = text.Colors{text.Reset, text.BgBlack}
-
 	// use fancy characters if we're outputting to a terminal
 	if terminalWidth > 0 {
 		outputTable.SetStyle(table.StyleRounded)
 		outputTable.SetAllowedRowLength(terminalWidth)
 	}
+
+	outputTable.Style().Options.DoNotColorBordersAndSeparators = true
+	outputTable.Style().Color.Row = text.Colors{text.Reset, text.BgHiBlack}
+	outputTable.Style().Color.RowAlternate = text.Colors{text.Reset, text.BgBlack}
 
 	return outputTable
 }


### PR DESCRIPTION
I mistakenly changed the order that styles are applied in #1087 for the table formatter so our custom styles were immediately overridden when the rounded style was applied