### PR TITLE
fix: don't assume there's always a reason for a package being filtered out

### DIFF
--- a/cmd/osv-scanner/__snapshots__/main_test.snap
+++ b/cmd/osv-scanner/__snapshots__/main_test.snap
@@ -337,8 +337,8 @@ Scanning dir ./fixtures/locks-insecure
 Scanned <rootdir>/fixtures/locks-insecure/composer.lock file and found 1 package
 Scanning dir ./fixtures/maven-transitive
 Scanned <rootdir>/fixtures/maven-transitive/pom.xml file and found 3 packages
-Package npm/ansi-html/0.0.1 has been filtered out
-Package npm/balanced-match/1.0.2 has been filtered out
+Package npm/ansi-html/0.0.1 has been filtered out because: (no reason given)
+Package npm/balanced-match/1.0.2 has been filtered out because: (no reason given)
 Package Maven/org.apache.logging.log4j:log4j-api/2.14.1 has been filtered out because: it makes the table output really really long
 Package Maven/org.apache.logging.log4j:log4j-core/2.14.1 has been filtered out because: it makes the table output really really long
 Package Maven/org.apache.logging.log4j:log4j-web/2.14.1 has been filtered out because: it makes the table output really really long
@@ -1110,8 +1110,8 @@ Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
 Scanned <rootdir>/fixtures/locks-many/yarn.lock file and found 1 package
 Scanning dir ./fixtures/locks-insecure
 Scanned <rootdir>/fixtures/locks-insecure/composer.lock file and found 1 package
-Package npm/ansi-html/0.0.1 has been filtered out
-Package npm/balanced-match/1.0.2 has been filtered out
+Package npm/ansi-html/0.0.1 has been filtered out because: (no reason given)
+Package npm/balanced-match/1.0.2 has been filtered out because: (no reason given)
 Filtered 2 ignored package/s from the scan.
 ignoring license for package Alpine/alpine-baselayout/3.4.0-r0
 ignoring license for package Alpine/alpine-baselayout-data/3.4.0-r0

--- a/cmd/osv-scanner/__snapshots__/main_test.snap
+++ b/cmd/osv-scanner/__snapshots__/main_test.snap
@@ -335,8 +335,8 @@ Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
 Scanned <rootdir>/fixtures/locks-many/yarn.lock file and found 1 package
 Scanning dir ./fixtures/locks-insecure
 Scanned <rootdir>/fixtures/locks-insecure/composer.lock file and found 1 package
-Package npm/ansi-html/0.0.1 has been filtered out because: 
-Package npm/balanced-match/1.0.2 has been filtered out because: 
+Package npm/ansi-html/0.0.1 has been filtered out
+Package npm/balanced-match/1.0.2 has been filtered out
 Filtered 2 ignored package/s from the scan.
 overriding license for package Alpine/alpine-baselayout/3.4.0-r0 with MIT
 overriding license for package Alpine/alpine-baselayout-data/3.4.0-r0 with MIT
@@ -1105,8 +1105,8 @@ Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
 Scanned <rootdir>/fixtures/locks-many/yarn.lock file and found 1 package
 Scanning dir ./fixtures/locks-insecure
 Scanned <rootdir>/fixtures/locks-insecure/composer.lock file and found 1 package
-Package npm/ansi-html/0.0.1 has been filtered out because: 
-Package npm/balanced-match/1.0.2 has been filtered out because: 
+Package npm/ansi-html/0.0.1 has been filtered out
+Package npm/balanced-match/1.0.2 has been filtered out
 Filtered 2 ignored package/s from the scan.
 ignoring license for package Alpine/alpine-baselayout/3.4.0-r0
 ignoring license for package Alpine/alpine-baselayout-data/3.4.0-r0

--- a/cmd/osv-scanner/__snapshots__/main_test.snap
+++ b/cmd/osv-scanner/__snapshots__/main_test.snap
@@ -574,6 +574,23 @@ Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
 ::error file=fixtures/locks-many/package-lock.json::fixtures/locks-many/package-lock.json%0A+-----------+-------------------------------------+------+-----------------+---------------+%0A| PACKAGE   | VULNERABILITY ID                    | CVSS | CURRENT VERSION | FIXED VERSION |%0A+-----------+-------------------------------------+------+-----------------+---------------+%0A| ansi-html | https://osv.dev/GHSA-whgm-jr23-g3j9 | 7.5  | 0.0.1           | 0.0.8         |%0A+-----------+-------------------------------------+------+-----------------+---------------+
 ---
 
