### PR TITLE
feat(guided remediation): Add `FIXED-VULN-IDS` to non-interactive output

### DIFF
--- a/cmd/osv-scanner/__snapshots__/fix_test.snap
+++ b/cmd/osv-scanner/__snapshots__/fix_test.snap
@@ -5,6 +5,7 @@ Found 7 vulnerabilities matching the filter
 Can fix 2/7 matching vulnerabilities by changing 2 dependencies
 UPGRADED-PACKAGE: concat-stream,1.5.0,1.6.1
 UPGRADED-PACKAGE: hosted-git-info,2.1.4,2.8.9
+FIXED-VULN-IDS: GHSA-43f8-2h32-f4cj,GHSA-g74r-ffvr-5q9f
 REMAINING-VULNS: 5
 UNFIXABLE-VULNS: 5
 Rewriting <tempdir>/package-lock.json...
@@ -1750,6 +1751,7 @@ OVERRIDE-PACKAGE: org.apache.httpcomponents:httpclient,4.5.13
 OVERRIDE-PACKAGE: org.codehaus.plexus:plexus-utils,3.0.24
 OVERRIDE-PACKAGE: org.jsoup:jsoup,1.15.3
 OVERRIDE-PACKAGE: commons-io:commons-io,2.7
+FIXED-VULN-IDS: GHSA-2x83-r56g-cv47,GHSA-7r82-7xv7-xcpj,GHSA-8vhq-qq4p-grq3,GHSA-cfh5-3ghh-wfjx,GHSA-fmj5-wv96-r2ch,GHSA-g6ph-x5wf-g337,GHSA-gp7f-rwcx-9369,GHSA-gw85-4gmf-m7rh,GHSA-gwrp-pvrq-jmwv,GHSA-jcwr-x25h-x5fh,GHSA-m72m-mhq2-9p6c
 REMAINING-VULNS: 0
 UNFIXABLE-VULNS: 0
 Rewriting <tempdir>/pom.xml...
@@ -1813,6 +1815,7 @@ Resolving <tempdir>/package.json...
 Found 5 vulnerabilities matching the filter
 Can fix 3/5 matching vulnerabilities by changing 1 dependencies
 UPGRADED-PACKAGE: npm-registry-client,6.2.0,^7.5.0
+FIXED-VULN-IDS: GHSA-43f8-2h32-f4cj,GHSA-c2qf-rxjj-qqgw,GHSA-c6rq-rjc2-86v2
 REMAINING-VULNS: 2
 UNFIXABLE-VULNS: 2
 Rewriting <tempdir>/package.json...

