### PR TITLE
chore: add PR title check to follow Git commit convention

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -70,15 +70,6 @@ jobs:
           check-latest: true
       - name: Run lint action
         uses: ./.github/workflows/lint-action
-  pr_title_validate:
-    permissions:
-      pull-requests: read # to access PR title
-    name: Validate PR title
-    runs-on: ubuntu-latest
-    steps:
-      - uses: amannn/action-semantic-pull-request@v5
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   prepare_test_image_fixtures:
     permissions:
       contents: read # to fetch code (actions/checkout)

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -70,6 +70,15 @@ jobs:
           check-latest: true
       - name: Run lint action
         uses: ./.github/workflows/lint-action
+  pr_title_validate:
+    permissions:
+      pull-requests: read # to access PR title
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   prepare_test_image_fixtures:
     permissions:
       contents: read # to fetch code (actions/checkout)

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,0 +1,34 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: OSV PR format check
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+
+permissions:
+  pull-requests: read
+
+jobs:
+  title-check:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -15,6 +15,7 @@
 name: OSV PR format check
 
 on:
+  # `pull_request_target` is only required when editing PRs from forks.
   pull_request:
     types:
       - opened


### PR DESCRIPTION
Enforces PR naming to follow with the Git [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- Uses https://github.com/amannn/action-semantic-pull-request to check
- Fails to comply will result in the PR title check failing:
![image](https://github.com/user-attachments/assets/2c9da64b-b1a4-4347-9bd0-2ba5183498ec)
