### PR TITLE
test: ensure `cmp.Diff` usage is consistent

### DIFF
--- a/internal/resolution/lockfile/npm_test.go
+++ b/internal/resolution/lockfile/npm_test.go
@@ -62,7 +62,7 @@ r 1.0.0
 	}
 
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("npm lockfile mismatch (-want/+got):\n%s", diff)
+		t.Errorf("npm lockfile mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -109,7 +109,7 @@ r 1.0.0
 	}
 
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("npm lockfile mismatch (-want/+got):\n%s", diff)
+		t.Errorf("npm lockfile mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/internal/resolution/manifest/maven_test.go
+++ b/internal/resolution/manifest/maven_test.go
@@ -409,7 +409,7 @@ func TestMavenReadWrite(t *testing.T) {
 		},
 	}
 	if diff := cmp.Diff(got, want); diff != "" {
-		t.Errorf("Maven manifest mismatch: %s", diff)
+		t.Errorf("Maven manifest mismatch (-want +got):\n%s", diff)
 	}
 
 	// Re-open the file for writing.
@@ -954,7 +954,7 @@ func TestBuildPatches(t *testing.T) {
 		t.Fatalf("failed to build patches: %v", err)
 	}
 	if diff := cmp.Diff(allPatches, want); diff != "" {
-		t.Errorf("result patches mismatch: %s", diff)
+		t.Errorf("result patches mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/internal/resolution/manifest/maven_test.go
+++ b/internal/resolution/manifest/maven_test.go
@@ -408,7 +408,7 @@ func TestMavenReadWrite(t *testing.T) {
 			},
 		},
 	}
-	if diff := cmp.Diff(got, want); diff != "" {
+	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("Maven manifest mismatch (-want +got):\n%s", diff)
 	}
 
@@ -953,7 +953,7 @@ func TestBuildPatches(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to build patches: %v", err)
 	}
-	if diff := cmp.Diff(allPatches, want); diff != "" {
+	if diff := cmp.Diff(want, allPatches); diff != "" {
 		t.Errorf("result patches mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/internal/sbom/cyclonedx_test.go
+++ b/internal/sbom/cyclonedx_test.go
@@ -31,7 +31,7 @@ func runCycloneGetPackages(t *testing.T, bomFile string, want []sbom.Identifier)
 	}
 
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("GetPackages() returned an unexpected result (-want, +got):\n%s", diff)
+		t.Errorf("GetPackages() returned an unexpected result (-want +got):\n%s", diff)
 	}
 }
 

--- a/internal/sbom/spdx_test.go
+++ b/internal/sbom/spdx_test.go
@@ -31,7 +31,7 @@ func runSPDXGetPackages(t *testing.T, bomFile string, want []sbom.Identifier) {
 	}
 
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("GetPackages() returned an unexpected result (-want, +got):\n%s", diff)
+		t.Errorf("GetPackages() returned an unexpected result (-want +got):\n%s", diff)
 	}
 }
 

--- a/pkg/grouper/grouper_test.go
+++ b/pkg/grouper/grouper_test.go
@@ -149,7 +149,7 @@ func TestGroup(t *testing.T) {
 	} {
 		grouped := grouper.Group(tc.vulns)
 		if diff := cmp.Diff(tc.want, grouped); diff != "" {
-			t.Errorf("GroupedVulns() returned an unexpected result (-want, +got):\n%s", diff)
+			t.Errorf("GroupedVulns() returned an unexpected result (-want +got):\n%s", diff)
 		}
 	}
 }

