### PR TITLE
fix: don't allow `LoadPath` to be set via config file

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,7 +31,7 @@ type ConfigManager struct {
 type Config struct {
 	IgnoredVulns      []IgnoreEntry          `toml:"IgnoredVulns"`
 	PackageOverrides  []PackageOverrideEntry `toml:"PackageOverrides"`
-	LoadPath          string                 `toml:"LoadPath"`
+	LoadPath          string                 `toml:"-"`
 	GoVersionOverride string                 `toml:"GoVersionOverride"`
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,10 +31,10 @@ type ConfigManager struct {
 type Config struct {
 	IgnoredVulns      []IgnoreEntry          `toml:"IgnoredVulns"`
 	PackageOverrides  []PackageOverrideEntry `toml:"PackageOverrides"`
+	GoVersionOverride string                 `toml:"GoVersionOverride"`
 	// The path to config file that this config was loaded from,
 	// set by the scanner after having successfully parsed the file
-	LoadPath          string                 `toml:"-"`
-	GoVersionOverride string                 `toml:"GoVersionOverride"`
+	LoadPath string `toml:"-"`
 }
 
 type IgnoreEntry struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,6 +31,8 @@ type ConfigManager struct {
 type Config struct {
 	IgnoredVulns      []IgnoreEntry          `toml:"IgnoredVulns"`
 	PackageOverrides  []PackageOverrideEntry `toml:"PackageOverrides"`
+	// The path to config file that this config was loaded from,
+	// set by the scanner after having successfully parsed the file
 	LoadPath          string                 `toml:"-"`
 	GoVersionOverride string                 `toml:"GoVersionOverride"`
 }


### PR DESCRIPTION
This is a pseudo bug I introduced way back in #190 - it doesn't actually happen as our implementation always explicitly sets the property after we've successfully parsed the file into the struct, but it is possible for refactors like #1248 to reveal this and ultimately we don't want this behaviour so we might as well fix it.