### PR TITLE
Add original manifest to Maven ManifestPatch

### DIFF
--- a/internal/remediation/suggest/maven.go
+++ b/internal/remediation/suggest/maven.go
@@ -53,8 +53,8 @@ func (ms *MavenSuggester) Suggest(ctx context.Context, client resolve.Client, mf
 	}
 
 	return manifest.ManifestPatch{
-		Deps:              changedDeps,
-		EcosystemSpecific: specific,
+		Deps:     changedDeps,
+		Manifest: &mf,
 	}, nil
 }
 

--- a/internal/remediation/suggest/maven_test.go
+++ b/internal/remediation/suggest/maven_test.go
@@ -353,66 +353,7 @@ func TestSuggest(t *testing.T) {
 				NewRequire:  "2.3.5",
 			},
 		},
-		EcosystemSpecific: manifest.MavenManifestSpecific{
-			// Copied from Manifest.EcosystemSpecific
-			RequirementsForUpdates: []resolve.RequirementVersion{
-				{
-					VersionKey: resolve.VersionKey{
-						PackageKey: resolve.PackageKey{
-							System: resolve.Maven,
-							Name:   "com.mycompany.app:parent-pom",
-						},
-						VersionType: resolve.Requirement,
-						Version:     "1.0.0",
-					},
-					Type: depParent,
-				},
-				{
-					VersionKey: resolve.VersionKey{
-						PackageKey: resolve.PackageKey{
-							System: resolve.Maven,
-							Name:   "org.profile:abc",
-						},
-						VersionType: resolve.Requirement,
-						Version:     "1.2.3",
-					},
-					Type: depProfileOne,
-				},
-				{
-					VersionKey: resolve.VersionKey{
-						PackageKey: resolve.PackageKey{
-							System: resolve.Maven,
-							Name:   "org.profile:def",
-						},
-						VersionType: resolve.Requirement,
-						Version:     "2.3.4",
-					},
-					Type: depProfileOne,
-				},
-				{
-					VersionKey: resolve.VersionKey{
-						PackageKey: resolve.PackageKey{
-							System: resolve.Maven,
-							Name:   "org.import:xyz",
-						},
-						VersionType: resolve.Requirement,
-						Version:     "6.6.6",
-					},
-					Type: depProfileTwoMgmt,
-				},
-				{
-					VersionKey: resolve.VersionKey{
-						PackageKey: resolve.PackageKey{
-							System: resolve.Maven,
-							Name:   "org.dep:plugin-dep",
-						},
-						VersionType: resolve.Requirement,
-						Version:     "2.3.3",
-					},
-					Type: depPlugin,
-				},
-			},
-		},
+		Manifest: &mf,
 	}
 	sort.Slice(got.Deps, func(i, j int) bool {
 		return got.Deps[i].Pkg.Name < got.Deps[j].Pkg.Name

--- a/internal/resolution/manifest/maven.go
+++ b/internal/resolution/manifest/maven.go
@@ -341,7 +341,7 @@ func mavenOrigin(list ...string) string {
 }
 
 func (MavenManifestIO) Write(df lockfile.DepFile, w io.Writer, patch ManifestPatch) error {
-	specific, ok := patch.EcosystemSpecific.(MavenManifestSpecific)
+	specific, ok := patch.Manifest.EcosystemSpecific.(MavenManifestSpecific)
 	if !ok {
 		return errors.New("invalid MavenManifestSpecific data")
 	}


### PR DESCRIPTION
Copying the `EcosystemSpecific` data from the `Manifest` to the `ManifestPatch` is a bit cumbersome for the override strategy, and `ManifestPatch` already has a field for the original manifest.

I don't think the current Maven `EcosystemSpecific` data is ever going to differ from the what's in the original manifest?