+[TestRun/ignores_without_reason_should_be_explicitly_called_out - 1]
+Scanning dir ./fixtures/locks-many/package-lock.json
+Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
+Scanning dir ./fixtures/locks-many/composer.lock
+Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
+Package Packagist/sentry/sdk/2.0.4 has been filtered out because: (no reason given)
+Filtered 1 ignored package/s from the scan.
+GHSA-whgm-jr23-g3j9 and 1 alias have been filtered out because: (no reason given)
+Filtered 1 vulnerability from output
+No issues found
+
+---
+
+[TestRun/ignores_without_reason_should_be_explicitly_called_out - 2]
+
+---
+
 [TestRun/invalid_--verbosity_value - 1]
 
 ---

--- a/cmd/osv-scanner/__snapshots__/main_test.snap
+++ b/cmd/osv-scanner/__snapshots__/main_test.snap
@@ -335,9 +335,14 @@ Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
 Scanned <rootdir>/fixtures/locks-many/yarn.lock file and found 1 package
 Scanning dir ./fixtures/locks-insecure
 Scanned <rootdir>/fixtures/locks-insecure/composer.lock file and found 1 package
+Scanning dir ./fixtures/maven-transitive
+Scanned <rootdir>/fixtures/maven-transitive/pom.xml file and found 3 packages
 Package npm/ansi-html/0.0.1 has been filtered out
 Package npm/balanced-match/1.0.2 has been filtered out
-Filtered 2 ignored package/s from the scan.
+Package Maven/org.apache.logging.log4j:log4j-api/2.14.1 has been filtered out because: it makes the table output really really long
+Package Maven/org.apache.logging.log4j:log4j-core/2.14.1 has been filtered out because: it makes the table output really really long
+Package Maven/org.apache.logging.log4j:log4j-web/2.14.1 has been filtered out because: it makes the table output really really long
+Filtered 5 ignored package/s from the scan.
 overriding license for package Alpine/alpine-baselayout/3.4.0-r0 with MIT
 overriding license for package Alpine/alpine-baselayout-data/3.4.0-r0 with MIT
 overriding license for package Alpine/alpine-keys/2.4-r1 with MIT

--- a/cmd/osv-scanner/fixtures/osv-scanner-composite-config.toml
+++ b/cmd/osv-scanner/fixtures/osv-scanner-composite-config.toml
@@ -3,6 +3,11 @@ ecosystem = "npm"
 ignore = true
 
 [[PackageOverrides]]
+ecosystem = "Maven"
+ignore = true
+reason = "it makes the table output really really long"
+
+[[PackageOverrides]]
 ecosystem = "Packagist"
 license.override = ["0BSD"]
 