--- a/pkg/models/results_test.go
+++ b/pkg/models/results_test.go
@@ -13,7 +13,7 @@ func TestFlatten(t *testing.T) {
 	vulns := models.VulnerabilityResults{Results: []models.PackageSource{}}
 	expectedFlattened := []models.VulnerabilityFlattened{}
 	flattened := vulns.Flatten()
-	if diff := cmp.Diff(flattened, expectedFlattened); diff != "" {
+	if diff := cmp.Diff(expectedFlattened, flattened); diff != "" {
 		t.Errorf("Flatten() returned unexpected result (-want +got):\n%s", diff)
 	}
 
@@ -48,7 +48,7 @@ func TestFlatten(t *testing.T) {
 		},
 	}
 	flattened = vulns.Flatten()
-	if diff := cmp.Diff(flattened, expectedFlattened); diff != "" {
+	if diff := cmp.Diff(expectedFlattened, flattened); diff != "" {
 		t.Errorf("Flatten() returned unexpected result (-want +got):\n%s", diff)
 	}
 
@@ -73,7 +73,7 @@ func TestFlatten(t *testing.T) {
 		},
 	}
 	flattened = vulns.Flatten()
-	if diff := cmp.Diff(flattened, expectedFlattened); diff != "" {
+	if diff := cmp.Diff(expectedFlattened, flattened); diff != "" {
 		t.Errorf("Flatten() returned unexpected result (-want +got):\n%s", diff)
 	}
 
@@ -116,7 +116,7 @@ func TestFlatten(t *testing.T) {
 		},
 	}
 	flattened = vulns.Flatten()
-	if diff := cmp.Diff(flattened, expectedFlattened); diff != "" {
+	if diff := cmp.Diff(expectedFlattened, flattened); diff != "" {
 		t.Errorf("Flatten() returned unexpected result (-want +got):\n%s", diff)
 	}
 }

--- a/pkg/models/results_test.go
+++ b/pkg/models/results_test.go
@@ -14,7 +14,7 @@ func TestFlatten(t *testing.T) {
 	expectedFlattened := []models.VulnerabilityFlattened{}
 	flattened := vulns.Flatten()
 	if diff := cmp.Diff(flattened, expectedFlattened); diff != "" {
-		t.Errorf("Flatten() returned unexpected result (-got +want):\n%s", diff)
+		t.Errorf("Flatten() returned unexpected result (-want +got):\n%s", diff)
 	}
 
 	// Test case 2: When there are vulnerabilities
@@ -49,7 +49,7 @@ func TestFlatten(t *testing.T) {
 	}
 	flattened = vulns.Flatten()
 	if diff := cmp.Diff(flattened, expectedFlattened); diff != "" {
-		t.Errorf("Flatten() returned unexpected result (-got +want):\n%s", diff)
+		t.Errorf("Flatten() returned unexpected result (-want +got):\n%s", diff)
 	}
 
 	// Test case 3: When there are no vulnerabilities and license violations
@@ -74,7 +74,7 @@ func TestFlatten(t *testing.T) {
 	}
 	flattened = vulns.Flatten()
 	if diff := cmp.Diff(flattened, expectedFlattened); diff != "" {
-		t.Errorf("Flatten() returned unexpected result (-got +want):\n%s", diff)
+		t.Errorf("Flatten() returned unexpected result (-want +got):\n%s", diff)
 	}
 
 	// Test case 4: When there are vulnerabilities and license violations
@@ -117,6 +117,6 @@ func TestFlatten(t *testing.T) {
 	}
 	flattened = vulns.Flatten()
 	if diff := cmp.Diff(flattened, expectedFlattened); diff != "" {
-		t.Errorf("Flatten() returned unexpected result (-got +want):\n%s", diff)
+		t.Errorf("Flatten() returned unexpected result (-want +got):\n%s", diff)
 	}
 }

--- a/pkg/osvscanner/osvscanner_internal_test.go
+++ b/pkg/osvscanner/osvscanner_internal_test.go
@@ -101,7 +101,7 @@ func Test_scanGit(t *testing.T) {
 		if (err != nil) != tt.wantErr {
 			t.Errorf("scanGit() error = %v, wantErr %v", err, tt.wantErr)
 		}
-		if diff := cmp.Diff(tt.wantPkg, pkg); diff != "" {
+		if !cmp.Equal(tt.wantPkg, pkg) {
 			t.Errorf("scanGit() package = %v, wantPackage %v", pkg, tt.wantPkg)
 		}
 	}


### PR DESCRIPTION
The examples in the docs suggest passing `want, got` rather the other way around which we're already mostly doing but have a few cases where we're not - likewise with the messaging we've been mostly consistent between three slightly different phrasing, which I've updated to always be `(-want +got)` which is what's in the example for `cmp.Diff`