### PR TITLE
chore: update test snapshots

### DIFF
--- a/cmd/osv-scanner/__snapshots__/update_test.snap
+++ b/cmd/osv-scanner/__snapshots__/update_test.snap
@@ -34,7 +34,7 @@ Warning: `update` exists as both a subcommand of OSV-Scanner and as a file on th
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.17.2</version>
+      <version>2.18.0-rc1</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Package `com.fasterxml.jackson.core:jackson-core` has a new version `2.18.0-rc1` https://central.sonatype.com/artifact/com.fasterxml.jackson.core/jackson-core/2.18.0-rc1

This PR updates the snapshot of `update` subcommand to this latest version.