### PR TITLE
fix: make Alpine ecosystem fallback to latest release version

### DIFF
--- a/pkg/lockfile/apk-installed.go
+++ b/pkg/lockfile/apk-installed.go
@@ -9,6 +9,7 @@ import (
 )
 
 const AlpineEcosystem Ecosystem = "Alpine"
+const AlpineFallbackVersion = "v3.20"
 
 func groupApkPackageLines(scanner *bufio.Scanner) [][]string {
 	var groups [][]string
@@ -83,10 +84,12 @@ func (e ApkInstalledExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 	}
 
 	alpineVersion, alpineVerErr := alpineReleaseExtractor(f)
-	if alpineVerErr == nil { // TODO: Log error? We might not be on a alpine system
-		for i := range packages {
-			packages[i].Ecosystem = Ecosystem(string(packages[i].Ecosystem) + ":" + alpineVersion)
-		}
+	if alpineVerErr != nil { // TODO: Log error? We might not be on a alpine system
+		// Alpine ecosystems MUST have a version suffix. Fallback to the latest version.
+		alpineVersion = AlpineFallbackVersion
+	}
+	for i := range packages {
+		packages[i].Ecosystem = Ecosystem(string(packages[i].Ecosystem) + ":" + alpineVersion)
 	}
 
 	if err := scanner.Err(); err != nil {

--- a/pkg/lockfile/apk-installed_test.go
+++ b/pkg/lockfile/apk-installed_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/google/osv-scanner/pkg/lockfile"
 )
 
+const alpineEcosystem = lockfile.AlpineEcosystem + ":" + lockfile.AlpineFallbackVersion
+
 func TestParseApkInstalled_FileDoesNotExist(t *testing.T) {
 	t.Parallel()
 
@@ -54,7 +56,7 @@ func TestParseApkInstalled_Malformed(t *testing.T) {
 			Name:      "busybox",
 			Version:   "",
 			Commit:    "1dbf7a793afae640ea643a055b6dd4f430ac116b",
-			Ecosystem: lockfile.AlpineEcosystem,
+			Ecosystem: alpineEcosystem,
 			CompareAs: lockfile.AlpineEcosystem,
 		},
 	})
@@ -74,7 +76,7 @@ func TestParseApkInstalled_Single(t *testing.T) {
 			Name:      "apk-tools",
 			Version:   "2.12.10-r1",
 			Commit:    "0188f510baadbae393472103427b9c1875117136",
-			Ecosystem: lockfile.AlpineEcosystem,
+			Ecosystem: alpineEcosystem,
 			CompareAs: lockfile.AlpineEcosystem,
 		},
 	})
@@ -94,7 +96,7 @@ func TestParseApkInstalled_Shuffled(t *testing.T) {
 			Name:      "apk-tools",
 			Version:   "2.12.10-r1",
 			Commit:    "0188f510baadbae393472103427b9c1875117136",
-			Ecosystem: lockfile.AlpineEcosystem,
+			Ecosystem: alpineEcosystem,
 			CompareAs: lockfile.AlpineEcosystem,
 		},
 	})
@@ -114,21 +116,21 @@ func TestParseApkInstalled_Multiple(t *testing.T) {
 			Name:      "alpine-baselayout-data",
 			Version:   "3.4.0-r0",
 			Commit:    "bd965a7ebf7fd8f07d7a0cc0d7375bf3e4eb9b24",
-			Ecosystem: lockfile.AlpineEcosystem,
+			Ecosystem: alpineEcosystem,
 			CompareAs: lockfile.AlpineEcosystem,
 		},
 		{
 			Name:      "musl",
 			Version:   "1.2.3-r4",
 			Commit:    "f93af038c3de7146121c2ea8124ba5ce29b4b058",
-			Ecosystem: lockfile.AlpineEcosystem,
+			Ecosystem: alpineEcosystem,
 			CompareAs: lockfile.AlpineEcosystem,
 		},
 		{
 			Name:      "busybox",
 			Version:   "1.35.0-r29",
 			Commit:    "1dbf7a793afae640ea643a055b6dd4f430ac116b",
-			Ecosystem: lockfile.AlpineEcosystem,
+			Ecosystem: alpineEcosystem,
 			CompareAs: lockfile.AlpineEcosystem,
 		},
 	})


### PR DESCRIPTION
The latest release of osv.dev enforces the Alpine release version suffix in queries.
Make the apk-installed parser use the latest Alpine version (`v3.20`) when it can't find the version file to stop it from erroring.