### PR TITLE
fix: only trim XML elements with no inner elements

### DIFF
--- a/internal/manifest/maven.go
+++ b/internal/manifest/maven.go
@@ -169,11 +169,7 @@ func MergeMavenParents(ctx context.Context, mavenClient datasource.MavenRegistry
 			if err := xml.NewDecoder(f).Decode(&proj); err != nil {
 				return fmt.Errorf("failed to unmarshal project: %w", err)
 			}
-			if proj.GroupID == "" {
-				// A project may inherit groupId from parent
-				proj.GroupID = proj.Parent.GroupID
-			}
-			if proj.ProjectKey == current.ProjectKey && proj.Packaging == "pom" {
+			if mavenProjectKey(proj) == current.ProjectKey && proj.Packaging == "pom" {
 				// Only mark parent is found when the identifiers and packaging are exptected.
 				parentFound = true
 			}
@@ -192,11 +188,7 @@ func MergeMavenParents(ctx context.Context, mavenClient datasource.MavenRegistry
 				// A parent project should only be of "pom" packaging type.
 				return fmt.Errorf("invalid packaging for parent project %s", proj.Packaging)
 			}
-			if proj.GroupID == "" {
-				// A project may inherit groupId from parent
-				proj.GroupID = proj.Parent.GroupID
-			}
-			if proj.ProjectKey != current.ProjectKey {
+			if mavenProjectKey(proj) != current.ProjectKey {
 				// The identifiers in parent does not match what we want.
 				return fmt.Errorf("parent identifiers mismatch: %v, expect %v", proj.ProjectKey, current.ProjectKey)
 			}
@@ -210,6 +202,19 @@ func MergeMavenParents(ctx context.Context, mavenClient datasource.MavenRegistry
 	}
 	// Interpolate the project to resolve the properties.
 	return result.Interpolate()
+}
+
+// mavenProjectKey returns a project key with empty groupId/version
+// filled by corresponding fields in parent.
+func mavenProjectKey(proj maven.Project) maven.ProjectKey {
+	if proj.GroupID == "" {
+		proj.GroupID = proj.Parent.GroupID
+	}
+	if proj.Version == "" {
+		proj.Version = proj.Parent.Version
+	}
+
+	return proj.ProjectKey
 }
 
 // Maven looks for the parent POM first in 'relativePath',

--- a/internal/manifest/maven.go
+++ b/internal/manifest/maven.go
@@ -171,7 +171,7 @@ func MergeMavenParents(ctx context.Context, mavenClient datasource.MavenRegistry
 			}
 			if proj.GroupID == "" {
 				// A project may inherit groupId from parent
-				proj.GroupID = current.GroupID
+				proj.GroupID = proj.Parent.GroupID
 			}
 			if proj.ProjectKey == current.ProjectKey && proj.Packaging == "pom" {
 				// Only mark parent is found when the identifiers and packaging are exptected.
@@ -194,7 +194,7 @@ func MergeMavenParents(ctx context.Context, mavenClient datasource.MavenRegistry
 			}
 			if proj.GroupID == "" {
 				// A project may inherit groupId from parent
-				proj.GroupID = current.GroupID
+				proj.GroupID = proj.Parent.GroupID
 			}
 			if proj.ProjectKey != current.ProjectKey {
 				// The identifiers in parent does not match what we want.

--- a/internal/manifest/maven.go
+++ b/internal/manifest/maven.go
@@ -169,7 +169,7 @@ func MergeMavenParents(ctx context.Context, mavenClient datasource.MavenRegistry
 			if err := xml.NewDecoder(f).Decode(&proj); err != nil {
 				return fmt.Errorf("failed to unmarshal project: %w", err)
 			}
-			if proj.ProjectKey == current.ProjectKey && proj.Packaging == "pom" {
+			if proj.ArtifactID == current.ArtifactID && proj.Version == current.Version && proj.Packaging == "pom" {
 				// Only mark parent is found when the identifiers and packaging are exptected.
 				parentFound = true
 			}

--- a/internal/manifest/maven.go
+++ b/internal/manifest/maven.go
@@ -169,7 +169,11 @@ func MergeMavenParents(ctx context.Context, mavenClient datasource.MavenRegistry
 			if err := xml.NewDecoder(f).Decode(&proj); err != nil {
 				return fmt.Errorf("failed to unmarshal project: %w", err)
 			}
-			if proj.ArtifactID == current.ArtifactID && proj.Version == current.Version && proj.Packaging == "pom" {
+			if proj.GroupID == "" {
+				// A project may inherit groupId from parent
+				proj.GroupID = current.GroupID
+			}
+			if proj.ProjectKey == current.ProjectKey && proj.Packaging == "pom" {
 				// Only mark parent is found when the identifiers and packaging are exptected.
 				parentFound = true
 			}
@@ -187,6 +191,10 @@ func MergeMavenParents(ctx context.Context, mavenClient datasource.MavenRegistry
 			if n > 0 && proj.Packaging != "pom" {
 				// A parent project should only be of "pom" packaging type.
 				return fmt.Errorf("invalid packaging for parent project %s", proj.Packaging)
+			}
+			if proj.GroupID == "" {
+				// A project may inherit groupId from parent
+				proj.GroupID = current.GroupID
 			}
 			if proj.ProjectKey != current.ProjectKey {
 				// The identifiers in parent does not match what we want.

--- a/internal/resolution/manifest/__snapshots__/maven_test.snap
+++ b/internal/resolution/manifest/__snapshots__/maven_test.snap
@@ -45,6 +45,17 @@
       <groupId>org.example</groupId>
       <artifactId>no-version</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.example</groupId>
+      <artifactId>exclusions</artifactId>
+      <version>1.0.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.exclude</groupId>
+          <artifactId>exclude</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <dependencyManagement>

--- a/internal/resolution/manifest/fixtures/maven/my-app/pom.xml
+++ b/internal/resolution/manifest/fixtures/maven/my-app/pom.xml
@@ -45,6 +45,17 @@
       <groupId>org.example</groupId>
       <artifactId>no-version</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.example</groupId>
+      <artifactId>exclusions</artifactId>
+      <version>1.0.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.exclude</groupId>
+          <artifactId>exclude</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <dependencyManagement>

--- a/internal/resolution/manifest/maven.go
+++ b/internal/resolution/manifest/maven.go
@@ -828,7 +828,7 @@ func writeDependency(w io.Writer, enc *xml.Encoder, raw string, patches map[Mave
 }
 
 // writeString writes XML string specified by raw with replacements pecified in values.
-// skipTags specifies the tags we skip for writting (usually higer level tags).
+// skipTags specifies the tags we skip for writing (usually higher level tags).
 // White space is trimmed during writing to prevent the text being escaped.
 // TODO: investigate if we can rely on the nesting level to decide trimming or not.
 func writeString(enc *xml.Encoder, raw string, skipTags []string, values map[string]string) error {

--- a/internal/resolution/manifest/maven_test.go
+++ b/internal/resolution/manifest/maven_test.go
@@ -128,6 +128,9 @@ func TestMavenRead(t *testing.T) {
 
 	depParent.AddAttr(dep.MavenArtifactType, "pom")
 
+	var depExclusions dep.Type
+	depExclusions.AddAttr(dep.MavenExclusions, "org.exclude:exclude")
+
 	want := Manifest{
 		Root: resolve.Version{
 			VersionKey: resolve.VersionKey{
@@ -170,6 +173,17 @@ func TestMavenRead(t *testing.T) {
 					VersionType: resolve.Requirement,
 					Version:     "2.0.0",
 				},
+			},
+			{
+				VersionKey: resolve.VersionKey{
+					PackageKey: resolve.PackageKey{
+						System: resolve.Maven,
+						Name:   "org.example:exclusions",
+					},
+					VersionType: resolve.Requirement,
+					Version:     "1.0.0",
+				},
+				Type: depExclusions,
 			},
 			{
 				VersionKey: resolve.VersionKey{
@@ -273,6 +287,12 @@ func TestMavenRead(t *testing.T) {
 				},
 				{
 					Dependency: maven.Dependency{GroupID: "org.example", ArtifactID: "no-version"},
+				},
+				{
+					Dependency: maven.Dependency{GroupID: "org.example", ArtifactID: "exclusions", Version: "1.0.0",
+						Exclusions: []maven.Exclusion{
+							{GroupID: "org.exclude", ArtifactID: "exclude"},
+						}},
 				},
 				{
 					Dependency: maven.Dependency{GroupID: "org.example", ArtifactID: "xyz", Version: "2.0.0"},


### PR DESCRIPTION
This PR fixes two issues when reading/writing Maven manifest:
 - when merging parents, if `groupId` or `version` is empty, inherit these values from the parent;
 - only trim elements with no inner elements, otherwise inner elements will be wiped.