### PR TITLE
refactor: update linter and address minor violations

### DIFF
--- a/.github/workflows/lint-action/action.yml
+++ b/.github/workflows/lint-action/action.yml
@@ -22,4 +22,4 @@ runs:
       uses: golangci/golangci-lint-action@a4f60bb28d35aeee14e6880718e0c85ff1882e64 # v6.0.1
       with:
         # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-        version: v1.57.2
+        version: v1.58.2

--- a/.github/workflows/lint-action/action.yml
+++ b/.github/workflows/lint-action/action.yml
@@ -22,4 +22,4 @@ runs:
       uses: golangci/golangci-lint-action@a4f60bb28d35aeee14e6880718e0c85ff1882e64 # v6.0.1
       with:
         # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-        version: v1.56.2
+        version: v1.57.2

--- a/.github/workflows/lint-action/action.yml
+++ b/.github/workflows/lint-action/action.yml
@@ -22,4 +22,4 @@ runs:
       uses: golangci/golangci-lint-action@a4f60bb28d35aeee14e6880718e0c85ff1882e64 # v6.0.1
       with:
         # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-        version: v1.58.2
+        version: v1.59.1

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -8,17 +8,8 @@ linters:
   disable:
     - tagliatelle      # we're parsing data from external sources (g-rath)
     - varnamelen       # maybe later (g-rath)
-    - exhaustivestruct # deprecated
     - exhaustruct      # overkill (g-rath)
     - forcetypeassert  # too hard (g-rath)
-    - interfacer       # deprecated
-    - golint           # deprecated
-    - scopelint        # deprecated
-    - maligned         # deprecated
-    - varcheck         # deprecated
-    - structcheck      # deprecated
-    - deadcode         # deprecated
-    - nosnakecase      # deprecated
     - lll              # line length is hard (g-rath)
     - godox            # to-do comments are fine (g-rath)
     - godot            # comments are fine without full stops (g-rath)

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -23,12 +23,13 @@ linters:
     - godox            # to-do comments are fine (g-rath)
     - godot            # comments are fine without full stops (g-rath)
     - gomnd            # not every number is magic (g-rath)
+    - mnd              # not every number is magic (g-rath)
     - wsl              # disagree with, for now (g-rath)
     - ireturn          # disagree with, sort of (g-rath)
     - gochecknoglobals # disagree with, for non changing variables (another-rex)
     - wrapcheck        # too difficult, will re-add later (another-rex)
     - testpackage      # will re-add later (another-rex)
-    - goerr113         # will re-add later (another-rex)
+    - err113           # will re-add later (another-rex)
     - nonamedreturns   # disagree with, for now (another-rex)
     - goconst          # not everything should be a constant
   presets:
@@ -81,7 +82,6 @@ issues:
         - dupl
     - path: _test\.go
       linters:
-        - goerr113
         - dupl
     - path: main.go
       linters:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -74,6 +74,3 @@ issues:
     - path: _test\.go
       linters:
         - dupl
-    - path: main.go
-      linters:
-        - gochecknoglobals

--- a/internal/local/zip.go
+++ b/internal/local/zip.go
@@ -55,7 +55,7 @@ func fetchRemoteArchiveCRC32CHash(url string) (uint32, error) {
 		return 0, fmt.Errorf("db host returned %s", resp.Status)
 	}
 
-	for _, value := range resp.Header.Values("x-goog-hash") {
+	for _, value := range resp.Header.Values("X-Goog-Hash") {
 		if strings.HasPrefix(value, "crc32c=") {
 			value = strings.TrimPrefix(value, "crc32c=")
 			out, err := base64.StdEncoding.DecodeString(value)

--- a/internal/output/result.go
+++ b/internal/output/result.go
@@ -12,8 +12,8 @@ import (
 )
 
 type pkgWithSource struct {
-	Package models.PackageInfo
-	Source  models.SourceInfo
+	Package models.PackageInfo `json:"Package"`
+	Source  models.SourceInfo  `json:"Source"`
 }
 
 // Custom implementation of this unique set map to allow it to serialize to JSON

--- a/internal/semantic/version-maven.go
+++ b/internal/semantic/version-maven.go
@@ -44,7 +44,6 @@ func (vt *mavenVersionToken) equal(wt mavenVersionToken) bool {
 	return vt.prefix == wt.prefix && vt.value == wt.value
 }
 
-//nolint:gochecknoglobals // this is read-only and the nicest implementation
 var keywordOrder = []string{"alpha", "beta", "milestone", "rc", "snapshot", "", "sp"}
 
 func findKeywordOrder(keyword string) int {

--- a/scripts/run_lints.sh
+++ b/scripts/run_lints.sh
@@ -2,4 +2,4 @@
 
 set -ex
 
-go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.57.2 run ./... --max-same-issues 0
+go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.58.2 run ./... --max-same-issues 0

--- a/scripts/run_lints.sh
+++ b/scripts/run_lints.sh
@@ -2,4 +2,4 @@
 
 set -ex
 
-go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.2 run ./... --max-same-issues 0
+go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.57.2 run ./... --max-same-issues 0

--- a/scripts/run_lints.sh
+++ b/scripts/run_lints.sh
@@ -2,4 +2,4 @@
 
 set -ex
 
-go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.58.2 run ./... --max-same-issues 0
+go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1 run ./... --max-same-issues 0


### PR DESCRIPTION
There's nothing too major here though we do get to remove a bunch of config for deprecated linters that have finally been removed; the more exciting thing is when we move to Go v1.22 as there's a few linters that'll start running like for cleaning up our looping variables