### PR TITLE
Add go compiler to enable call analysis in the github action

### DIFF
--- a/goreleaser-action.dockerfile
+++ b/goreleaser-action.dockerfile
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0ls
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/goreleaser-action.dockerfile
+++ b/goreleaser-action.dockerfile
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0ls
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,8 @@ FROM alpine:3.20@sha256:b89d9c93e9ed3597455c90a0b88a8bbb5cb7188438f70953fede212a
 RUN apk --no-cache add \
   ca-certificates \
   git \
-  bash
+  bash \
+  go
 
 # Allow git to run on mounted directories
 RUN git config --global --add safe.directory '*'


### PR DESCRIPTION
This allows the OSV-scanner GitHub action to automatically run go call analysis. This does increase the total size of the image (no compression, no layer caching) by 5x. From 70mb to 400mb  , as it now includes the go compiler in the image. 