--- a/cmd/osv-scanner/fixtures/osv-scanner-reasonless-ignores-config.toml
+++ b/cmd/osv-scanner/fixtures/osv-scanner-reasonless-ignores-config.toml
@@ -1,0 +1,6 @@
+[[IgnoredVulns]]
+id = "GHSA-whgm-jr23-g3j9"
+
+[[PackageOverrides]]
+ecosystem = "Packagist"
+ignore = true

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -315,7 +315,7 @@ func TestRun(t *testing.T) {
 		// broad config file that overrides a whole ecosystem
 		{
 			name: "config file can be broad",
-			args: []string{"", "--config=./fixtures/osv-scanner-composite-config.toml", "--experimental-licenses", "MIT", "./fixtures/locks-many", "./fixtures/locks-insecure"},
+			args: []string{"", "--config=./fixtures/osv-scanner-composite-config.toml", "--experimental-licenses", "MIT", "./fixtures/locks-many", "./fixtures/locks-insecure", "./fixtures/maven-transitive"},
 			exit: 1,
 		},
 		// invalid config file

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -318,6 +318,12 @@ func TestRun(t *testing.T) {
 			args: []string{"", "--config=./fixtures/osv-scanner-composite-config.toml", "--experimental-licenses", "MIT", "./fixtures/locks-many", "./fixtures/locks-insecure", "./fixtures/maven-transitive"},
 			exit: 1,
 		},
+		// ignored vulnerabilities and packages without a reason should be called out
+		{
+			name: "ignores without reason should be explicitly called out",
+			args: []string{"", "--config=./fixtures/osv-scanner-reasonless-ignores-config.toml", "./fixtures/locks-many/package-lock.json", "./fixtures/locks-many/composer.lock"},
+			exit: 0,
+		},
 		// invalid config file
 		{
 			name: "config file is invalid",

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -707,18 +707,18 @@ func filterPackageVulns(r reporter.Reporter, pkgVulns models.PackageVulns, confi
 
 				reason := ignoreLine.Reason
 
-				if reason != "" {
-					reason = " because: " + reason
+				if reason == "" {
+					reason = "(no reason given)"
 				}
 
 				// NB: This only prints the first reason encountered in all the aliases.
 				switch len(group.Aliases) {
 				case 1:
-					r.Infof("%s has been filtered out%s\n", ignoreLine.ID, reason)
+					r.Infof("%s has been filtered out because: %s\n", ignoreLine.ID, reason)
 				case 2:
-					r.Infof("%s and 1 alias have been filtered out%s\n", ignoreLine.ID, reason)
+					r.Infof("%s and 1 alias have been filtered out because: %s\n", ignoreLine.ID, reason)
 				default:
-					r.Infof("%s and %d aliases have been filtered out%s\n", ignoreLine.ID, len(group.Aliases)-1, reason)
+					r.Infof("%s and %d aliases have been filtered out because: %s\n", ignoreLine.ID, len(group.Aliases)-1, reason)
 				}
 
 				break
@@ -988,10 +988,10 @@ func filterIgnoredPackages(r reporter.Reporter, packages []scannedPackage, confi
 			pkgString := fmt.Sprintf("%s/%s/%s", p.Ecosystem, p.Name, p.Version)
 			reason := ignoreLine.Reason
 
-			if reason != "" {
-				reason = " because: " + reason
+			if reason == "" {
+				reason = "(no reason given)"
 			}
-			r.Infof("Package %s has been filtered out%s\n", pkgString, reason)
+			r.Infof("Package %s has been filtered out because: %s\n", pkgString, reason)
 
 			continue
 		}

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -704,14 +704,21 @@ func filterPackageVulns(r reporter.Reporter, pkgVulns models.PackageVulns, confi
 				for _, id := range group.Aliases {
 					ignoredVulns[id] = struct{}{}
 				}
+
+				reason := ignoreLine.Reason
+
+				if reason != "" {
+					reason = " because: " + reason
+				}
+
 				// NB: This only prints the first reason encountered in all the aliases.
 				switch len(group.Aliases) {
 				case 1:
-					r.Infof("%s has been filtered out because: %s\n", ignoreLine.ID, ignoreLine.Reason)
+					r.Infof("%s has been filtered out%s\n", ignoreLine.ID, reason)
 				case 2:
-					r.Infof("%s and 1 alias have been filtered out because: %s\n", ignoreLine.ID, ignoreLine.Reason)
+					r.Infof("%s and 1 alias have been filtered out%s\n", ignoreLine.ID, reason)
 				default:
-					r.Infof("%s and %d aliases have been filtered out because: %s\n", ignoreLine.ID, len(group.Aliases)-1, ignoreLine.Reason)
+					r.Infof("%s and %d aliases have been filtered out%s\n", ignoreLine.ID, len(group.Aliases)-1, reason)
 				}
 
 				break
@@ -979,7 +986,12 @@ func filterIgnoredPackages(r reporter.Reporter, packages []scannedPackage, confi
 
 		if ignore, ignoreLine := configToUse.ShouldIgnorePackage(pkg); ignore {
 			pkgString := fmt.Sprintf("%s/%s/%s", p.Ecosystem, p.Name, p.Version)
-			r.Infof("Package %s has been filtered out because: %s\n", pkgString, ignoreLine.Reason)
+			reason := ignoreLine.Reason
+
+			if reason != "" {
+				reason = " because: " + reason
+			}
+			r.Infof("Package %s has been filtered out%s\n", pkgString, reason)
 
 			continue
 		}


### PR DESCRIPTION
Currently if you don't provide a reason for an override the scanner will just output "because: " which looks weird and results in a trailing space in our snapshots which IDEs try to trim.

Since we want to encourage people to provide a reason, I've changed the scanner to explicitly state "(no reason provided)" in this situation