### PR TITLE
chore: add missed test ignore vuln

### DIFF
--- a/internal/remediation/fixtures/zeppelin-server/parent/osv-scanner.toml
+++ b/internal/remediation/fixtures/zeppelin-server/parent/osv-scanner.toml
@@ -27,3 +27,9 @@ name = "org.apache.thrift:libthrift"
 ecosystem = "Maven"
 ignore = true
 reason = "This is an intentionally vulnerable test project"
+
+[[PackageOverrides]]
+name = "org.apache.commons:commons-text"
+ecosystem = "Maven"
+ignore = true
+reason = "This is an intentionally vulnerable test project"


### PR DESCRIPTION
Missed this in #1202, probably because its in a parent's `dependencyManagement`