### PR TITLE
ci(workflow): address address github.com/rhysd/actionlint findings

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -20,8 +20,6 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [main]
-  merge_group:
-    branches: [main]
 
 concurrency:
   # Pushing new changes to a branch will cancel any in-progress CI runs

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,8 +17,6 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [main]
-  merge_group:
-    branches: [main]
 
 # Restrict jobs in this workflow to have no permissions by default; permissions
 # should be granted per job as needed using a dedicated `permissions` block

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -25,7 +25,6 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           fetch-depth: 0
-          ref: ${{ inputs.commit }}
       - name: Set up Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:

--- a/.github/workflows/osv-scanner-unified-action.yml
+++ b/.github/workflows/osv-scanner-unified-action.yml
@@ -17,8 +17,6 @@ name: OSV-Scanner Scheduled Scan
 on:
   pull_request:
     branches: ["main"]
-  merge_group:
-    branches: ["main"]
   schedule:
     - cron: "12 12 * * 1"
   push:


### PR DESCRIPTION
- `branches` is invalid for `on.merge-group`
- `inputs.commit` was not being defined (and `refs` defaults to using the relevant tag, based on https://github.com/google/osv-scanner/actions/runs/10278144006/job/28441323524#step:2:106)