### PR TITLE
fix: ensure that `semantic` is passed a valid `models.Ecosystem`

### DIFF
--- a/internal/utility/vulns/vulnerability.go
+++ b/internal/utility/vulns/vulnerability.go
@@ -32,6 +32,15 @@ func eventVersion(e models.Event) string {
 	return ""
 }
 
+// convertEcosystem handles converting from a "lockfile" ecosystem to a "models" ecosystem.
+//
+// todo: this should go away in v2 once we've moved to a single ecosystem type
+func convertLockfileEcosystem(version lockfile.Ecosystem) models.Ecosystem {
+	b, _, _ := strings.Cut(string(version), ":")
+
+	return models.Ecosystem(b)
+}
+
 func rangeContainsVersion(ar models.Range, pkg lockfile.PackageDetails) bool {
 	if ar.Type != models.RangeEcosystem && ar.Type != models.RangeSemVer {
 		return false
@@ -41,7 +50,7 @@ func rangeContainsVersion(ar models.Range, pkg lockfile.PackageDetails) bool {
 		return false
 	}
 
-	vp := semantic.MustParse(pkg.Version, models.Ecosystem(pkg.CompareAs))
+	vp := semantic.MustParse(pkg.Version, convertLockfileEcosystem(pkg.CompareAs))
 
 	sort.Slice(ar.Events, func(i, j int) bool {
 		a := ar.Events[i]
@@ -55,7 +64,7 @@ func rangeContainsVersion(ar models.Range, pkg lockfile.PackageDetails) bool {
 			return false
 		}
 
-		return semantic.MustParse(eventVersion(a), models.Ecosystem(pkg.CompareAs)).CompareStr(eventVersion(b)) < 0
+		return semantic.MustParse(eventVersion(a), convertLockfileEcosystem(pkg.CompareAs)).CompareStr(eventVersion(b)) < 0
 	})
 
 	var affected bool

--- a/internal/utility/vulns/vulnerability_test.go
+++ b/internal/utility/vulns/vulnerability_test.go
@@ -704,3 +704,32 @@ func TestOSV_IsAffected_OnlyVersions(t *testing.T) {
 	// an empty version should always be treated as affected
 	expectIsAffected(t, vuln, "", true)
 }
+
+func TestOSV_EcosystemsWithSuffix(t *testing.T) {
+	t.Parallel()
+
+	vuln := buildOSVWithAffected(
+		models.Affected{
+			Package: models.Package{Ecosystem: "Debian:12", Name: "my-package"},
+			Ranges: []models.Range{
+				buildSemverAffectsRange(
+					models.Event{Introduced: "0"},
+					models.Event{Introduced: "2.1.0"},
+					models.Event{Fixed: "1"},
+					models.Event{LastAffected: "3.1.9"},
+				),
+			},
+		},
+	)
+
+	pkg := lockfile.PackageDetails{
+		Name:      "my-package",
+		Version:   "0.0.0",
+		Ecosystem: "Debian:12",
+		CompareAs: "Debian:12",
+	}
+
+	if !vulns.IsAffected(vuln, pkg) {
+		t.Errorf("Expected OSV to affect package version %s but it did not", "0.0.0")
+	}
+}

--- a/internal/utility/vulns/vulnerability_test.go
+++ b/internal/utility/vulns/vulnerability_test.go
@@ -714,9 +714,6 @@ func TestOSV_EcosystemsWithSuffix(t *testing.T) {
 			Ranges: []models.Range{
 				buildSemverAffectsRange(
 					models.Event{Introduced: "0"},
-					models.Event{Introduced: "2.1.0"},
-					models.Event{Fixed: "1"},
-					models.Event{LastAffected: "3.1.9"},
 				),
 			},
 		},


### PR DESCRIPTION
Resolves #1115