### PR TITLE
Update github action docs in osv-scanner

### DIFF
--- a/.github/workflows/osv-scanner-unified-action.yml
+++ b/.github/workflows/osv-scanner-unified-action.yml
@@ -20,7 +20,7 @@ on:
   merge_group:
     branches: ["main"]
   schedule:
-  - cron: "12 12 * * 1"
+    - cron: "12 12 * * 1"
   push:
     branches: ["main"]
 

--- a/.github/workflows/osv-scanner-unified-action.yml
+++ b/.github/workflows/osv-scanner-unified-action.yml
@@ -33,6 +33,7 @@ jobs:
     permissions:
       contents: read # to fetch code (actions/checkout)
       security-events: write # for uploading SARIF files
+      actions: read
     if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
     # If you want to copy this config, highly suggest pinning this version to a release rather than tracking the main branch
     uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@main"
@@ -46,6 +47,7 @@ jobs:
     permissions:
       contents: read # to fetch code (actions/checkout)
       security-events: write # for uploading SARIF files
+      actions: read
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
     # If you want to copy this config, highly suggest pinning this version to a release rather than tracking the main branch
     uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@main"

--- a/.github/workflows/osv-scanner-unified-action.yml
+++ b/.github/workflows/osv-scanner-unified-action.yml
@@ -20,7 +20,7 @@ on:
   merge_group:
     branches: ["main"]
   schedule:
-    - cron: "12 12 * * 1"
+  - cron: "12 12 * * 1"
   push:
     branches: ["main"]
 
@@ -34,7 +34,8 @@ jobs:
       contents: read # to fetch code (actions/checkout)
       security-events: write # for uploading SARIF files
     if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@staging"
+    # If you want to copy this config, highly suggest pinning this version to a release rather than tracking the main branch
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@main"
     with:
       # Just scan the root directory and docs, since everything else is fixtures
       scan-args: |-
@@ -46,7 +47,8 @@ jobs:
       contents: read # to fetch code (actions/checkout)
       security-events: write # for uploading SARIF files
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@staging"
+    # If you want to copy this config, highly suggest pinning this version to a release rather than tracking the main branch
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@main"
     with:
       # Just scan the root directory and docs, since everything else is fixtures
       scan-args: |-

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -46,6 +46,8 @@ on:
     branches: [main]
 
 permissions:
+  # Required to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117
+  actions: read
   # Require writing security events to upload SARIF file to security tab
   security-events: write
   # Only need to read contents
@@ -53,7 +55,7 @@ permissions:
 
 jobs:
   scan-pr:
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v1.7.1"
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v1.8.1"
 ```
 
 ### View results
@@ -87,6 +89,8 @@ on:
     branches: [main]
 
 permissions:
+  # Required to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117
+  actions: read
   # Require writing security events to upload SARIF file to security tab
   security-events: write
   # Only need to read contents
@@ -94,7 +98,7 @@ permissions:
 
 jobs:
   scan-scheduled:
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v1.7.1"
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v1.8.1"
 ```
 
 As written, the scanner will run on 12:30 pm UTC every Monday, and also on every push to the main branch. You can change the schedule by following the instructions [here](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule).
@@ -120,7 +124,12 @@ on:
       - "*" # triggers only if push new tag version, like `0.8.4` or else
 
 permissions:
-  contents: read # to fetch code (actions/checkout)
+  # Required to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117
+  actions: read
+  # Require writing security events to upload SARIF file to security tab
+  security-events: write
+  # to fetch code (actions/checkout)
+  contents: read
 
 jobs:
   osv-scan:
@@ -177,7 +186,7 @@ Examples
 ```yml
 jobs:
   scan-pr:
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v1.7.1"
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v1.8.1"
     with:
       scan-args: |-
         --lockfile=./path/to/lockfile1
@@ -189,7 +198,7 @@ jobs:
 ```yml
 jobs:
   scan-pr:
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v1.7.1"
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v1.8.1"
     with:
       scan-args: |-
         --recursive
@@ -216,7 +225,7 @@ jobs:
     name: Vulnerability scanning
     # makes sure the extraction step is completed before running the scanner
     needs: extract-deps
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v1.7.1"
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v1.8.1"
     with:
       # Download the artifact uploaded in extract-deps step
       download-artifact: converted-OSV-Scanner-deps
@@ -227,6 +236,7 @@ jobs:
       # Needed to upload the SARIF results to code-scanning dashboard.
       security-events: write
       contents: read
+      actions: read
 ```
 
 </details>


### PR DESCRIPTION
Fixes #1090 

Also makes our osv-scanner action in this repo track the main branch so we always dogfood the latest version.