### PR TITLE
feat(guided remediation): add `--upgrade-config` flag

### DIFF
--- a/cmd/osv-scanner/fix/main_test.go
+++ b/cmd/osv-scanner/fix/main_test.go
@@ -1,0 +1,138 @@
+package fix
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/google/osv-scanner/internal/remediation/upgrade"
+	"github.com/google/osv-scanner/pkg/reporter"
+	"github.com/urfave/cli/v2"
+)
+
+func parseFlags(t *testing.T, flags []string, arguments []string) (*cli.Context, error) {
+	// This is a bit hacky: make a mock App with only the flags we care about.
+	// Then use app.Run() to parse the flags into the cli.Context, which is returned.
+	t.Helper()
+	appFlags := make([]cli.Flag, 0, len(flags))
+	for _, f := range Command(nil, nil, nil).Flags {
+		if slices.ContainsFunc(f.Names(), func(s string) bool { return slices.Contains(flags, s) }) {
+			appFlags = append(appFlags, f)
+		}
+	}
+	var parsedContext *cli.Context
+	app := cli.App{
+		Flags: appFlags,
+		Action: func(ctx *cli.Context) error {
+			t.Helper()
+			parsedContext = ctx
+
+			return nil
+		},
+	}
+	err := app.Run(append([]string{""}, arguments...))
+
+	return parsedContext, err
+}
+
+func TestParseUpgradeConfig(t *testing.T) {
+	t.Parallel()
+	flags := []string{"upgrade-config", "disallow-major-upgrades", "disallow-package-upgrades"}
+
+	tests := []struct {
+		name string
+		args []string
+		want map[string]upgrade.Level
+	}{
+		{
+			name: "default behaviour",
+			args: []string{},
+			want: map[string]upgrade.Level{
+				"foo": upgrade.Major,
+				"bar": upgrade.Major,
+			},
+		},
+		{
+			name: "general level config",
+			args: []string{"--upgrade-config=minor"},
+			want: map[string]upgrade.Level{
+				"foo": upgrade.Minor,
+				"bar": upgrade.Minor,
+			},
+		},
+		{
+			name: "all levels",
+			args: []string{
+				"--upgrade-config", "major:major",
+				"--upgrade-config", "minor:minor",
+				"--upgrade-config", "patch:patch",
+				"--upgrade-config", "none:none",
+			},
+			want: map[string]upgrade.Level{
+				"major": upgrade.Major,
+				"minor": upgrade.Minor,
+				"patch": upgrade.Patch,
+				"none":  upgrade.None,
+				"other": upgrade.Major,
+			},
+		},
+		{
+			name: "package takes precedence over general",
+			args: []string{
+				"--upgrade-config", "pkg1:minor",
+				"--upgrade-config", "none",
+				"--upgrade-config", "pkg2:major",
+			},
+			want: map[string]upgrade.Level{
+				"pkg1": upgrade.Minor,
+				"pkg2": upgrade.Major,
+				"pkg3": upgrade.None,
+			},
+		},
+		{
+			name: "package names with colons",
+			args: []string{
+				"--upgrade-config=none:patch:minor:major",
+				"--upgrade-config=none:patch:minor",
+				"--upgrade-config=none:patch",
+				"--upgrade-config=none",
+			},
+			want: map[string]upgrade.Level{
+				"none:patch:minor": upgrade.Major,
+				"none:patch":       upgrade.Minor,
+				"none":             upgrade.Patch,
+				"other":            upgrade.None,
+			},
+		},
+		{
+			name: "deprecated flag",
+			args: []string{
+				"--disallow-major-upgrades",
+				"--disallow-package-upgrades=pkg1,pkg2",
+				"--upgrade-config=pkg3:patch",
+			},
+			want: map[string]upgrade.Level{
+				"pkg1": upgrade.None,
+				"pkg2": upgrade.None,
+				"pkg3": upgrade.Patch,
+				"pkg4": upgrade.Minor,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx, err := parseFlags(t, flags, tt.args)
+			if err != nil {
+				t.Fatalf("error parsing flags: %v", err)
+			}
+			config := parseUpgradeConfig(ctx, &reporter.VoidReporter{})
+			for pkg, want := range tt.want {
+				if got := config.Get(pkg); got != want {
+					t.Errorf("Config.Get(%s) got = %v, want %v", pkg, got, want)
+				}
+			}
+		})
+	}
+}

--- a/docs/guided-remediation.md
+++ b/docs/guided-remediation.md
@@ -235,7 +235,9 @@ The following flag may be used to limit the patches allowed for your dependencie
   - `patch` allows for updates `>=1.2.3, <1.3.0`
   - `none` disallows any updates
 
