### PR TITLE
Fix npm grouping

### DIFF
--- a/pkg/lockfile/parse-npm-lock.go
+++ b/pkg/lockfile/parse-npm-lock.go
@@ -102,7 +102,10 @@ func parseNpmLockDependencies(dependencies map[string]NpmLockDependency) map[str
 
 	for name, detail := range dependencies {
 		if detail.Dependencies != nil {
-			maps.Copy(details, parseNpmLockDependencies(detail.Dependencies))
+			nestedDeps := parseNpmLockDependencies(detail.Dependencies)
+			for k, v := range nestedDeps {
+				details.add(k, v)
+			}
 		}
 
 		version := detail.Version


### PR DESCRIPTION
Fix bug in the npm grouping code, the current maps.Copy method doesn't use the merging applied in details.add, causing inconsistent test failures.