### PR TITLE
fix(guided remediation): error on `--data-source=native` for Maven

### DIFF
--- a/internal/resolution/lockfile/lockfile.go
+++ b/internal/resolution/lockfile/lockfile.go
@@ -18,6 +18,8 @@ type DependencyPatch struct {
 }
 
 type LockfileIO interface {
+	// System returns which ecosystem this LockfileIO is for.
+	System() resolve.System
 	// Read parses a lockfile into a resolved graph
 	Read(file lockfile.DepFile) (*resolve.Graph, error)
 	// Write applies the DependencyPatches to the lockfile, with minimal changes to the file.

--- a/internal/resolution/lockfile/npm.go
+++ b/internal/resolution/lockfile/npm.go
@@ -17,6 +17,8 @@ import (
 
 type NpmLockfileIO struct{}
 
+func (NpmLockfileIO) System() resolve.System { return resolve.NPM }
+
 type npmNodeModule struct {
 	NodeID       resolve.NodeID
 	Parent       *npmNodeModule

--- a/internal/resolution/manifest/manifest.go
+++ b/internal/resolution/manifest/manifest.go
@@ -60,6 +60,8 @@ type ManifestPatch struct {
 }
 
 type ManifestIO interface {
+	// System returns which ecosystem this ManifestIO is for.
+	System() resolve.System
 	// Read parses a manifest file into a Manifest, possibly recursively following references to other local manifest files
 	Read(file lockfile.DepFile) (Manifest, error)
 	// Write applies the ManifestPatch to the manifest, with minimal changes to the file.

--- a/internal/resolution/manifest/maven.go
+++ b/internal/resolution/manifest/maven.go
@@ -37,6 +37,8 @@ type MavenManifestIO struct {
 	datasource.MavenRegistryAPIClient
 }
 
+func (MavenManifestIO) System() resolve.System { return resolve.Maven }
+
 func NewMavenManifestIO() MavenManifestIO {
 	return MavenManifestIO{
 		MavenRegistryAPIClient: *datasource.NewMavenRegistryAPIClient(datasource.MavenCentral),

--- a/internal/resolution/manifest/npm.go
+++ b/internal/resolution/manifest/npm.go
@@ -28,6 +28,8 @@ func npmRequirementKey(requirement resolve.RequirementVersion) RequirementKey {
 
 type NpmManifestIO struct{}
 
+func (NpmManifestIO) System() resolve.System { return resolve.NPM }
+
 type PackageJSON struct {
 	Name    string `json:"name"`
 	Version string `json:"version"`


### PR DESCRIPTION
Add a check for the ecosystem & error for unimplemented native registry clients.