### PR TITLE
fix: handle parsing versions in `composer.lock` files that are numbers rather than strings

### DIFF
--- a/pkg/lockfile/fixtures/composer/with-bad-version.json
+++ b/pkg/lockfile/fixtures/composer/with-bad-version.json
@@ -1,0 +1,183 @@
+{
+  "_readme": [
+    "This file locks the dependencies of your project to a known state",
+    "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+    "This file is @generated automatically"
+  ],
+  "content-hash": "035277326fc4da8f74a4f00bb10a888a",
+  "packages": [
+    {
+      "name": "composer/installers",
+      "version": "v2.3.0",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/composer/installers.git",
+        "reference": "12fb2dfe5e16183de69e784a7b84046c43d97e8e"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/composer/installers/zipball/12fb2dfe5e16183de69e784a7b84046c43d97e8e",
+        "reference": "12fb2dfe5e16183de69e784a7b84046c43d97e8e",
+        "shasum": ""
+      },
+      "require": {
+        "composer-plugin-api": "^1.0 || ^2.0",
+        "php": "^7.2 || ^8.0"
+      },
+      "require-dev": {
+        "composer/composer": "^1.10.27 || ^2.7",
+        "composer/semver": "^1.7.2 || ^3.4.0",
+        "phpstan/phpstan": "^1.11",
+        "phpstan/phpstan-phpunit": "^1",
+        "symfony/phpunit-bridge": "^7.1.1",
+        "symfony/process": "^5 || ^6 || ^7"
+      },
+      "type": "composer-plugin",
+      "extra": {
+        "class": "Composer\\Installers\\Plugin",
+        "branch-alias": {
+          "dev-main": "2.x-dev"
+        },
+        "plugin-modifies-install-path": true
+      },
+      "autoload": {
+        "psr-4": {
+          "Composer\\Installers\\": "src/Composer/Installers"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Kyle Robinson Young",
+          "email": "kyle@dontkry.com",
+          "homepage": "https://github.com/shama"
+        }
+      ],
+      "description": "A multi-framework Composer library installer",
+      "homepage": "https://composer.github.io/installers/",
+      "keywords": [
+        "Dolibarr",
+        "Eliasis",
+        "Hurad",
+        "ImageCMS",
+        "Kanboard",
+        "Lan Management System",
+        "MODX Evo",
+        "MantisBT",
+        "Mautic",
+        "Maya",
+        "OXID",
+        "Plentymarkets",
+        "Porto",
+        "RadPHP",
+        "SMF",
+        "Starbug",
+        "Thelia",
+        "Whmcs",
+        "WolfCMS",
+        "agl",
+        "annotatecms",
+        "attogram",
+        "bitrix",
+        "cakephp",
+        "chef",
+        "cockpit",
+        "codeigniter",
+        "concrete5",
+        "concreteCMS",
+        "croogo",
+        "dokuwiki",
+        "drupal",
+        "eZ Platform",
+        "elgg",
+        "expressionengine",
+        "fuelphp",
+        "grav",
+        "installer",
+        "itop",
+        "known",
+        "kohana",
+        "laravel",
+        "lavalite",
+        "lithium",
+        "magento",
+        "majima",
+        "mako",
+        "matomo",
+        "mediawiki",
+        "miaoxing",
+        "modulework",
+        "modx",
+        "moodle",
+        "osclass",
+        "pantheon",
+        "phpbb",
+        "piwik",
+        "ppi",
+        "processwire",
+        "puppet",
+        "pxcms",
+        "reindex",
+        "roundcube",
+        "shopware",
+        "silverstripe",
+        "sydes",
+        "sylius",
+        "tastyigniter",
+        "wordpress",
+        "yawik",
+        "zend",
+        "zikula"
+      ],
+      "support": {
+        "issues": "https://github.com/composer/installers/issues",
+        "source": "https://github.com/composer/installers/tree/v2.3.0"
+      },
+      "funding": [
+        {
+          "url": "https://packagist.com",
+          "type": "custom"
+        },
+        {
+          "url": "https://github.com/composer",
+          "type": "github"
+        },
+        {
+          "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+          "type": "tidelift"
+        }
+      ],
+      "time": "2024-06-24T20:46:46+00:00"
+    },
+    {
+      "name": "wpackagist-plugin/block-bad-queries",
+      "version": {},
+      "source": {
+        "type": "svn",
+        "url": "https://plugins.svn.wordpress.org/block-bad-queries/",
+        "reference": "tags/20190220"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://downloads.wordpress.org/plugin/block-bad-queries.20190220.zip"
+      },
+      "require": {
+        "composer/installers": "^1.0 || ^2.0"
+      },
+      "type": "wordpress-plugin",
+      "homepage": "https://wordpress.org/plugins/block-bad-queries/"
+    }
+  ],
+  "packages-dev": [],
+  "aliases": [],
+  "minimum-stability": "stable",
+  "stability-flags": [],
+  "prefer-stable": false,
+  "prefer-lowest": false,
+  "platform": [],
+  "platform-dev": [],
+  "plugin-api-version": "2.6.0"
+}

