### PR TITLE
chore: update Go to version 1.22.7

### DIFF
--- a/cmd/osv-reporter/main_test.go
+++ b/cmd/osv-reporter/main_test.go
@@ -29,7 +29,6 @@ func Test_splitLastArg(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := splitLastArg(tt.args); !reflect.DeepEqual(got, tt.want) {

--- a/cmd/osv-scanner/fix/main_test.go
+++ b/cmd/osv-scanner/fix/main_test.go
@@ -120,7 +120,6 @@ func TestParseUpgradeConfig(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctx, err := parseFlags(t, flags, tt.args)

--- a/cmd/osv-scanner/fix_test.go
+++ b/cmd/osv-scanner/fix_test.go
@@ -63,7 +63,6 @@ func TestRun_Fix(t *testing.T) {
 		// TODO: add tests with the cli flags
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -314,7 +314,6 @@ func TestRun(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -340,7 +339,6 @@ func TestRunCallAnalysis(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -473,7 +471,6 @@ func TestRun_LockfileWithExplicitParseAs(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -499,7 +496,6 @@ func TestRun_GithubActions(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -592,7 +588,6 @@ func TestRun_LocalDatabases(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -661,7 +656,6 @@ func TestRun_Licenses(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -718,7 +712,6 @@ func TestRun_OCIImage(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -761,7 +754,6 @@ func TestRun_SubCommands(t *testing.T) {
 		// TODO: add tests for other future subcommands
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -818,7 +810,6 @@ func TestRun_InsertDefaultCommand(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		stdout := &bytes.Buffer{}
 		stderr := &bytes.Buffer{}
 		argsActual := insertDefaultCommand(tt.originalArgs, commands, defaultCommand, stdout, stderr)
@@ -854,7 +845,6 @@ func TestRun_MavenTransitive(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			testCli(t, tt)

--- a/cmd/osv-scanner/update_test.go
+++ b/cmd/osv-scanner/update_test.go
@@ -26,7 +26,6 @@ func TestRun_Update(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			tc := cliTestCase{

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -77,7 +77,7 @@ Alternatively, you can install this from source by running:
 go install github.com/google/osv-scanner/cmd/osv-scanner@v1
 ```
 
-This requires Go 1.21.12+ to be installed.
+This requires Go 1.22.7+ to be installed.
 
 ## Build from source
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/osv-scanner
 
-go 1.21.12
+go 1.22.7
 
 require (
 	deps.dev/api/v3 v3.0.0-20240807013505-16da96fe8b66

--- a/internal/ci/vulnerability_result_diff_test.go
+++ b/internal/ci/vulnerability_result_diff_test.go
@@ -69,7 +69,6 @@ func TestDiffVulnerabilityResults(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := ci.DiffVulnerabilityResults(tt.args.oldRes, tt.args.newRes)
@@ -123,7 +122,6 @@ func TestDiffVulnerabilityByUniqueVulnCountResults(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := ci.DiffVulnerabilityResultsByOccurrences(tt.args.oldRes, tt.args.newRes)

--- a/internal/image/image_test.go
+++ b/internal/image/image_test.go
@@ -74,7 +74,6 @@ func TestScanImage(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/manifest/maven_test.go
+++ b/internal/manifest/maven_test.go
@@ -51,7 +51,6 @@ func TestMavenResolverExtractor_ShouldExtract(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			e := manifest.MavenResolverExtractor{}

--- a/internal/output/form_test.go
+++ b/internal/output/form_test.go
@@ -48,7 +48,6 @@ func TestForm(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/output/helpers_test.go
+++ b/internal/output/helpers_test.go
@@ -1019,7 +1019,6 @@ func testOutputWithVulnerabilities(t *testing.T, run outputTestRunner) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1619,7 +1618,6 @@ func testOutputWithLicenseViolations(t *testing.T, run outputTestRunner) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1999,7 +1997,6 @@ func testOutputWithMixedIssues(t *testing.T, run outputTestRunner) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/output/identifiers_test.go
+++ b/internal/output/identifiers_test.go
@@ -33,7 +33,6 @@ func Test_idSortFunc(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -68,7 +67,6 @@ func Test_idSortFuncUsage(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/output/result_test.go
+++ b/internal/output/result_test.go
@@ -38,7 +38,6 @@ func Test_groupFixedVersions(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := groupFixedVersions(tt.args)
@@ -72,8 +71,6 @@ func Test_mapIDsToGroupedSARIFFinding(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/output/sarif_internal_test.go
+++ b/internal/output/sarif_internal_test.go
@@ -28,7 +28,6 @@ func Test_createSARIFHelpText(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := createSARIFHelpText(&tt.args)

--- a/internal/output/sarif_test.go
+++ b/internal/output/sarif_test.go
@@ -35,7 +35,6 @@ func TestGroupFixedVersions(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := output.GroupFixedVersions(tt.args)
@@ -73,7 +72,6 @@ func TestPrintSARIFReport(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/remediation/in_place_test.go
+++ b/internal/remediation/in_place_test.go
@@ -132,7 +132,6 @@ func TestComputeInPlacePatches(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			g, cl := parseInPlaceFixture(t, tt.universePath, tt.lockfilePath)

--- a/internal/remediation/override_test.go
+++ b/internal/remediation/override_test.go
@@ -62,7 +62,6 @@ func TestComputeOverridePatches(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			res, cl := parseRemediationFixture(t, tt.universePath, tt.manifestPath)

--- a/internal/remediation/relax/npm_test.go
+++ b/internal/remediation/relax/npm_test.go
@@ -166,7 +166,6 @@ func TestRelaxNpm(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			cl := resolve.NewLocalClient()

--- a/internal/remediation/relax_test.go
+++ b/internal/remediation/relax_test.go
@@ -32,7 +32,6 @@ func TestComputeRelaxPatches(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			res, cl := parseRemediationFixture(t, tt.universePath, tt.manifestPath)

--- a/internal/remediation/remediation_test.go
+++ b/internal/remediation/remediation_test.go
@@ -198,7 +198,6 @@ func TestMatchVuln(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/resolution/datasource/npmrc_test.go
+++ b/internal/resolution/datasource/npmrc_test.go
@@ -283,7 +283,6 @@ func TestNpmRegistryAuthOpts(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			header := make(http.Header)

--- a/internal/resolution/manifest/maven.go
+++ b/internal/resolution/manifest/maven.go
@@ -294,7 +294,7 @@ func (MavenManifestIO) Write(df lockfile.DepFile, w io.Writer, patch ManifestPat
 	currentPath := df.Path()
 	parent := specific.Parent
 	visited := make(map[maven.ProjectKey]bool, mavenutil.MaxParent)
-	for n := 0; n < mavenutil.MaxParent; n++ {
+	for range mavenutil.MaxParent {
 		if parent.GroupID == "" || parent.ArtifactID == "" || parent.Version == "" {
 			break
 		}

--- a/internal/resolution/resolve_test.go
+++ b/internal/resolution/resolve_test.go
@@ -206,7 +206,6 @@ func TestResolve(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			cl := clienttest.NewMockResolutionClient(t, tt.universe)

--- a/internal/semantic/compare_test.go
+++ b/internal/semantic/compare_test.go
@@ -236,7 +236,6 @@ func TestVersion_Compare_Ecosystems(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/semantic/version-alpine.go
+++ b/internal/semantic/version-alpine.go
@@ -106,7 +106,7 @@ type AlpineVersion struct {
 func (v AlpineVersion) compareComponents(w AlpineVersion) int {
 	numberOfComponents := max(len(v.components), len(w.components))
 
-	for i := 0; i < numberOfComponents; i++ {
+	for i := range numberOfComponents {
 		diff := v.components.Fetch(i).Cmp(w.components.Fetch(i))
 
 		if diff != 0 {
@@ -150,7 +150,7 @@ func (as alpineSuffix) Cmp(bs alpineSuffix) int {
 func (v AlpineVersion) compareSuffixes(w AlpineVersion) int {
 	numberOfSuffixes := max(len(v.suffixes), len(w.suffixes))
 
-	for i := 0; i < numberOfSuffixes; i++ {
+	for i := range numberOfSuffixes {
 		diff := v.fetchSuffix(i).Cmp(w.fetchSuffix(i))
 
 		if diff != 0 {

--- a/internal/semantic/version-debian.go
+++ b/internal/semantic/version-debian.go
@@ -91,7 +91,7 @@ func compareDebianVersions(a, b string) int {
 			apSplit := strings.Split(ap, "")
 			bpSplit := strings.Split(bp, "")
 
-			for i := 0; i < max(len(ap), len(bp)); i++ {
+			for i := range max(len(ap), len(bp)) {
 				aw := weighDebianChar(fetch(apSplit, i, ""))
 				bw := weighDebianChar(fetch(bpSplit, i, ""))
 

--- a/internal/semantic/version-maven.go
+++ b/internal/semantic/version-maven.go
@@ -107,7 +107,7 @@ func (mv MavenVersion) equal(mw MavenVersion) bool {
 		return false
 	}
 
-	for i := 0; i < len(mv.tokens); i++ {
+	for i := range len(mv.tokens) {
 		if !mv.tokens[i].equal(mw.tokens[i]) {
 			return false
 		}
@@ -141,7 +141,7 @@ func (mv MavenVersion) lessThan(mw MavenVersion) bool {
 	var left mavenVersionToken
 	var right mavenVersionToken
 
-	for i := 0; i < numberOfTokens; i++ {
+	for i := range numberOfTokens {
 		// the shorter one padded with enough "null" values with matching prefix to
 		// have the same length as the longer one. Padded "null" values depend on
 		// the prefix of the other version: 0 for '.', "" for '-'

--- a/internal/semantic/version-packagist.go
+++ b/internal/semantic/version-packagist.go
@@ -57,7 +57,7 @@ func comparePackagistComponents(a, b []string) int {
 
 	var compare int
 
-	for i := 0; i < minLength; i++ {
+	for i := range minLength {
 		ai, aIsNumber := convertToBigInt(a[i])
 		bi, bIsNumber := convertToBigInt(b[i])
 

--- a/internal/semantic/version-pypi.go
+++ b/internal/semantic/version-pypi.go
@@ -286,7 +286,7 @@ func (pv PyPIVersion) compareLocal(pw PyPIVersion) int {
 
 	var compare int
 
-	for i := 0; i < minVersionLength; i++ {
+	for i := range minVersionLength {
 		ai, aIsNumber := convertToBigInt(pv.local[i])
 		bi, bIsNumber := convertToBigInt(pw.local[i])
 

--- a/internal/semantic/version-rubygems.go
+++ b/internal/semantic/version-rubygems.go
@@ -77,7 +77,7 @@ func compareRubyGemsComponents(a, b []string) int {
 
 	var compare int
 
-	for i := 0; i < numberOfComponents; i++ {
+	for i := range numberOfComponents {
 		as := fetch(a, i, "0")
 		bs := fetch(b, i, "0")
 

--- a/internal/semantic/version-semver.go
+++ b/internal/semantic/version-semver.go
@@ -43,7 +43,7 @@ func compareSemverBuildComponents(a, b []string) int {
 
 	var compare int
 
-	for i := 0; i < minComponentLength; i++ {
+	for i := range minComponentLength {
 		ai, aIsNumber := convertToBigInt(a[i])
 		bi, bIsNumber := convertToBigInt(b[i])
 

--- a/internal/semantic/version.go
+++ b/internal/semantic/version.go
@@ -25,7 +25,7 @@ func (components *Components) Fetch(n int) *big.Int {
 func (components *Components) Cmp(b Components) int {
 	numberOfComponents := max(len(*components), len(b))
 
-	for i := 0; i < numberOfComponents; i++ {
+	for i := range numberOfComponents {
 		diff := components.Fetch(i).Cmp(b.Fetch(i))
 
 		if diff != 0 {

--- a/internal/url/url_test.go
+++ b/internal/url/url_test.go
@@ -17,7 +17,6 @@ func TestURLFromFilePath(t *testing.T) {
 		if tc.filePath == "" {
 			continue
 		}
-		tc := tc
 
 		t.Run(tc.filePath, func(t *testing.T) {
 			t.Parallel()

--- a/internal/utility/severity/severity_test.go
+++ b/internal/utility/severity/severity_test.go
@@ -75,7 +75,6 @@ func TestSeverity_CalculateScore(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/utility/vulns/vulnerabilities_test.go
+++ b/internal/utility/vulns/vulnerabilities_test.go
@@ -117,7 +117,6 @@ func TestVulnerabilities_Includes(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/config/config_internal_test.go
+++ b/pkg/config/config_internal_test.go
@@ -199,7 +199,6 @@ func TestConfig_ShouldIgnore(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -318,7 +317,6 @@ func TestConfig_ShouldIgnorePackageVersion(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -434,7 +432,6 @@ func TestConfig_ShouldOverridePackageVersionLicense(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/config/config_internal_test.go
+++ b/pkg/config/config_internal_test.go
@@ -633,7 +633,6 @@ func TestConfig_ShouldIgnorePackage(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -868,7 +867,6 @@ func TestConfig_ShouldOverridePackageLicense(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/depsdev/license.go
+++ b/pkg/depsdev/license.go
@@ -81,7 +81,6 @@ func MakeVersionRequestsWithContext(ctx context.Context, queries []*depsdevpb.Ge
 			licenses[i] = []models.License{models.License("UNKNOWN")}
 			continue
 		}
-		i := i
 		g.Go(func() error {
 			resp, err := client.GetVersion(ctx, queries[i])
 			if err != nil {

--- a/pkg/grouper/grouper.go
+++ b/pkg/grouper/grouper.go
@@ -26,12 +26,12 @@ func Group(vulns []IDAliases) []models.GroupInfo {
 	groups := make([]int, len(vulns))
 
 	// Initially make every vulnerability its own group.
-	for i := 0; i < len(vulns); i++ {
+	for i := range len(vulns) {
 		groups[i] = i
 	}
 
 	// Do a pair-wise (n^2) comparison and merge all intersecting vulns.
-	for i := 0; i < len(vulns); i++ {
+	for i := range len(vulns) {
 		for j := i + 1; j < len(vulns); j++ {
 			if hasAliasIntersection(vulns[i], vulns[j]) {
 				// Merge the two groups. Use the smaller index as the representative ID.

--- a/pkg/lockfile/csv_test.go
+++ b/pkg/lockfile/csv_test.go
@@ -139,7 +139,6 @@ func TestFromCSVRows(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -241,7 +240,6 @@ func TestFromCSVRows_Errors(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -481,7 +479,6 @@ func TestFromCSVFile(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -529,7 +526,6 @@ func TestFromCSVFile_Errors(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/lockfile/go-binary_test.go
+++ b/pkg/lockfile/go-binary_test.go
@@ -62,7 +62,6 @@ func TestGoBinaryExtractor_ShouldExtract(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			e := lockfile.GoBinaryExtractor{}

--- a/pkg/lockfile/node-modules_test.go
+++ b/pkg/lockfile/node-modules_test.go
@@ -105,7 +105,6 @@ func TestNodeModulesExtractor_ShouldExtract(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			e := lockfile.NodeModulesExtractor{}

--- a/pkg/lockfile/parse-cargo-lock_test.go
+++ b/pkg/lockfile/parse-cargo-lock_test.go
@@ -47,7 +47,6 @@ func TestCargoLockExtractor_ShouldExtract(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			e := lockfile.CargoLockExtractor{}

--- a/pkg/lockfile/parse-composer-lock_test.go
+++ b/pkg/lockfile/parse-composer-lock_test.go
@@ -47,7 +47,6 @@ func TestComposerLockExtractor_ShouldExtract(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			e := lockfile.ComposerLockExtractor{}

--- a/pkg/lockfile/parse-conan-lock_test.go
+++ b/pkg/lockfile/parse-conan-lock_test.go
@@ -46,7 +46,6 @@ func TestConanLockExtractor_ShouldExtract(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			e := lockfile.ConanLockExtractor{}

--- a/pkg/lockfile/parse-gemfile-lock_test.go
+++ b/pkg/lockfile/parse-gemfile-lock_test.go
@@ -47,7 +47,6 @@ func TestGemfileLockExtractor_ShouldExtract(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			e := lockfile.GemfileLockExtractor{}

--- a/pkg/lockfile/parse-go-lock_test.go
+++ b/pkg/lockfile/parse-go-lock_test.go
@@ -47,7 +47,6 @@ func TestGoLockExtractor_ShouldExtract(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			e := lockfile.GoLockExtractor{}

--- a/pkg/lockfile/parse-gradle-lock_test.go
+++ b/pkg/lockfile/parse-gradle-lock_test.go
@@ -72,7 +72,6 @@ func TestGradleLockExtractor_ShouldExtract(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			e := lockfile.GradleLockExtractor{}

--- a/pkg/lockfile/parse-gradle-verification-metadata_test.go
+++ b/pkg/lockfile/parse-gradle-verification-metadata_test.go
@@ -72,7 +72,6 @@ func TestGradleVerificationMetadataExtractor_ShouldExtract(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			e := lockfile.GradleVerificationMetadataExtractor{}

--- a/pkg/lockfile/parse-maven-lock_test.go
+++ b/pkg/lockfile/parse-maven-lock_test.go
@@ -47,7 +47,6 @@ func TestMavenLockExtractor_ShouldExtract(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			e := lockfile.MavenLockExtractor{}
@@ -277,7 +276,6 @@ func TestMavenLockDependency_ResolveVersion(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/lockfile/parse-mix-lock_test.go
+++ b/pkg/lockfile/parse-mix-lock_test.go
@@ -47,7 +47,6 @@ func TestMixLockExtractor_ShouldExtract(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			e := lockfile.MixLockExtractor{}

--- a/pkg/lockfile/parse-npm-lock_test.go
+++ b/pkg/lockfile/parse-npm-lock_test.go
@@ -46,7 +46,6 @@ func TestNpmLockExtractor_ShouldExtract(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			e := lockfile.NpmLockExtractor{}

--- a/pkg/lockfile/parse-nuget-lock_test.go
+++ b/pkg/lockfile/parse-nuget-lock_test.go
@@ -46,7 +46,6 @@ func TestNuGetLockExtractor_ShouldExtract(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			e := lockfile.NuGetLockExtractor{}

--- a/pkg/lockfile/parse-pipenv-lock_test.go
+++ b/pkg/lockfile/parse-pipenv-lock_test.go
@@ -47,7 +47,6 @@ func TestPipenvLockExtractor_ShouldExtract(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			e := lockfile.PipenvLockExtractor{}

--- a/pkg/lockfile/parse-pnpm-lock_test.go
+++ b/pkg/lockfile/parse-pnpm-lock_test.go
@@ -47,7 +47,6 @@ func TestPnpmLockExtractor_ShouldExtract(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			e := lockfile.PnpmLockExtractor{}

--- a/pkg/lockfile/parse-poetry-lock_test.go
+++ b/pkg/lockfile/parse-poetry-lock_test.go
@@ -47,7 +47,6 @@ func TestPoetryLockExtractor_ShouldExtract(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			e := lockfile.PoetryLockExtractor{}

--- a/pkg/lockfile/parse-pubspec-lock_test.go
+++ b/pkg/lockfile/parse-pubspec-lock_test.go
@@ -47,7 +47,6 @@ func TestPubspecLockExtractor_ShouldExtract(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			e := lockfile.PubspecLockExtractor{}

--- a/pkg/lockfile/parse-requirements-txt_test.go
+++ b/pkg/lockfile/parse-requirements-txt_test.go
@@ -47,7 +47,6 @@ func TestRequirementsTxtExtractor_ShouldExtract(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			e := lockfile.RequirementsTxtExtractor{}

--- a/pkg/lockfile/parse-yarn-lock_test.go
+++ b/pkg/lockfile/parse-yarn-lock_test.go
@@ -46,7 +46,6 @@ func TestYarnLockExtractor_ShouldExtract(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			e := lockfile.YarnLockExtractor{}

--- a/pkg/lockfile/parse_test.go
+++ b/pkg/lockfile/parse_test.go
@@ -305,7 +305,6 @@ func TestPackages_Ecosystems(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/models/purl_to_package_test.go
+++ b/pkg/models/purl_to_package_test.go
@@ -83,7 +83,6 @@ func TestPURLToPackage(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := models.PURLToPackage(tt.args.purl)

--- a/pkg/models/vulnerabilities_test.go
+++ b/pkg/models/vulnerabilities_test.go
@@ -45,7 +45,6 @@ func TestVulnerabilities_MarshalJSON(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := tt.vs.MarshalJSON()

--- a/pkg/osv/osv.go
+++ b/pkg/osv/osv.go
@@ -282,7 +282,6 @@ func HydrateWithClient(resp *BatchedResponse, client *http.Client) (*HydratedBat
 		for resultIdx, vuln := range response.Vulns {
 			id := vuln.ID
 			batchIdx := batchIdx
-			resultIdx := resultIdx
 			g.Go(func() error {
 				// exit early if another hydration request has already failed
 				// results are thrown away later, so avoid needless work

--- a/pkg/osv/osv.go
+++ b/pkg/osv/osv.go
@@ -311,7 +311,7 @@ func makeRetryRequest(action func() (*http.Response, error)) (*http.Response, er
 	var resp *http.Response
 	var err error
 
-	for i := 0; i < maxRetryAttempts; i++ {
+	for i := range maxRetryAttempts {
 		// rand is initialized with a random number (since go1.20), and is also safe to use concurrently
 		// we do not need to use a cryptographically secure random jitter, this is just to spread out the retry requests
 		// #nosec G404

--- a/pkg/osvscanner/osvscanner_internal_test.go
+++ b/pkg/osvscanner/osvscanner_internal_test.go
@@ -37,7 +37,6 @@ func Test_filterResults(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Reinitialize for t.Parallel()
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			r := &reporter.VoidReporter{}

--- a/pkg/osvscanner/vulnerability_result_internal_test.go
+++ b/pkg/osvscanner/vulnerability_result_internal_test.go
@@ -197,7 +197,6 @@ func Test_assembleResult(t *testing.T) {
 		},
 	}}
 	for _, tt := range tests {
-		tt := tt // Reinitialize for t.Parallel()
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := buildVulnerabilityResults(tt.args.r, tt.args.packages, tt.args.vulnsResp, tt.args.licensesResp, tt.args.actions, tt.args.config)

--- a/pkg/spdx/verify_test.go
+++ b/pkg/spdx/verify_test.go
@@ -27,7 +27,6 @@ func Test_unrecognized(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Reinitialize for t.Parallel()
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := Unrecognized(tt.licenses); !reflect.DeepEqual(got, tt.want) {

--- a/renovate.json
+++ b/renovate.json
@@ -27,7 +27,7 @@
     }
   ],
   "constraints": {
-    "go": "1.21.12"
+    "go": "1.22.7"
   },
   "ignorePaths": ["**/fixtures/**", "**/fixtures-go/**"],
   "ignoreDeps": ["golang.org/x/vuln"]

--- a/scripts/generate_mock_resolution_universe/main.go
+++ b/scripts/generate_mock_resolution_universe/main.go
@@ -293,7 +293,6 @@ func main() {
 
 	group := &errgroup.Group{}
 	for _, filename := range os.Args[1:] {
-		filename := filename
 		if io, err := manifest.GetManifestIO(filename); err == nil {
 			if remediation.SupportsRelax(io) {
 				group.Go(func() error {


### PR DESCRIPTION
A few Go vulnerabilities are reported so this PR updates Go to the fixed version 1.22.7.

Also `golang.org/x/mod@v0.21.0` requires Go 1.22.0 as mentioned in https://github.com/google/osv-scanner/pull/1204.

Due to this version update, there are two new lint checks: [copyloopvar](https://github.com/karamaru-alpha/copyloopvar) and [intrange](https://github.com/ckaznocha/intrange).