### PR TITLE
feat(guided remediation): remediate unresolved dependency management vulns

### DIFF
--- a/cmd/osv-scanner/fix/main.go
+++ b/cmd/osv-scanner/fix/main.go
@@ -163,8 +163,8 @@ func Command(stdout, stderr io.Writer, r *reporter.Reporter) *cli.Command {
 			},
 			&cli.BoolFlag{
 				Category: vulnCategory,
-				Name:     "maven-ignore-management",
-				Usage:    "(pom.xml) ignore vulnerabilities in dependencyManagement packages that do not appear in the resolved dependency graph",
+				Name:     "maven-fix-management",
+				Usage:    "(pom.xml) also remediate vulnerabilities in dependencyManagement packages that do not appear in the resolved dependency graph",
 			},
 		},
 		Action: func(ctx *cli.Context) error {
@@ -240,7 +240,7 @@ func action(ctx *cli.Context, stdout, stderr io.Writer) (reporter.Reporter, erro
 	opts := osvFixOptions{
 		RemediationOptions: remediation.RemediationOptions{
 			ResolveOpts: resolution.ResolveOpts{
-				MavenManagement: !ctx.Bool("maven-ignore-management"),
+				MavenManagement: ctx.Bool("maven-fix-management"),
 			},
 			IgnoreVulns:   ctx.StringSlice("ignore-vulns"),
 			ExplicitVulns: ctx.StringSlice("vulns"),

--- a/cmd/osv-scanner/fix/main.go
+++ b/cmd/osv-scanner/fix/main.go
@@ -11,6 +11,7 @@ import (
 	"deps.dev/util/resolve"
 	"github.com/google/osv-scanner/internal/remediation"
 	"github.com/google/osv-scanner/internal/remediation/upgrade"
+	"github.com/google/osv-scanner/internal/resolution"
 	"github.com/google/osv-scanner/internal/resolution/client"
 	"github.com/google/osv-scanner/internal/resolution/datasource"
 	"github.com/google/osv-scanner/internal/resolution/lockfile"
@@ -160,6 +161,11 @@ func Command(stdout, stderr io.Writer, r *reporter.Reporter) *cli.Command {
 				Name:     "ignore-dev",
 				Usage:    "ignore vulnerabilities affecting only development dependencies",
 			},
+			&cli.BoolFlag{
+				Category: vulnCategory,
+				Name:     "maven-ignore-management",
+				Usage:    "(pom.xml) ignore vulnerabilities in dependencyManagement packages that do not appear in the resolved dependency graph",
+			},
 		},
 		Action: func(ctx *cli.Context) error {
 			var err error
@@ -233,6 +239,9 @@ func action(ctx *cli.Context, stdout, stderr io.Writer) (reporter.Reporter, erro
 
 	opts := osvFixOptions{
 		RemediationOptions: remediation.RemediationOptions{
+			ResolveOpts: resolution.ResolveOpts{
+				MavenManagement: !ctx.Bool("maven-ignore-management"),
+			},
 			IgnoreVulns:   ctx.StringSlice("ignore-vulns"),
 			ExplicitVulns: ctx.StringSlice("vulns"),
 			DevDeps:       !ctx.Bool("ignore-dev"),

--- a/cmd/osv-scanner/fix/model.go
+++ b/cmd/osv-scanner/fix/model.go
@@ -201,8 +201,8 @@ type doRelockMsg struct {
 	err error
 }
 
-func doRelock(ctx context.Context, cl client.ResolutionClient, m manif.Manifest, matchFn func(resolution.ResolutionVuln) bool) tea.Msg {
-	res, err := resolution.Resolve(ctx, cl, m)
+func doRelock(ctx context.Context, cl client.ResolutionClient, m manif.Manifest, opts resolution.ResolveOpts, matchFn func(resolution.ResolutionVuln) bool) tea.Msg {
+	res, err := resolution.Resolve(ctx, cl, m, opts)
 	if err != nil {
 		return doRelockMsg{nil, err}
 	}
@@ -228,7 +228,7 @@ func doInitialRelock(ctx context.Context, opts osvFixOptions) tea.Msg {
 	}
 	opts.Client.PreFetch(ctx, m.Requirements, m.FilePath)
 
-	return doRelock(ctx, opts.Client, m, opts.MatchVuln)
+	return doRelock(ctx, opts.Client, m, opts.ResolveOpts, opts.MatchVuln)
 }
 
 // tui.ViewModel for showing non-interactive strings

--- a/cmd/osv-scanner/fix/noninteractive.go
+++ b/cmd/osv-scanner/fix/noninteractive.go
@@ -130,7 +130,7 @@ func autoRelock(ctx context.Context, r reporter.Reporter, opts osvFixOptions, ma
 	}
 
 	opts.Client.PreFetch(ctx, manif.Requirements, manif.FilePath)
-	res, err := resolution.Resolve(ctx, opts.Client, manif)
+	res, err := resolution.Resolve(ctx, opts.Client, manif, opts.ResolveOpts)
 	if err != nil {
 		return err
 	}
@@ -295,7 +295,7 @@ func autoOverride(ctx context.Context, r reporter.Reporter, opts osvFixOptions, 
 	}
 
 	opts.Client.PreFetch(ctx, manif.Requirements, manif.FilePath)
-	res, err := resolution.Resolve(ctx, opts.Client, manif)
+	res, err := resolution.Resolve(ctx, opts.Client, manif, opts.ResolveOpts)
 	if err != nil {
 		return err
 	}

--- a/cmd/osv-scanner/fix/state-relock-result.go
+++ b/cmd/osv-scanner/fix/state-relock-result.go
@@ -305,7 +305,7 @@ func (st *stateRelockResult) relaxChoice(m model) (model, tea.Cmd) {
 	st.currRes = nil
 
 	return m, func() tea.Msg {
-		return doRelock(m.ctx, m.cl, manifest, m.options.MatchVuln)
+		return doRelock(m.ctx, m.cl, manifest, m.options.ResolveOpts, m.options.MatchVuln)
 	}
 }
 

--- a/internal/remediation/__snapshots__/testhelpers_test.snap
+++ b/internal/remediation/__snapshots__/testhelpers_test.snap
@@ -3,6 +3,158 @@
 []
 ---
 
+[TestComputeOverridePatches/maven-management-only - 1]
+[
+  {
+    "Patch": {
+      "Deps": [
+        {
+          "Pkg": {
+            "System": 6,
+            "Name": "org.apache.commons:commons-configuration2"
+          },
+          "Type": {},
+          "OrigRequire": "",
+          "NewRequire": "2.10.1",
+          "OrigResolved": "2.8.0",
+          "NewResolved": "2.10.1"
+        }
+      ],
+      "EcosystemSpecific": null
+    },
+    "RemovedVulns": [
+      {
+        "ID": "GHSA-9w38-p64v-xpmv",
+        "AffectedNodes": [
+          16
+        ]
+      },
+      {
+        "ID": "GHSA-xjp4-hw94-mvp5",
+        "AffectedNodes": [
+          16
+        ]
+      }
+    ],
+    "AddedVulns": []
+  },
+  {
+    "Patch": {
+      "Deps": [
+        {
+          "Pkg": {
+            "System": 6,
+            "Name": "org.apache.shiro:shiro-web"
+          },
+          "Type": {},
+          "OrigRequire": "",
+          "NewRequire": "1.13.0",
+          "OrigResolved": "1.10.0",
+          "NewResolved": "1.13.0"
+        }
+      ],
+      "EcosystemSpecific": null
+    },
+    "RemovedVulns": [
+      {
+        "ID": "GHSA-hhw5-c326-822h",
+        "AffectedNodes": [
+          23
+        ]
+      },
+      {
+        "ID": "GHSA-pmhc-2g4f-85cg",
+        "AffectedNodes": [
+          23
+        ]
+      }
+    ],
+    "AddedVulns": []
+  },
+  {
+    "Patch": {
+      "Deps": [
+        {
+          "Pkg": {
+            "System": 6,
+            "Name": "org.apache.shiro:shiro-core"
+          },
+          "Type": {},
+          "OrigRequire": "",
+          "NewRequire": "1.13.0",
+          "OrigResolved": "1.10.0",
+          "NewResolved": "1.13.0"
+        }
+      ],
+      "EcosystemSpecific": null
+    },
+    "RemovedVulns": [
+      {
+        "ID": "GHSA-jc7h-c423-mpjc",
+        "AffectedNodes": [
+          22
+        ]
+      }
+    ],
+    "AddedVulns": []
+  },
+  {
+    "Patch": {
+      "Deps": [
+        {
+          "Pkg": {
+            "System": 6,
+            "Name": "org.apache.shiro:shiro-web"
+          },
+          "Type": {},
+          "OrigRequire": "",
+          "NewRequire": "1.12.0",
+          "OrigResolved": "1.10.0",
+          "NewResolved": "1.12.0"
+        }
+      ],
+      "EcosystemSpecific": null
+    },
+    "RemovedVulns": [
+      {
+        "ID": "GHSA-pmhc-2g4f-85cg",
+        "AffectedNodes": [
+          23
+        ]
+      }
+    ],
+    "AddedVulns": []
+  },
+  {
+    "Patch": {
+      "Deps": [
+        {
+          "Pkg": {
+            "System": 6,
+            "Name": "org.apache.thrift:libthrift"
+          },
+          "Type": {},
+          "OrigRequire": "",
+          "NewRequire": "0.14.0",
+          "OrigResolved": "0.13.0",
+          "NewResolved": "0.14.0"
+        }
+      ],
+      "EcosystemSpecific": null
+    },
+    "RemovedVulns": [
+      {
+        "ID": "GHSA-g2fg-mr77-6vrm",
+        "AffectedNodes": [
+          6
+        ]
+      }
+    ],
+    "AddedVulns": []
+  }
+]
+---
+
 [TestComputeOverridePatches/maven-zeppelin-server - 1]
 [
   {

--- a/internal/remediation/override.go
+++ b/internal/remediation/override.go
@@ -225,7 +225,7 @@ func overridePatchVulns(ctx context.Context, cl client.ResolutionClient, result 
 			return nil, nil, err
 		}
 
-		result, err = resolution.Resolve(ctx, cl, newManif)
+		result, err = resolution.Resolve(ctx, cl, newManif, opts.ResolveOpts)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/internal/remediation/override_test.go
+++ b/internal/remediation/override_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/osv-scanner/internal/remediation"
 	"github.com/google/osv-scanner/internal/remediation/upgrade"
+	"github.com/google/osv-scanner/internal/resolution"
 )
 
 func TestComputeOverridePatches(t *testing.T) {
@@ -36,6 +37,19 @@ func TestComputeOverridePatches(t *testing.T) {
 			opts:         basicOpts,
 		},
 		{
+			name:         "maven-management-only",
+			universePath: "./fixtures/zeppelin-server/universe.yaml",
+			manifestPath: "./fixtures/zeppelin-server/parent/pom.xml",
+			opts: remediation.RemediationOptions{
+				ResolveOpts: resolution.ResolveOpts{
+					MavenManagement: true,
+				},
+				DevDeps:       true,
+				MaxDepth:      -1,
+				UpgradeConfig: upgrade.NewConfig(),
+			},
+		},
+		{
 			name:         "workaround-maven-guava-none-to-jre",
 			universePath: "./fixtures/override-workaround/universe.yaml",
 			manifestPath: "./fixtures/override-workaround/guava/none-to-jre/pom.xml",
@@ -64,7 +78,7 @@ func TestComputeOverridePatches(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			res, cl := parseRemediationFixture(t, tt.universePath, tt.manifestPath)
+			res, cl := parseRemediationFixture(t, tt.universePath, tt.manifestPath, tt.opts.ResolveOpts)
 			res.FilterVulns(tt.opts.MatchVuln)
 			p, err := remediation.ComputeOverridePatches(context.Background(), cl, res, tt.opts)
 			if err != nil {

--- a/internal/remediation/relax.go
+++ b/internal/remediation/relax.go
@@ -105,7 +105,7 @@ func tryRelaxRemediate(
 		}
 
 		// re-resolve relaxed manifest
-		newRes, err = resolution.Resolve(ctx, cl, manif)
+		newRes, err = resolution.Resolve(ctx, cl, manif, opts.ResolveOpts)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/remediation/relax_test.go
+++ b/internal/remediation/relax_test.go
@@ -34,7 +34,7 @@ func TestComputeRelaxPatches(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			res, cl := parseRemediationFixture(t, tt.universePath, tt.manifestPath)
+			res, cl := parseRemediationFixture(t, tt.universePath, tt.manifestPath, tt.opts.ResolveOpts)
 			res.FilterVulns(tt.opts.MatchVuln)
 			p, err := remediation.ComputeRelaxPatches(context.Background(), cl, res, tt.opts)
 			if err != nil {

--- a/internal/remediation/remediation.go
+++ b/internal/remediation/remediation.go
@@ -40,6 +40,7 @@ func SupportsInPlace(l lockfile.LockfileIO) bool {
 }
 
 type RemediationOptions struct {
+	resolution.ResolveOpts
 	IgnoreVulns   []string // Vulnerability IDs to ignore
 	ExplicitVulns []string // If set, only consider these vulnerability IDs & ignore all others
 

--- a/internal/remediation/testhelpers_test.go
+++ b/internal/remediation/testhelpers_test.go
@@ -37,7 +37,7 @@ func parseRemediationFixture(t *testing.T, universePath, manifestPath string) (*
 
 	cl := clienttest.NewMockResolutionClient(t, universePath)
 
-	res, err := resolution.Resolve(context.Background(), cl, m)
+	res, err := resolution.Resolve(context.Background(), cl, m, resolution.ResolveOpts{})
 	if err != nil {
 		t.Fatalf("Failed to resolve manifest: %v", err)
 	}

--- a/internal/remediation/testhelpers_test.go
+++ b/internal/remediation/testhelpers_test.go
@@ -16,7 +16,7 @@ import (
 	"golang.org/x/exp/maps"
 )
 
-func parseRemediationFixture(t *testing.T, universePath, manifestPath string) (*resolution.ResolutionResult, client.ResolutionClient) {
+func parseRemediationFixture(t *testing.T, universePath, manifestPath string, opts resolution.ResolveOpts) (*resolution.ResolutionResult, client.ResolutionClient) {
 	t.Helper()
 
 	io, err := manifest.GetManifestIO(manifestPath)
@@ -37,7 +37,7 @@ func parseRemediationFixture(t *testing.T, universePath, manifestPath string) (*
 
 	cl := clienttest.NewMockResolutionClient(t, universePath)
 
-	res, err := resolution.Resolve(context.Background(), cl, m, resolution.ResolveOpts{})
+	res, err := resolution.Resolve(context.Background(), cl, m, opts)
 	if err != nil {
 		t.Fatalf("Failed to resolve manifest: %v", err)
 	}

--- a/internal/resolution/resolve.go
+++ b/internal/resolution/resolve.go
@@ -123,9 +123,10 @@ func resolvePostProcess(ctx context.Context, cl client.ResolutionClient, m manif
 		}
 
 		// Search through OriginalRequirements management dependencies in this pom only (not parents).
+		// TODO: Possibly refactor RequirementsForUpdates for this purpose.
 		for _, req := range manifestSpecific.OriginalRequirements {
 			if req.Origin != mavenutil.OriginManagement {
-				// TODO: also check management in activated profiles
+				// TODO: also check management in activated profiles and dependencies in inactive profiles.
 				continue
 			}
 

--- a/internal/resolution/resolve.go
+++ b/internal/resolution/resolve.go
@@ -125,6 +125,7 @@ func resolvePostProcess(ctx context.Context, cl client.ResolutionClient, m manif
 		// Search through OriginalRequirements management dependencies in this pom only (not parents).
 		for _, req := range manifestSpecific.OriginalRequirements {
 			if req.Origin != mavenutil.OriginManagement {
+				// TODO: also check management in activated profiles
 				continue
 			}
 

--- a/internal/resolution/resolve_test.go
+++ b/internal/resolution/resolve_test.go
@@ -70,6 +70,7 @@ func TestResolve(t *testing.T) {
 		system       resolve.System
 		universe     string
 		requirements []requirement
+		opts         resolution.ResolveOpts
 	}{
 		{
 			name:     "simple", // simple root -> dependency -> vuln
@@ -237,7 +238,7 @@ func TestResolve(t *testing.T) {
 				m.Groups[manifest.MakeRequirementKey(m.Requirements[i])] = req.groups
 			}
 
-			res, err := resolution.Resolve(context.Background(), cl, m)
+			res, err := resolution.Resolve(context.Background(), cl, m, tt.opts)
 			if err != nil {
 				t.Fatalf("error resolving: %v", err)
 			}

--- a/scripts/generate_mock_resolution_universe/main.go
+++ b/scripts/generate_mock_resolution_universe/main.go
@@ -39,8 +39,13 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-var resolveOpts = resolution.ResolveOpts{
-	MavenManagement: true,
+var remediationOpts = remediation.RemediationOptions{
+	ResolveOpts: resolution.ResolveOpts{
+		MavenManagement: true,
+	},
+	DevDeps:       true,
+	MaxDepth:      -1,
+	UpgradeConfig: upgrade.NewConfig(),
 }
 
 func doRelockRelax(ddCl *client.DepsDevClient, io manifest.ManifestIO, filename string) error {
@@ -61,15 +66,11 @@ func doRelockRelax(ddCl *client.DepsDevClient, io manifest.ManifestIO, filename 
 	}
 
 	cl.PreFetch(context.Background(), manif.Requirements, manif.FilePath)
-	res, err := resolution.Resolve(context.Background(), cl, manif, resolveOpts)
+	res, err := resolution.Resolve(context.Background(), cl, manif, remediationOpts.ResolveOpts)
 	if err != nil {
 		return err
 	}
-	_, err = remediation.ComputeRelaxPatches(context.Background(), cl, res, remediation.RemediationOptions{
-		DevDeps:       true,
-		MaxDepth:      -1,
-		UpgradeConfig: upgrade.NewConfig(),
-	})
+	_, err = remediation.ComputeRelaxPatches(context.Background(), cl, res, remediationOpts)
 
 	return err
 }
@@ -92,15 +93,11 @@ func doOverride(ddCl *client.DepsDevClient, io manifest.ManifestIO, filename str
 	}
 
 	cl.PreFetch(context.Background(), manif.Requirements, manif.FilePath)
-	res, err := resolution.Resolve(context.Background(), cl, manif, resolveOpts)
+	res, err := resolution.Resolve(context.Background(), cl, manif, remediationOpts.ResolveOpts)
 	if err != nil {
 		return err
 	}
-	_, err = remediation.ComputeOverridePatches(context.Background(), cl, res, remediation.RemediationOptions{
-		DevDeps:       true,
-		MaxDepth:      -1,
-		UpgradeConfig: upgrade.NewConfig(),
-	})
+	_, err = remediation.ComputeOverridePatches(context.Background(), cl, res, remediationOpts)
 
 	return err
 }
@@ -134,11 +131,7 @@ func doInPlace(ddCl *client.DepsDevClient, io lockfile.LockfileIO, filename stri
 	}
 	_ = group.Wait()
 
-	_, err = remediation.ComputeInPlacePatches(context.Background(), cl, g, remediation.RemediationOptions{
-		DevDeps:       true,
-		MaxDepth:      -1,
-		UpgradeConfig: upgrade.NewConfig(),
-	})
+	_, err = remediation.ComputeInPlacePatches(context.Background(), cl, g, remediationOpts)
 
 	return err
 }

--- a/scripts/generate_mock_resolution_universe/main.go
+++ b/scripts/generate_mock_resolution_universe/main.go
@@ -39,6 +39,10 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+var resolveOpts = resolution.ResolveOpts{
+	MavenManagement: true,
+}
+
 func doRelockRelax(ddCl *client.DepsDevClient, io manifest.ManifestIO, filename string) error {
 	cl := client.ResolutionClient{
 		VulnerabilityClient: client.NewOSVClient(),
@@ -57,7 +61,7 @@ func doRelockRelax(ddCl *client.DepsDevClient, io manifest.ManifestIO, filename 
 	}
 
 	cl.PreFetch(context.Background(), manif.Requirements, manif.FilePath)
-	res, err := resolution.Resolve(context.Background(), cl, manif)
+	res, err := resolution.Resolve(context.Background(), cl, manif, resolveOpts)
 	if err != nil {
 		return err
 	}
@@ -88,7 +92,7 @@ func doOverride(ddCl *client.DepsDevClient, io manifest.ManifestIO, filename str
 	}
 
 	cl.PreFetch(context.Background(), manif.Requirements, manif.FilePath)
-	res, err := resolution.Resolve(context.Background(), cl, manif)
+	res, err := resolution.Resolve(context.Background(), cl, manif, resolveOpts)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Adds functionality to allow guided remediation to fix vulns in `dependencyManagement` dependencies that do not appear in the resolved dependency graph of the POM - useful for 'remediating' POMs without any actual dependencies.

I've accomplished this by checking if each of the original management dependencies (*excluding* those inherited from parents) appear in the graph after the initial resolution. If they're missing, I add them to the graph as direct dependencies (not resolving their transitive dependencies).

This behaviour is disabled by default, and I've added a `--maven-fix-management` flag to enable it. I was going to try combine this and `--ignore-dev` into a `--groups` flag but it seemed like it would be a bit too complicated.