--- a/pkg/lockfile/fixtures/composer/with-number-version.json
+++ b/pkg/lockfile/fixtures/composer/with-number-version.json
@@ -1,0 +1,183 @@
+{
+  "_readme": [
+    "This file locks the dependencies of your project to a known state",
+    "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+    "This file is @generated automatically"
+  ],
+  "content-hash": "035277326fc4da8f74a4f00bb10a888a",
+  "packages": [
+    {
+      "name": "composer/installers",
+      "version": "v2.3.0",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/composer/installers.git",
+        "reference": "12fb2dfe5e16183de69e784a7b84046c43d97e8e"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/composer/installers/zipball/12fb2dfe5e16183de69e784a7b84046c43d97e8e",
+        "reference": "12fb2dfe5e16183de69e784a7b84046c43d97e8e",
+        "shasum": ""
+      },
+      "require": {
+        "composer-plugin-api": "^1.0 || ^2.0",
+        "php": "^7.2 || ^8.0"
+      },
+      "require-dev": {
+        "composer/composer": "^1.10.27 || ^2.7",
+        "composer/semver": "^1.7.2 || ^3.4.0",
+        "phpstan/phpstan": "^1.11",
+        "phpstan/phpstan-phpunit": "^1",
+        "symfony/phpunit-bridge": "^7.1.1",
+        "symfony/process": "^5 || ^6 || ^7"
+      },
+      "type": "composer-plugin",
+      "extra": {
+        "class": "Composer\\Installers\\Plugin",
+        "branch-alias": {
+          "dev-main": "2.x-dev"
+        },
+        "plugin-modifies-install-path": true
+      },
+      "autoload": {
+        "psr-4": {
+          "Composer\\Installers\\": "src/Composer/Installers"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Kyle Robinson Young",
+          "email": "kyle@dontkry.com",
+          "homepage": "https://github.com/shama"
+        }
+      ],
+      "description": "A multi-framework Composer library installer",
+      "homepage": "https://composer.github.io/installers/",
+      "keywords": [
+        "Dolibarr",
+        "Eliasis",
+        "Hurad",
+        "ImageCMS",
+        "Kanboard",
+        "Lan Management System",
+        "MODX Evo",
+        "MantisBT",
+        "Mautic",
+        "Maya",
+        "OXID",
+        "Plentymarkets",
+        "Porto",
+        "RadPHP",
+        "SMF",
+        "Starbug",
+        "Thelia",
+        "Whmcs",
+        "WolfCMS",
+        "agl",
+        "annotatecms",
+        "attogram",
+        "bitrix",
+        "cakephp",
+        "chef",
+        "cockpit",
+        "codeigniter",
+        "concrete5",
+        "concreteCMS",
+        "croogo",
+        "dokuwiki",
+        "drupal",
+        "eZ Platform",
+        "elgg",
+        "expressionengine",
+        "fuelphp",
+        "grav",
+        "installer",
+        "itop",
+        "known",
+        "kohana",
+        "laravel",
+        "lavalite",
+        "lithium",
+        "magento",
+        "majima",
+        "mako",
+        "matomo",
+        "mediawiki",
+        "miaoxing",
+        "modulework",
+        "modx",
+        "moodle",
+        "osclass",
+        "pantheon",
+        "phpbb",
+        "piwik",
+        "ppi",
+        "processwire",
+        "puppet",
+        "pxcms",
+        "reindex",
+        "roundcube",
+        "shopware",
+        "silverstripe",
+        "sydes",
+        "sylius",
+        "tastyigniter",
+        "wordpress",
+        "yawik",
+        "zend",
+        "zikula"
+      ],
+      "support": {
+        "issues": "https://github.com/composer/installers/issues",
+        "source": "https://github.com/composer/installers/tree/v2.3.0"
+      },
+      "funding": [
+        {
+          "url": "https://packagist.com",
+          "type": "custom"
+        },
+        {
+          "url": "https://github.com/composer",
+          "type": "github"
+        },
+        {
+          "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+          "type": "tidelift"
+        }
+      ],
+      "time": "2024-06-24T20:46:46+00:00"
+    },
+    {
+      "name": "wpackagist-plugin/block-bad-queries",
+      "version": 20190220,
+      "source": {
+        "type": "svn",
+        "url": "https://plugins.svn.wordpress.org/block-bad-queries/",
+        "reference": "tags/20190220"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://downloads.wordpress.org/plugin/block-bad-queries.20190220.zip"
+      },
+      "require": {
+        "composer/installers": "^1.0 || ^2.0"
+      },
+      "type": "wordpress-plugin",
+      "homepage": "https://wordpress.org/plugins/block-bad-queries/"
+    }
+  ],
+  "packages-dev": [],
+  "aliases": [],
+  "minimum-stability": "stable",
+  "stability-flags": [],
+  "prefer-stable": false,
+  "prefer-lowest": false,
+  "platform": [],
+  "platform-dev": [],
+  "plugin-api-version": "2.6.0"
+}

