### PR TITLE
fix(workflow): correct permission name

### DIFF
--- a/.github/workflows/staleness.yml
+++ b/.github/workflows/staleness.yml
@@ -1,6 +1,6 @@
 name: "Close stale issues and PRs"
 
-permissions: all-read
+permissions: read-all
 
 on:
   schedule:


### PR DESCRIPTION
Is there a way to catch errors like this, pre-merge?