### PR TITLE
feat: write Maven updates to parent pom.xml if possible

### DIFF
--- a/internal/manifest/maven.go
+++ b/internal/manifest/maven.go
@@ -169,7 +169,7 @@ func MergeMavenParents(ctx context.Context, mavenClient datasource.MavenRegistry
 			if err := xml.NewDecoder(f).Decode(&proj); err != nil {
 				return fmt.Errorf("failed to unmarshal project: %w", err)
 			}
-			if mavenProjectKey(proj) == current.ProjectKey && proj.Packaging == "pom" {
+			if MavenProjectKey(proj) == current.ProjectKey && proj.Packaging == "pom" {
 				// Only mark parent is found when the identifiers and packaging are exptected.
 				parentFound = true
 			}
@@ -188,7 +188,7 @@ func MergeMavenParents(ctx context.Context, mavenClient datasource.MavenRegistry
 				// A parent project should only be of "pom" packaging type.
 				return fmt.Errorf("invalid packaging for parent project %s", proj.Packaging)
 			}
-			if mavenProjectKey(proj) != current.ProjectKey {
+			if MavenProjectKey(proj) != current.ProjectKey {
 				// The identifiers in parent does not match what we want.
 				return fmt.Errorf("parent identifiers mismatch: %v, expect %v", proj.ProjectKey, current.ProjectKey)
 			}
@@ -204,9 +204,9 @@ func MergeMavenParents(ctx context.Context, mavenClient datasource.MavenRegistry
 	return result.Interpolate()
 }
 
-// mavenProjectKey returns a project key with empty groupId/version
+// MavenProjectKey returns a project key with empty groupId/version
 // filled by corresponding fields in parent.
-func mavenProjectKey(proj maven.Project) maven.ProjectKey {
+func MavenProjectKey(proj maven.Project) maven.ProjectKey {
 	if proj.GroupID == "" {
 		proj.GroupID = proj.Parent.GroupID
 	}

--- a/internal/resolution/manifest/fixtures/maven/parent/pom.xml
+++ b/internal/resolution/manifest/fixtures/maven/parent/pom.xml
@@ -25,6 +25,14 @@
     <aaa.version>1.1.1</aaa.version>
   </properties>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.example</groupId>
+      <artifactId>ddd</artifactId>
+      <version>1.2.3</version>
+    </dependency>
+  </dependencies>
+
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/internal/resolution/manifest/maven_test.go
+++ b/internal/resolution/manifest/maven_test.go
@@ -195,6 +195,16 @@ func TestMavenRead(t *testing.T) {
 				VersionKey: resolve.VersionKey{
 					PackageKey: resolve.PackageKey{
 						System: resolve.Maven,
+						Name:   "org.example:ddd",
+					},
+					VersionType: resolve.Requirement,
+					Version:     "1.2.3",
+				},
+			},
+			{
+				VersionKey: resolve.VersionKey{
+					PackageKey: resolve.PackageKey{
+						System: resolve.Maven,
 						Name:   "org.example:xyz",
 					},
 					VersionType: resolve.Requirement,
@@ -252,6 +262,14 @@ func TestMavenRead(t *testing.T) {
 			mavenReqKey(t, "org.import:xyz", "pom", ""): {"import"},
 		},
 		EcosystemSpecific: MavenManifestSpecific{
+			Parent: maven.Parent{
+				ProjectKey: maven.ProjectKey{
+					GroupID:    "org.parent",
+					ArtifactID: "parent-pom",
+					Version:    "1.1.1",
+				},
+				RelativePath: "../parent/pom.xml",
+			},
 			Properties: []PropertyWithOrigin{
 				{Property: maven.Property{Name: "project.build.sourceEncoding", Value: "UTF-8"}},
 				{Property: maven.Property{Name: "maven.compiler.source", Value: "1.7"}},
@@ -393,93 +411,95 @@ func TestMavenWrite(t *testing.T) {
 		t.Fatalf("failed to read from DepFile: %v", err)
 	}
 
-	depPatches := MavenDependencyPatches{
-		"": map[MavenPatch]bool{
-			{
-				DependencyKey: maven.DependencyKey{
-					GroupID:    "org.example",
-					ArtifactID: "abc",
-					Type:       "jar",
-				},
-				NewRequire: "1.0.2",
-			}: true,
-			{
-				DependencyKey: maven.DependencyKey{
-					GroupID:    "org.example",
-					ArtifactID: "no-version",
-					Type:       "jar",
-				},
-				NewRequire: "2.0.1",
-			}: true,
+	patches := MavenPatches{
+		DependencyPatches: MavenDependencyPatches{
+			"": map[MavenPatch]bool{
+				{
+					DependencyKey: maven.DependencyKey{
+						GroupID:    "org.example",
+						ArtifactID: "abc",
+						Type:       "jar",
+					},
+					NewRequire: "1.0.2",
+				}: true,
+				{
+					DependencyKey: maven.DependencyKey{
+						GroupID:    "org.example",
+						ArtifactID: "no-version",
+						Type:       "jar",
+					},
+					NewRequire: "2.0.1",
+				}: true,
+			},
+			"management": map[MavenPatch]bool{
+				{
+					DependencyKey: maven.DependencyKey{
+						GroupID:    "org.example",
+						ArtifactID: "xyz",
+						Type:       "jar",
+					},
+					NewRequire: "2.0.1",
+				}: true,
+				{
+					DependencyKey: maven.DependencyKey{
+						GroupID:    "org.example",
+						ArtifactID: "extra-one",
+						Type:       "jar",
+					},
+					NewRequire: "6.6.6",
+				}: false,
+				{
+					DependencyKey: maven.DependencyKey{
+						GroupID:    "org.example",
+						ArtifactID: "extra-two",
+						Type:       "jar",
+					},
+					NewRequire: "9.9.9",
+				}: false,
+			},
+			"profile@profile-one": map[MavenPatch]bool{
+				{
+					DependencyKey: maven.DependencyKey{
+						GroupID:    "org.profile",
+						ArtifactID: "abc",
+						Type:       "jar",
+					},
+					NewRequire: "1.2.4",
+				}: true,
+			},
+			"profile@profile-two@management": map[MavenPatch]bool{
+				{
+					DependencyKey: maven.DependencyKey{
+						GroupID:    "org.import",
+						ArtifactID: "xyz",
+						Type:       "pom",
+					},
+					NewRequire: "7.0.0",
+				}: true,
+			},
+			"plugin@org.plugin:plugin": map[MavenPatch]bool{
+				{
+					DependencyKey: maven.DependencyKey{
+						GroupID:    "org.dep",
+						ArtifactID: "plugin-dep",
+						Type:       "jar",
+					},
+					NewRequire: "2.3.4",
+				}: true,
+			},
 		},
-		"management": map[MavenPatch]bool{
-			{
-				DependencyKey: maven.DependencyKey{
-					GroupID:    "org.example",
-					ArtifactID: "xyz",
-					Type:       "jar",
-				},
-				NewRequire: "2.0.1",
-			}: true,
-			{
-				DependencyKey: maven.DependencyKey{
-					GroupID:    "org.example",
-					ArtifactID: "extra-one",
-					Type:       "jar",
-				},
-				NewRequire: "6.6.6",
-			}: false,
-			{
-				DependencyKey: maven.DependencyKey{
-					GroupID:    "org.example",
-					ArtifactID: "extra-two",
-					Type:       "jar",
-				},
-				NewRequire: "9.9.9",
-			}: false,
-		},
-		"profile@profile-one": map[MavenPatch]bool{
-			{
-				DependencyKey: maven.DependencyKey{
-					GroupID:    "org.profile",
-					ArtifactID: "abc",
-					Type:       "jar",
-				},
-				NewRequire: "1.2.4",
-			}: true,
-		},
-		"profile@profile-two@management": map[MavenPatch]bool{
-			{
-				DependencyKey: maven.DependencyKey{
-					GroupID:    "org.import",
-					ArtifactID: "xyz",
-					Type:       "pom",
-				},
-				NewRequire: "7.0.0",
-			}: true,
-		},
-		"plugin@org.plugin:plugin": map[MavenPatch]bool{
-			{
-				DependencyKey: maven.DependencyKey{
-					GroupID:    "org.dep",
-					ArtifactID: "plugin-dep",
-					Type:       "jar",
-				},
-				NewRequire: "2.3.4",
-			}: true,
-		},
-	}
-	propertyPatches := MavenPropertyPatches{
-		"": {
-			"junit.version": "4.13.2",
-		},
-		"profile@profile-one": {
-			"def.version": "2.3.5",
+		PropertyPatches: MavenPropertyPatches{
+			"": {
+				"junit.version": "4.13.2",
+			},
+			"profile@profile-one": {
+				"def.version": "2.3.5",
+			},
 		},
 	}
 
 	out := new(bytes.Buffer)
-	if err := write(buf, out, depPatches, propertyPatches); err != nil {
+	if err := write(buf, out, patches); err != nil {
 		t.Fatalf("unable to update Maven pom.xml: %v", err)
 	}
 	testutility.NewSnapshot().WithCRLFReplacement().MatchText(t, out.String())
@@ -503,49 +523,51 @@ func TestMavenWriteDM(t *testing.T) {
 		t.Fatalf("failed to read from DepFile: %v", err)
 	}
 
-	depPatches := MavenDependencyPatches{
-		"": map[MavenPatch]bool{
-			{
-				DependencyKey: maven.DependencyKey{
-					GroupID:    "junit",
-					ArtifactID: "junit",
-					Type:       "jar",
-				},
-				NewRequire: "4.13.2",
-			}: true,
-		},
-		"parent": map[MavenPatch]bool{
-			{
-				DependencyKey: maven.DependencyKey{
-					GroupID:    "org.parent",
-					ArtifactID: "parent-pom",
-					Type:       "jar",
-				},
-				NewRequire: "1.2.0",
-			}: true,
-		},
-		"management": map[MavenPatch]bool{
-			{
-				DependencyKey: maven.DependencyKey{
-					GroupID:    "org.management",
-					ArtifactID: "abc",
-					Type:       "jar",
-				},
-				NewRequire: "1.2.3",
-			}: false,
-			{
-				DependencyKey: maven.DependencyKey{
-					GroupID:    "org.management",
-					ArtifactID: "xyz",
-					Type:       "jar",
-				},
-				NewRequire: "2.3.4",
-			}: false,
+	patches := MavenPatches{
+		DependencyPatches: MavenDependencyPatches{
+			"": map[MavenPatch]bool{
+				{
+					DependencyKey: maven.DependencyKey{
+						GroupID:    "junit",
+						ArtifactID: "junit",
+						Type:       "jar",
+					},
+					NewRequire: "4.13.2",
+				}: true,
+			},
+			"parent": map[MavenPatch]bool{
+				{
+					DependencyKey: maven.DependencyKey{
+						GroupID:    "org.parent",
+						ArtifactID: "parent-pom",
+						Type:       "jar",
+					},
+					NewRequire: "1.2.0",
+				}: true,
+			},
+			"management": map[MavenPatch]bool{
+				{
+					DependencyKey: maven.DependencyKey{
+						GroupID:    "org.management",
+						ArtifactID: "abc",
+						Type:       "jar",
+					},
+					NewRequire: "1.2.3",
+				}: false,
+				{
+					DependencyKey: maven.DependencyKey{
+						GroupID:    "org.management",
+						ArtifactID: "xyz",
+						Type:       "jar",
+					},
+					NewRequire: "2.3.4",
+				}: false,
+			},
 		},
 	}
 
 	out := new(bytes.Buffer)
-	if err := write(buf, out, depPatches, MavenPropertyPatches{}); err != nil {
+	if err := write(buf, out, patches); err != nil {
 		t.Fatalf("unable to update Maven pom.xml: %v", err)
 	}
 	testutility.NewSnapshot().WithCRLFReplacement().MatchText(t, out.String())
@@ -553,6 +575,12 @@ func TestMavenWriteDM(t *testing.T) {
 
 func TestBuildPatches(t *testing.T) {
 	t.Parallel()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get current directory: %v", err)
+	}
+	parentPath := filepath.Join(dir, "fixtures", "maven", "parent", "pom.xml")
 
 	depProfileTwoMgmt.AddAttr(dep.MavenArtifactType, "pom")
 	depProfileTwoMgmt.AddAttr(dep.Scope, "import")
@@ -574,6 +602,20 @@ func TestBuildPatches(t *testing.T) {
 				Name:   "org.example:abc",
 			},
 			NewRequire: "1.0.2",
+		},
+		{
+			Pkg: resolve.PackageKey{
+				System: resolve.Maven,
+				Name:   "org.example:aaa",
+			},
+			NewRequire: "1.2.0",
+		},
+		{
+			Pkg: resolve.PackageKey{
+				System: resolve.Maven,
+				Name:   "org.example:ddd",
+			},
+			NewRequire: "1.3.0",
 		},
 		{
 			Pkg: resolve.PackageKey{
@@ -670,10 +712,19 @@ func TestBuildPatches(t *testing.T) {
 		},
 	}
 	specific := MavenManifestSpecific{
+		Parent: maven.Parent{
+			ProjectKey: maven.ProjectKey{
+				GroupID:    "org.parent",
+				ArtifactID: "parent-pom",
+				Version:    "1.1.1",
+			},
+			RelativePath: "../parent/pom.xml",
+		},
 		Properties: []PropertyWithOrigin{
 			{Property: maven.Property{Name: "property.version", Value: "1.0.0"}},
 			{Property: maven.Property{Name: "no.update.minor", Value: "9"}},
 			{Property: maven.Property{Name: "def.version", Value: "2.3.4"}, Origin: "profile@profile-one"},
+			{Property: maven.Property{Name: "aaa.version", Value: "1.1.1"}, Origin: "parent@" + parentPath},
 		},
 		OriginalRequirements: []DependencyWithOrigin{
 			{
@@ -728,120 +779,148 @@ func TestBuildPatches(t *testing.T) {
 				Dependency: maven.Dependency{GroupID: "org.dep", ArtifactID: "plugin-dep", Version: "2.3.3"},
 				Origin:     "plugin@org.plugin:plugin",
 			},
+			{
+				Dependency: maven.Dependency{GroupID: "org.example", ArtifactID: "ddd", Version: "1.2.3"},
+				Origin:     "parent@" + parentPath,
+			},
+			{
+				Dependency: maven.Dependency{GroupID: "org.example", ArtifactID: "aaa", Version: "${aaa.version}"},
+				Origin:     "parent@" + parentPath + "@management",
+			},
 		},
 	}
-	wantDepPatches := MavenDependencyPatches{
-		"": map[MavenPatch]bool{
-			{
-				DependencyKey: maven.DependencyKey{
-					GroupID:    "org.example",
-					ArtifactID: "abc",
-					Type:       "jar",
-				},
-				NewRequire: "1.0.2",
-			}: true,
-			{
-				DependencyKey: maven.DependencyKey{
-					GroupID:    "org.example",
-					ArtifactID: "another-property",
-					Type:       "jar",
-				},
-				NewRequire: "1.1.0",
-			}: true,
-			{
-				DependencyKey: maven.DependencyKey{
-					GroupID:    "org.example",
-					ArtifactID: "property-no-update",
-					Type:       "jar",
-				},
-				NewRequire: "2.0.0",
-			}: true,
-		},
-		"management": map[MavenPatch]bool{
-			{
-				DependencyKey: maven.DependencyKey{
-					GroupID:    "org.example",
-					ArtifactID: "xyz",
-					Type:       "jar",
-				},
-				NewRequire: "2.0.1",
-			}: true,
-			{
-				DependencyKey: maven.DependencyKey{
-					GroupID:    "org.example",
-					ArtifactID: "no-version",
-					Type:       "jar",
-				},
-				NewRequire: "2.0.1",
-			}: true,
-			{
-				DependencyKey: maven.DependencyKey{
-					GroupID:    "org.example",
-					ArtifactID: "override",
-					Type:       "jar",
-				},
-				NewRequire: "2.0.0",
-			}: false,
-		},
-		"profile@profile-one": map[MavenPatch]bool{
-			{
-				DependencyKey: maven.DependencyKey{
-					GroupID:    "org.profile",
-					ArtifactID: "abc",
-					Type:       "jar",
-				},
-				NewRequire: "1.2.4",
-			}: true,
-		},
-		"profile@profile-two@management": map[MavenPatch]bool{
-			{
-				DependencyKey: maven.DependencyKey{
-					GroupID:    "org.import",
-					ArtifactID: "xyz",
-					Type:       "pom",
-				},
-				NewRequire: "6.7.0",
-			}: true,
-		},
-		"plugin@org.plugin:plugin": map[MavenPatch]bool{
-			{
-				DependencyKey: maven.DependencyKey{
-					GroupID:    "org.dep",
-					ArtifactID: "plugin-dep",
-					Type:       "jar",
-				},
-				NewRequire: "2.3.4",
-			}: true,
-		},
-		"parent": map[MavenPatch]bool{
-			{
-				DependencyKey: maven.DependencyKey{
-					GroupID:    "org.parent",
-					ArtifactID: "parent-pom",
-					Type:       "pom",
-				},
-				NewRequire: "1.2.0",
-			}: true,
-		},
-	}
-	wantPropertyPatches := MavenPropertyPatches{
+	want := map[string]MavenPatches{
 		"": {
-			"property.version": "1.0.1",
+			DependencyPatches: MavenDependencyPatches{
+				"": map[MavenPatch]bool{
+					{
+						DependencyKey: maven.DependencyKey{
+							GroupID:    "org.example",
+							ArtifactID: "abc",
+							Type:       "jar",
+						},
+						NewRequire: "1.0.2",
+					}: true,
+					{
+						DependencyKey: maven.DependencyKey{
+							GroupID:    "org.example",
+							ArtifactID: "another-property",
+							Type:       "jar",
+						},
+						NewRequire: "1.1.0",
+					}: true,
+					{
+						DependencyKey: maven.DependencyKey{
+							GroupID:    "org.example",
+							ArtifactID: "property-no-update",
+							Type:       "jar",
+						},
+						NewRequire: "2.0.0",
+					}: true,
+				},
+				"management": map[MavenPatch]bool{
+					{
+						DependencyKey: maven.DependencyKey{
+							GroupID:    "org.example",
+							ArtifactID: "xyz",
+							Type:       "jar",
+						},
+						NewRequire: "2.0.1",
+					}: true,
+					{
+						DependencyKey: maven.DependencyKey{
+							GroupID:    "org.example",
+							ArtifactID: "no-version",
+							Type:       "jar",
+						},
+						NewRequire: "2.0.1",
+					}: true,
+					{
+						DependencyKey: maven.DependencyKey{
+							GroupID:    "org.example",
+							ArtifactID: "override",
+							Type:       "jar",
+						},
+						NewRequire: "2.0.0",
+					}: false,
+				},
+				"profile@profile-one": map[MavenPatch]bool{
+					{
+						DependencyKey: maven.DependencyKey{
+							GroupID:    "org.profile",
+							ArtifactID: "abc",
+							Type:       "jar",
+						},
+						NewRequire: "1.2.4",
+					}: true,
+				},
+				"profile@profile-two@management": map[MavenPatch]bool{
+					{
+						DependencyKey: maven.DependencyKey{
+							GroupID:    "org.import",
+							ArtifactID: "xyz",
+							Type:       "pom",
+						},
+						NewRequire: "6.7.0",
+					}: true,
+				},
+				"plugin@org.plugin:plugin": map[MavenPatch]bool{
+					{
+						DependencyKey: maven.DependencyKey{
+							GroupID:    "org.dep",
+							ArtifactID: "plugin-dep",
+							Type:       "jar",
+						},
+						NewRequire: "2.3.4",
+					}: true,
+				},
+				"parent": map[MavenPatch]bool{
+					{
+						DependencyKey: maven.DependencyKey{
+							GroupID:    "org.parent",
+							ArtifactID: "parent-pom",
+							Type:       "pom",
+						},
+						NewRequire: "1.2.0",
+					}: true,
+				},
+			},
+			PropertyPatches: MavenPropertyPatches{
+				"": {
+					"property.version": "1.0.1",
+				},
+				"profile@profile-one": {
+					"def.version": "2.3.5",
+				},
+			},
 		},
-		"profile@profile-one": {
-			"def.version": "2.3.5",
+		parentPath: {
+			DependencyPatches: MavenDependencyPatches{
+				"": map[MavenPatch]bool{
+					{
+						DependencyKey: maven.DependencyKey{
+							GroupID:    "org.example",
+							ArtifactID: "ddd",
+							Type:       "jar",
+						},
+						NewRequire: "1.3.0",
+					}: true,
+				},
+			},
+			PropertyPatches: MavenPropertyPatches{
+				"": {
+					"aaa.version": "1.2.0",
+				},
+			},
 		},
 	}
 
-	depPatches, propertyPatches, err := buildPatches(patches, specific)
+	allPatches, err := buildPatches(patches, specific)
 	if err != nil {
 		t.Fatalf("failed to build patches: %v", err)
 	}
-	if diff := cmp.Diff(depPatches, wantDepPatches); diff != "" {
-		t.Errorf("depednecy patches mismatch: %s", diff)
-	}
-	if diff := cmp.Diff(propertyPatches, wantPropertyPatches); diff != "" {
-		t.Errorf("property patches mismatch: %s", diff)
+	if diff := cmp.Diff(allPatches, want); diff != "" {
+		t.Errorf("result patches mismatch: %s", diff)
 	}
 }
 


### PR DESCRIPTION
https://github.com/google/osv-scanner/issues/1169

Currently, Maven updater only supports writing updates in base pom.xml, but we would like to write updates to local parent pom.xml to minimize diffs.

This PR supports writing updates to parent pom.xml:
 - when building patches, local parent pom.xml files are walked through to collect original dependencies and properties (this step may be done when we merge parents in reading manifest). Paths to parent manifests are recorded in the origin so we don't need to walk through the parents again.
 - when writing the patches, if any patch is found for specific parent path, the manifest will be overwritten with the new patches.

TODO: we should investigate how to test the updated local parent pom.xml which is not in this PR.