### PR TITLE
refactor: simplify and reuse `tryLoadConfig`

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -205,8 +205,8 @@ func normalizeConfigLoadPath(target string) (string, error) {
 	return configPath, nil
 }
 
-// tryLoadConfig tries to load config in `target` (or it's containing directory)
-// `target` will be the key for the entry in configMap
+// tryLoadConfig attempts to parse the config file at the given path as TOML,
+// returning the Config object if successful or otherwise the error
 func tryLoadConfig(configPath string) (Config, error) {
 	config := Config{}
 	_, err := toml.DecodeFile(configPath, &config)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -208,19 +208,11 @@ func normalizeConfigLoadPath(target string) (string, error) {
 // tryLoadConfig tries to load config in `target` (or it's containing directory)
 // `target` will be the key for the entry in configMap
 func tryLoadConfig(configPath string) (Config, error) {
-	file, err := os.Open(configPath)
-	var config Config
-	if err == nil { // File exists, and we have permission to read
-		defer file.Close()
-
-		_, err := toml.NewDecoder(file).Decode(&config)
-		if err != nil {
-			return Config{}, err
-		}
+	config := Config{}
+	_, err := toml.DecodeFile(configPath, &config)
+	if err == nil {
 		config.LoadPath = configPath
-
-		return config, nil
 	}
 
-	return Config{}, err
+	return config, err
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -142,12 +142,10 @@ func shouldIgnoreTimestamp(ignoreUntil time.Time) bool {
 // Sets the override config by reading the config file at configPath.
 // Will return an error if loading the config file fails
 func (c *ConfigManager) UseOverride(configPath string) error {
-	config := Config{}
-	_, err := toml.DecodeFile(configPath, &config)
-	if err != nil {
-		return err
+	config, configErr := tryLoadConfig(configPath)
+	if configErr != nil {
+		return configErr
 	}
-	config.LoadPath = configPath
 	c.OverrideConfig = &config
 
 	return nil


### PR DESCRIPTION
`toml.DecodeFile` does literally what we're doing except without the custom error messages, which I don't think should matter as we don't intentionally expose those as an actual API; there also doesn't seem to be anything special about what `UseOverride` is doing to prevent it from using `tryLoadConfig`.

This will mean error output will probably have changed slightly, but it should still be accurate and we're not purposely providing custom or dedicated errors in this package so I don't think it should be considered breaking.