-  If `package-name:` is omitted, `level` is applied to all packages. Default is `--upgrade-config=major`.
+  If `package-name:` is omitted, `level` is applied to all packages. The specific `package-name:level` will take precedence over the general `level` (e.g. specifying both `minor` `pkg:none` will use `none` as the allowed level for `pkg`).
+
+  Default behaviour is `--upgrade-config=major`.
 
   Example usage:
 

--- a/docs/guided-remediation.md
+++ b/docs/guided-remediation.md
@@ -227,16 +227,18 @@ A vulnerability is only considered if it satisfies all the conditions set by the
 The following flag may be used to limit the patches allowed for your dependencies:
 
 - `--upgrade-config=<[package-name:]level>` Sets the maximum upgrade level allowed for a package. Can be repeated for multiple packages.
-  
-  `level` is the SemVer component to allow updates to, can be one of `major`, `minor`, `patch`, or `none`. e.g. If a package was at version `1.2.3` 
+
+  `level` is the SemVer component to allow updates to, can be one of `major`, `minor`, `patch`, or `none`. e.g. If a package was at version `1.2.3`
+
   - `major` allows for updates to any version `>=1.2.3`
   - `minor` allows for updates `>=1.2.3, <2.0.0`
   - `patch` allows for updates `>=1.2.3, <1.3.0`
   - `none` disallows any updates
-  
+
   If `package-name:` is omitted, `level` is applied to all packages. Default is `--upgrade-config=major`.
 
   Example usage:
+
   - `--upgrade-config=minor` - disallow any patches that would bump a major version of any package.
   - `--upgrade-config=foo:minor` - disallow any patches that bumps package `foo` by a major version. Other packages may receive major version-updating patches.
   - `--upgrade-config=none --upgrade-config=foo:patch` - only allow patches to package `foo`, and only allow changes to `foo`'s SemVer patch level.

--- a/docs/guided-remediation.md
+++ b/docs/guided-remediation.md
@@ -224,10 +224,22 @@ A vulnerability is only considered if it satisfies all the conditions set by the
 
 ### Dependency upgrade options
 
-The following flags may be used to limit the patches allowed for your dependencies:
+The following flag may be used to limit the patches allowed for your dependencies:
 
-- `--disallow-major-upgrades`: Do no allow patches that would result in the major version number of any dependency from being changed.
-- `--disallow-package-upgrades=<comma-separated list of package names>`: Do no allow patches to any of the listed packages.
+- `--upgrade-config=<[package-name:]level>` Sets the maximum upgrade level allowed for a package. Can be repeated for multiple packages.
+  
+  `level` is the SemVer component to allow updates to, can be one of `major`, `minor`, `patch`, or `none`. e.g. If a package was at version `1.2.3` 
+  - `major` allows for updates to any version `>=1.2.3`
+  - `minor` allows for updates `>=1.2.3, <2.0.0`
+  - `patch` allows for updates `>=1.2.3, <1.3.0`
+  - `none` disallows any updates
+  
+  If `package-name:` is omitted, `level` is applied to all packages. Default is `--upgrade-config=major`.
+
+  Example usage:
+  - `--upgrade-config=minor` - disallow any patches that would bump a major version of any package.
+  - `--upgrade-config=foo:minor` - disallow any patches that bumps package `foo` by a major version. Other packages may receive major version-updating patches.
+  - `--upgrade-config=none --upgrade-config=foo:patch` - only allow patches to package `foo`, and only allow changes to `foo`'s SemVer patch level.
 
 ### Data source
 

