### PR TITLE
chore: use the latest version of `golangci-lint`

### DIFF
--- a/.github/workflows/lint-action/action.yml
+++ b/.github/workflows/lint-action/action.yml
@@ -22,4 +22,4 @@ runs:
       uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6.1.0
       with:
         # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-        version: v1.59.1
+        version: v1.60.1

--- a/cmd/osv-scanner/fix/noninteractive.go
+++ b/cmd/osv-scanner/fix/noninteractive.go
@@ -121,7 +121,7 @@ func autoRelock(ctx context.Context, r reporter.Reporter, opts osvFixOptions, ma
 
 	if errs := res.Errors(); len(errs) > 0 {
 		r.Warnf("WARNING: encountered %d errors during dependency resolution:\n", len(errs))
-		r.Warnf(resolutionErrorString(res, errs))
+		r.Warnf("%s", resolutionErrorString(res, errs))
 	}
 
 	res.FilterVulns(opts.MatchVuln)
@@ -272,7 +272,7 @@ func autoOverride(ctx context.Context, r reporter.Reporter, opts osvFixOptions, 
 
 	if errs := res.Errors(); len(errs) > 0 {
 		r.Warnf("WARNING: encountered %d errors during dependency resolution:\n", len(errs))
-		r.Warnf(resolutionErrorString(res, errs))
+		r.Warnf("%s", resolutionErrorString(res, errs))
 	}
 
 	res.FilterVulns(opts.MatchVuln)

--- a/internal/image/extractor.go
+++ b/internal/image/extractor.go
@@ -55,7 +55,7 @@ func extractArtifactDeps(path string, layer *imgLayer) (lockfile.Lockfile, error
 		f.Close()
 
 		if err != nil {
-			if errors.Is(lockfile.ErrIncompatibleFileFormat, err) {
+			if errors.Is(err, lockfile.ErrIncompatibleFileFormat) {
 				continue
 			}
 

--- a/internal/image/scan.go
+++ b/internal/image/scan.go
@@ -99,7 +99,7 @@ func traceOrigin(img *Image, scannedLockfiles *ScanResults) {
 
 			// Look at the layer before the current layer
 			oldFileNode, err := img.layers[layerIdx-1].getFileNode(file.FilePath)
-			if errors.Is(fs.ErrNotExist, err) || (err == nil && oldFileNode.isWhiteout) {
+			if errors.Is(err, fs.ErrNotExist) || (err == nil && oldFileNode.isWhiteout) {
 				// Did not exist in the layer before
 
 				// All entries in sourceLayerIdx would have been set in the previous loop, or just above the loop

--- a/internal/output/vertical.go
+++ b/internal/output/vertical.go
@@ -152,7 +152,7 @@ func printVerticalLicenseViolations(result models.PackageSource, out io.Writer) 
 		fmt.Fprintf(out,
 			"    %s (%s)\n",
 			text.FgYellow.Sprintf("%s@%s", pkg.Package.Name, pkg.Package.Version),
-			text.FgCyan.Sprintf(strings.Join(violations, ", ")),
+			text.FgCyan.Sprintf("%s", strings.Join(violations, ", ")),
 		)
 	}
 

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -523,7 +523,7 @@ func scanSBOMFile(r reporter.Reporter, path string, fromFSScan bool) ([]scannedP
 	if !fromFSScan {
 		r.Infof("Failed to parse SBOM using all supported formats:\n")
 		for _, err := range errs {
-			r.Infof(err.Error() + "\n")
+			r.Infof("%s\n", err.Error())
 		}
 	}
 

--- a/pkg/reporter/cyclonedx_test.go
+++ b/pkg/reporter/cyclonedx_test.go
@@ -24,7 +24,7 @@ func TestCycloneDXReporter_Errorf(t *testing.T) {
 		writer := &bytes.Buffer{}
 		r := reporter.NewCycloneDXReporter(io.Discard, writer, test.version, reporter.ErrorLevel)
 
-		r.Errorf(text)
+		r.Errorf("%s", text)
 
 		if writer.String() != text {
 			t.Error("Error level message should have been printed")
@@ -54,7 +54,7 @@ func TestCycloneDXReporter_Warnf(t *testing.T) {
 		writer := &bytes.Buffer{}
 		r := reporter.NewCycloneDXReporter(io.Discard, writer, test.version, test.lvl)
 
-		r.Warnf(text)
+		r.Warnf("%s", text)
 
 		if writer.String() != test.expectedPrintout {
 			t.Errorf("expected \"%s\", got \"%s\"", test.expectedPrintout, writer.String())
@@ -81,7 +81,7 @@ func TestCycloneDXReporter_Infof(t *testing.T) {
 		writer := &bytes.Buffer{}
 		r := reporter.NewCycloneDXReporter(io.Discard, writer, test.version, test.lvl)
 
-		r.Infof(text)
+		r.Infof("%s", text)
 
 		if writer.String() != test.expectedPrintout {
 			t.Errorf("expected \"%s\", got \"%s\"", test.expectedPrintout, writer.String())
@@ -123,7 +123,7 @@ func TestCycloneDXReporter_Verbosef(t *testing.T) {
 		writer := &bytes.Buffer{}
 		r := reporter.NewCycloneDXReporter(io.Discard, writer, test.version, test.lvl)
 
-		r.Verbosef(text)
+		r.Verbosef("%s", text)
 
 		if writer.String() != test.expectedPrintout {
 			t.Errorf("expected \"%s\", got \"%s\"", test.expectedPrintout, writer.String())

--- a/pkg/reporter/gh-annotations_reporter_test.go
+++ b/pkg/reporter/gh-annotations_reporter_test.go
@@ -15,7 +15,7 @@ func TestGHAnnotationsReporter_Errorf(t *testing.T) {
 	r := reporter.NewGHAnnotationsReporter(io.Discard, writer, reporter.ErrorLevel)
 	text := "hello world!"
 
-	r.Errorf(text)
+	r.Errorf("%s", text)
 
 	if writer.String() != text {
 		t.Error("Error level message should have been printed")
@@ -41,7 +41,7 @@ func TestGHAnnotationsReporter_Warnf(t *testing.T) {
 		writer := &bytes.Buffer{}
 		r := reporter.NewGHAnnotationsReporter(io.Discard, writer, test.lvl)
 
-		r.Warnf(text)
+		r.Warnf("%s", text)
 
 		if writer.String() != test.expectedPrintout {
 			t.Errorf("expected \"%s\", got \"%s\"", test.expectedPrintout, writer.String())
@@ -65,7 +65,7 @@ func TestGHAnnotationsReporter_Infof(t *testing.T) {
 		writer := &bytes.Buffer{}
 		r := reporter.NewGHAnnotationsReporter(io.Discard, writer, test.lvl)
 
-		r.Infof(text)
+		r.Infof("%s", text)
 
 		if writer.String() != test.expectedPrintout {
 			t.Errorf("expected \"%s\", got \"%s\"", test.expectedPrintout, writer.String())
@@ -89,7 +89,7 @@ func TestGHAnnotationsReporter_Verbosef(t *testing.T) {
 		writer := &bytes.Buffer{}
 		r := reporter.NewGHAnnotationsReporter(io.Discard, writer, test.lvl)
 
-		r.Verbosef(text)
+		r.Verbosef("%s", text)
 
 		if writer.String() != test.expectedPrintout {
 			t.Errorf("expected \"%s\", got \"%s\"", test.expectedPrintout, writer.String())

--- a/pkg/reporter/json_reporter_test.go
+++ b/pkg/reporter/json_reporter_test.go
@@ -15,7 +15,7 @@ func TestJSONReporter_Errorf(t *testing.T) {
 	r := reporter.NewJSONReporter(io.Discard, writer, reporter.ErrorLevel)
 	text := "hello world!"
 
-	r.Errorf(text)
+	r.Errorf("%s", text)
 
 	if writer.String() != text {
 		t.Error("Error level message should have been printed")
@@ -41,7 +41,7 @@ func TestJSONReporter_Warnf(t *testing.T) {
 		writer := &bytes.Buffer{}
 		r := reporter.NewJSONReporter(io.Discard, writer, test.lvl)
 
-		r.Warnf(text)
+		r.Warnf("%s", text)
 
 		if writer.String() != test.expectedPrintout {
 			t.Errorf("expected \"%s\", got \"%s\"", test.expectedPrintout, writer.String())
@@ -65,7 +65,7 @@ func TestJSONReporter_Infof(t *testing.T) {
 		writer := &bytes.Buffer{}
 		r := reporter.NewJSONReporter(io.Discard, writer, test.lvl)
 
-		r.Infof(text)
+		r.Infof("%s", text)
 
 		if writer.String() != test.expectedPrintout {
 			t.Errorf("expected \"%s\", got \"%s\"", test.expectedPrintout, writer.String())
@@ -89,7 +89,7 @@ func TestJSONReporter_Verbosef(t *testing.T) {
 		writer := &bytes.Buffer{}
 		r := reporter.NewJSONReporter(io.Discard, writer, test.lvl)
 
-		r.Verbosef(text)
+		r.Verbosef("%s", text)
 
 		if writer.String() != test.expectedPrintout {
 			t.Errorf("expected \"%s\", got \"%s\"", test.expectedPrintout, writer.String())

--- a/pkg/reporter/sarif_reporter_test.go
+++ b/pkg/reporter/sarif_reporter_test.go
@@ -15,7 +15,7 @@ func TestSarifReporter_Errorf(t *testing.T) {
 	r := reporter.NewSarifReporter(io.Discard, writer, reporter.ErrorLevel)
 	text := "hello world!"
 
-	r.Errorf(text)
+	r.Errorf("%s", text)
 
 	if writer.String() != text {
 		t.Error("Error level message should have been printed")
@@ -41,7 +41,7 @@ func TestSarifReporter_Warnf(t *testing.T) {
 		writer := &bytes.Buffer{}
 		r := reporter.NewSarifReporter(io.Discard, writer, test.lvl)
 
-		r.Warnf(text)
+		r.Warnf("%s", text)
 
 		if writer.String() != test.expectedPrintout {
 			t.Errorf("expected \"%s\", got \"%s\"", test.expectedPrintout, writer.String())
@@ -65,7 +65,7 @@ func TestSarifReporter_Infof(t *testing.T) {
 		writer := &bytes.Buffer{}
 		r := reporter.NewSarifReporter(io.Discard, writer, test.lvl)
 
-		r.Infof(text)
+		r.Infof("%s", text)
 
 		if writer.String() != test.expectedPrintout {
 			t.Errorf("expected \"%s\", got \"%s\"", test.expectedPrintout, writer.String())
@@ -89,7 +89,7 @@ func TestSarifReporter_Verbosef(t *testing.T) {
 		writer := &bytes.Buffer{}
 		r := reporter.NewSarifReporter(io.Discard, writer, test.lvl)
 
-		r.Verbosef(text)
+		r.Verbosef("%s", text)
 
 		if writer.String() != test.expectedPrintout {
 			t.Errorf("expected \"%s\", got \"%s\"", test.expectedPrintout, writer.String())

--- a/pkg/reporter/table_reporter_test.go
+++ b/pkg/reporter/table_reporter_test.go
@@ -15,7 +15,7 @@ func TestTableReporter_Errorf(t *testing.T) {
 	r := reporter.NewTableReporter(io.Discard, writer, reporter.ErrorLevel, false, 0)
 	text := "hello world!"
 
-	r.Errorf(text)
+	r.Errorf("%s", text)
 
 	if writer.String() != text {
 		t.Error("Error level message should have been printed")
@@ -41,7 +41,7 @@ func TestTableReporter_Warnf(t *testing.T) {
 		writer := &bytes.Buffer{}
 		r := reporter.NewTableReporter(writer, io.Discard, test.lvl, false, 0)
 
-		r.Warnf(text)
+		r.Warnf("%s", text)
 
 		if writer.String() != test.expectedPrintout {
 			t.Errorf("expected \"%s\", got \"%s\"", test.expectedPrintout, writer.String())
@@ -65,7 +65,7 @@ func TestTableReporter_Infof(t *testing.T) {
 		writer := &bytes.Buffer{}
 		r := reporter.NewTableReporter(writer, io.Discard, test.lvl, false, 0)
 
-		r.Infof(text)
+		r.Infof("%s", text)
 
 		if writer.String() != test.expectedPrintout {
 			t.Errorf("expected \"%s\", got \"%s\"", test.expectedPrintout, writer.String())
@@ -89,7 +89,7 @@ func TestTableReporter_Verbosef(t *testing.T) {
 		writer := &bytes.Buffer{}
 		r := reporter.NewTableReporter(writer, io.Discard, test.lvl, false, 0)
 
-		r.Verbosef(text)
+		r.Verbosef("%s", text)
 
 		if writer.String() != test.expectedPrintout {
 			t.Errorf("expected \"%s\", got \"%s\"", test.expectedPrintout, writer.String())

--- a/pkg/reporter/vertical_reporter_test.go
+++ b/pkg/reporter/vertical_reporter_test.go
@@ -15,7 +15,7 @@ func TestVerticalReporter_Errorf(t *testing.T) {
 	r := reporter.NewVerticalReporter(io.Discard, writer, reporter.ErrorLevel, false, 0)
 	text := "hello world!"
 
-	r.Errorf(text)
+	r.Errorf("%s", text)
 
 	if writer.String() != text {
 		t.Error("Error level message should have been printed")
@@ -41,7 +41,7 @@ func TestVerticalReporter_Warnf(t *testing.T) {
 		writer := &bytes.Buffer{}
 		r := reporter.NewVerticalReporter(writer, io.Discard, test.lvl, false, 0)
 
-		r.Warnf(text)
+		r.Warnf("%s", text)
 
 		if writer.String() != test.expectedPrintout {
 			t.Errorf("expected \"%s\", got \"%s\"", test.expectedPrintout, writer.String())
@@ -65,7 +65,7 @@ func TestVerticalReporter_Infof(t *testing.T) {
 		writer := &bytes.Buffer{}
 		r := reporter.NewVerticalReporter(writer, io.Discard, test.lvl, false, 0)
 
-		r.Infof(text)
+		r.Infof("%s", text)
 
 		if writer.String() != test.expectedPrintout {
 			t.Errorf("expected \"%s\", got \"%s\"", test.expectedPrintout, writer.String())
@@ -89,7 +89,7 @@ func TestVerticalReporter_Verbosef(t *testing.T) {
 		writer := &bytes.Buffer{}
 		r := reporter.NewVerticalReporter(writer, io.Discard, test.lvl, false, 0)
 
-		r.Verbosef(text)
+		r.Verbosef("%s", text)
 
 		if writer.String() != test.expectedPrintout {
 			t.Errorf("expected \"%s\", got \"%s\"", test.expectedPrintout, writer.String())

--- a/scripts/run_lints.sh
+++ b/scripts/run_lints.sh
@@ -2,4 +2,4 @@
 
 set -ex
 
-go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1 run ./... --max-same-issues 0
+go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.1 run ./... --max-same-issues 0


### PR DESCRIPTION
`golangci-lint` just released [v1.60.1](https://github.com/golangci/golangci-lint/releases/tag/v1.60.1) recently.

This PR updates the version of `golangci-lint` to its latest version. This should unblock the `golangci-lint` failures.