### PR TITLE
Increase frequency of staleness runs

### DIFF
--- a/.github/workflows/staleness.yml
+++ b/.github/workflows/staleness.yml
@@ -1,7 +1,7 @@
 name: "Close stale issues and PRs"
 on:
   schedule:
-    - cron: "0 18 * * *"
+    - cron: "0 * * * *"
 
 jobs:
   stale:
@@ -11,6 +11,7 @@ jobs:
         with:
           days-before-stale: 60
           days-before-close: 14
+          operations-per-run: 100
           stale-issue-label: stale
           stale-pr-label: stale
           remove-stale-when-updated: true


### PR DESCRIPTION
Run hourly and increase operations per run

This will allow a single pass through all the existing issues to complete, and react to removing the stale label with less latency

https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#primary-rate-limit-for-github_token-in-github-actions