--- a/internal/remediation/in_place_test.go
+++ b/internal/remediation/in_place_test.go
@@ -8,6 +8,7 @@ import (
 
 	"deps.dev/util/resolve"
 	"github.com/google/osv-scanner/internal/remediation"
+	"github.com/google/osv-scanner/internal/remediation/upgrade"
 	"github.com/google/osv-scanner/internal/resolution"
 	"github.com/google/osv-scanner/internal/resolution/client"
 	"github.com/google/osv-scanner/internal/resolution/clienttest"
@@ -111,9 +112,9 @@ func TestComputeInPlacePatches(t *testing.T) {
 	t.Parallel()
 
 	basicOpts := remediation.RemediationOptions{
-		DevDeps:    true,
-		MaxDepth:   -1,
-		AllowMajor: true,
+		DevDeps:       true,
+		MaxDepth:      -1,
+		UpgradeConfig: upgrade.NewConfig(),
 	}
 
 	tests := []struct {

--- a/internal/remediation/override_test.go
+++ b/internal/remediation/override_test.go
@@ -5,15 +5,16 @@ import (
 	"testing"
 
 	"github.com/google/osv-scanner/internal/remediation"
+	"github.com/google/osv-scanner/internal/remediation/upgrade"
 )
 
 func TestComputeOverridePatches(t *testing.T) {
 	t.Parallel()
 
 	basicOpts := remediation.RemediationOptions{
-		DevDeps:    true,
-		MaxDepth:   -1,
-		AllowMajor: true,
+		DevDeps:       true,
+		MaxDepth:      -1,
+		UpgradeConfig: upgrade.NewConfig(),
 	}
 
 	tests := []struct {

--- a/internal/remediation/relax.go
+++ b/internal/remediation/relax.go
@@ -7,6 +7,7 @@ import (
 
 	"deps.dev/util/resolve"
 	"github.com/google/osv-scanner/internal/remediation/relax"
+	"github.com/google/osv-scanner/internal/remediation/upgrade"
 	"github.com/google/osv-scanner/internal/resolution"
 	"github.com/google/osv-scanner/internal/resolution/client"
 )
@@ -93,10 +94,10 @@ func tryRelaxRemediate(
 		for _, idx := range toRelax {
 			rv := manif.Requirements[idx]
 			// If we'd need to relax a package we want to avoid changing, we cannot fix the vuln
-			if slices.Contains(opts.AvoidPkgs, rv.Name) {
+			if opts.UpgradeConfig.Get(rv.Name) == upgrade.None {
 				return nil, errRelaxRemediateImpossible
 			}
-			newVer, ok := relaxer.Relax(ctx, cl, rv, opts.AllowMajor)
+			newVer, ok := relaxer.Relax(ctx, cl, rv, opts.UpgradeConfig)
 			if !ok {
 				return nil, errRelaxRemediateImpossible
 			}

--- a/internal/remediation/relax/npm.go
+++ b/internal/remediation/relax/npm.go
@@ -6,11 +6,17 @@ import (
 
 	"deps.dev/util/resolve"
 	"deps.dev/util/semver"
+	"github.com/google/osv-scanner/internal/remediation/upgrade"
 )
 
 type NpmRelaxer struct{}
 
-func (r NpmRelaxer) Relax(ctx context.Context, cl resolve.Client, req resolve.RequirementVersion, allowMajor bool) (resolve.RequirementVersion, bool) {
+func (r NpmRelaxer) Relax(ctx context.Context, cl resolve.Client, req resolve.RequirementVersion, config upgrade.Config) (resolve.RequirementVersion, bool) {
+	configLevel := config.Get(req.Name)
+	if configLevel == upgrade.None {
+		return req, false
+	}
+
 	c, err := semver.NPM.ParseConstraint(req.Version)
 	if err != nil {
 		// The specified version is not a valid semver constraint
@@ -77,10 +83,10 @@ func (r NpmRelaxer) Relax(ctx context.Context, cl resolve.Client, req resolve.Re
 
 	cmpVer := vers[lastIdx]
 	_, diff, _ := semver.NPM.Difference(cmpVer, vers[nextIdx])
+	if !configLevel.Allows(diff) {
+		return req, false
+	}
 	if diff == semver.DiffMajor {
-		if !allowMajor {
-			return req, false
-		}
 		// Want to step only one major version at a time
 		// Instead of looking for a difference larger than major,
 		// we want to look for a major version bump from the first next version
@@ -95,6 +101,12 @@ func (r NpmRelaxer) Relax(ctx context.Context, cl resolve.Client, req resolve.Re
 		if err != nil {
 			continue
 		}
+
+		// If we've exceeded our allowed upgrade level, stop looking.
+		if !configLevel.Allows(d) {
+			break
+		}
+
 		// DiffMajor < DiffMinor < DiffPatch < DiffPrerelease
 		// So if d is less than the original diff, it represents a larger change
 		if d < diff {

--- a/internal/remediation/relax/npm_test.go
+++ b/internal/remediation/relax/npm_test.go
@@ -6,6 +6,7 @@ import (
 
 	"deps.dev/util/resolve"
 	"github.com/google/osv-scanner/internal/remediation/relax"
+	"github.com/google/osv-scanner/internal/remediation/upgrade"
 )
 
 func TestRelaxNpm(t *testing.T) {
@@ -16,117 +17,117 @@ func TestRelaxNpm(t *testing.T) {
 		ok      bool
 	}
 	tests := []struct {
-		name       string
-		versions   []string
-		from       string
-		allowMajor bool
-		want       result
+		name          string
+		versions      []string
+		from          string
+		upgradeConfig upgrade.Config
+		want          result
 	}{
 		{
-			name:       "pinned-to-patch",
-			versions:   []string{"1.2.3", "1.2.4", "1.2.5", "1.3.0", "2.0.0"},
-			from:       "1.2.3",
-			allowMajor: false,
+			name:          "pinned-to-patch",
+			versions:      []string{"1.2.3", "1.2.4", "1.2.5", "1.3.0", "2.0.0"},
+			from:          "1.2.3",
+			upgradeConfig: upgrade.Config{"": upgrade.Minor},
 			want: result{
 				version: "~1.2.5",
 				ok:      true,
 			},
 		},
 		{
-			name:       "patch-to-minor",
-			versions:   []string{"1.2.3", "1.2.4", "1.3.0", "1.3.1", "2.0.0"},
-			from:       "~1.2.3",
-			allowMajor: false,
+			name:          "patch-to-minor",
+			versions:      []string{"1.2.3", "1.2.4", "1.3.0", "1.3.1", "2.0.0"},
+			from:          "~1.2.3",
+			upgradeConfig: upgrade.Config{"": upgrade.Minor},
 			want: result{
 				version: "^1.3.1",
 				ok:      true,
 			},
 		},
 		{
-			name:       "minor-to-next-major",
-			versions:   []string{"1.2.3", "1.3.4", "2.3.4", "2.4.5", "3.0.0"},
-			from:       "^1.2.3",
-			allowMajor: true,
+			name:          "minor-to-next-major",
+			versions:      []string{"1.2.3", "1.3.4", "2.3.4", "2.4.5", "3.0.0"},
+			from:          "^1.2.3",
+			upgradeConfig: upgrade.Config{"": upgrade.Major},
 			want: result{
 				version: "^2.4.5",
 				ok:      true,
 			},
 		},
 		{
-			name:       "skip-missing-major",
-			versions:   []string{"1.0.0", "3.0.0", "4.0.0"},
-			from:       "^1.0.0",
-			allowMajor: true,
+			name:          "skip-missing-major",
+			versions:      []string{"1.0.0", "3.0.0", "4.0.0"},
+			from:          "^1.0.0",
+			upgradeConfig: upgrade.Config{"": upgrade.Major},
 			want: result{
 				version: "^3.0.0",
 				ok:      true,
 			},
 		},
 		{
-			name:       "no-more-versions",
-			versions:   []string{"1.2.3", "1.3.4", "1.4.5"},
-			from:       "^1.2.3",
-			allowMajor: true,
+			name:          "no-more-versions",
+			versions:      []string{"1.2.3", "1.3.4", "1.4.5"},
+			from:          "^1.2.3",
+			upgradeConfig: upgrade.Config{"": upgrade.Major},
 			want: result{
 				version: "^1.2.3",
 				ok:      false,
 			},
 		},
 		{
-			name:       "disallow-major",
-			versions:   []string{"1.2.3", "1.3.4", "2.3.4", "2.4.5", "3.0.0"},
-			from:       "^1.2.3",
-			allowMajor: false,
+			name:          "disallow-major",
+			versions:      []string{"1.2.3", "1.3.4", "2.3.4", "2.4.5", "3.0.0"},
+			from:          "^1.2.3",
+			upgradeConfig: upgrade.Config{"": upgrade.Minor},
 			want: result{
 				version: "^1.2.3",
 				ok:      false,
 			},
 		},
 		{
-			name:       "avoid-prerelease-patch",
-			versions:   []string{"1.2.3", "1.2.4", "1.2.5-alpha"},
-			from:       "1.2.3",
-			allowMajor: false,
+			name:          "avoid-prerelease-patch",
+			versions:      []string{"1.2.3", "1.2.4", "1.2.5-alpha"},
+			from:          "1.2.3",
+			upgradeConfig: upgrade.Config{"": upgrade.Minor},
 			want: result{
 				version: "~1.2.4",
 				ok:      true,
 			},
 		},
 		{
-			name:       "avoid-prerelease-minor",
-			versions:   []string{"1.2.3", "1.3.4", "1.4.5-alpha"},
-			from:       "~1.2.3",
-			allowMajor: true,
+			name:          "avoid-prerelease-minor",
+			versions:      []string{"1.2.3", "1.3.4", "1.4.5-alpha"},
+			from:          "~1.2.3",
+			upgradeConfig: upgrade.Config{"": upgrade.Major},
 			want: result{
 				version: "^1.3.4",
 				ok:      true,
 			},
 		},
 		{
-			name:       "skip-prerelease",
-			versions:   []string{"1.2.3", "2.0.0-alpha", "2.0.0", "3.0.0"},
-			from:       "^1.0.0",
-			allowMajor: true,
+			name:          "skip-prerelease",
+			versions:      []string{"1.2.3", "2.0.0-alpha", "2.0.0", "3.0.0"},
+			from:          "^1.0.0",
+			upgradeConfig: upgrade.Config{"": upgrade.Major},
 			want: result{
 				version: "^2.0.0",
 				ok:      true,
 			},
 		},
 		{
-			name:       "choose-final-prerelease",
-			versions:   []string{"1.2.3", "2.0.0-alpha.0", "2.0.0-alpha.1", "2.0.0-beta"},
-			from:       "^1.0.0",
-			allowMajor: true,
+			name:          "choose-final-prerelease",
+			versions:      []string{"1.2.3", "2.0.0-alpha.0", "2.0.0-alpha.1", "2.0.0-beta"},
+			from:          "^1.0.0",
+			upgradeConfig: upgrade.Config{"": upgrade.Major},
 			want: result{
 				version: "^2.0.0-beta",
 				ok:      true,
 			},
 		},
 		{
-			name:       "from-prerelease",
-			versions:   []string{"1.0.0-pre", "1.2.3", "2.0.0-pre", "2.3.4"},
-			from:       "^1.0.0-pre",
-			allowMajor: true,
+			name:          "from-prerelease",
+			versions:      []string{"1.0.0-pre", "1.2.3", "2.0.0-pre", "2.3.4"},
+			from:          "^1.0.0-pre",
+			upgradeConfig: upgrade.Config{"": upgrade.Major},
 			want: result{
 				version: "^2.3.4",
 				ok:      true,
@@ -159,7 +160,7 @@ func TestRelaxNpm(t *testing.T) {
 					PackageKey:  pk,
 					VersionType: resolve.Requirement,
 					Version:     tt.from,
-				}}, tt.allowMajor)
+				}}, tt.upgradeConfig)
 
 			if got.Version != tt.want.version || ok != tt.want.ok {
 				t.Errorf("Relax() = (%s, %v), want (%s, %v)", got.Version, ok, tt.want.version, tt.want.ok)

--- a/internal/remediation/relax/npm_test.go
+++ b/internal/remediation/relax/npm_test.go
@@ -74,16 +74,6 @@ func TestRelaxNpm(t *testing.T) {
 			},
 		},
 		{
-			name:          "disallow-major",
-			versions:      []string{"1.2.3", "1.3.4", "2.3.4", "2.4.5", "3.0.0"},
-			from:          "^1.2.3",
-			upgradeConfig: upgrade.Config{"": upgrade.Minor},
-			want: result{
-				version: "^1.2.3",
-				ok:      false,
-			},
-		},
-		{
 			name:          "avoid-prerelease-patch",
 			versions:      []string{"1.2.3", "1.2.4", "1.2.5-alpha"},
 			from:          "1.2.3",
@@ -131,6 +121,46 @@ func TestRelaxNpm(t *testing.T) {
 			want: result{
 				version: "^2.3.4",
 				ok:      true,
+			},
+		},
+		{
+			name:          "disallow-major",
+			versions:      []string{"1.2.3", "1.3.4", "2.3.4", "2.4.5", "3.0.0"},
+			from:          "^1.2.3",
+			upgradeConfig: upgrade.Config{"": upgrade.Minor},
+			want: result{
+				version: "^1.2.3",
+				ok:      false,
+			},
+		},
+		{
+			name:          "disallow-major-pkg-only",
+			versions:      []string{"1.2.3", "1.3.4", "2.3.4", "2.4.5", "3.0.0"},
+			from:          "^1.2.3",
+			upgradeConfig: upgrade.Config{"disallow-major-pkg-only": upgrade.Minor, "": upgrade.None},
+			want: result{
+				version: "^1.2.3",
+				ok:      false,
+			},
+		},
+		{
+			name:          "disallow-pkg",
+			versions:      []string{"1.2.3", "1.3.4", "2.3.4", "2.4.5", "3.0.0"},
+			from:          "^1.2.3",
+			upgradeConfig: upgrade.Config{"disallow-pkg": upgrade.None},
+			want: result{
+				version: "^1.2.3",
+				ok:      false,
+			},
+		},
+		{
+			name:          "disallow-minor",
+			versions:      []string{"1.2.3", "1.3.4", "2.3.4", "2.4.5", "3.0.0"},
+			from:          "~1.2.3",
+			upgradeConfig: upgrade.Config{"disallow-minor": upgrade.Patch},
+			want: result{
+				version: "~1.2.3",
+				ok:      false,
 			},
 		},
 	}

--- a/internal/remediation/relax/relax.go
+++ b/internal/remediation/relax/relax.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"deps.dev/util/resolve"
+	"github.com/google/osv-scanner/internal/remediation/upgrade"
 )
 
 // A RequirementRelaxer provides an ecosystem-specific method for 'relaxing' the
@@ -20,7 +21,7 @@ type RequirementRelaxer interface {
 	// Relax attempts to relax import requirement.
 	// Returns the newly relaxed import and true it was successful.
 	// If unsuccessful, it returns the original import and false.
-	Relax(ctx context.Context, cl resolve.Client, req resolve.RequirementVersion, allowMajor bool) (resolve.RequirementVersion, bool)
+	Relax(ctx context.Context, cl resolve.Client, req resolve.RequirementVersion, config upgrade.Config) (resolve.RequirementVersion, bool)
 }
 
 func GetRelaxer(ecosystem resolve.System) (RequirementRelaxer, error) {

--- a/internal/remediation/relax_test.go
+++ b/internal/remediation/relax_test.go
@@ -5,15 +5,16 @@ import (
 	"testing"
 
 	"github.com/google/osv-scanner/internal/remediation"
+	"github.com/google/osv-scanner/internal/remediation/upgrade"
 )
 
 func TestComputeRelaxPatches(t *testing.T) {
 	t.Parallel()
 
 	basicOpts := remediation.RemediationOptions{
-		DevDeps:    true,
-		MaxDepth:   -1,
-		AllowMajor: true,
+		DevDeps:       true,
+		MaxDepth:      -1,
+		UpgradeConfig: upgrade.NewConfig(),
 	}
 
 	tests := []struct {

--- a/internal/remediation/remediation.go
+++ b/internal/remediation/remediation.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"slices"
 
+	"github.com/google/osv-scanner/internal/remediation/upgrade"
 	"github.com/google/osv-scanner/internal/resolution"
 	"github.com/google/osv-scanner/internal/resolution/lockfile"
 	"github.com/google/osv-scanner/internal/resolution/manifest"
@@ -46,8 +47,9 @@ type RemediationOptions struct {
 	MinSeverity float64 // Minimum vulnerability CVSS score to consider
 	MaxDepth    int     // Maximum depth of dependency to consider vulnerabilities for (e.g. 1 for direct only)
 
-	AvoidPkgs  []string // Names of dependencies to avoid upgrading
-	AllowMajor bool     // Whether to allow changes to major versions of direct dependencies
+	UpgradeConfig upgrade.Config // Allowed upgrade levels per package.
+	// AvoidPkgs     []string       // Names of dependencies to avoid upgrading
+	// AllowMajor    bool          // Whether to allow changes to major versions of direct dependencies
 }
 
 func (opts RemediationOptions) MatchVuln(v resolution.ResolutionVuln) bool {

--- a/internal/remediation/remediation.go
+++ b/internal/remediation/remediation.go
@@ -48,8 +48,6 @@ type RemediationOptions struct {
 	MaxDepth    int     // Maximum depth of dependency to consider vulnerabilities for (e.g. 1 for direct only)
 
 	UpgradeConfig upgrade.Config // Allowed upgrade levels per package.
-	// AvoidPkgs     []string       // Names of dependencies to avoid upgrading
-	// AllowMajor    bool          // Whether to allow changes to major versions of direct dependencies
 }
 
 func (opts RemediationOptions) MatchVuln(v resolution.ResolutionVuln) bool {

--- a/internal/remediation/upgrade/config.go
+++ b/internal/remediation/upgrade/config.go
@@ -1,0 +1,35 @@
+package upgrade
+
+type Config map[string]Level
+
+func NewConfig() Config {
+	return make(Config)
+}
+
+// Set the allowed upgrade level for a given pkg name.
+// If level for pkg was previously set, sets the package to the new level and returns true.
+// Otherwise, sets the package's level and returns false.
+func (c Config) Set(pkg string, level Level) bool {
+	_, alreadySet := c[pkg]
+	c[pkg] = level
+
+	return alreadySet
+}
+
+// SetDefault sets the default allowed upgrade level packages that weren't explicitly set.
+// If default was previously set, sets the default to the new level and returns true.
+// Otherwise, sets the default and returns false.
+func (c Config) SetDefault(level Level) bool {
+	// Empty package name is used as the default level.
+	return c.Set("", level)
+}
+
+// Get the allowed Level for the given pkg name.
+func (c Config) Get(pkg string) Level {
+	if lvl, ok := c[pkg]; ok {
+		return lvl
+	}
+
+	// Empty package name is used as the default level.
+	return c[""]
+}

--- a/internal/remediation/upgrade/config_test.go
+++ b/internal/remediation/upgrade/config_test.go
@@ -1,0 +1,65 @@
+package upgrade_test
+
+import (
+	"testing"
+
+	"github.com/google/osv-scanner/internal/remediation/upgrade"
+)
+
+func configSetExpect(t *testing.T, config upgrade.Config, pkg string, level upgrade.Level, want bool) {
+	t.Helper()
+	got := config.Set(pkg, level)
+	if got != want {
+		t.Errorf("Set(%v, %v) got %v, want %v", pkg, level, got, want)
+	}
+}
+
+func configSetDefaultExpect(t *testing.T, config upgrade.Config, level upgrade.Level, want bool) {
+	t.Helper()
+	got := config.SetDefault(level)
+	if got != want {
+		t.Errorf("SetDefault(%v) got %v, want %v", level, got, want)
+	}
+}
+
+func configGetExpect(t *testing.T, config upgrade.Config, pkg string, want upgrade.Level) {
+	t.Helper()
+	if got := config.Get(pkg); got != want {
+		t.Errorf("Get(%v) got %v, want %v", pkg, got, want)
+	}
+}
+
+func TestConfig(t *testing.T) {
+	t.Parallel()
+	config := upgrade.NewConfig()
+
+	// Default everything to allow major
+	configGetExpect(t, config, "foo", upgrade.Major)
+	configGetExpect(t, config, "bar", upgrade.Major)
+
+	// Set specific package
+	configSetExpect(t, config, "foo", upgrade.Minor, false)
+	configGetExpect(t, config, "foo", upgrade.Minor)
+	configGetExpect(t, config, "bar", upgrade.Major)
+
+	// Set package again
+	configSetExpect(t, config, "foo", upgrade.None, true)
+	configGetExpect(t, config, "foo", upgrade.None)
+	configGetExpect(t, config, "bar", upgrade.Major)
+
+	// Set default
+	configSetDefaultExpect(t, config, upgrade.Patch, false)
+	configGetExpect(t, config, "foo", upgrade.None)
+	configGetExpect(t, config, "bar", upgrade.Patch)
+
+	// Set default again
+	configSetDefaultExpect(t, config, upgrade.Major, true)
+	configGetExpect(t, config, "foo", upgrade.None)
+	configGetExpect(t, config, "bar", upgrade.Major)
+
+	// Set other package
+	configSetExpect(t, config, "bar", upgrade.Minor, false)
+	configGetExpect(t, config, "foo", upgrade.None)
+	configGetExpect(t, config, "bar", upgrade.Minor)
+	configGetExpect(t, config, "baz", upgrade.Major)
+}

--- a/internal/remediation/upgrade/level.go
+++ b/internal/remediation/upgrade/level.go
@@ -1,0 +1,34 @@
+package upgrade
+
+import (
+	"deps.dev/util/semver"
+)
+
+type Level int
+
+const (
+	Major Level = iota
+	Minor
+	Patch
+	None
+)
+
+// Allows returns if the semver.Diff is allowable for this upgrade level constraint.
+func (level Level) Allows(diff semver.Diff) bool {
+	if diff == semver.Same {
+		return true
+	}
+
+	switch level {
+	case Major:
+		return true
+	case Minor:
+		return diff != semver.DiffMajor
+	case Patch:
+		return (diff != semver.DiffMajor) && (diff != semver.DiffMinor)
+	case None:
+		return false
+	default: // Invalid level
+		return false
+	}
+}

--- a/internal/remediation/upgrade/level_test.go
+++ b/internal/remediation/upgrade/level_test.go
@@ -1,0 +1,40 @@
+package upgrade_test
+
+import (
+	"slices"
+	"testing"
+
+	"deps.dev/util/semver"
+	"github.com/google/osv-scanner/internal/remediation/upgrade"
+)
+
+func TestLevelAllows(t *testing.T) {
+	t.Parallel()
+	// Check every combination of Level + Diff
+	allDiffs := [...]semver.Diff{
+		semver.Same,
+		semver.DiffOther,
+		semver.DiffMajor,
+		semver.DiffMinor,
+		semver.DiffPatch,
+		semver.DiffPrerelease,
+		semver.DiffBuild,
+	}
+
+	levelDisallowed := map[upgrade.Level][]semver.Diff{
+		upgrade.Major: {},
+		upgrade.Minor: {semver.DiffMajor},
+		upgrade.Patch: {semver.DiffMajor, semver.DiffMinor},
+		upgrade.None:  allDiffs[1:], // everything but semver.Same
+	}
+
+	for level, disallowed := range levelDisallowed {
+		for _, diff := range allDiffs {
+			want := !slices.Contains(disallowed, diff)
+			got := level.Allows(diff)
+			if want != got {
+				t.Errorf("(Level: %v, Diff: %v) Allows() = %v, want %v", level, diff, got, want)
+			}
+		}
+	}
+}

--- a/scripts/examples/auto_guided_remediation.py
+++ b/scripts/examples/auto_guided_remediation.py
@@ -17,9 +17,9 @@ PATCH_STRATEGIES = [
     # This could also include things like:
     # '--min-severity=X'  Minimum severity of vulnerabilities to consider.
     # '--max-depth=Y': Maximum (shortest) dependency depth
-    # '--disallow-major-upgrades={true/false}':  Whether or not major upgrades are done.
+    # '--upgrade-config={major/minor/patch}':  What level of package upgrades are allowed.
     # etc... which can help reduce/increase the scope of changes by prioritizing vulnerabilities according to these filters.
-    # e.g. ['--strategy=relock', '--disallow-major-upgrades=true', '--max-depth=5'],  # Relock the manifest and try direct dependency bumps.
+    # e.g. ['--strategy=relock', '--upgrade-config=minor', '--max-depth=5'],  # Relock the manifest and try direct dependency bumps.
     # See `osv-scanner fix --help`.
 ]
 
@@ -49,8 +49,8 @@ def run_fix(n_patches: int, avoid_pkgs: List[str], strategy: List[str]) -> Tuple
   if n_patches != 0:
     cmd.extend(['--apply-top', str(n_patches)])
 
-  if len(avoid_pkgs) > 0:
-    cmd.extend(['--disallow-package-upgrades', ','.join(avoid_pkgs)])
+  for pkg in avoid_pkgs:
+    cmd.extend(['--upgrade-config', f'{pkg}:none'])
 
   try:
     output = subprocess.check_output(cmd, text=True)

--- a/scripts/generate_mock_resolution_universe/main.go
+++ b/scripts/generate_mock_resolution_universe/main.go
@@ -23,6 +23,7 @@ import (
 	"deps.dev/util/resolve"
 	"deps.dev/util/resolve/dep"
 	"github.com/google/osv-scanner/internal/remediation"
+	"github.com/google/osv-scanner/internal/remediation/upgrade"
 	"github.com/google/osv-scanner/internal/resolution"
 	"github.com/google/osv-scanner/internal/resolution/client"
 	"github.com/google/osv-scanner/internal/resolution/clienttest"
@@ -61,9 +62,9 @@ func doRelockRelax(ddCl *client.DepsDevClient, io manifest.ManifestIO, filename 
 		return err
 	}
 	_, err = remediation.ComputeRelaxPatches(context.Background(), cl, res, remediation.RemediationOptions{
-		DevDeps:    true,
-		MaxDepth:   -1,
-		AllowMajor: true,
+		DevDeps:       true,
+		MaxDepth:      -1,
+		UpgradeConfig: upgrade.NewConfig(),
 	})
 
 	return err
@@ -92,9 +93,9 @@ func doOverride(ddCl *client.DepsDevClient, io manifest.ManifestIO, filename str
 		return err
 	}
 	_, err = remediation.ComputeOverridePatches(context.Background(), cl, res, remediation.RemediationOptions{
-		DevDeps:    true,
-		MaxDepth:   -1,
-		AllowMajor: true,
+		DevDeps:       true,
+		MaxDepth:      -1,
+		UpgradeConfig: upgrade.NewConfig(),
 	})
 
 	return err
@@ -130,9 +131,9 @@ func doInPlace(ddCl *client.DepsDevClient, io lockfile.LockfileIO, filename stri
 	_ = group.Wait()
 
 	_, err = remediation.ComputeInPlacePatches(context.Background(), cl, g, remediation.RemediationOptions{
-		DevDeps:    true,
-		MaxDepth:   -1,
-		AllowMajor: true,
+		DevDeps:       true,
+		MaxDepth:      -1,
+		UpgradeConfig: upgrade.NewConfig(),
 	})
 
 	return err


### PR DESCRIPTION
closes #1177

- Adds `--upgrade-config` flag for configuring allowed upgrades on a per-package basis.
- Hide & deprecate previous `--disallow-major-upgrades` and `--disallow-package-upgrades` flags.
- Update docs & example script to use new flag.