### PR TITLE
ci: don't mark v2 wishlished issues as stale

### DIFF
--- a/.github/workflows/staleness.yml
+++ b/.github/workflows/staleness.yml
@@ -14,7 +14,7 @@ jobs:
           stale-issue-label: stale
           stale-pr-label: stale
           remove-stale-when-updated: true
-          exempt-issue-labels: "good first issue"
+          exempt-issue-labels: "good first issue, V2 Wishlist"
           exempt-all-assignees: true
           ignore-updates: false
           stale-issue-message: "This issue has not had any activity for 60 days and will be automatically closed in two weeks"


### PR DESCRIPTION
Such issues will never not be stale right up until work on v2 starts (and even then they'll likely be stale on and off)

(note I'm not entirely sure if this will work re the spaces - I've found some issues on the action repo that suggest it should, but no actual example docs; I think we just need to try it and see 🤷)