### PR TITLE
feat: support composite-based package overrides

### DIFF
--- a/cmd/osv-scanner/__snapshots__/main_test.snap
+++ b/cmd/osv-scanner/__snapshots__/main_test.snap
@@ -326,6 +326,53 @@ Attempted to scan lockfile but failed: <rootdir>/fixtures/locks-many-with-invali
 
 ---
 
+[TestRun/config_file_can_be_broad - 1]
+Scanning dir ./fixtures/locks-many
+Scanned <rootdir>/fixtures/locks-many/Gemfile.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/alpine.cdx.xml as CycloneDX SBOM and found 14 packages
+Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/yarn.lock file and found 1 package
+Scanning dir ./fixtures/locks-insecure
+Scanned <rootdir>/fixtures/locks-insecure/composer.lock file and found 1 package
+Package npm/ansi-html/0.0.1 has been filtered out because: 
+Package npm/balanced-match/1.0.2 has been filtered out because: 
+Filtered 2 ignored package/s from the scan.
+overriding license for package Alpine/alpine-baselayout/3.4.0-r0 with MIT
+overriding license for package Alpine/alpine-baselayout-data/3.4.0-r0 with MIT
+overriding license for package Alpine/alpine-keys/2.4-r1 with MIT
+overriding license for package Alpine/apk-tools/2.12.10-r1 with MIT
+overriding license for package Alpine/busybox-binsh/1.36.1-r27 with MIT
+overriding license for package Alpine/ca-certificates-bundle/20220614-r4 with MIT
+overriding license for package Alpine/libc-utils/0.7.2-r3 with MIT
+overriding license for package Alpine/libcrypto3/3.0.8-r0 with MIT
+overriding license for package Alpine/libssl3/3.0.8-r0 with MIT
+overriding license for package Alpine/musl/1.2.3-r4 with MIT
+overriding license for package Alpine/musl-utils/1.2.3-r4 with MIT
+overriding license for package Alpine/scanelf/1.3.5-r1 with MIT
+overriding license for package Alpine/ssl_client/1.36.1-r27 with MIT
+overriding license for package Alpine/zlib/1.2.13-r0 with MIT
+overriding license for package Packagist/sentry/sdk/2.0.4 with 0BSD
+overriding license for package Packagist/league/flysystem/1.0.8 with 0BSD
++-------------------------------------+------+-----------+------------------+---------+---------------------------------------+
+| OSV URL                             | CVSS | ECOSYSTEM | PACKAGE          | VERSION | SOURCE                                |
++-------------------------------------+------+-----------+------------------+---------+---------------------------------------+
+| https://osv.dev/GHSA-9f46-5r25-5wfm | 9.8  | Packagist | league/flysystem | 1.0.8   | fixtures/locks-insecure/composer.lock |
++-------------------------------------+------+-----------+------------------+---------+---------------------------------------+
++-------------------+-----------+------------------+---------+---------------------------------------+
+| LICENSE VIOLATION | ECOSYSTEM | PACKAGE          | VERSION | SOURCE                                |
++-------------------+-----------+------------------+---------+---------------------------------------+
+| 0BSD              | Packagist | league/flysystem | 1.0.8   | fixtures/locks-insecure/composer.lock |
+| UNKNOWN           | RubyGems  | ast              | 2.4.2   | fixtures/locks-many/Gemfile.lock      |
+| 0BSD              | Packagist | sentry/sdk       | 2.0.4   | fixtures/locks-many/composer.lock     |
++-------------------+-----------+------------------+---------+---------------------------------------+
+
+---
+
+[TestRun/config_file_can_be_broad - 2]
+
+---
+
 [TestRun/cyclonedx_1.4_output - 1]
 {
   "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",

--- a/cmd/osv-scanner/fixtures/osv-scanner-composite-config.toml
+++ b/cmd/osv-scanner/fixtures/osv-scanner-composite-config.toml
@@ -1,0 +1,11 @@
+[[PackageOverrides]]
+ecosystem = "npm"
+ignore = true
+
+[[PackageOverrides]]
+ecosystem = "Packagist"
+license.override = ["0BSD"]
+
+[[PackageOverrides]]
+ecosystem = "Alpine"
+license.override = ["MIT"]

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -312,6 +312,12 @@ func TestRun(t *testing.T) {
 			args: []string{"", "--config=./fixtures/go-project/go-version-config.toml", "./fixtures/go-project"},
 			exit: 0,
 		},
+		// broad config file that overrides a whole ecosystem
+		{
+			name: "config file can be broad",
+			args: []string{"", "--config=./fixtures/osv-scanner-composite-config.toml", "--experimental-licenses", "MIT", "./fixtures/locks-many", "./fixtures/locks-insecure"},
+			exit: 1,
+		},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -49,7 +49,7 @@ effectiveUntil = 2022-11-09 # Optional exception expiry date, after which the ov
 reason = "abc" # Optional reason for the override, to explain why it was added
 ```
 
-Each override entry will be checked against every package being scanned, and applied if all the configured fields match. This enables both very broad and very specific overrides based on your needs:
+Overrides are applied if all the configured fields match, enabling you to create very broad or very specific overrides based on your needs:
 
 ```toml
 # ignore everything

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,26 +52,26 @@ reason = "abc" # Optional reason for the override, to explain why it was added
 Overrides are applied if all the configured fields match, enabling you to create very broad or very specific overrides based on your needs:
 
 ```toml
-# ignore everything
+# ignore everything in the current directory
 [[PackageOverrides]]
 ignore = true
 
-# ignore everything in a particular group
+# ignore a particular group
 [[PackageOverrides]]
 group = "dev"
 ignore = true
 
-# ignore everything in a particular ecosystem
+# ignore a particular ecosystem
 [[PackageOverrides]]
 ecosystem = "go"
 ignore = true
 
-# ignore all packages named "axios" regardless of ecosystem or group
+# ignore packages named "axios" regardless of ecosystem or group
 [[PackageOverrides]]
 name = "axios"
 ignore = true
 
-# ignore all packages named "axios" in the npm ecosystem that are in the dev group
+# ignore packages named "axios" in the npm ecosystem that are in the dev group
 [[PackageOverrides]]
 name = "axios"
 ecosystem = "npm"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,22 +29,54 @@ reason = "No external http servers are written in Go lang."
 
 Ignoring a vulnerability will also ignore vulnerabilities that are considered aliases of that vulnerability.
 
-## Override specific package
+## Override packages
 
-To ignore a specific a package, or manually set its license, enter the package name and ecosystem under the `PackageOverrides` key.
+You can specify overrides for particular packages to have them either ignored entirely or to set their license using the `PackageOverrides` key:
 
 ```toml
 [[PackageOverrides]]
-# The package name, version, and ecosystem to match against
+# One or more fields to match each package against:
 name = "lib"
-# If version is not set or empty, it will match every version
 version = "1.0.0"
 ecosystem = "Go"
-# Ignore this package entirely, including license scanning
+group = "dev"
+
+# Actions to take for matching packages:
+ignore = true # Ignore this package entirely, including license scanning
+license.override = ["MIT", "0BSD"] # Override the license of the package, if it is not ignored
+
+effectiveUntil = 2022-11-09 # Optional exception expiry date, after which the override will no longer apply
+reason = "abc" # Optional reason for the override, to explain why it was added
+```
+
+Each override entry will be checked against every package being scanned, and applied if all the configured fields match. This enables both very broad and very specific overrides based on your needs:
+
+```toml
+# ignore everything
+[[PackageOverrides]]
 ignore = true
-# Override the license of the package
-# This is not used if ignore = true
-license.override = ["MIT", "0BSD"]
-# effectiveUntil = 2022-11-09 # Optional exception expiry date
-reason = "abc"
+
+# ignore everything in a particular group
+[[PackageOverrides]]
+group = "dev"
+ignore = true
+
+# ignore everything in a particular ecosystem
+[[PackageOverrides]]
+ecosystem = "go"
+ignore = true
+
+# ignore all packages named "axios" regardless of ecosystem or group
+[[PackageOverrides]]
+name = "axios"
+ignore = true
+
+# ignore all packages named "axios" in the npm ecosystem that are in the dev group
+[[PackageOverrides]]
+name = "axios"
+ecosystem = "npm"
+group = "dev"
+ignore = true
+
+# ... and so on
 ```

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -114,6 +114,14 @@ func (c *Config) ShouldIgnorePackageVersion(name, version, ecosystem string) (bo
 	)
 }
 
+// ShouldOverridePackageLicense determines if the given package should have its license changed based on override entries in the config
+func (c *Config) ShouldOverridePackageLicense(pkg models.PackageVulns) (bool, PackageOverrideEntry) {
+	return c.filterPackageVersionEntries(pkg, func(e PackageOverrideEntry) bool {
+		return len(e.License.Override) > 0
+	})
+}
+
+// Deprecated: Use ShouldOverridePackageLicense instead
 func (c *Config) ShouldOverridePackageVersionLicense(name, version, ecosystem string) (bool, PackageOverrideEntry) {
 	return c.filterPackageVersionEntries(
 		models.PackageVulns{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -100,18 +100,13 @@ func (c *Config) ShouldIgnorePackage(pkg models.PackageVulns) (bool, PackageOver
 
 // Deprecated: Use ShouldIgnorePackage instead
 func (c *Config) ShouldIgnorePackageVersion(name, version, ecosystem string) (bool, PackageOverrideEntry) {
-	return c.filterPackageVersionEntries(
-		models.PackageVulns{
-			Package: models.PackageInfo{
-				Name:      name,
-				Version:   version,
-				Ecosystem: ecosystem,
-			},
+	return c.ShouldIgnorePackage(models.PackageVulns{
+		Package: models.PackageInfo{
+			Name:      name,
+			Version:   version,
+			Ecosystem: ecosystem,
 		},
-		func(e PackageOverrideEntry) bool {
-			return e.Ignore
-		},
-	)
+	})
 }
 
 // ShouldOverridePackageLicense determines if the given package should have its license changed based on override entries in the config
@@ -123,18 +118,13 @@ func (c *Config) ShouldOverridePackageLicense(pkg models.PackageVulns) (bool, Pa
 
 // Deprecated: Use ShouldOverridePackageLicense instead
 func (c *Config) ShouldOverridePackageVersionLicense(name, version, ecosystem string) (bool, PackageOverrideEntry) {
-	return c.filterPackageVersionEntries(
-		models.PackageVulns{
-			Package: models.PackageInfo{
-				Name:      name,
-				Version:   version,
-				Ecosystem: ecosystem,
-			},
+	return c.ShouldOverridePackageLicense(models.PackageVulns{
+		Package: models.PackageInfo{
+			Name:      name,
+			Version:   version,
+			Ecosystem: ecosystem,
 		},
-		func(e PackageOverrideEntry) bool {
-			return len(e.License.Override) > 0
-		},
-	)
+	})
 }
 
 func shouldIgnoreTimestamp(ignoreUntil time.Time) bool {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -91,13 +91,14 @@ func (c *Config) filterPackageVersionEntries(pkg models.PackageVulns, condition 
 	return shouldIgnoreTimestamp(ignoredLine.EffectiveUntil), ignoredLine
 }
 
-func (c *Config) ShouldIgnorePackageVulns(pkg models.PackageVulns) (bool, PackageOverrideEntry) {
+// ShouldIgnorePackage determines if the given package should be ignored based on override entries in the config
+func (c *Config) ShouldIgnorePackage(pkg models.PackageVulns) (bool, PackageOverrideEntry) {
 	return c.filterPackageVersionEntries(pkg, func(e PackageOverrideEntry) bool {
 		return e.Ignore
 	})
 }
 
-// Deprecated: Use ShouldIgnorePackageVulns instead
+// Deprecated: Use ShouldIgnorePackage instead
 func (c *Config) ShouldIgnorePackageVersion(name, version, ecosystem string) (bool, PackageOverrideEntry) {
 	return c.filterPackageVersionEntries(
 		models.PackageVulns{

--- a/pkg/config/config_internal_test.go
+++ b/pkg/config/config_internal_test.go
@@ -649,18 +649,13 @@ func TestConfig_ShouldIgnorePackage(t *testing.T) {
 	}
 }
 
-func TestConfig_ShouldOverridePackageVersionLicense(t *testing.T) {
+func TestConfig_ShouldOverridePackageLicense(t *testing.T) {
 	t.Parallel()
 
-	type args struct {
-		name      string
-		version   string
-		ecosystem string
-	}
 	tests := []struct {
 		name      string
 		config    Config
-		args      args
+		args      models.PackageVulns
 		wantOk    bool
 		wantEntry PackageOverrideEntry
 	}{
@@ -679,10 +674,12 @@ func TestConfig_ShouldOverridePackageVersionLicense(t *testing.T) {
 					},
 				},
 			},
-			args: args{
-				name:      "lib1",
-				version:   "1.0.0",
-				ecosystem: "Go",
+			args: models.PackageVulns{
+				Package: models.PackageInfo{
+					Name:      "lib1",
+					Version:   "1.0.0",
+					Ecosystem: "Go",
+				},
 			},
 			wantOk: true,
 			wantEntry: PackageOverrideEntry{
@@ -710,10 +707,12 @@ func TestConfig_ShouldOverridePackageVersionLicense(t *testing.T) {
 					},
 				},
 			},
-			args: args{
-				name:      "lib1",
-				version:   "1.0.1",
-				ecosystem: "Go",
+			args: models.PackageVulns{
+				Package: models.PackageInfo{
+					Name:      "lib1",
+					Version:   "1.0.1",
+					Ecosystem: "Go",
+				},
 			},
 			wantOk:    false,
 			wantEntry: PackageOverrideEntry{},
@@ -732,10 +731,12 @@ func TestConfig_ShouldOverridePackageVersionLicense(t *testing.T) {
 					},
 				},
 			},
-			args: args{
-				name:      "lib1",
-				version:   "1.0.1",
-				ecosystem: "Go",
+			args: models.PackageVulns{
+				Package: models.PackageInfo{
+					Name:      "lib1",
+					Version:   "1.0.1",
+					Ecosystem: "Go",
+				},
 			},
 			wantOk: true,
 			wantEntry: PackageOverrideEntry{
@@ -754,12 +755,12 @@ func TestConfig_ShouldOverridePackageVersionLicense(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			gotOk, gotEntry := tt.config.ShouldOverridePackageVersionLicense(tt.args.name, tt.args.version, tt.args.ecosystem)
+			gotOk, gotEntry := tt.config.ShouldOverridePackageLicense(tt.args)
 			if gotOk != tt.wantOk {
-				t.Errorf("ShouldOverridePackageVersionLicense() gotOk = %v, wantOk %v", gotOk, tt.wantOk)
+				t.Errorf("ShouldOverridePackageLicense() gotOk = %v, wantOk %v", gotOk, tt.wantOk)
 			}
 			if !reflect.DeepEqual(gotEntry, tt.wantEntry) {
-				t.Errorf("ShouldOverridePackageVersionLicense() gotEntry = %v, wantEntry %v", gotEntry, tt.wantEntry)
+				t.Errorf("ShouldOverridePackageLicense() gotEntry = %v, wantEntry %v", gotEntry, tt.wantEntry)
 			}
 		})
 	}

--- a/pkg/config/config_internal_test.go
+++ b/pkg/config/config_internal_test.go
@@ -638,12 +638,12 @@ func TestConfig_ShouldIgnorePackage(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			gotOk, gotEntry := tt.config.ShouldIgnorePackageVulns(tt.args)
+			gotOk, gotEntry := tt.config.ShouldIgnorePackage(tt.args)
 			if gotOk != tt.wantOk {
-				t.Errorf("ShouldIgnorePackageVulns() gotOk = %v, wantOk %v", gotOk, tt.wantOk)
+				t.Errorf("ShouldIgnorePackage() gotOk = %v, wantOk %v", gotOk, tt.wantOk)
 			}
 			if !reflect.DeepEqual(gotEntry, tt.wantEntry) {
-				t.Errorf("ShouldIgnorePackageVulns() gotEntry = %v, wantEntry %v", gotEntry, tt.wantEntry)
+				t.Errorf("ShouldIgnorePackage() gotEntry = %v, wantEntry %v", gotEntry, tt.wantEntry)
 			}
 		})
 	}

--- a/pkg/config/config_internal_test.go
+++ b/pkg/config/config_internal_test.go
@@ -649,6 +649,125 @@ func TestConfig_ShouldIgnorePackage(t *testing.T) {
 	}
 }
 
+func TestConfig_ShouldIgnorePackageVersion(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		name      string
+		version   string
+		ecosystem string
+	}
+	tests := []struct {
+		name      string
+		config    Config
+		args      args
+		wantOk    bool
+		wantEntry PackageOverrideEntry
+	}{
+		{
+			name: "Version-level entry exists",
+			config: Config{
+				PackageOverrides: []PackageOverrideEntry{
+					{
+						Name:           "lib1",
+						Version:        "1.0.0",
+						Ecosystem:      "Go",
+						Ignore:         true,
+						EffectiveUntil: time.Time{},
+						Reason:         "abc",
+					},
+				},
+			},
+			args: args{
+				name:      "lib1",
+				version:   "1.0.0",
+				ecosystem: "Go",
+			},
+			wantOk: true,
+			wantEntry: PackageOverrideEntry{
+				Name:           "lib1",
+				Version:        "1.0.0",
+				Ecosystem:      "Go",
+				Ignore:         true,
+				EffectiveUntil: time.Time{},
+				Reason:         "abc",
+			},
+		},
+		{
+			name: "Package-level entry exists",
+			config: Config{
+				PackageOverrides: []PackageOverrideEntry{
+					{
+						Name:           "lib1",
+						Ecosystem:      "Go",
+						Ignore:         true,
+						EffectiveUntil: time.Time{},
+						Reason:         "abc",
+					},
+				},
+			},
+			args: args{
+				name:      "lib1",
+				version:   "1.0.0",
+				ecosystem: "Go",
+			},
+			wantOk: true,
+			wantEntry: PackageOverrideEntry{
+				Name:           "lib1",
+				Ecosystem:      "Go",
+				Ignore:         true,
+				EffectiveUntil: time.Time{},
+				Reason:         "abc",
+			},
+		},
+		{
+			name: "Entry doesn't exist",
+			config: Config{
+				PackageOverrides: []PackageOverrideEntry{
+					{
+						Name:           "lib1",
+						Version:        "2.0.0",
+						Ecosystem:      "Go",
+						Ignore:         false,
+						EffectiveUntil: time.Time{},
+						Reason:         "abc",
+					},
+					{
+						Name:           "lib2",
+						Version:        "2.0.0",
+						Ignore:         true,
+						Ecosystem:      "Go",
+						EffectiveUntil: time.Time{},
+						Reason:         "abc",
+					},
+				},
+			},
+			args: args{
+				name:      "lib1",
+				version:   "2.0.0",
+				ecosystem: "Go",
+			},
+			wantOk:    false,
+			wantEntry: PackageOverrideEntry{},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotOk, gotEntry := tt.config.ShouldIgnorePackageVersion(tt.args.name, tt.args.version, tt.args.ecosystem)
+			if gotOk != tt.wantOk {
+				t.Errorf("ShouldIgnorePackageVersion() gotOk = %v, wantOk %v", gotOk, tt.wantOk)
+			}
+			if !reflect.DeepEqual(gotEntry, tt.wantEntry) {
+				t.Errorf("ShouldIgnorePackageVersion() gotEntry = %v, wantEntry %v", gotEntry, tt.wantEntry)
+			}
+		})
+	}
+}
+
 func TestConfig_ShouldOverridePackageLicense(t *testing.T) {
 	t.Parallel()
 
@@ -761,6 +880,122 @@ func TestConfig_ShouldOverridePackageLicense(t *testing.T) {
 			}
 			if !reflect.DeepEqual(gotEntry, tt.wantEntry) {
 				t.Errorf("ShouldOverridePackageLicense() gotEntry = %v, wantEntry %v", gotEntry, tt.wantEntry)
+			}
+		})
+	}
+}
+
+func TestConfig_ShouldOverridePackageVersionLicense(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		name      string
+		version   string
+		ecosystem string
+	}
+	tests := []struct {
+		name      string
+		config    Config
+		args      args
+		wantOk    bool
+		wantEntry PackageOverrideEntry
+	}{
+		{
+			name: "Exact version entry exists",
+			config: Config{
+				PackageOverrides: []PackageOverrideEntry{
+					{
+						Name:      "lib1",
+						Version:   "1.0.0",
+						Ecosystem: "Go",
+						License: License{
+							Override: []string{"mit"},
+						},
+						Reason: "abc",
+					},
+				},
+			},
+			args: args{
+				name:      "lib1",
+				version:   "1.0.0",
+				ecosystem: "Go",
+			},
+			wantOk: true,
+			wantEntry: PackageOverrideEntry{
+				Name:      "lib1",
+				Version:   "1.0.0",
+				Ecosystem: "Go",
+				License: License{
+					Override: []string{"mit"},
+				},
+				Reason: "abc",
+			},
+		},
+		{
+			name: "Version entry doesn't exist",
+			config: Config{
+				PackageOverrides: []PackageOverrideEntry{
+					{
+						Name:      "lib1",
+						Version:   "1.0.0",
+						Ecosystem: "Go",
+						License: License{
+							Override: []string{"mit"},
+						},
+						Reason: "abc",
+					},
+				},
+			},
+			args: args{
+				name:      "lib1",
+				version:   "1.0.1",
+				ecosystem: "Go",
+			},
+			wantOk:    false,
+			wantEntry: PackageOverrideEntry{},
+		},
+		{
+			name: "Name matches",
+			config: Config{
+				PackageOverrides: []PackageOverrideEntry{
+					{
+						Name:      "lib1",
+						Ecosystem: "Go",
+						License: License{
+							Override: []string{"mit"},
+						},
+						Reason: "abc",
+					},
+				},
+			},
+			args: args{
+				name:      "lib1",
+				version:   "1.0.1",
+				ecosystem: "Go",
+			},
+			wantOk: true,
+			wantEntry: PackageOverrideEntry{
+				Name:      "lib1",
+				Ecosystem: "Go",
+				License: License{
+					Override: []string{"mit"},
+				},
+				Reason: "abc",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotOk, gotEntry := tt.config.ShouldOverridePackageVersionLicense(tt.args.name, tt.args.version, tt.args.ecosystem)
+			if gotOk != tt.wantOk {
+				t.Errorf("ShouldOverridePackageVersionLicense() gotOk = %v, wantOk %v", gotOk, tt.wantOk)
+			}
+			if !reflect.DeepEqual(gotEntry, tt.wantEntry) {
+				t.Errorf("ShouldOverridePackageVersionLicense() gotEntry = %v, wantEntry %v", gotEntry, tt.wantEntry)
 			}
 		})
 	}

--- a/pkg/config/config_internal_test.go
+++ b/pkg/config/config_internal_test.go
@@ -226,7 +226,264 @@ func TestConfig_ShouldIgnorePackage(t *testing.T) {
 		wantEntry PackageOverrideEntry
 	}{
 		{
-			name: "Version-level entry exists",
+			name: "Everything-level entry exists",
+			config: Config{
+				PackageOverrides: []PackageOverrideEntry{
+					{
+						Ignore:         true,
+						EffectiveUntil: time.Time{},
+						Reason:         "abc",
+					},
+				},
+			},
+			args: models.PackageVulns{
+				Package: models.PackageInfo{
+					Name:      "lib1",
+					Version:   "1.0.0",
+					Ecosystem: "Go",
+				},
+				DepGroups: []string{"dev"},
+			},
+			wantOk: true,
+			wantEntry: PackageOverrideEntry{
+				Ignore:         true,
+				EffectiveUntil: time.Time{},
+				Reason:         "abc",
+			},
+		},
+		// -------------------------------------------------------------------------
+		{
+			name: "Ecosystem-level entry exists and does match",
+			config: Config{
+				PackageOverrides: []PackageOverrideEntry{
+					{
+						Ecosystem:      "Go",
+						Ignore:         true,
+						EffectiveUntil: time.Time{},
+						Reason:         "abc",
+					},
+				},
+			},
+			args: models.PackageVulns{
+				Package: models.PackageInfo{
+					Name:      "lib1",
+					Version:   "1.0.0",
+					Ecosystem: "Go",
+				},
+				DepGroups: []string{"dev"},
+			},
+			wantOk: true,
+			wantEntry: PackageOverrideEntry{
+				Ecosystem:      "Go",
+				Ignore:         true,
+				EffectiveUntil: time.Time{},
+				Reason:         "abc",
+			},
+		},
+		{
+			name: "Ecosystem-level entry exists and does not match",
+			config: Config{
+				PackageOverrides: []PackageOverrideEntry{
+					{
+						Ecosystem:      "Go",
+						Ignore:         true,
+						EffectiveUntil: time.Time{},
+						Reason:         "abc",
+					},
+				},
+			},
+			args: models.PackageVulns{
+				Package: models.PackageInfo{
+					Name:      "lib2",
+					Version:   "1.0.0",
+					Ecosystem: "npm",
+				},
+				DepGroups: []string{"dev"},
+			},
+			wantOk:    false,
+			wantEntry: PackageOverrideEntry{},
+		},
+		// -------------------------------------------------------------------------
+		{
+			name: "Group-level entry exists and does match",
+			config: Config{
+				PackageOverrides: []PackageOverrideEntry{
+					{
+						Group:          "dev",
+						Ignore:         true,
+						EffectiveUntil: time.Time{},
+						Reason:         "abc",
+					},
+				},
+			},
+			args: models.PackageVulns{
+				Package: models.PackageInfo{
+					Name:      "lib1",
+					Version:   "1.0.0",
+					Ecosystem: "Go",
+				},
+				DepGroups: []string{"dev"},
+			},
+			wantOk: true,
+			wantEntry: PackageOverrideEntry{
+				Group:          "dev",
+				Ignore:         true,
+				EffectiveUntil: time.Time{},
+				Reason:         "abc",
+			},
+		},
+		{
+			name: "Group-level entry exists and does not match",
+			config: Config{
+				PackageOverrides: []PackageOverrideEntry{
+					{
+						Group:          "dev",
+						Ignore:         true,
+						EffectiveUntil: time.Time{},
+						Reason:         "abc",
+					},
+				},
+			},
+			args: models.PackageVulns{
+				Package: models.PackageInfo{
+					Name:      "lib2",
+					Version:   "1.0.0",
+					Ecosystem: "npm",
+				},
+				DepGroups: []string{"optional"},
+			},
+			wantOk:    false,
+			wantEntry: PackageOverrideEntry{},
+		},
+		{
+			name: "Group-level entry exists and does not match when empty",
+			config: Config{
+				PackageOverrides: []PackageOverrideEntry{
+					{
+						Group:          "dev",
+						Ignore:         true,
+						EffectiveUntil: time.Time{},
+						Reason:         "abc",
+					},
+				},
+			},
+			args: models.PackageVulns{
+				Package: models.PackageInfo{
+					Name:      "lib2",
+					Version:   "1.0.0",
+					Ecosystem: "npm",
+				},
+			},
+			wantOk:    false,
+			wantEntry: PackageOverrideEntry{},
+		},
+		// -------------------------------------------------------------------------
+		{
+			name: "Version-level entry exists and does match",
+			config: Config{
+				PackageOverrides: []PackageOverrideEntry{
+					{
+						Version:        "1.0.0",
+						Ignore:         true,
+						EffectiveUntil: time.Time{},
+						Reason:         "abc",
+					},
+				},
+			},
+			args: models.PackageVulns{
+				Package: models.PackageInfo{
+					Name:      "lib1",
+					Version:   "1.0.0",
+					Ecosystem: "Go",
+				},
+				DepGroups: []string{"dev"},
+			},
+			wantOk: true,
+			wantEntry: PackageOverrideEntry{
+				Version:        "1.0.0",
+				Ignore:         true,
+				EffectiveUntil: time.Time{},
+				Reason:         "abc",
+			},
+		},
+		{
+			name: "Version-level entry exists and does not match",
+			config: Config{
+				PackageOverrides: []PackageOverrideEntry{
+					{
+						Version:        "1.0.0",
+						Ignore:         true,
+						EffectiveUntil: time.Time{},
+						Reason:         "abc",
+					},
+				},
+			},
+			args: models.PackageVulns{
+				Package: models.PackageInfo{
+					Name:      "lib1",
+					Version:   "1.0.1",
+					Ecosystem: "Go",
+				},
+				DepGroups: []string{"dev"},
+			},
+			wantOk:    false,
+			wantEntry: PackageOverrideEntry{},
+		},
+		// -------------------------------------------------------------------------
+		{
+			name: "Name-level entry exists and does match",
+			config: Config{
+				PackageOverrides: []PackageOverrideEntry{
+					{
+						Name:           "lib1",
+						Ignore:         true,
+						EffectiveUntil: time.Time{},
+						Reason:         "abc",
+					},
+				},
+			},
+			args: models.PackageVulns{
+				Package: models.PackageInfo{
+					Name:      "lib1",
+					Version:   "1.0.0",
+					Ecosystem: "Go",
+				},
+				DepGroups: []string{"dev"},
+			},
+			wantOk: true,
+			wantEntry: PackageOverrideEntry{
+				Name:           "lib1",
+				Ignore:         true,
+				EffectiveUntil: time.Time{},
+				Reason:         "abc",
+			},
+		},
+		{
+			name: "Name-level entry exists and does not match",
+			config: Config{
+				PackageOverrides: []PackageOverrideEntry{
+					{
+						Name:           "lib1",
+						Ignore:         true,
+						EffectiveUntil: time.Time{},
+						Reason:         "abc",
+					},
+				},
+			},
+			args: models.PackageVulns{
+				Package: models.PackageInfo{
+					Name:      "lib2",
+					Version:   "1.0.0",
+					Ecosystem: "npm",
+				},
+				DepGroups: []string{"dev"},
+			},
+			wantOk:    false,
+			wantEntry: PackageOverrideEntry{},
+		},
+		// -------------------------------------------------------------------------
+		{
+			name: "Name, Version, and Ecosystem entry exists",
 			config: Config{
 				PackageOverrides: []PackageOverrideEntry{
 					{
@@ -257,7 +514,7 @@ func TestConfig_ShouldIgnorePackage(t *testing.T) {
 			},
 		},
 		{
-			name: "Package-level entry exists",
+			name: "Name and Ecosystem entry exists",
 			config: Config{
 				PackageOverrides: []PackageOverrideEntry{
 					{
@@ -286,7 +543,7 @@ func TestConfig_ShouldIgnorePackage(t *testing.T) {
 			},
 		},
 		{
-			name: "Group-level entry exists and matches",
+			name: "Name, Ecosystem, and Group entry exists and matches",
 			config: Config{
 				PackageOverrides: []PackageOverrideEntry{
 					{
@@ -318,7 +575,7 @@ func TestConfig_ShouldIgnorePackage(t *testing.T) {
 			},
 		},
 		{
-			name: "Group-level entry exists but does not match",
+			name: "Name, Ecosystem, and Group entry exists but does not match",
 			config: Config{
 				PackageOverrides: []PackageOverrideEntry{
 					{
@@ -339,7 +596,7 @@ func TestConfig_ShouldIgnorePackage(t *testing.T) {
 				},
 				DepGroups: []string{"prod"},
 			},
-			wantOk: false,
+			wantOk:    false,
 			wantEntry: PackageOverrideEntry{},
 		},
 		{

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -967,17 +967,17 @@ func filterIgnoredPackages(r reporter.Reporter, packages []scannedPackage, confi
 	out := make([]scannedPackage, 0, len(packages))
 	for _, p := range packages {
 		configToUse := configManager.Get(r, p.Source.Path)
-		if ignore, ignoreLine := configToUse.ShouldIgnorePackage(
-			models.PackageVulns{
-				Package: models.PackageInfo{
-					Name:      p.Name,
-					Version:   p.Version,
-					Ecosystem: string(p.Ecosystem),
-					Commit:    p.Commit,
-				},
-				DepGroups: p.DepGroups,
+		pkg := models.PackageVulns{
+			Package: models.PackageInfo{
+				Name:      p.Name,
+				Version:   p.Version,
+				Ecosystem: string(p.Ecosystem),
+				Commit:    p.Commit,
 			},
-		); ignore {
+			DepGroups: p.DepGroups,
+		}
+
+		if ignore, ignoreLine := configToUse.ShouldIgnorePackage(pkg); ignore {
 			pkgString := fmt.Sprintf("%s/%s/%s", p.Ecosystem, p.Name, p.Version)
 			r.Infof("Package %s has been filtered out because: %s\n", pkgString, ignoreLine.Reason)
 

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -967,7 +967,17 @@ func filterIgnoredPackages(r reporter.Reporter, packages []scannedPackage, confi
 	out := make([]scannedPackage, 0, len(packages))
 	for _, p := range packages {
 		configToUse := configManager.Get(r, p.Source.Path)
-		if ignore, ignoreLine := configToUse.ShouldIgnorePackageVersion(p.Name, p.Version, string(p.Ecosystem)); ignore {
+		if ignore, ignoreLine := configToUse.ShouldIgnorePackage(
+			models.PackageVulns{
+				Package: models.PackageInfo{
+					Name:      p.Name,
+					Version:   p.Version,
+					Ecosystem: string(p.Ecosystem),
+					Commit:    p.Commit,
+				},
+				DepGroups: p.DepGroups,
+			},
+		); ignore {
 			pkgString := fmt.Sprintf("%s/%s/%s", p.Ecosystem, p.Name, p.Version)
 			r.Infof("Package %s has been filtered out because: %s\n", pkgString, ignoreLine.Reason)
 

--- a/pkg/osvscanner/vulnerability_result.go
+++ b/pkg/osvscanner/vulnerability_result.go
@@ -68,7 +68,7 @@ func buildVulnerabilityResults(
 		}
 		if actions.ScanLicensesSummary || len(actions.ScanLicensesAllowlist) > 0 {
 			configToUse := configManager.Get(r, rawPkg.Source.Path)
-			if override, entry := configToUse.ShouldOverridePackageVersionLicense(pkg.Package.Name, pkg.Package.Version, pkg.Package.Ecosystem); override {
+			if override, entry := configToUse.ShouldOverridePackageLicense(pkg); override {
 				overrideLicenses := make([]models.License, len(entry.License.Override))
 				for j, license := range entry.License.Override {
 					overrideLicenses[j] = models.License(license)


### PR DESCRIPTION
This rewrites the package overrides logic to be composition based, granting a lot more flexibility:

```
# ignore everything
[[PackageOverrides]]
ignore = true

# ignore everything in this group
[[PackageOverrides]]
group = "dev"
ignore = true

# ignore everything in this ecosystem
[[PackageOverrides]]
ecosystem = "go"
ignore = true

# ignore all packages named "axios" regardless of ecosystem or group
[[PackageOverrides]]
name = "axios"
ignore = true

# ignore all packages named "axios" in the npm ecosystem that are in the dev group
[[PackageOverrides]]
name = "axios"
ecosystem = "npm"
group = "dev"
ignore = true

# ... and so on
```

While some of these might seem a bit extreme, ultimately I think this is probably the way to go as the logic itself is very straightforward and it gives a lot more power to the people.

Since `config` is a public package, I've had to deprecated the related existing public methods and there's a bit of naming & structural yuck but I figure that's not a big deal since v2 is right around the corner and again the logic itself is very straightforward.

Resolves #1211
Resolves #1155