--- a/pkg/lockfile/parse-composer-lock_test.go
+++ b/pkg/lockfile/parse-composer-lock_test.go
@@ -209,3 +209,12 @@ func TestParseComposerLock_NumberForVersion(t *testing.T) {
 		},
 	})
 }
+
+func TestParseComposerLock_ObjectForVersion(t *testing.T) {
+	t.Parallel()
+
+	packages, err := lockfile.ParseComposerLock("fixtures/composer/with-bad-version.json")
+
+	expectErrContaining(t, err, "unexpected type for version")
+	expectPackages(t, packages, []lockfile.PackageDetails{})
+}

--- a/pkg/lockfile/parse-composer-lock_test.go
+++ b/pkg/lockfile/parse-composer-lock_test.go
@@ -183,3 +183,29 @@ func TestParseComposerLock_TwoPackagesAlt(t *testing.T) {
 		},
 	})
 }
+
+func TestParseComposerLock_NumberForVersion(t *testing.T) {
+	t.Parallel()
+
+	packages, err := lockfile.ParseComposerLock("fixtures/composer/with-number-version.json")
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	expectPackages(t, packages, []lockfile.PackageDetails{
+		{
+			Name:      "composer/installers",
+			Version:   "v2.3.0",
+			Commit:    "12fb2dfe5e16183de69e784a7b84046c43d97e8e",
+			Ecosystem: lockfile.ComposerEcosystem,
+			CompareAs: lockfile.ComposerEcosystem,
+		},
+		{
+			Name:      "wpackagist-plugin/block-bad-queries",
+			Version:   "20190220",
+			Ecosystem: lockfile.ComposerEcosystem,
+			CompareAs: lockfile.ComposerEcosystem,
+		},
+	})
+}


### PR DESCRIPTION
It seems it's technically possible for `composer.lock` files to have a number for `version` in packages - I can't actually reproduce this with `composer` itself, but if I manually edit a lockfile to have a number instead of a string it doesn't complain or change the value.

It would be good to understand more about how this could happen in the wild, but it's easy enough to support either way.

Resolves #1138