--- a/cmd/osv-scanner/fix/noninteractive.go
+++ b/cmd/osv-scanner/fix/noninteractive.go
@@ -1,6 +1,7 @@
 package fix
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -15,6 +16,7 @@ import (
 	"github.com/google/osv-scanner/internal/resolution/manifest"
 	"github.com/google/osv-scanner/pkg/lockfile"
 	"github.com/google/osv-scanner/pkg/reporter"
+	"golang.org/x/exp/maps"
 )
 
 func autoInPlace(ctx context.Context, r reporter.Reporter, opts osvFixOptions, maxUpgrades int) error {
@@ -39,7 +41,8 @@ func autoInPlace(ctx context.Context, r reporter.Reporter, opts osvFixOptions, m
 		return err
 	}
 
-	patches, nFixed, nRemain := autoChooseInPlacePatches(res, maxUpgrades)
+	patches, fixed, nRemain := autoChooseInPlacePatches(res, maxUpgrades)
+	nFixed := len(fixed)
 	totalVulns := nFixed + nRemain + len(res.Unfixable)
 
 	r.Infof("Found %d vulnerabilities matching the filter\n", totalVulns)
@@ -48,18 +51,28 @@ func autoInPlace(ctx context.Context, r reporter.Reporter, opts osvFixOptions, m
 	for _, p := range patches {
 		r.Infof("UPGRADED-PACKAGE: %s,%s,%s\n", p.Pkg.Name, p.OrigVersion, p.NewVersion)
 	}
+
+	r.Infof("FIXED-VULN-IDS: ")
+	for i, v := range fixed {
+		if i > 0 {
+			r.Infof(",")
+		}
+		r.Infof("%s", v.Vulnerability.ID)
+	}
+	r.Infof("\n")
+
 	r.Infof("REMAINING-VULNS: %d\n", totalVulns-nFixed)
 	r.Infof("UNFIXABLE-VULNS: %d\n", len(res.Unfixable))
-	// TODO: Print the FIXED-VULN-IDS, REMAINING-VULN-IDS, UNFIXABLE-VULN-IDS
+	// TODO: Print the REMAINING-VULN-IDS, UNFIXABLE-VULN-IDS
 
 	r.Infof("Rewriting %s...\n", opts.Lockfile)
 
 	return lf.Overwrite(opts.LockfileRW, opts.Lockfile, patches)
 }
 
-// returns the top {maxUpgrades} compatible patches, the number of vulns fixed, and the number of potentially fixable vulns left unfixed
+// returns the top {maxUpgrades} compatible patches, the vulns fixed, and the number of potentially fixable vulns left unfixed
 // if maxUpgrades is < 0, do as many patches as possible
-func autoChooseInPlacePatches(res remediation.InPlaceResult, maxUpgrades int) ([]lf.DependencyPatch, int, int) {
+func autoChooseInPlacePatches(res remediation.InPlaceResult, maxUpgrades int) ([]lf.DependencyPatch, []resolution.ResolutionVuln, int) {
 	// Keep track of the VersionKeys we've already patched so we know which patches are incompatible
 	seenVKs := make(map[resolve.VersionKey]bool)
 
@@ -70,7 +83,7 @@ func autoChooseInPlacePatches(res remediation.InPlaceResult, maxUpgrades int) ([
 	}
 	uniqueVulns := make(map[vulnKey]struct{})
 	var patches []lf.DependencyPatch
-	numFixed := 0
+	var fixed []resolution.ResolutionVuln
 
 	for _, p := range res.Patches {
 		vk := resolve.VersionKey{
@@ -89,11 +102,14 @@ func autoChooseInPlacePatches(res remediation.InPlaceResult, maxUpgrades int) ([
 			seenVKs[vk] = true
 			patches = append(patches, p.DependencyPatch)
 			maxUpgrades--
-			numFixed += len(p.ResolvedVulns)
+			fixed = append(fixed, p.ResolvedVulns...)
 		}
 	}
 
-	return patches, numFixed, len(uniqueVulns) - numFixed
+	// Sort the fixed vulns by ID for consistency.
+	slices.SortFunc(fixed, func(a, b resolution.ResolutionVuln) int { return cmp.Compare(a.Vulnerability.ID, b.Vulnerability.ID) })
+
+	return patches, fixed, len(uniqueVulns) - len(fixed)
 }
 
 func autoRelock(ctx context.Context, r reporter.Reporter, opts osvFixOptions, maxUpgrades int) error {
@@ -146,15 +162,26 @@ func autoRelock(ctx context.Context, r reporter.Reporter, opts osvFixOptions, ma
 		return nil
 	}
 
-	depPatches, nFixed := autoChooseRelockPatches(allPatches, maxUpgrades)
+	depPatches, fixed := autoChooseRelockPatches(allPatches, maxUpgrades)
+	nFixed := len(fixed)
 	nUnfixable := len(relockUnfixableVulns(allPatches))
 	r.Infof("Can fix %d/%d matching vulnerabilities by changing %d dependencies\n", nFixed, totalVulns, len(depPatches))
 	for _, p := range depPatches {
 		r.Infof("UPGRADED-PACKAGE: %s,%s,%s\n", p.Pkg.Name, p.OrigRequire, p.NewRequire)
 	}
+
+	r.Infof("FIXED-VULN-IDS: ")
+	for i, v := range fixed {
+		if i > 0 {
+			r.Infof(",")
+		}
+		r.Infof("%s", v.Vulnerability.ID)
+	}
+	r.Infof("\n")
+
 	r.Infof("REMAINING-VULNS: %d\n", totalVulns-nFixed)
 	r.Infof("UNFIXABLE-VULNS: %d\n", nUnfixable)
-	// TODO: Print the FIXED-VULN-IDS, REMAINING-VULN-IDS, UNFIXABLE-VULN-IDS
+	// TODO: Print the REMAINING-VULN-IDS, UNFIXABLE-VULN-IDS
 	// TODO: Consider potentially introduced vulnerabilities
 
 	r.Infof("Rewriting %s...\n", opts.Manifest)
@@ -196,12 +223,12 @@ func autoRelock(ctx context.Context, r reporter.Reporter, opts osvFixOptions, ma
 	return nil
 }
 
-// returns the top {maxUpgrades} compatible patches, and the number of vulns fixed
+// returns the top {maxUpgrades} compatible patches, and the vulns fixed
 // if maxUpgrades is < 0, do as many patches as possible
-func autoChooseRelockPatches(diffs []resolution.ResolutionDiff, maxUpgrades int) ([]manifest.DependencyPatch, int) {
+func autoChooseRelockPatches(diffs []resolution.ResolutionDiff, maxUpgrades int) ([]manifest.DependencyPatch, []resolution.ResolutionVuln) {
 	var patches []manifest.DependencyPatch
 	pkgChanged := make(map[resolve.VersionKey]bool) // dependencies we've already applied a patch to
-	numFixed := 0
+	var fixed []resolution.ResolutionVuln
 
 	for _, diff := range diffs {
 		// If we are not picking any more patches, or this patch is incompatible with existing patches, skip adding it to the patch list.
@@ -212,8 +239,8 @@ func autoChooseRelockPatches(diffs []resolution.ResolutionDiff, maxUpgrades int)
 			continue
 		}
 
-		// Add all individual package patches to the final patch list, and count the number of vulns this is anticipated to resolve
-		numFixed += len(diff.RemovedVulns)
+		// Add all individual package patches to the final patch list, and add the vulns this is anticipated to resolve
+		fixed = append(fixed, diff.RemovedVulns...)
 		for _, dp := range diff.Deps {
 			patches = append(patches, dp)
 			pkgChanged[resolve.VersionKey{PackageKey: dp.Pkg, Version: dp.OrigRequire}] = true
@@ -221,7 +248,10 @@ func autoChooseRelockPatches(diffs []resolution.ResolutionDiff, maxUpgrades int)
 		maxUpgrades--
 	}
 
-	return patches, numFixed
+	// Sort the fixed vulns by ID for consistency.
+	slices.SortFunc(fixed, func(a, b resolution.ResolutionVuln) int { return cmp.Compare(a.Vulnerability.ID, b.Vulnerability.ID) })
+
+	return patches, fixed
 }
 
 func relockUnfixableVulns(diffs []resolution.ResolutionDiff) []*resolution.ResolutionVuln {
@@ -297,12 +327,23 @@ func autoOverride(ctx context.Context, r reporter.Reporter, opts osvFixOptions, 
 		return nil
 	}
 
-	depPatches, nFixed := autoChooseOverridePatches(allPatches, maxUpgrades)
+	depPatches, fixed := autoChooseOverridePatches(allPatches, maxUpgrades)
+	nFixed := len(fixed)
 	nUnfixable := len(relockUnfixableVulns(allPatches))
 	r.Infof("Can fix %d/%d matching vulnerabilities by overriding %d dependencies\n", nFixed, totalVulns, len(depPatches))
 	for _, p := range depPatches {
 		r.Infof("OVERRIDE-PACKAGE: %s,%s\n", p.Pkg.Name, p.NewRequire)
 	}
+
+	r.Infof("FIXED-VULN-IDS: ")
+	for i, v := range fixed {
+		if i > 0 {
+			r.Infof(",")
+		}
+		r.Infof("%s", v.Vulnerability.ID)
+	}
+	r.Infof("\n")
+
 	r.Infof("REMAINING-VULNS: %d\n", totalVulns-nFixed)
 	r.Infof("UNFIXABLE-VULNS: %d\n", nUnfixable)
 	// TODO: Print the FIXED-VULN-IDS, REMAINING-VULN-IDS, UNFIXABLE-VULN-IDS
@@ -316,14 +357,14 @@ func autoOverride(ctx context.Context, r reporter.Reporter, opts osvFixOptions, 
 	return nil
 }
 
-func autoChooseOverridePatches(diffs []resolution.ResolutionDiff, maxUpgrades int) ([]manifest.DependencyPatch, int) {
+func autoChooseOverridePatches(diffs []resolution.ResolutionDiff, maxUpgrades int) ([]manifest.DependencyPatch, []resolution.ResolutionVuln) {
 	if maxUpgrades == 0 {
-		return nil, 0
+		return nil, nil
 	}
 
 	var patches []manifest.DependencyPatch
-	pkgChanged := make(map[resolve.PackageKey]bool) // dependencies we've already applied a patch to
-	fixedVulns := make(map[string]bool)             // vulns that have already been fixed by a patch
+	pkgChanged := make(map[resolve.PackageKey]bool)          // dependencies we've already applied a patch to
+	fixedVulns := make(map[string]resolution.ResolutionVuln) // vulns that have already been fixed by a patch
 	for _, diff := range diffs {
 		// If this patch is incompatible with existing patches, skip adding it to the patch list.
 
@@ -336,7 +377,7 @@ func autoChooseOverridePatches(diffs []resolution.ResolutionDiff, maxUpgrades in
 		// e.g. We have {foo@1 -> bar@1}, and two possible patches [foo@3, bar@2].
 		// Patching foo@3 makes {foo@3 -> bar@3}, which also fixes the vulnerability in bar.
 		// Applying both patches would force {foo@3 -> bar@2}, which is less desirable.
-		if slices.ContainsFunc(diff.RemovedVulns, func(rv resolution.ResolutionVuln) bool { return fixedVulns[rv.Vulnerability.ID] }) {
+		if slices.ContainsFunc(diff.RemovedVulns, func(rv resolution.ResolutionVuln) bool { _, ok := fixedVulns[rv.Vulnerability.ID]; return ok }) {
 			continue
 		}
 
@@ -346,7 +387,7 @@ func autoChooseOverridePatches(diffs []resolution.ResolutionDiff, maxUpgrades in
 			pkgChanged[dp.Pkg] = true
 		}
 		for _, rv := range diff.RemovedVulns {
-			fixedVulns[rv.Vulnerability.ID] = true
+			fixedVulns[rv.Vulnerability.ID] = rv
 		}
 
 		maxUpgrades--
@@ -355,7 +396,11 @@ func autoChooseOverridePatches(diffs []resolution.ResolutionDiff, maxUpgrades in
 		}
 	}
 
-	return patches, len(fixedVulns)
+	// Sort the fixed vulns by ID for consistency.
+	fixed := maps.Values(fixedVulns)
+	slices.SortFunc(fixed, func(a, b resolution.ResolutionVuln) int { return cmp.Compare(a.Vulnerability.ID, b.Vulnerability.ID) })
+
+	return patches, fixed
 }
 
 func resolutionErrorString(res *resolution.ResolutionResult, errs []resolution.ResolutionError) string {

--- a/docs/guided-remediation.md
+++ b/docs/guided-remediation.md
@@ -54,10 +54,12 @@ The output format might change with minor version updates.
 
 ```
 Scanning path/to/package-lock.json...
-Found 52 vulnerabilities matching the filter
-Can fix 23/52 matching vulnerabilities by changing 21 dependencies
+Found 55 vulnerabilities matching the filter
+Can fix 25/55 matching vulnerabilities by changing 21 dependencies
 UPGRADED-PACKAGE: lodash,4.17.20,4.17.21
 UPGRADED-PACKAGE: minimist,1.2.0,1.2.8
+UPGRADED-PACKAGE: ws,6.2.1,6.2.3
+UPGRADED-PACKAGE: ws,7.1.2,7.5.10
 UPGRADED-PACKAGE: acorn,5.7.3,5.4.1
 UPGRADED-PACKAGE: acorn,6.0.2,6.4.2
 UPGRADED-PACKAGE: acorn,7.1.0,7.4.1
@@ -74,11 +76,10 @@ UPGRADED-PACKAGE: qs,6.5.2,6.5.3
 UPGRADED-PACKAGE: semver,5.5.1,5.7.2
 UPGRADED-PACKAGE: semver,5.6.0,5.7.2
 UPGRADED-PACKAGE: semver,6.3.0,6.3.1
-UPGRADED-PACKAGE: ws,6.2.1,6.2.2
-UPGRADED-PACKAGE: ws,7.1.2,7.5.9
 UPGRADED-PACKAGE: y18n,4.0.0,4.0.3
-REMAINING-VULNS: 29
-UNFIXABLE-VULNS: 29
+FIXED-VULN-IDS: GHSA-29mw-wpgm-hmr9,GHSA-35jh-r3h4-6jhm,GHSA-3h5v-q93c-6h6q,GHSA-3h5v-q93c-6h6q,GHSA-4q6p-r6v2-jvc5,GHSA-6chw-6frg-f759,GHSA-6chw-6frg-f759,GHSA-6chw-6frg-f759,GHSA-6fc8-4gx4-v693,GHSA-6fc8-4gx4-v693,GHSA-93q8-gq69-wqmw,GHSA-9c47-m6qq-7p4h,GHSA-c2qf-rxjj-qqgw,GHSA-c2qf-rxjj-qqgw,GHSA-c2qf-rxjj-qqgw,GHSA-c4w7-xm78-47vh,GHSA-chwr-hf3w-c984,GHSA-g6ww-v8xp-vmwg,GHSA-hj48-42vr-x3v9,GHSA-hrpp-h998-j3pp,GHSA-r683-j2x4-v87g,GHSA-vh95-rmgr-6w4m,GHSA-ww39-953v-wcq6,GHSA-xvch-5gv4-984h,GHSA-xvch-5gv4-984h
+REMAINING-VULNS: 30
+UNFIXABLE-VULNS: 30
 Rewriting path/to/package-lock.json...
 ```
 
@@ -98,14 +99,15 @@ The output format might change with minor version updates.
 
 ```
 Resolving path/to/package.json...
-Found 11 vulnerabilities matching the filter
-Can fix 8/11 matching vulnerabilities by changing 6 dependencies
+Found 12 vulnerabilities matching the filter
+Can fix 9/12 matching vulnerabilities by changing 6 dependencies
 UPGRADED-PACKAGE: mocha,^5.2.0,^9.2.2
-UPGRADED-PACKAGE: @google-cloud/cloudbuild,^2.6.0,^3.10.0
-UPGRADED-PACKAGE: autoprefixer,^9.3.0,^10.4.17
+UPGRADED-PACKAGE: @google-cloud/cloudbuild,^2.6.0,^4.5.0
+UPGRADED-PACKAGE: autoprefixer,^9.3.0,^10.4.20
 UPGRADED-PACKAGE: google-closure-library,^20190909.0.0,^20200315.0.0
 UPGRADED-PACKAGE: terser,^3.10.11,^4.8.1
 UPGRADED-PACKAGE: yargs,^12.0.2,^13.3.2
+FIXED-VULN-IDS: GHSA-4wf5-vphf-c2xc,GHSA-7fh5-64p2-3v2j,GHSA-7v5v-9h63-cj86,GHSA-f8q6-p94x-37v3,GHSA-h755-8qp9-cq85,GHSA-p9pc-299p-vxgp,GHSA-vh5w-fg69-rc8m,GHSA-vh95-rmgr-6w4m,GHSA-xvch-5gv4-984h
 REMAINING-VULNS: 3
 UNFIXABLE-VULNS: 3
 Rewriting path/to/package.json...


### PR DESCRIPTION
Closes #1203
Add a `FIXED-VULN-IDS: ` line to non-interactive guided remediation output, which is a comma-separated list of the IDs of the vulnerability resolved, in alphabetical order.