### PR TITLE
Fix the wrong dependencies/dependency tags

### DIFF
--- a/internal/resolution/manifest/__snapshots__/maven_test.snap
+++ b/internal/resolution/manifest/__snapshots__/maven_test.snap
@@ -158,14 +158,16 @@
 
   <dependencyManagement>
     <dependencies>
-      <groupId>org.management</groupId>
-      <artifactId>abc</artifactId>
-      <version>1.2.3</version>
-    </dependencies>
-    <dependencies>
-      <groupId>org.management</groupId>
-      <artifactId>xyz</artifactId>
-      <version>2.3.4</version>
+      <dependency>
+        <groupId>org.management</groupId>
+        <artifactId>abc</artifactId>
+        <version>1.2.3</version>
+      </dependency>
+      <dependency>
+        <groupId>org.management</groupId>
+        <artifactId>xyz</artifactId>
+        <version>2.3.4</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/internal/resolution/manifest/maven.go
+++ b/internal/resolution/manifest/maven.go
@@ -763,7 +763,7 @@ func updateProject(w io.Writer, enc *xml.Encoder, raw, prefix, id string, patche
 
 // Only for writing dependencies that are not from the base project.
 type dependencyManagement struct {
-	Dependencies []dependency `xml:"dependencies,omitempty"`
+	Dependencies []dependency `xml:"dependencies>dependency,omitempty"`
 }
 
 type dependency struct {


### PR DESCRIPTION
Currently, the newly added dependency management is not written correctly - `dependency` tags are missing.
This PR fixes this by specifying `dependency` in the struct. 