### PR TITLE
fix: unescape tabs before writing to pom.xml

### DIFF
--- a/internal/resolution/manifest/__snapshots__/maven_test.snap
+++ b/internal/resolution/manifest/__snapshots__/maven_test.snap
@@ -1,4 +1,148 @@
 
+[TestMavenReadWrite - 1]
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.mycompany.app</groupId>
+  <artifactId>my-app</artifactId>
+  <version>1.0</version>
+
+  <name>my-app</name>
+  <!-- FIXME change it to the project's website -->
+  <url>http://www.example.com</url>
+
+  <parent>
+    <groupId>org.parent</groupId>
+    <artifactId>parent-pom</artifactId>
+    <version>1.1.1</version>
+    <relativePath>../parent/pom.xml</relativePath>
+  </parent>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
+    <junit.version>4.12</junit.version>
+      <zeppelin.daemon.package.base>
+        ../bin
+      </zeppelin.daemon.package.base>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.example</groupId>
+      <artifactId>abc</artifactId>
+      <version>1.0.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.example</groupId>
+      <artifactId>no-version</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.example</groupId>
+      <artifactId>exclusions</artifactId>
+      <version>1.0.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.exclude</groupId>
+          <artifactId>exclude</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.example</groupId>
+        <artifactId>xyz</artifactId>
+        <version>2.0.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.example</groupId>
+        <artifactId>no-version</artifactId>
+        <version>2.0.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.import</groupId>
+        <artifactId>import</artifactId>
+        <version>1.0.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <profiles>
+    <profile>
+      <id>profile-one</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <def.version>2.3.4</def.version>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>org.profile</groupId>
+          <artifactId>abc</artifactId>
+          <version>1.2.3</version>
+        </dependency>
+        <dependency>
+          <groupId>org.profile</groupId>
+          <artifactId>def</artifactId>
+          <version>${def.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>profile-two</id>
+      <dependencyManagement>
+        <dependencies>
+          <dependency>
+            <groupId>org.import</groupId>
+            <artifactId>xyz</artifactId>
+            <version>6.6.6</version>
+            <scope>import</scope>
+            <type>pom</type>
+          </dependency>
+        </dependencies>
+      </dependencyManagement>
+    </profile>
+  </profiles>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.plugin</groupId>
+          <artifactId>plugin</artifactId>
+          <version>1.0.0</version>
+          <dependencies>
+            <dependency>
+              <groupId>org.dep</groupId>
+              <artifactId>plugin-dep</artifactId>
+              <version>2.3.3</version>
+            </dependency>
+          </dependencies>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+</project>
+
+---
+
 [TestMavenWrite - 1]
 <?xml version="1.0" encoding="UTF-8"?>
 
@@ -26,7 +170,9 @@
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>
     <junit.version>4.13.2</junit.version>
-    <zeppelin.daemon.package.base>../bin</zeppelin.daemon.package.base>
+&#x9;  <zeppelin.daemon.package.base>
+&#x9;    ../bin
+&#x9;  </zeppelin.daemon.package.base>
   </properties>
 
   <dependencies>

--- a/internal/resolution/manifest/fixtures/maven/my-app/pom.xml
+++ b/internal/resolution/manifest/fixtures/maven/my-app/pom.xml
@@ -24,9 +24,9 @@
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>
     <junit.version>4.12</junit.version>
-    <zeppelin.daemon.package.base>
+	  <zeppelin.daemon.package.base>
 	    ../bin
-    </zeppelin.daemon.package.base>
+	  </zeppelin.daemon.package.base>
   </properties>
 
   <dependencies>

--- a/internal/resolution/manifest/maven.go
+++ b/internal/resolution/manifest/maven.go
@@ -631,6 +631,7 @@ func compareDependency(d1, d2 dependency) int {
 
 
 func write(raw string, w io.Writer, depPatches MavenDependencyPatches, propertyPatches MavenPropertyPatches) error {
+	// Replace all tabs with two white space so that they are escaped during encoding.
 	dec := xml.NewDecoder(bytes.NewReader([]byte(strings.ReplaceAll(raw, "\t", "  "))))
 	enc := xml.NewEncoder(w)
 

--- a/internal/resolution/manifest/maven.go
+++ b/internal/resolution/manifest/maven.go
@@ -347,7 +347,7 @@ func (MavenManifestIO) Write(df lockfile.DepFile, w io.Writer, patch ManifestPat
 		depFile.Close() // Make sure the file is closed before we start writing to it.
 
 		var out bytes.Buffer
-		if err := write(in, &out, patches); err != nil {
+		if err := write(in.String(), &out, patches); err != nil {
 			return err
 		}
 		//nolint:gosec
@@ -361,7 +361,7 @@ func (MavenManifestIO) Write(df lockfile.DepFile, w io.Writer, patch ManifestPat
 		return fmt.Errorf("failed to read from DepFile: %w", err)
 	}
 
-  return write(buf.String(), w, allPatches[""])
+	return write(buf.String(), w, allPatches[""])
 }
 
 type MavenPatches struct {
@@ -629,8 +629,7 @@ func compareDependency(d1, d2 dependency) int {
 	return cmp.Compare(d1.Version, d2.Version)
 }
 
-
-func write(raw string, w io.Writer, depPatches MavenDependencyPatches, propertyPatches MavenPropertyPatches) error {
+func write(raw string, w io.Writer, patches MavenPatches) error {
 	// Replace all tabs with two white space so that they are escaped during encoding.
 	dec := xml.NewDecoder(bytes.NewReader([]byte(strings.ReplaceAll(raw, "\t", "  "))))
 	enc := xml.NewEncoder(w)

--- a/internal/resolution/manifest/maven.go
+++ b/internal/resolution/manifest/maven.go
@@ -370,6 +370,7 @@ func (MavenManifestIO) Write(df lockfile.DepFile, w io.Writer, patch ManifestPat
 	return err
 }
 
+// Unescape replaces escaped tabs and newlines with unescaped characters.
 func unescape(out string) []byte {
 	out = strings.ReplaceAll(out, "&#x9;", "\t")
 	out = strings.ReplaceAll(out, "&#xA;", "\n")

--- a/internal/resolution/manifest/maven.go
+++ b/internal/resolution/manifest/maven.go
@@ -370,10 +370,9 @@ func (MavenManifestIO) Write(df lockfile.DepFile, w io.Writer, patch ManifestPat
 	return err
 }
 
-// Unescape replaces escaped tabs and newlines with unescaped characters.
+// Unescape replaces escaped tabs with unescaped characters.
 func unescape(out string) []byte {
 	out = strings.ReplaceAll(out, "&#x9;", "\t")
-	out = strings.ReplaceAll(out, "&#xA;", "\n")
 
 	return []byte(out)
 }

--- a/internal/resolution/manifest/maven.go
+++ b/internal/resolution/manifest/maven.go
@@ -294,7 +294,7 @@ func (MavenManifestIO) Write(df lockfile.DepFile, w io.Writer, patch ManifestPat
 		return fmt.Errorf("failed to read from DepFile: %w", err)
 	}
 
-	return write(buf, w, depPatches, propertyPatches)
+	return write(buf.String(), w, depPatches, propertyPatches)
 }
 
 type MavenPatch struct {
@@ -536,8 +536,8 @@ func compareDependency(d1, d2 dependency) int {
 	return cmp.Compare(d1.Version, d2.Version)
 }
 
-func write(buf *bytes.Buffer, w io.Writer, depPatches MavenDependencyPatches, propertyPatches MavenPropertyPatches) error {
-	dec := xml.NewDecoder(bytes.NewReader(buf.Bytes()))
+func write(raw string, w io.Writer, depPatches MavenDependencyPatches, propertyPatches MavenPropertyPatches) error {
+	dec := xml.NewDecoder(bytes.NewReader([]byte(strings.ReplaceAll(raw, "\t", "  "))))
 	enc := xml.NewEncoder(w)
 
 	for {
@@ -564,7 +564,7 @@ func write(buf *bytes.Buffer, w io.Writer, depPatches MavenDependencyPatches, pr
 				// Thus this would cause a big diff when we try to encode the start element of project.
 
 				// We first capture the raw start element string and write it.
-				projectStart := projectStartElement(buf.String())
+				projectStart := projectStartElement(raw)
 				if projectStart == "" {
 					return errors.New("unable to get start element of project")
 				}

--- a/internal/resolution/manifest/maven_test.go
+++ b/internal/resolution/manifest/maven_test.go
@@ -519,7 +519,7 @@ func TestMavenWrite(t *testing.T) {
 	}
 
 	out := new(bytes.Buffer)
-  if err := write(buf.String(), out, patches); err != nil {
+	if err := write(buf.String(), out, patches); err != nil {
 		t.Fatalf("unable to update Maven pom.xml: %v", err)
 	}
 	testutility.NewSnapshot().WithCRLFReplacement().MatchText(t, out.String())
@@ -587,7 +587,7 @@ func TestMavenWriteDM(t *testing.T) {
 	}
 
 	out := new(bytes.Buffer)
-  if err := write(buf.String(), out, patches); err != nil {
+	if err := write(buf.String(), out, patches); err != nil {
 		t.Fatalf("unable to update Maven pom.xml: %v", err)
 	}
 	testutility.NewSnapshot().WithCRLFReplacement().MatchText(t, out.String())

--- a/internal/resolution/manifest/maven_test.go
+++ b/internal/resolution/manifest/maven_test.go
@@ -499,7 +499,7 @@ func TestMavenWrite(t *testing.T) {
 	}
 
 	out := new(bytes.Buffer)
-	if err := write(buf, out, depPatches, propertyPatches); err != nil {
+	if err := write(buf.String(), out, depPatches, propertyPatches); err != nil {
 		t.Fatalf("unable to update Maven pom.xml: %v", err)
 	}
 	testutility.NewSnapshot().WithCRLFReplacement().MatchText(t, out.String())
@@ -565,7 +565,7 @@ func TestMavenWriteDM(t *testing.T) {
 	}
 
 	out := new(bytes.Buffer)
-	if err := write(buf, out, depPatches, MavenPropertyPatches{}); err != nil {
+	if err := write(buf.String(), out, depPatches, MavenPropertyPatches{}); err != nil {
 		t.Fatalf("unable to update Maven pom.xml: %v", err)
 	}
 	testutility.NewSnapshot().WithCRLFReplacement().MatchText(t, out.String())

--- a/internal/resolution/manifest/maven_test.go
+++ b/internal/resolution/manifest/maven_test.go
@@ -420,6 +420,7 @@ func TestMavenReadWrite(t *testing.T) {
 	defer df.Close()
 
 	out := new(bytes.Buffer)
+	// There are no patches since we are only testing tabs are not escaped.
 	if err := mavenIO.Write(df, out, ManifestPatch{Manifest: &want}); err != nil {
 		t.Fatalf("failed to write Maven pom.xml: %v", err)
 	}


### PR DESCRIPTION
https://github.com/google/osv-scanner/issues/1184

When encoding tokens to pom.xml, tabs are escaped and this is not what we want.
In this PR, before writing to pom.xml, we replace all escaped tabs with unescaped characters. 