### PR TITLE
Add Maven dependency management to override client

### DIFF
--- a/internal/manifest/fixtures/maven/transitive.xml
+++ b/internal/manifest/fixtures/maven/transitive.xml
@@ -3,6 +3,16 @@
   <artifactId>my-app</artifactId>
   <version>1.0</version>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.transitive</groupId>
+        <artifactId>frank</artifactId>
+        <version>4.4.4</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.direct</groupId>
@@ -13,6 +23,11 @@
       <groupId>org.direct</groupId>
       <artifactId>bob</artifactId>
       <version>2.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.direct</groupId>
+      <artifactId>chris</artifactId>
+      <version>3.0.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/internal/manifest/fixtures/universe/basic-universe.yaml
+++ b/internal/manifest/fixtures/universe/basic-universe.yaml
@@ -24,6 +24,9 @@ schema: |
   org.direct:bob
     2.0.0
       org.transitive:eve@3.3.3
+  org.direct:chris
+    3.0.0
+      org.transitive:frank@3.3.3
   org.eve:eve
     5.0.0
   org.frank:frank
@@ -52,3 +55,6 @@ schema: |
     1.1.1
     2.2.2
     3.3.3
+  org.transitive:frank
+    3.3.3
+    4.4.4

--- a/internal/manifest/maven_test.go
+++ b/internal/manifest/maven_test.go
@@ -327,6 +327,12 @@ func TestParseMavenWithResolver_Transitive(t *testing.T) {
 			CompareAs: lockfile.MavenEcosystem,
 		},
 		{
+			Name:      "org.direct:chris",
+			Version:   "3.0.0",
+			Ecosystem: lockfile.MavenEcosystem,
+			CompareAs: lockfile.MavenEcosystem,
+		},
+		{
 			Name:      "org.transitive:chuck",
 			Version:   "1.1.1",
 			Ecosystem: lockfile.MavenEcosystem,
@@ -341,6 +347,12 @@ func TestParseMavenWithResolver_Transitive(t *testing.T) {
 		{
 			Name:      "org.transitive:eve",
 			Version:   "3.3.3",
+			Ecosystem: lockfile.MavenEcosystem,
+			CompareAs: lockfile.MavenEcosystem,
+		},
+		{
+			Name:      "org.transitive:frank",
+			Version:   "4.4.4",
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
 		},


### PR DESCRIPTION
Currently, Maven dependency management is not added to the override client so they are not considered when computing Maven dependency graph. 

This PR adds all direct dependency management to override client so that transitive dependencies are resolved correctly.