### PR TITLE
chore: make guided remediation follow revive's default lint rules

### DIFF
--- a/cmd/osv-scanner/fix/main.go
+++ b/cmd/osv-scanner/fix/main.go
@@ -32,9 +32,9 @@ type osvFixOptions struct {
 	remediation.Options
 	Client     client.ResolutionClient
 	Manifest   string
-	ManifestRW manifest.IO
+	ManifestRW manifest.ReadWriter
 	Lockfile   string
-	LockfileRW lockfile.IO
+	LockfileRW lockfile.ReadWriter
 	RelockCmd  string
 }
 
@@ -260,7 +260,7 @@ func action(ctx *cli.Context, stdout, stderr io.Writer) (reporter.Reporter, erro
 	system := resolve.UnknownSystem
 
 	if opts.Lockfile != "" {
-		rw, err := lockfile.GetLockfileIO(opts.Lockfile)
+		rw, err := lockfile.GetReadWriter(opts.Lockfile)
 		if err != nil {
 			return nil, err
 		}
@@ -269,7 +269,7 @@ func action(ctx *cli.Context, stdout, stderr io.Writer) (reporter.Reporter, erro
 	}
 
 	if opts.Manifest != "" {
-		rw, err := manifest.GetManifestIO(opts.Manifest)
+		rw, err := manifest.GetReadWriter(opts.Manifest)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/osv-scanner/fix/main.go
+++ b/cmd/osv-scanner/fix/main.go
@@ -29,12 +29,12 @@ const (
 )
 
 type osvFixOptions struct {
-	remediation.RemediationOptions
+	remediation.Options
 	Client     client.ResolutionClient
 	Manifest   string
-	ManifestRW manifest.ManifestIO
+	ManifestRW manifest.IO
 	Lockfile   string
-	LockfileRW lockfile.LockfileIO
+	LockfileRW lockfile.IO
 	RelockCmd  string
 }
 
@@ -60,7 +60,7 @@ func Command(stdout, stderr io.Writer, r *reporter.Reporter) *cli.Command {
 				Name:  "data-source",
 				Usage: "source to fetch package information from; value can be: deps.dev, native",
 				Value: "deps.dev",
-				Action: func(ctx *cli.Context, s string) error {
+				Action: func(_ *cli.Context, s string) error {
 					if s != "deps.dev" && s != "native" {
 						return fmt.Errorf("unsupported data-source \"%s\" - must be one of: deps.dev, native", s)
 					}
@@ -238,7 +238,7 @@ func action(ctx *cli.Context, stdout, stderr io.Writer) (reporter.Reporter, erro
 	r := reporter.NewTableReporter(stdout, stderr, reporter.InfoLevel, false, 0)
 
 	opts := osvFixOptions{
-		RemediationOptions: remediation.RemediationOptions{
+		Options: remediation.Options{
 			ResolveOpts: resolution.ResolveOpts{
 				MavenManagement: ctx.Bool("maven-fix-management"),
 			},

--- a/cmd/osv-scanner/fix/model.go
+++ b/cmd/osv-scanner/fix/model.go
@@ -43,9 +43,9 @@ type model struct {
 	err     error      // set if a fatal error occurs within the program
 	writing bool       // whether the model is currently shelling out writing lockfile/manifest file
 
-	inPlaceResult     *remediation.InPlaceResult   // results & patches from minimal / in-place resolution
-	relockBaseRes     *resolution.ResolutionResult // Base relock result, matching the current manifest on disk
-	relockBaseResErrs []resolution.ResolutionError // Errors in base relock result
+	inPlaceResult     *remediation.InPlaceResult // results & patches from minimal / in-place resolution
+	relockBaseRes     *resolution.Result         // Base relock result, matching the current manifest on disk
+	relockBaseResErrs []resolution.NodeError     // Errors in base relock result
 }
 
 func newModel(ctx context.Context, opts osvFixOptions, cl client.ResolutionClient) model {
@@ -191,17 +191,17 @@ func doInPlaceResolution(ctx context.Context, cl client.ResolutionClient, opts o
 	if err != nil {
 		return inPlaceResolutionMsg{err: err}
 	}
-	res, err := remediation.ComputeInPlacePatches(ctx, cl, g, opts.RemediationOptions)
+	res, err := remediation.ComputeInPlacePatches(ctx, cl, g, opts.Options)
 
 	return inPlaceResolutionMsg{res, g, err}
 }
 
 type doRelockMsg struct {
-	res *resolution.ResolutionResult
+	res *resolution.Result
 	err error
 }
 
-func doRelock(ctx context.Context, cl client.ResolutionClient, m manif.Manifest, opts resolution.ResolveOpts, matchFn func(resolution.ResolutionVuln) bool) tea.Msg {
+func doRelock(ctx context.Context, cl client.ResolutionClient, m manif.Manifest, opts resolution.ResolveOpts, matchFn func(resolution.Vulnerability) bool) tea.Msg {
 	res, err := resolution.Resolve(ctx, cl, m, opts)
 	if err != nil {
 		return doRelockMsg{nil, err}
@@ -226,7 +226,7 @@ func doInitialRelock(ctx context.Context, opts osvFixOptions) tea.Msg {
 	if err != nil {
 		return doRelockMsg{err: err}
 	}
-	client.PreFetch(opts.Client, ctx, m.Requirements, m.FilePath)
+	client.PreFetch(ctx, opts.Client, m.Requirements, m.FilePath)
 
 	return doRelock(ctx, opts.Client, m, opts.ResolveOpts, opts.MatchVuln)
 }
@@ -240,7 +240,7 @@ func (s infoStringView) Resize(int, int)                         {}
 
 var emptyInfoView = infoStringView("")
 
-func resolutionErrorView(res *resolution.ResolutionResult, errs []resolution.ResolutionError) tui.ViewModel {
+func resolutionErrorView(res *resolution.Result, errs []resolution.NodeError) tui.ViewModel {
 	if len(errs) == 0 {
 		return emptyInfoView
 	}

--- a/cmd/osv-scanner/fix/noninteractive.go
+++ b/cmd/osv-scanner/fix/noninteractive.go
@@ -405,7 +405,7 @@ func autoChooseOverridePatches(diffs []resolution.Difference, maxUpgrades int) (
 }
 
 func resolutionErrorString(res *resolution.Result, errs []resolution.NodeError) string {
-	// we pass in the []ResolutionErrors because calling res.Errors() is costly
+	// we pass in the []resolution.NodeError because calling res.Errors() is costly
 	s := strings.Builder{}
 	for _, e := range errs {
 		node := res.Graph.Nodes[e.NodeID]

--- a/cmd/osv-scanner/fix/state-choose-in-place-patches.go
+++ b/cmd/osv-scanner/fix/state-choose-in-place-patches.go
@@ -97,7 +97,7 @@ func (st *stateChooseInPlacePatches) Update(m model, msg tea.Msg) (tea.Model, te
 	return m, tea.Batch(cmd, c)
 }
 
-func (st *stateChooseInPlacePatches) View(m model) string {
+func (st *stateChooseInPlacePatches) View(_ model) string {
 	tableStr := lipgloss.PlaceHorizontal(st.viewWidth, lipgloss.Center, st.table.View())
 	return lipgloss.JoinVertical(lipgloss.Left,
 		tableStr,

--- a/cmd/osv-scanner/fix/state-choose-strategy.go
+++ b/cmd/osv-scanner/fix/state-choose-strategy.go
@@ -47,7 +47,7 @@ func (st *stateChooseStrategy) Init(m model) tea.Cmd {
 	// pre-generate the info views for each option
 
 	// make a slice of vuln pointers for the all vulnerabilities list
-	// TODO: be consistent & efficient with how we pass ResolutionVulns around
+	// TODO: be consistent & efficient with how we pass resolution.Vulnerabilities around
 	var allVulns []*resolution.Vulnerability //nolint:prealloc // it's a bit annoying to count beforehand
 	for _, p := range m.inPlaceResult.Patches {
 		for i := range p.ResolvedVulns {

--- a/cmd/osv-scanner/fix/state-choose-strategy.go
+++ b/cmd/osv-scanner/fix/state-choose-strategy.go
@@ -48,7 +48,7 @@ func (st *stateChooseStrategy) Init(m model) tea.Cmd {
 
 	// make a slice of vuln pointers for the all vulnerabilities list
 	// TODO: be consistent & efficient with how we pass ResolutionVulns around
-	var allVulns []*resolution.ResolutionVuln //nolint:prealloc // it's a bit annoying to count beforehand
+	var allVulns []*resolution.Vulnerability //nolint:prealloc // it's a bit annoying to count beforehand
 	for _, p := range m.inPlaceResult.Patches {
 		for i := range p.ResolvedVulns {
 			allVulns = append(allVulns, &p.ResolvedVulns[i])
@@ -65,10 +65,10 @@ func (st *stateChooseStrategy) Init(m model) tea.Cmd {
 	if m.options.Manifest != "" {
 		// find the vulns fixed by relocking to show on the relock hover
 		st.canRelock = true
-		var relockFixes []*resolution.ResolutionVuln
+		var relockFixes []*resolution.Vulnerability
 		for _, v := range allVulns {
-			if !slices.ContainsFunc(m.relockBaseRes.Vulns, func(r resolution.ResolutionVuln) bool {
-				return r.Vulnerability.ID == v.Vulnerability.ID
+			if !slices.ContainsFunc(m.relockBaseRes.Vulns, func(r resolution.Vulnerability) bool {
+				return r.OSV.ID == v.OSV.ID
 			}) {
 				relockFixes = append(relockFixes, v)
 			}
@@ -218,7 +218,7 @@ func (st *stateChooseStrategy) parseInput(m model) (tea.Model, tea.Cmd) {
 		}
 
 		// Reset state. TODO: Add a spinner and do this I/O as a command.
-		res, err := remediation.ComputeInPlacePatches(m.ctx, m.cl, m.lockfileGraph, m.options.RemediationOptions)
+		res, err := remediation.ComputeInPlacePatches(m.ctx, m.cl, m.lockfileGraph, m.options.Options)
 		if err != nil {
 			panic(err)
 		}
@@ -329,7 +329,7 @@ func (st *stateChooseStrategy) InfoView() string {
 	return v.View()
 }
 
-func (st *stateChooseStrategy) Resize(w, h int) {}
+func (st *stateChooseStrategy) Resize(_, _ int) {}
 
 func (st *stateChooseStrategy) ResizeInfo(w, h int) {
 	st.vulnList.Resize(w, h)

--- a/cmd/osv-scanner/fix/state-in-place-result.go
+++ b/cmd/osv-scanner/fix/state-in-place-result.go
@@ -40,7 +40,7 @@ func (st *stateInPlaceResult) Init(m model) tea.Cmd {
 	// pre-generate the info views for each option
 	// inPlaceInfo is given to this by stateChooseStrategy when it makes this struct
 	// Get the list of remaining vulns
-	vulns := make([]*resolution.ResolutionVuln, len(m.inPlaceResult.Unfixable))
+	vulns := make([]*resolution.Vulnerability, len(m.inPlaceResult.Unfixable))
 	for i := range m.inPlaceResult.Unfixable {
 		vulns[i] = &m.inPlaceResult.Unfixable[i]
 	}
@@ -49,10 +49,10 @@ func (st *stateInPlaceResult) Init(m model) tea.Cmd {
 	// recompute the vulns fixed by relocking after the in-place update
 	if m.options.Manifest != "" {
 		st.canRelock = true
-		var relockFixes []*resolution.ResolutionVuln
+		var relockFixes []*resolution.Vulnerability
 		for _, v := range vulns {
-			if !slices.ContainsFunc(m.relockBaseRes.Vulns, func(r resolution.ResolutionVuln) bool {
-				return r.Vulnerability.ID == v.Vulnerability.ID
+			if !slices.ContainsFunc(m.relockBaseRes.Vulns, func(r resolution.Vulnerability) bool {
+				return r.OSV.ID == v.OSV.ID
 			}) {
 				relockFixes = append(relockFixes, v)
 			}
@@ -183,7 +183,7 @@ func (st *stateInPlaceResult) View(m model) string {
 	nSelected := 0
 	for _, s := range st.selectedChanges {
 		if s {
-			nSelected += 1
+			nSelected++
 		}
 	}
 
@@ -247,7 +247,7 @@ func (st *stateInPlaceResult) InfoView() string {
 	return v.View()
 }
 
-func (st *stateInPlaceResult) Resize(w, h int) {}
+func (st *stateInPlaceResult) Resize(_, _ int) {}
 
 func (st *stateInPlaceResult) ResizeInfo(w, h int) {
 	st.inPlaceInfo.Resize(w, h)

--- a/cmd/osv-scanner/fix/state-initialize.go
+++ b/cmd/osv-scanner/fix/state-initialize.go
@@ -106,6 +106,6 @@ func (st *stateInitialize) View(m model) string {
 }
 
 func (st *stateInitialize) InfoView() string    { return "" }
-func (st *stateInitialize) Resize(w, h int)     {}
-func (st *stateInitialize) ResizeInfo(w, h int) {}
+func (st *stateInitialize) Resize(_, _ int)     {}
+func (st *stateInitialize) ResizeInfo(_, _ int) {}
 func (st *stateInitialize) IsInfoFocused() bool { return false }

--- a/cmd/osv-scanner/fix/state-relock-result.go
+++ b/cmd/osv-scanner/fix/state-relock-result.go
@@ -18,11 +18,11 @@ import (
 )
 
 type stateRelockResult struct {
-	currRes      *resolution.ResolutionResult // In-progress relock result, with user-selected patches applied
-	currErrs     []resolution.ResolutionError // In-progress relock errors
-	patches      []resolution.ResolutionDiff  // current possible patches applicable to relockCurrRes
-	patchesDone  bool                         // whether the relockPatches has finished being computed
-	numUnfixable int                          // count of unfixable vulns, for rendering
+	currRes      *resolution.Result      // In-progress relock result, with user-selected patches applied
+	currErrs     []resolution.NodeError  // In-progress relock errors
+	patches      []resolution.Difference // current possible patches applicable to relockCurrRes
+	patchesDone  bool                    // whether the relockPatches has finished being computed
+	numUnfixable int                     // count of unfixable vulns, for rendering
 
 	spinner         spinner.Model
 	cursorPos       int              // TODO: use an enum ?
@@ -96,7 +96,7 @@ func (st *stateRelockResult) Init(m model) tea.Cmd {
 	st.viewWidth = m.mainViewWidth
 
 	// Make the vulnerability list view model
-	vulns := make([]*resolution.ResolutionVuln, len(st.currRes.Vulns))
+	vulns := make([]*resolution.Vulnerability, len(st.currRes.Vulns))
 	for i := range st.currRes.Vulns {
 		vulns[i] = &st.currRes.Vulns[i]
 	}
@@ -120,7 +120,7 @@ func (st *stateRelockResult) Update(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		st.currRes = msg.res
 		// recreate the vuln list info view
-		var vulns []*resolution.ResolutionVuln
+		var vulns []*resolution.Vulnerability
 		for i := range st.currRes.Vulns {
 			vulns = append(vulns, &st.currRes.Vulns[i])
 		}
@@ -276,7 +276,7 @@ func (st *stateRelockResult) relaxChoice(m model) (model, tea.Cmd) {
 			st.currErrs = st.currRes.Errors()
 			st.resolveErrors = resolutionErrorView(st.currRes, st.currErrs)
 			// recreate vuln list view
-			var vulns []*resolution.ResolutionVuln
+			var vulns []*resolution.Vulnerability
 			for i := range st.currRes.Vulns {
 				vulns = append(vulns, &st.currRes.Vulns[i])
 			}
@@ -425,7 +425,7 @@ func (st *stateRelockResult) View(m model) string {
 	return s.String()
 }
 
-func diffString(diff resolution.ResolutionDiff) string {
+func diffString(diff resolution.Difference) string {
 	var depStr string
 	if len(diff.Deps) == 1 {
 		dep := diff.Deps[0]
@@ -469,7 +469,7 @@ func (st *stateRelockResult) patchCompatible(idx int) bool {
 	return true
 }
 
-func (st *stateRelockResult) Resize(w, h int) {
+func (st *stateRelockResult) Resize(w, _ int) {
 	st.viewWidth = w
 }
 
@@ -487,7 +487,7 @@ func (st *stateRelockResult) IsInfoFocused() bool {
 // TODO: Work out a better way to output npm commands
 func (st *stateRelockResult) write(m model) tea.Msg {
 	changes := m.relockBaseRes.CalculateDiff(st.currRes)
-	if err := manif.Overwrite(m.options.ManifestRW, m.options.Manifest, changes.ManifestPatch); err != nil {
+	if err := manif.Overwrite(m.options.ManifestRW, m.options.Manifest, changes.Patch); err != nil {
 		return writeMsg{err}
 	}
 
@@ -518,13 +518,13 @@ func (st *stateRelockResult) write(m model) tea.Msg {
 }
 
 type relockPatchMsg struct {
-	patches []resolution.ResolutionDiff
+	patches []resolution.Difference
 	err     error
 }
 
 // Find all groups of dependency bumps required to resolve each vulnerability individually
-func doComputeRelockPatches(ctx context.Context, cl client.ResolutionClient, currRes *resolution.ResolutionResult, opts osvFixOptions) relockPatchMsg {
-	patches, err := remediation.ComputeRelaxPatches(ctx, cl, currRes, opts.RemediationOptions)
+func doComputeRelockPatches(ctx context.Context, cl client.ResolutionClient, currRes *resolution.Result, opts osvFixOptions) relockPatchMsg {
+	patches, err := remediation.ComputeRelaxPatches(ctx, cl, currRes, opts.Options)
 	if err != nil {
 		return relockPatchMsg{err: err}
 	}

--- a/cmd/osv-scanner/update/main.go
+++ b/cmd/osv-scanner/update/main.go
@@ -57,7 +57,7 @@ type updateOptions struct {
 	IgnoreDev  bool
 
 	Client     client.ResolutionClient
-	ManifestRW manifest.IO
+	ManifestRW manifest.ReadWriter
 }
 
 func action(ctx *cli.Context, stdout, stderr io.Writer) (reporter.Reporter, error) {
@@ -78,7 +78,7 @@ func action(ctx *cli.Context, stdout, stderr io.Writer) (reporter.Reporter, erro
 	if err != nil {
 		return nil, err
 	}
-	options.ManifestRW, err = manifest.GetManifestIO(options.Manifest)
+	options.ManifestRW, err = manifest.GetReadWriter(options.Manifest)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/osv-scanner/update/main.go
+++ b/cmd/osv-scanner/update/main.go
@@ -57,7 +57,7 @@ type updateOptions struct {
 	IgnoreDev  bool
 
 	Client     client.ResolutionClient
-	ManifestRW manifest.ManifestIO
+	ManifestRW manifest.IO
 }
 
 func action(ctx *cli.Context, stdout, stderr io.Writer) (reporter.Reporter, error) {

--- a/internal/remediation/in_place.go
+++ b/internal/remediation/in_place.go
@@ -254,7 +254,7 @@ func inPlaceVulnsNodes(cl client.VulnerabilityClient, graph *resolve.Graph) (inP
 		}
 	}
 
-	// Construct ResolutionVulns for all vulnerable packages
+	// Construct resolution.Vulnerability for all vulnerable packages
 	// combining nodes with the same package & versions number
 	var nodeIDs []resolve.NodeID
 	for nID, vulns := range nodeVulns {

--- a/internal/remediation/in_place_test.go
+++ b/internal/remediation/in_place_test.go
@@ -50,7 +50,7 @@ func checkInPlaceResults(t *testing.T, res remediation.InPlaceResult) {
 		AffectedNodes []resolve.NodeID
 	}
 
-	toMinimalVuln := func(v resolution.ResolutionVuln) minimalVuln {
+	toMinimalVuln := func(v resolution.Vulnerability) minimalVuln {
 		t.Helper()
 		nodes := make(map[resolve.NodeID]struct{})
 		for _, c := range v.ProblemChains {
@@ -63,7 +63,7 @@ func checkInPlaceResults(t *testing.T, res remediation.InPlaceResult) {
 		slices.Sort(sortedNodes)
 
 		return minimalVuln{
-			ID:            v.Vulnerability.ID,
+			ID:            v.OSV.ID,
 			AffectedNodes: sortedNodes,
 		}
 	}
@@ -111,7 +111,7 @@ func checkInPlaceResults(t *testing.T, res remediation.InPlaceResult) {
 func TestComputeInPlacePatches(t *testing.T) {
 	t.Parallel()
 
-	basicOpts := remediation.RemediationOptions{
+	basicOpts := remediation.Options{
 		DevDeps:       true,
 		MaxDepth:      -1,
 		UpgradeConfig: upgrade.NewConfig(),
@@ -121,7 +121,7 @@ func TestComputeInPlacePatches(t *testing.T) {
 		name         string
 		universePath string
 		lockfilePath string
-		opts         remediation.RemediationOptions
+		opts         remediation.Options
 	}{
 		{
 			name:         "npm-santatracker",

--- a/internal/remediation/in_place_test.go
+++ b/internal/remediation/in_place_test.go
@@ -21,9 +21,9 @@ import (
 func parseInPlaceFixture(t *testing.T, universePath, lockfilePath string) (*resolve.Graph, client.ResolutionClient) {
 	t.Helper()
 
-	io, err := lockfile.GetLockfileIO(lockfilePath)
+	rw, err := lockfile.GetReadWriter(lockfilePath)
 	if err != nil {
-		t.Fatalf("Failed to get LockfileIO: %v", err)
+		t.Fatalf("Failed to get ReadWriter: %v", err)
 	}
 
 	f, err := lf.OpenLocalDepFile(lockfilePath)
@@ -32,7 +32,7 @@ func parseInPlaceFixture(t *testing.T, universePath, lockfilePath string) (*reso
 	}
 	defer f.Close()
 
-	g, err := io.Read(f)
+	g, err := rw.Read(f)
 	if err != nil {
 		t.Fatalf("Failed to parse lockfile: %v", err)
 	}

--- a/internal/remediation/override.go
+++ b/internal/remediation/override.go
@@ -27,7 +27,7 @@ type overridePatch struct {
 // ComputeOverridePatches attempts to resolve each vulnerability found in result independently, returning the list of unique possible patches.
 // Vulnerabilities are resolved by directly overriding versions of vulnerable packages to non-vulnerable versions.
 // If a patch introduces new vulnerabilities, additional overrides are attempted for the new vulnerabilities.
-func ComputeOverridePatches(ctx context.Context, cl client.ResolutionClient, result *resolution.ResolutionResult, opts RemediationOptions) ([]resolution.ResolutionDiff, error) {
+func ComputeOverridePatches(ctx context.Context, cl client.ResolutionClient, result *resolution.Result, opts Options) ([]resolution.Difference, error) {
 	// TODO: this is very similar to ComputeRelaxPatches - can the common parts be factored out?
 	// Filter the original result just in case it hasn't been already
 	result.FilterVulns(opts.MatchVuln)
@@ -35,7 +35,7 @@ func ComputeOverridePatches(ctx context.Context, cl client.ResolutionClient, res
 	// Do the resolutions concurrently
 	type overrideResult struct {
 		vulnIDs []string
-		result  *resolution.ResolutionResult
+		result  *resolution.Result
 		patches []overridePatch
 		err     error
 	}
@@ -56,11 +56,11 @@ func ComputeOverridePatches(ctx context.Context, cl client.ResolutionClient, res
 	toProcess := 0
 	for _, v := range result.Vulns {
 		// TODO: limit the number of goroutines
-		go doOverride([]string{v.Vulnerability.ID})
+		go doOverride([]string{v.OSV.ID})
 		toProcess++
 	}
 
-	var allResults []resolution.ResolutionDiff
+	var allResults []resolution.Difference
 	for toProcess > 0 {
 		res := <-ch
 		toProcess--
@@ -97,8 +97,8 @@ func ComputeOverridePatches(ctx context.Context, cl client.ResolutionClient, res
 		// If there are any new vulns, try override them as well
 		var newlyAdded []string
 		for _, v := range diff.AddedVulns {
-			if !slices.Contains(res.vulnIDs, v.Vulnerability.ID) {
-				newlyAdded = append(newlyAdded, v.Vulnerability.ID)
+			if !slices.Contains(res.vulnIDs, v.OSV.ID) {
+				newlyAdded = append(newlyAdded, v.OSV.ID)
 			}
 		}
 
@@ -109,8 +109,8 @@ func ComputeOverridePatches(ctx context.Context, cl client.ResolutionClient, res
 	}
 
 	// Sort and remove duplicate patches
-	slices.SortFunc(allResults, func(a, b resolution.ResolutionDiff) int { return a.Compare(b) })
-	allResults = slices.CompactFunc(allResults, func(a, b resolution.ResolutionDiff) bool { return a.Compare(b) == 0 })
+	slices.SortFunc(allResults, func(a, b resolution.Difference) int { return a.Compare(b) })
+	allResults = slices.CompactFunc(allResults, func(a, b resolution.Difference) bool { return a.Compare(b) == 0 })
 
 	return allResults, nil
 }
@@ -119,13 +119,13 @@ var errOverrideImpossible = errors.New("cannot fix vulns by overrides")
 
 // overridePatchVulns tries to fix as many vulns in vulnIDs as possible by overriding dependency versions.
 // returns errOverrideImpossible if 0 vulns are patchable, otherwise returns the most possible patches.
-func overridePatchVulns(ctx context.Context, cl client.ResolutionClient, result *resolution.ResolutionResult, vulnIDs []string, opts RemediationOptions) (*resolution.ResolutionResult, []overridePatch, error) {
+func overridePatchVulns(ctx context.Context, cl client.ResolutionClient, result *resolution.Result, vulnIDs []string, opts Options) (*resolution.Result, []overridePatch, error) {
 	var effectivePatches []overridePatch
 	for {
 		// Find the relevant vulns affecting each version key.
-		vkVulns := make(map[resolve.VersionKey][]*resolution.ResolutionVuln)
+		vkVulns := make(map[resolve.VersionKey][]*resolution.Vulnerability)
 		for i, v := range result.Vulns {
-			if !slices.Contains(vulnIDs, v.Vulnerability.ID) {
+			if !slices.Contains(vulnIDs, v.OSV.ID) {
 				continue
 			}
 			// Keep track of VersionKeys we've seen for this vuln to avoid duplicates.
@@ -191,7 +191,7 @@ func overridePatchVulns(ctx context.Context, cl client.ResolutionClient, result 
 				// Count the remaining known vulns that affect this version.
 				count := 0 // remaining vulns
 				for _, rv := range vulnerabilities {
-					if vulns.IsAffected(rv.Vulnerability, util.VKToPackageDetails(ver.VersionKey)) {
+					if vulns.IsAffected(rv.OSV, util.VKToPackageDetails(ver.VersionKey)) {
 						count++
 					}
 				}

--- a/internal/remediation/override_test.go
+++ b/internal/remediation/override_test.go
@@ -12,7 +12,7 @@ import (
 func TestComputeOverridePatches(t *testing.T) {
 	t.Parallel()
 
-	basicOpts := remediation.RemediationOptions{
+	basicOpts := remediation.Options{
 		DevDeps:       true,
 		MaxDepth:      -1,
 		UpgradeConfig: upgrade.NewConfig(),
@@ -22,7 +22,7 @@ func TestComputeOverridePatches(t *testing.T) {
 		name         string
 		universePath string
 		manifestPath string
-		opts         remediation.RemediationOptions
+		opts         remediation.Options
 	}{
 		{
 			name:         "maven-zeppelin-server",
@@ -40,7 +40,7 @@ func TestComputeOverridePatches(t *testing.T) {
 			name:         "maven-management-only",
 			universePath: "./fixtures/zeppelin-server/universe.yaml",
 			manifestPath: "./fixtures/zeppelin-server/parent/pom.xml",
-			opts: remediation.RemediationOptions{
+			opts: remediation.Options{
 				ResolveOpts: resolution.ResolveOpts{
 					MavenManagement: true,
 				},

--- a/internal/remediation/relax.go
+++ b/internal/remediation/relax.go
@@ -13,14 +13,14 @@ import (
 )
 
 // ComputeRelaxPatches attempts to resolve each vulnerability found in result independently, returning the list of unique possible patches
-func ComputeRelaxPatches(ctx context.Context, cl client.ResolutionClient, result *resolution.ResolutionResult, opts RemediationOptions) ([]resolution.ResolutionDiff, error) {
+func ComputeRelaxPatches(ctx context.Context, cl client.ResolutionClient, result *resolution.Result, opts Options) ([]resolution.Difference, error) {
 	// Filter the original result just in case it hasn't been already
 	result.FilterVulns(opts.MatchVuln)
 
 	// Do the resolutions concurrently
 	type relaxResult struct {
 		vulnIDs []string
-		result  *resolution.ResolutionResult
+		result  *resolution.Result
 		err     error
 	}
 	ch := make(chan relaxResult)
@@ -39,11 +39,11 @@ func ComputeRelaxPatches(ctx context.Context, cl client.ResolutionClient, result
 	toProcess := 0
 	for _, vuln := range result.Vulns {
 		// TODO: limit the number of goroutines
-		go doRelax([]string{vuln.Vulnerability.ID})
+		go doRelax([]string{vuln.OSV.ID})
 		toProcess++
 	}
 
-	var allResults []resolution.ResolutionDiff
+	var allResults []resolution.Difference
 	for toProcess > 0 {
 		res := <-ch
 		toProcess--
@@ -60,14 +60,14 @@ func ComputeRelaxPatches(ctx context.Context, cl client.ResolutionClient, result
 		// If this patch adds a new vuln, see if we can fix it also
 		// TODO: If there's more than 1 added vuln, this can possibly cause every permutation of those vulns to be computed
 		for _, added := range diff.AddedVulns {
-			go doRelax(append(slices.Clone(res.vulnIDs), added.Vulnerability.ID))
+			go doRelax(append(slices.Clone(res.vulnIDs), added.OSV.ID))
 			toProcess++
 		}
 	}
 
 	// Sort and remove duplicate patches
-	slices.SortFunc(allResults, func(a, b resolution.ResolutionDiff) int { return a.Compare(b) })
-	allResults = slices.CompactFunc(allResults, func(a, b resolution.ResolutionDiff) bool { return a.Compare(b) == 0 })
+	slices.SortFunc(allResults, func(a, b resolution.Difference) int { return a.Compare(b) })
+	allResults = slices.CompactFunc(allResults, func(a, b resolution.Difference) bool { return a.Compare(b) == 0 })
 
 	return allResults, nil
 }
@@ -77,10 +77,10 @@ var errRelaxRemediateImpossible = errors.New("cannot fix vulns by relaxing")
 func tryRelaxRemediate(
 	ctx context.Context,
 	cl client.ResolutionClient,
-	orig *resolution.ResolutionResult,
+	orig *resolution.Result,
 	vulnIDs []string,
-	opts RemediationOptions,
-) (*resolution.ResolutionResult, error) {
+	opts Options,
+) (*resolution.Result, error) {
 	relaxer, err := relax.GetRelaxer(orig.Manifest.System())
 	if err != nil {
 		return nil, err
@@ -115,11 +115,11 @@ func tryRelaxRemediate(
 	return newRes, nil
 }
 
-func reqsToRelax(res *resolution.ResolutionResult, vulnIDs []string, opts RemediationOptions) []int {
+func reqsToRelax(res *resolution.Result, vulnIDs []string, opts Options) []int {
 	toRelax := make(map[resolve.VersionKey]string)
 	for _, v := range res.Vulns {
 		// Don't do a full opts.MatchVuln() since we know we don't need to check every condition
-		if !slices.Contains(vulnIDs, v.Vulnerability.ID) || (!opts.DevDeps && v.DevOnly) {
+		if !slices.Contains(vulnIDs, v.OSV.ID) || (!opts.DevDeps && v.DevOnly) {
 			continue
 		}
 		// Only relax dependencies if their chain length is less than MaxDepth

--- a/internal/remediation/relax/npm.go
+++ b/internal/remediation/relax/npm.go
@@ -46,9 +46,9 @@ func (r NpmRelaxer) Relax(ctx context.Context, cl resolve.Client, req resolve.Re
 	slices.SortFunc(vers, semver.NPM.Compare)
 
 	// Find the versions on either side of the upper boundary of the requirement
-	var lastIdx int      // highest version matching constraint
-	var nextIdx int = -1 // next version outside of range, preferring non-prerelease
-	nextIsPre := true    // if the next version is a prerelease version
+	var lastIdx int   // highest version matching constraint
+	nextIdx := -1     // next version outside of range, preferring non-prerelease
+	nextIsPre := true // if the next version is a prerelease version
 	for lastIdx = len(vers) - 1; lastIdx >= 0; lastIdx-- {
 		v, err := semver.NPM.Parse(vers[lastIdx])
 		if err != nil {

--- a/internal/remediation/relax_test.go
+++ b/internal/remediation/relax_test.go
@@ -11,7 +11,7 @@ import (
 func TestComputeRelaxPatches(t *testing.T) {
 	t.Parallel()
 
-	basicOpts := remediation.RemediationOptions{
+	basicOpts := remediation.Options{
 		DevDeps:       true,
 		MaxDepth:      -1,
 		UpgradeConfig: upgrade.NewConfig(),
@@ -21,7 +21,7 @@ func TestComputeRelaxPatches(t *testing.T) {
 		name         string
 		universePath string
 		manifestPath string
-		opts         remediation.RemediationOptions
+		opts         remediation.Options
 	}{
 		{
 			name:         "npm-santatracker",

--- a/internal/remediation/remediation.go
+++ b/internal/remediation/remediation.go
@@ -12,7 +12,7 @@ import (
 )
 
 // TODO: Supported strategies should be part of the manifest/lockfile io directly
-func SupportsRelax(m manifest.ManifestIO) bool {
+func SupportsRelax(m manifest.IO) bool {
 	switch m.(type) {
 	case manifest.NpmManifestIO:
 		return true
@@ -21,7 +21,7 @@ func SupportsRelax(m manifest.ManifestIO) bool {
 	}
 }
 
-func SupportsOverride(m manifest.ManifestIO) bool {
+func SupportsOverride(m manifest.IO) bool {
 	switch m.(type) {
 	case manifest.MavenManifestIO:
 		return true
@@ -30,7 +30,7 @@ func SupportsOverride(m manifest.ManifestIO) bool {
 	}
 }
 
-func SupportsInPlace(l lockfile.LockfileIO) bool {
+func SupportsInPlace(l lockfile.IO) bool {
 	switch l.(type) {
 	case lockfile.NpmLockfileIO:
 		return true
@@ -39,7 +39,7 @@ func SupportsInPlace(l lockfile.LockfileIO) bool {
 	}
 }
 
-type RemediationOptions struct {
+type Options struct {
 	resolution.ResolveOpts
 	IgnoreVulns   []string // Vulnerability IDs to ignore
 	ExplicitVulns []string // If set, only consider these vulnerability IDs & ignore all others
@@ -51,7 +51,7 @@ type RemediationOptions struct {
 	UpgradeConfig upgrade.Config // Allowed upgrade levels per package.
 }
 
-func (opts RemediationOptions) MatchVuln(v resolution.ResolutionVuln) bool {
+func (opts Options) MatchVuln(v resolution.Vulnerability) bool {
 	if opts.matchID(v, opts.IgnoreVulns) {
 		return false
 	}
@@ -67,12 +67,12 @@ func (opts RemediationOptions) MatchVuln(v resolution.ResolutionVuln) bool {
 	return opts.matchSeverity(v) && opts.matchDepth(v)
 }
 
-func (opts RemediationOptions) matchID(v resolution.ResolutionVuln, ids []string) bool {
-	if slices.Contains(ids, v.Vulnerability.ID) {
+func (opts Options) matchID(v resolution.Vulnerability, ids []string) bool {
+	if slices.Contains(ids, v.OSV.ID) {
 		return true
 	}
 
-	for _, id := range v.Vulnerability.Aliases {
+	for _, id := range v.OSV.Aliases {
 		if slices.Contains(ids, id) {
 			return true
 		}
@@ -81,10 +81,10 @@ func (opts RemediationOptions) matchID(v resolution.ResolutionVuln, ids []string
 	return false
 }
 
-func (opts RemediationOptions) matchSeverity(v resolution.ResolutionVuln) bool {
+func (opts Options) matchSeverity(v resolution.Vulnerability) bool {
 	maxScore := -1.0
 	// TODO: also check Vulnerability.Affected[].Severity
-	for _, sev := range v.Vulnerability.Severity {
+	for _, sev := range v.OSV.Severity {
 		if score, _, _ := severity.CalculateScore(sev); score > maxScore {
 			maxScore = score
 		}
@@ -97,7 +97,7 @@ func (opts RemediationOptions) matchSeverity(v resolution.ResolutionVuln) bool {
 		maxScore < 0 // Always include vulns with unknown severities
 }
 
-func (opts RemediationOptions) matchDepth(v resolution.ResolutionVuln) bool {
+func (opts Options) matchDepth(v resolution.Vulnerability) bool {
 	if opts.MaxDepth <= 0 {
 		return true
 	}

--- a/internal/remediation/remediation.go
+++ b/internal/remediation/remediation.go
@@ -83,7 +83,7 @@ func (opts Options) matchID(v resolution.Vulnerability, ids []string) bool {
 
 func (opts Options) matchSeverity(v resolution.Vulnerability) bool {
 	maxScore := -1.0
-	// TODO: also check Vulnerability.Affected[].Severity
+	// TODO: also check OSV.Affected[].Severity
 	for _, sev := range v.OSV.Severity {
 		if score, _, _ := severity.CalculateScore(sev); score > maxScore {
 			maxScore = score

--- a/internal/remediation/remediation.go
+++ b/internal/remediation/remediation.go
@@ -11,28 +11,28 @@ import (
 	"github.com/google/osv-scanner/internal/utility/severity"
 )
 
-// TODO: Supported strategies should be part of the manifest/lockfile io directly
-func SupportsRelax(m manifest.IO) bool {
+// TODO: Supported strategies should be part of the manifest/lockfile ReadWriter directly
+func SupportsRelax(m manifest.ReadWriter) bool {
 	switch m.(type) {
-	case manifest.NpmManifestIO:
+	case manifest.NpmReadWriter:
 		return true
 	default:
 		return false
 	}
 }
 
-func SupportsOverride(m manifest.IO) bool {
+func SupportsOverride(m manifest.ReadWriter) bool {
 	switch m.(type) {
-	case manifest.MavenManifestIO:
+	case manifest.MavenReadWriter:
 		return true
 	default:
 		return false
 	}
 }
 
-func SupportsInPlace(l lockfile.IO) bool {
+func SupportsInPlace(l lockfile.ReadWriter) bool {
 	switch l.(type) {
-	case lockfile.NpmLockfileIO:
+	case lockfile.NpmReadWriter:
 		return true
 	default:
 		return false

--- a/internal/remediation/remediation_test.go
+++ b/internal/remediation/remediation_test.go
@@ -13,8 +13,8 @@ func TestMatchVuln(t *testing.T) {
 	t.Parallel()
 	var (
 		// ID: VULN-001, Dev: false, Severity: 6.6, Depth: 3, Aliases: CVE-111, OSV-2
-		vuln1 = resolution.ResolutionVuln{
-			Vulnerability: models.Vulnerability{
+		vuln1 = resolution.Vulnerability{
+			OSV: models.Vulnerability{
 				ID: "VULN-001",
 				Severity: []models.Severity{
 					{Type: models.SeverityCVSSV3, Score: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:H"}, // 6.6
@@ -28,8 +28,8 @@ func TestMatchVuln(t *testing.T) {
 			}},
 		}
 		// ID: VULN-002, Dev: true, Severity: N/A, Depth: 2
-		vuln2 = resolution.ResolutionVuln{
-			Vulnerability: models.Vulnerability{
+		vuln2 = resolution.Vulnerability{
+			OSV: models.Vulnerability{
 				ID: "VULN-002",
 				// No severity
 			},
@@ -44,14 +44,14 @@ func TestMatchVuln(t *testing.T) {
 	)
 	tests := []struct {
 		name string
-		vuln resolution.ResolutionVuln
-		opt  remediation.RemediationOptions
+		vuln resolution.Vulnerability
+		opt  remediation.Options
 		want bool
 	}{
 		{
 			name: "basic match",
 			vuln: vuln1,
-			opt: remediation.RemediationOptions{
+			opt: remediation.Options{
 				DevDeps:  true,
 				MaxDepth: -1,
 			},
@@ -60,7 +60,7 @@ func TestMatchVuln(t *testing.T) {
 		{
 			name: "accept depth",
 			vuln: vuln2,
-			opt: remediation.RemediationOptions{
+			opt: remediation.Options{
 				DevDeps:  true,
 				MaxDepth: 2,
 			},
@@ -69,7 +69,7 @@ func TestMatchVuln(t *testing.T) {
 		{
 			name: "reject depth",
 			vuln: vuln2,
-			opt: remediation.RemediationOptions{
+			opt: remediation.Options{
 				DevDeps:  true,
 				MaxDepth: 1,
 			},
@@ -78,7 +78,7 @@ func TestMatchVuln(t *testing.T) {
 		{
 			name: "accept severity",
 			vuln: vuln1,
-			opt: remediation.RemediationOptions{
+			opt: remediation.Options{
 				DevDeps:     true,
 				MaxDepth:    -1,
 				MinSeverity: 6.6,
@@ -88,7 +88,7 @@ func TestMatchVuln(t *testing.T) {
 		{
 			name: "reject severity",
 			vuln: vuln1,
-			opt: remediation.RemediationOptions{
+			opt: remediation.Options{
 				DevDeps:     true,
 				MaxDepth:    -1,
 				MinSeverity: 6.7,
@@ -98,7 +98,7 @@ func TestMatchVuln(t *testing.T) {
 		{
 			name: "accept unknown severity",
 			vuln: vuln2,
-			opt: remediation.RemediationOptions{
+			opt: remediation.Options{
 				DevDeps:     true,
 				MaxDepth:    -1,
 				MinSeverity: 10.0,
@@ -108,7 +108,7 @@ func TestMatchVuln(t *testing.T) {
 		{
 			name: "accept non-dev",
 			vuln: vuln1,
-			opt: remediation.RemediationOptions{
+			opt: remediation.Options{
 				DevDeps:  false,
 				MaxDepth: -1,
 			},
@@ -117,7 +117,7 @@ func TestMatchVuln(t *testing.T) {
 		{
 			name: "reject dev",
 			vuln: vuln2,
-			opt: remediation.RemediationOptions{
+			opt: remediation.Options{
 				DevDeps:  false,
 				MaxDepth: -1,
 			},
@@ -126,7 +126,7 @@ func TestMatchVuln(t *testing.T) {
 		{
 			name: "reject ID excluded",
 			vuln: vuln1,
-			opt: remediation.RemediationOptions{
+			opt: remediation.Options{
 				DevDeps:     true,
 				MaxDepth:    -1,
 				IgnoreVulns: []string{"VULN-001"},
@@ -136,7 +136,7 @@ func TestMatchVuln(t *testing.T) {
 		{
 			name: "reject ID not in explicit",
 			vuln: vuln1,
-			opt: remediation.RemediationOptions{
+			opt: remediation.Options{
 				DevDeps:       true,
 				MaxDepth:      -1,
 				ExplicitVulns: []string{"VULN-999"},
@@ -146,7 +146,7 @@ func TestMatchVuln(t *testing.T) {
 		{
 			name: "reject ID in explicit, but not matching other fields",
 			vuln: vuln2,
-			opt: remediation.RemediationOptions{
+			opt: remediation.Options{
 				DevDeps:       false,
 				MaxDepth:      1,
 				ExplicitVulns: []string{"VULN-002"},
@@ -156,7 +156,7 @@ func TestMatchVuln(t *testing.T) {
 		{
 			name: "accept matching multiple 1",
 			vuln: vuln1,
-			opt: remediation.RemediationOptions{
+			opt: remediation.Options{
 				DevDeps:     false,
 				MaxDepth:    3,
 				MinSeverity: 5.0,
@@ -167,7 +167,7 @@ func TestMatchVuln(t *testing.T) {
 		{
 			name: "accept matching multiple 2",
 			vuln: vuln2,
-			opt: remediation.RemediationOptions{
+			opt: remediation.Options{
 				DevDeps:       true,
 				MaxDepth:      2,
 				MinSeverity:   8.8,
@@ -178,7 +178,7 @@ func TestMatchVuln(t *testing.T) {
 		{
 			name: "accept explicit ID in alias",
 			vuln: vuln1,
-			opt: remediation.RemediationOptions{
+			opt: remediation.Options{
 				DevDeps:       true,
 				MaxDepth:      -1,
 				ExplicitVulns: []string{"CVE-111"},
@@ -188,7 +188,7 @@ func TestMatchVuln(t *testing.T) {
 		{
 			name: "reject excluded ID in alias",
 			vuln: vuln1,
-			opt: remediation.RemediationOptions{
+			opt: remediation.Options{
 				DevDeps:     true,
 				MaxDepth:    -1,
 				IgnoreVulns: []string{"OSV-2"},

--- a/internal/remediation/suggest/maven.go
+++ b/internal/remediation/suggest/maven.go
@@ -18,10 +18,10 @@ type MavenSuggester struct{}
 // Suggest returns the ManifestPatch to update Maven dependencies to a newer
 // version based on the options.
 // ManifestPatch also includes the property patches to update.
-func (ms *MavenSuggester) Suggest(ctx context.Context, client resolve.Client, mf manifest.Manifest, opts Options) (manifest.ManifestPatch, error) {
+func (ms *MavenSuggester) Suggest(ctx context.Context, client resolve.Client, mf manifest.Manifest, opts Options) (manifest.Patch, error) {
 	specific, ok := mf.EcosystemSpecific.(manifest.MavenManifestSpecific)
 	if !ok {
-		return manifest.ManifestPatch{}, errors.New("invalid MavenManifestSpecific data")
+		return manifest.Patch{}, errors.New("invalid MavenManifestSpecific data")
 	}
 
 	var changedDeps []manifest.DependencyPatch //nolint:prealloc
@@ -37,7 +37,7 @@ func (ms *MavenSuggester) Suggest(ctx context.Context, client resolve.Client, mf
 
 		latest, err := suggestMavenVersion(ctx, client, req, slices.Contains(opts.AvoidMajor, req.Name))
 		if err != nil {
-			return manifest.ManifestPatch{}, fmt.Errorf("suggesting latest version of %s: %w", req.Version, err)
+			return manifest.Patch{}, fmt.Errorf("suggesting latest version of %s: %w", req.Version, err)
 		}
 		if latest.Version == req.Version {
 			// No need to update
@@ -52,7 +52,7 @@ func (ms *MavenSuggester) Suggest(ctx context.Context, client resolve.Client, mf
 		})
 	}
 
-	return manifest.ManifestPatch{
+	return manifest.Patch{
 		Deps:     changedDeps,
 		Manifest: &mf,
 	}, nil

--- a/internal/remediation/suggest/maven_test.go
+++ b/internal/remediation/suggest/maven_test.go
@@ -265,7 +265,7 @@ func TestSuggest(t *testing.T) {
 		t.Fatalf("failed to suggest ManifestPatch: %v", err)
 	}
 
-	want := manifest.ManifestPatch{
+	want := manifest.Patch{
 		Deps: []manifest.DependencyPatch{
 			{
 				Pkg: resolve.PackageKey{

--- a/internal/remediation/suggest/suggest.go
+++ b/internal/remediation/suggest/suggest.go
@@ -21,7 +21,7 @@ type PatchSuggester interface {
 	// Suggest returns the ManifestPatch required to update the dependencies to
 	// a newer version based on the given options.
 	// ManifestPatch includes ecosystem-specific information.
-	Suggest(ctx context.Context, client resolve.Client, mf manifest.Manifest, opts Options) (manifest.ManifestPatch, error)
+	Suggest(ctx context.Context, client resolve.Client, mf manifest.Manifest, opts Options) (manifest.Patch, error)
 }
 
 func GetSuggester(system resolve.System) (PatchSuggester, error) {

--- a/internal/remediation/testhelpers_test.go
+++ b/internal/remediation/testhelpers_test.go
@@ -16,7 +16,7 @@ import (
 	"golang.org/x/exp/maps"
 )
 
-func parseRemediationFixture(t *testing.T, universePath, manifestPath string, opts resolution.ResolveOpts) (*resolution.ResolutionResult, client.ResolutionClient) {
+func parseRemediationFixture(t *testing.T, universePath, manifestPath string, opts resolution.ResolveOpts) (*resolution.Result, client.ResolutionClient) {
 	t.Helper()
 
 	io, err := manifest.GetManifestIO(manifestPath)
@@ -45,7 +45,7 @@ func parseRemediationFixture(t *testing.T, universePath, manifestPath string, op
 	return res, cl
 }
 
-func checkRemediationResults(t *testing.T, res []resolution.ResolutionDiff) {
+func checkRemediationResults(t *testing.T, res []resolution.Difference) {
 	// ResolutionDiff is too large when dumped as JSON.
 	// Extract & compare a subset of fields that are relevant for the tests.
 	t.Helper()
@@ -55,7 +55,7 @@ func checkRemediationResults(t *testing.T, res []resolution.ResolutionDiff) {
 		AffectedNodes []resolve.NodeID
 	}
 
-	toMinimalVuln := func(v resolution.ResolutionVuln) minimalVuln {
+	toMinimalVuln := func(v resolution.Vulnerability) minimalVuln {
 		t.Helper()
 		nodes := make(map[resolve.NodeID]struct{})
 		for _, c := range v.ProblemChains {
@@ -68,7 +68,7 @@ func checkRemediationResults(t *testing.T, res []resolution.ResolutionDiff) {
 		slices.Sort(sortedNodes)
 
 		return minimalVuln{
-			ID:            v.Vulnerability.ID,
+			ID:            v.OSV.ID,
 			AffectedNodes: sortedNodes,
 		}
 	}

--- a/internal/remediation/testhelpers_test.go
+++ b/internal/remediation/testhelpers_test.go
@@ -19,9 +19,9 @@ import (
 func parseRemediationFixture(t *testing.T, universePath, manifestPath string, opts resolution.ResolveOpts) (*resolution.Result, client.ResolutionClient) {
 	t.Helper()
 
-	io, err := manifest.GetManifestIO(manifestPath)
+	rw, err := manifest.GetReadWriter(manifestPath)
 	if err != nil {
-		t.Fatalf("Failed to get ManifestIO: %v", err)
+		t.Fatalf("Failed to get ReadWriter: %v", err)
 	}
 
 	f, err := lf.OpenLocalDepFile(manifestPath)
@@ -30,7 +30,7 @@ func parseRemediationFixture(t *testing.T, universePath, manifestPath string, op
 	}
 	defer f.Close()
 
-	m, err := io.Read(f)
+	m, err := rw.Read(f)
 	if err != nil {
 		t.Fatalf("Failed to parse manifest: %v", err)
 	}

--- a/internal/resolution/client/client.go
+++ b/internal/resolution/client/client.go
@@ -33,7 +33,7 @@ type DependencyClient interface {
 }
 
 // PreFetch loads cache, then makes and caches likely queries needed for resolving a package with a list of requirements
-func PreFetch(c DependencyClient, ctx context.Context, requirements []resolve.RequirementVersion, manifestPath string) {
+func PreFetch(ctx context.Context, c DependencyClient, requirements []resolve.RequirementVersion, manifestPath string) {
 	// It doesn't matter if loading the cache fails
 	_ = c.LoadCache(manifestPath)
 

--- a/internal/resolution/datasource/npm_registry.go
+++ b/internal/resolution/datasource/npm_registry.go
@@ -27,7 +27,7 @@ type NpmRegistryAPIClient struct {
 
 type npmRegistryPackageDetails struct {
 	// Only cache the info needed for the DependencyClient
-	Versions map[string]npmRegistryDependencies
+	Versions map[string]NpmRegistryDependencies
 	Tags     map[string]string
 }
 
@@ -43,24 +43,24 @@ func NewNpmRegistryAPIClient(workdir string) (*NpmRegistryAPIClient, error) {
 	}, nil
 }
 
-type npmRegistryVersions struct {
+type NpmRegistryVersions struct {
 	Versions []string
 	Tags     map[string]string
 }
 
-func (c *NpmRegistryAPIClient) Versions(ctx context.Context, pkg string) (npmRegistryVersions, error) {
+func (c *NpmRegistryAPIClient) Versions(ctx context.Context, pkg string) (NpmRegistryVersions, error) {
 	pkgDetails, err := c.getPackageDetails(ctx, pkg)
 	if err != nil {
-		return npmRegistryVersions{}, err
+		return NpmRegistryVersions{}, err
 	}
 
-	return npmRegistryVersions{
+	return NpmRegistryVersions{
 		Versions: maps.Keys(pkgDetails.Versions),
 		Tags:     pkgDetails.Tags,
 	}, nil
 }
 
-type npmRegistryDependencies struct {
+type NpmRegistryDependencies struct {
 	// TODO: These maps should preserve ordering from JSON response
 	Dependencies         map[string]string
 	DevDependencies      map[string]string
@@ -69,17 +69,17 @@ type npmRegistryDependencies struct {
 	BundleDependencies   []string
 }
 
-func (c *NpmRegistryAPIClient) Dependencies(ctx context.Context, pkg, version string) (npmRegistryDependencies, error) {
+func (c *NpmRegistryAPIClient) Dependencies(ctx context.Context, pkg, version string) (NpmRegistryDependencies, error) {
 	pkgDetails, err := c.getPackageDetails(ctx, pkg)
 	if err != nil {
-		return npmRegistryDependencies{}, err
+		return NpmRegistryDependencies{}, err
 	}
 
 	if deps, ok := pkgDetails.Versions[version]; ok {
 		return deps, nil
 	}
 
-	return npmRegistryDependencies{}, fmt.Errorf("no version %s for package %s", version, pkg)
+	return NpmRegistryDependencies{}, fmt.Errorf("no version %s for package %s", version, pkg)
 }
 
 func (c *NpmRegistryAPIClient) FullJSON(ctx context.Context, pkg, version string) (gjson.Result, error) {
@@ -119,9 +119,9 @@ func (c *NpmRegistryAPIClient) getPackageDetails(ctx context.Context, pkg string
 			return npmRegistryPackageDetails{}, err
 		}
 
-		versions := make(map[string]npmRegistryDependencies)
+		versions := make(map[string]NpmRegistryDependencies)
 		for v, data := range jsonData.Get("versions").Map() {
-			versions[v] = npmRegistryDependencies{
+			versions[v] = NpmRegistryDependencies{
 				Dependencies:         jsonToStringMap(data.Get("dependencies")),
 				DevDependencies:      jsonToStringMap(data.Get("devDependencies")),
 				PeerDependencies:     jsonToStringMap(data.Get("peerDependencies")),

--- a/internal/resolution/datasource/npmrc.go
+++ b/internal/resolution/datasource/npmrc.go
@@ -131,7 +131,7 @@ func builtinNpmrc() string {
 	return npmrc
 }
 
-type npmRegistryAuthInfo struct {
+type NpmRegistryAuthInfo struct {
 	authToken string
 	auth      string
 	username  string
@@ -139,7 +139,7 @@ type npmRegistryAuthInfo struct {
 	// TODO: certfile, keyfile
 }
 
-func (authInfo npmRegistryAuthInfo) AddToHeader(header http.Header) {
+func (authInfo NpmRegistryAuthInfo) AddToHeader(header http.Header) {
 	switch {
 	case authInfo.authToken != "":
 		header.Set("Authorization", "Bearer "+authInfo.authToken)
@@ -167,27 +167,27 @@ type NpmRegistryAuthOpts map[string]string
 
 var npmAuthFields = [...]string{":_authToken", ":_auth", ":username", ":_password"} // reference of the relevant config key suffixes
 
-func (opts NpmRegistryAuthOpts) getRegAuth(regKey string) (npmRegistryAuthInfo, bool) {
+func (opts NpmRegistryAuthOpts) getRegAuth(regKey string) (NpmRegistryAuthInfo, bool) {
 	if token, ok := opts[regKey+":_authToken"]; ok {
-		return npmRegistryAuthInfo{authToken: token}, true
+		return NpmRegistryAuthInfo{authToken: token}, true
 	}
 	if auth, ok := opts[regKey+":_auth"]; ok {
-		return npmRegistryAuthInfo{auth: auth}, true
+		return NpmRegistryAuthInfo{auth: auth}, true
 	}
 	if user, ok := opts[regKey+":username"]; ok {
 		if pass, ok := opts[regKey+":_password"]; ok {
-			return npmRegistryAuthInfo{username: user, password: pass}, true
+			return NpmRegistryAuthInfo{username: user, password: pass}, true
 		}
 	}
 	// TODO: certfile / keyfile
 
-	return npmRegistryAuthInfo{}, false
+	return NpmRegistryAuthInfo{}, false
 }
 
-func (opts NpmRegistryAuthOpts) GetAuth(uri string) npmRegistryAuthInfo {
+func (opts NpmRegistryAuthOpts) GetAuth(uri string) NpmRegistryAuthInfo {
 	parsed, err := url.Parse(uri)
 	if err != nil {
-		return npmRegistryAuthInfo{}
+		return NpmRegistryAuthInfo{}
 	}
 	regKey := "//" + parsed.Host + parsed.EscapedPath()
 	for regKey != "//" {
@@ -203,7 +203,7 @@ func (opts NpmRegistryAuthOpts) GetAuth(uri string) npmRegistryAuthInfo {
 		}
 	}
 
-	return npmRegistryAuthInfo{}
+	return NpmRegistryAuthInfo{}
 }
 
 // urlPathEscapeLower is url.PathEscape but with lowercase letters in hex codes (matching npm's behaviour)

--- a/internal/resolution/lockfile/lockfile.go
+++ b/internal/resolution/lockfile/lockfile.go
@@ -17,7 +17,7 @@ type DependencyPatch struct {
 	NewVersion  string
 }
 
-type LockfileIO interface {
+type IO interface {
 	// System returns which ecosystem this LockfileIO is for.
 	System() resolve.System
 	// Read parses a lockfile into a resolved graph
@@ -27,7 +27,7 @@ type LockfileIO interface {
 	Write(original lockfile.DepFile, output io.Writer, patches []DependencyPatch) error
 }
 
-func Overwrite(rw LockfileIO, filename string, patches []DependencyPatch) error {
+func Overwrite(rw IO, filename string, patches []DependencyPatch) error {
 	r, err := lockfile.OpenLocalDepFile(filename)
 	if err != nil {
 		return err
@@ -48,7 +48,7 @@ func Overwrite(rw LockfileIO, filename string, patches []DependencyPatch) error 
 	return nil
 }
 
-func GetLockfileIO(pathToLockfile string) (LockfileIO, error) {
+func GetLockfileIO(pathToLockfile string) (IO, error) {
 	base := filepath.Base(pathToLockfile)
 	switch {
 	case base == "package-lock.json":

--- a/internal/resolution/lockfile/lockfile.go
+++ b/internal/resolution/lockfile/lockfile.go
@@ -17,8 +17,8 @@ type DependencyPatch struct {
 	NewVersion  string
 }
 
-type IO interface {
-	// System returns which ecosystem this LockfileIO is for.
+type ReadWriter interface {
+	// System returns which ecosystem this ReadWriter is for.
 	System() resolve.System
 	// Read parses a lockfile into a resolved graph
 	Read(file lockfile.DepFile) (*resolve.Graph, error)
@@ -27,7 +27,7 @@ type IO interface {
 	Write(original lockfile.DepFile, output io.Writer, patches []DependencyPatch) error
 }
 
-func Overwrite(rw IO, filename string, patches []DependencyPatch) error {
+func Overwrite(rw ReadWriter, filename string, patches []DependencyPatch) error {
 	r, err := lockfile.OpenLocalDepFile(filename)
 	if err != nil {
 		return err
@@ -48,11 +48,11 @@ func Overwrite(rw IO, filename string, patches []DependencyPatch) error {
 	return nil
 }
 
-func GetLockfileIO(pathToLockfile string) (IO, error) {
+func GetReadWriter(pathToLockfile string) (ReadWriter, error) {
 	base := filepath.Base(pathToLockfile)
 	switch {
 	case base == "package-lock.json":
-		return NpmLockfileIO{}, nil
+		return NpmReadWriter{}, nil
 	default:
 		return nil, fmt.Errorf("unsupported lockfile type: %s", base)
 	}

--- a/internal/resolution/lockfile/npm.go
+++ b/internal/resolution/lockfile/npm.go
@@ -15,9 +15,9 @@ import (
 	"github.com/google/osv-scanner/pkg/lockfile"
 )
 
-type NpmLockfileIO struct{}
+type NpmReadWriter struct{}
 
-func (NpmLockfileIO) System() resolve.System { return resolve.NPM }
+func (NpmReadWriter) System() resolve.System { return resolve.NPM }
 
 type npmNodeModule struct {
 	NodeID       resolve.NodeID
@@ -33,7 +33,7 @@ func (n npmNodeModule) IsAliased() bool {
 	return len(n.ActualName) > 0
 }
 
-func (rw NpmLockfileIO) Read(file lockfile.DepFile) (*resolve.Graph, error) {
+func (rw NpmReadWriter) Read(file lockfile.DepFile) (*resolve.Graph, error) {
 	dec := json.NewDecoder(file)
 	var lockJSON lockfile.NpmLockfile
 	if err := dec.Decode(&lockJSON); err != nil {
@@ -124,7 +124,7 @@ func (rw NpmLockfileIO) Read(file lockfile.DepFile) (*resolve.Graph, error) {
 	return g, nil
 }
 
-func (rw NpmLockfileIO) findDependencyNode(node *npmNodeModule, depName string) resolve.NodeID {
+func (rw NpmReadWriter) findDependencyNode(node *npmNodeModule, depName string) resolve.NodeID {
 	// Walk up the node_modules to find which node would be used as the requirement
 	for node != nil {
 		if child, ok := node.Children[depName]; ok {
@@ -136,14 +136,14 @@ func (rw NpmLockfileIO) findDependencyNode(node *npmNodeModule, depName string) 
 	return resolve.NodeID(-1)
 }
 
-func (rw NpmLockfileIO) reVersionAliasedDeps(deps map[string]string) {
+func (rw NpmReadWriter) reVersionAliasedDeps(deps map[string]string) {
 	// for the dependency maps, change versions from "npm:pkg@version" to "version"
 	for k, v := range deps {
 		_, deps[k] = manifest.SplitNPMAlias(v)
 	}
 }
 
-func (rw NpmLockfileIO) Write(original lockfile.DepFile, output io.Writer, patches []DependencyPatch) error {
+func (rw NpmReadWriter) Write(original lockfile.DepFile, output io.Writer, patches []DependencyPatch) error {
 	var buf strings.Builder
 	_, err := io.Copy(&buf, original)
 	if err != nil {

--- a/internal/resolution/lockfile/npm_test.go
+++ b/internal/resolution/lockfile/npm_test.go
@@ -25,8 +25,8 @@ func TestNpmReadV2(t *testing.T) {
 	}
 	defer df.Close()
 
-	npmIO := lockfile.NpmLockfileIO{}
-	got, err := npmIO.Read(df)
+	npmRW := lockfile.NpmReadWriter{}
+	got, err := npmRW.Read(df)
 	if err != nil {
 		t.Fatalf("failed to read file: %v", err)
 	}
@@ -77,8 +77,8 @@ func TestNpmReadV1(t *testing.T) {
 	}
 	defer df.Close()
 
-	npmIO := lockfile.NpmLockfileIO{}
-	got, err := npmIO.Read(df)
+	npmRW := lockfile.NpmReadWriter{}
+	got, err := npmRW.Read(df)
 	if err != nil {
 		t.Fatalf("failed to read file: %v", err)
 	}
@@ -167,8 +167,8 @@ func TestNpmWrite(t *testing.T) {
 	defer df.Close()
 
 	buf := new(bytes.Buffer)
-	npmIO := lockfile.NpmLockfileIO{}
-	if err := npmIO.Write(df, buf, patches); err != nil {
+	npmRW := lockfile.NpmReadWriter{}
+	if err := npmRW.Write(df, buf, patches); err != nil {
 		t.Fatalf("unable to update npm package-lock.json: %v", err)
 	}
 	testutility.NewSnapshot().WithCRLFReplacement().MatchText(t, buf.String())

--- a/internal/resolution/lockfile/npm_v2.go
+++ b/internal/resolution/lockfile/npm_v2.go
@@ -22,7 +22,7 @@ import (
 // Installed packages are in the flat "packages" object, keyed by the install path
 // e.g. "node_modules/foo/node_modules/bar"
 // packages contain most information from their own manifests.
-func (rw NpmLockfileIO) nodesFromPackages(lockJSON lockfile.NpmLockfile) (*resolve.Graph, *npmNodeModule, error) {
+func (rw NpmReadWriter) nodesFromPackages(lockJSON lockfile.NpmLockfile) (*resolve.Graph, *npmNodeModule, error) {
 	var g resolve.Graph
 	// Create graph nodes and reconstruct the node_modules folder structure in memory
 	root, ok := lockJSON.Packages[""]
@@ -132,7 +132,7 @@ func (rw NpmLockfileIO) nodesFromPackages(lockJSON lockfile.NpmLockfile) (*resol
 	return &g, nodeModuleTree, nil
 }
 
-func (rw NpmLockfileIO) makeNodeModuleDeps(pkg lockfile.NpmLockPackage, includeDev bool) *npmNodeModule {
+func (rw NpmReadWriter) makeNodeModuleDeps(pkg lockfile.NpmLockPackage, includeDev bool) *npmNodeModule {
 	nm := npmNodeModule{
 		Children:     make(map[string]*npmNodeModule),
 		Deps:         make(map[string]string),
@@ -155,7 +155,7 @@ func (rw NpmLockfileIO) makeNodeModuleDeps(pkg lockfile.NpmLockPackage, includeD
 	return &nm
 }
 
-func (rw NpmLockfileIO) packageNamesByNodeModuleDepth(packages map[string]lockfile.NpmLockPackage) []string {
+func (rw NpmReadWriter) packageNamesByNodeModuleDepth(packages map[string]lockfile.NpmLockPackage) []string {
 	keys := maps.Keys(packages)
 	slices.SortFunc(keys, func(a, b string) int {
 		aSplit := strings.Split(a, "node_modules/")
@@ -170,7 +170,7 @@ func (rw NpmLockfileIO) packageNamesByNodeModuleDepth(packages map[string]lockfi
 	return keys
 }
 
-func (rw NpmLockfileIO) modifyPackageLockPackages(lockJSON string, patches map[string]map[string]string, api *datasource.NpmRegistryAPIClient) (string, error) {
+func (rw NpmReadWriter) modifyPackageLockPackages(lockJSON string, patches map[string]map[string]string, api *datasource.NpmRegistryAPIClient) (string, error) {
 	packages := gjson.Get(lockJSON, "packages")
 	if !packages.Exists() {
 		return lockJSON, nil
@@ -199,7 +199,7 @@ func (rw NpmLockfileIO) modifyPackageLockPackages(lockJSON string, patches map[s
 	return lockJSON, nil
 }
 
-func (rw NpmLockfileIO) updatePackage(jsonText, jsonPath, packageName, newVersion string, api *datasource.NpmRegistryAPIClient) (string, error) {
+func (rw NpmReadWriter) updatePackage(jsonText, jsonPath, packageName, newVersion string, api *datasource.NpmRegistryAPIClient) (string, error) {
 	npmData, err := api.FullJSON(context.Background(), packageName, newVersion)
 	if err != nil {
 		return "", err

--- a/internal/resolution/manifest/manifest.go
+++ b/internal/resolution/manifest/manifest.go
@@ -53,25 +53,25 @@ type DependencyPatch struct {
 	NewResolved  string             // The version the new resolves to e.g. "2.4.6" (for display only)
 }
 
-type ManifestPatch struct {
+type Patch struct {
 	Manifest          *Manifest         // The original manifest
 	Deps              []DependencyPatch // Changed direct dependencies
 	EcosystemSpecific any               // Any ecosystem-specific information
 }
 
-type ManifestIO interface {
+type IO interface {
 	// System returns which ecosystem this ManifestIO is for.
 	System() resolve.System
 	// Read parses a manifest file into a Manifest, possibly recursively following references to other local manifest files
 	Read(file lockfile.DepFile) (Manifest, error)
 	// Write applies the ManifestPatch to the manifest, with minimal changes to the file.
 	// `original` is the original manifest file to read from. The updated manifest is written to `output`.
-	Write(original lockfile.DepFile, output io.Writer, patches ManifestPatch) error
+	Write(original lockfile.DepFile, output io.Writer, patches Patch) error
 }
 
 // Overwrite applies the ManifestPatch to the manifest at filename.
 // Used so as to not have the same file open for reading and writing at the same time.
-func Overwrite(rw ManifestIO, filename string, p ManifestPatch) error {
+func Overwrite(rw IO, filename string, p Patch) error {
 	r, err := lockfile.OpenLocalDepFile(filename)
 	if err != nil {
 		return err
@@ -92,7 +92,7 @@ func Overwrite(rw ManifestIO, filename string, p ManifestPatch) error {
 	return nil
 }
 
-func GetManifestIO(pathToManifest string) (ManifestIO, error) {
+func GetManifestIO(pathToManifest string) (IO, error) {
 	base := filepath.Base(pathToManifest)
 	switch {
 	case base == "pom.xml":

--- a/internal/resolution/manifest/manifest.go
+++ b/internal/resolution/manifest/manifest.go
@@ -59,19 +59,19 @@ type Patch struct {
 	EcosystemSpecific any               // Any ecosystem-specific information
 }
 
-type IO interface {
-	// System returns which ecosystem this ManifestIO is for.
+type ReadWriter interface {
+	// System returns which ecosystem this ReadWriter is for.
 	System() resolve.System
 	// Read parses a manifest file into a Manifest, possibly recursively following references to other local manifest files
 	Read(file lockfile.DepFile) (Manifest, error)
-	// Write applies the ManifestPatch to the manifest, with minimal changes to the file.
+	// Write applies the Patch to the manifest, with minimal changes to the file.
 	// `original` is the original manifest file to read from. The updated manifest is written to `output`.
 	Write(original lockfile.DepFile, output io.Writer, patches Patch) error
 }
 
 // Overwrite applies the ManifestPatch to the manifest at filename.
 // Used so as to not have the same file open for reading and writing at the same time.
-func Overwrite(rw IO, filename string, p Patch) error {
+func Overwrite(rw ReadWriter, filename string, p Patch) error {
 	r, err := lockfile.OpenLocalDepFile(filename)
 	if err != nil {
 		return err
@@ -92,13 +92,13 @@ func Overwrite(rw IO, filename string, p Patch) error {
 	return nil
 }
 
-func GetManifestIO(pathToManifest string) (IO, error) {
+func GetReadWriter(pathToManifest string) (ReadWriter, error) {
 	base := filepath.Base(pathToManifest)
 	switch {
 	case base == "pom.xml":
-		return NewMavenManifestIO(), nil
+		return NewMavenReadWriter(), nil
 	case base == "package.json":
-		return NpmManifestIO{}, nil
+		return NpmReadWriter{}, nil
 	default:
 		return nil, fmt.Errorf("unsupported manifest type: %s", base)
 	}

--- a/internal/resolution/manifest/maven.go
+++ b/internal/resolution/manifest/maven.go
@@ -283,7 +283,7 @@ func mavenOrigin(list ...string) string {
 	return result
 }
 
-func (MavenManifestIO) Write(df lockfile.DepFile, w io.Writer, patch ManifestPatch) error {
+func (MavenManifestIO) Write(df lockfile.DepFile, w io.Writer, patch Patch) error {
 	specific, ok := patch.Manifest.EcosystemSpecific.(MavenManifestSpecific)
 	if !ok {
 		return errors.New("invalid MavenManifestSpecific data")

--- a/internal/resolution/manifest/maven.go
+++ b/internal/resolution/manifest/maven.go
@@ -35,14 +35,14 @@ func mavenRequirementKey(requirement resolve.RequirementVersion) RequirementKey 
 	}
 }
 
-type MavenManifestIO struct {
+type MavenReadWriter struct {
 	*datasource.MavenRegistryAPIClient
 }
 
-func (MavenManifestIO) System() resolve.System { return resolve.Maven }
+func (MavenReadWriter) System() resolve.System { return resolve.Maven }
 
-func NewMavenManifestIO() MavenManifestIO {
-	return MavenManifestIO{
+func NewMavenReadWriter() MavenReadWriter {
+	return MavenReadWriter{
 		MavenRegistryAPIClient: datasource.NewMavenRegistryAPIClient(datasource.MavenCentral),
 	}
 }
@@ -64,7 +64,7 @@ type DependencyWithOrigin struct {
 	Origin string // Origin indicates where the dependency comes from
 }
 
-func (m MavenManifestIO) Read(df lockfile.DepFile) (Manifest, error) {
+func (m MavenReadWriter) Read(df lockfile.DepFile) (Manifest, error) {
 	ctx := context.Background()
 
 	var project maven.Project
@@ -283,7 +283,7 @@ func mavenOrigin(list ...string) string {
 	return result
 }
 
-func (MavenManifestIO) Write(df lockfile.DepFile, w io.Writer, patch Patch) error {
+func (MavenReadWriter) Write(df lockfile.DepFile, w io.Writer, patch Patch) error {
 	specific, ok := patch.Manifest.EcosystemSpecific.(MavenManifestSpecific)
 	if !ok {
 		return errors.New("invalid MavenManifestSpecific data")

--- a/internal/resolution/manifest/maven_test.go
+++ b/internal/resolution/manifest/maven_test.go
@@ -421,7 +421,7 @@ func TestMavenReadWrite(t *testing.T) {
 
 	out := new(bytes.Buffer)
 	// There are no patches since we are only testing tabs are not escaped.
-	if err := mavenIO.Write(df, out, ManifestPatch{Manifest: &want}); err != nil {
+	if err := mavenIO.Write(df, out, Patch{Manifest: &want}); err != nil {
 		t.Fatalf("failed to write Maven pom.xml: %v", err)
 	}
 	testutility.NewSnapshot().WithCRLFReplacement().MatchText(t, out.String())

--- a/internal/resolution/manifest/maven_test.go
+++ b/internal/resolution/manifest/maven_test.go
@@ -109,11 +109,11 @@ func TestMavenReadWrite(t *testing.T) {
 	}
 	defer df.Close()
 
-	mavenIO := MavenManifestIO{
+	mavenRW := MavenReadWriter{
 		MavenRegistryAPIClient: datasource.NewMavenRegistryAPIClient(srv.URL),
 	}
 
-	got, err := mavenIO.Read(df)
+	got, err := mavenRW.Read(df)
 	if err != nil {
 		t.Fatalf("failed to read file: %v", err)
 	}
@@ -421,7 +421,7 @@ func TestMavenReadWrite(t *testing.T) {
 
 	out := new(bytes.Buffer)
 	// There are no patches since we are only testing tabs are not escaped.
-	if err := mavenIO.Write(df, out, Patch{Manifest: &want}); err != nil {
+	if err := mavenRW.Write(df, out, Patch{Manifest: &want}); err != nil {
 		t.Fatalf("failed to write Maven pom.xml: %v", err)
 	}
 	testutility.NewSnapshot().WithCRLFReplacement().MatchText(t, out.String())

--- a/internal/resolution/manifest/npm.go
+++ b/internal/resolution/manifest/npm.go
@@ -26,9 +26,9 @@ func npmRequirementKey(requirement resolve.RequirementVersion) RequirementKey {
 	}
 }
 
-type NpmManifestIO struct{}
+type NpmReadWriter struct{}
 
-func (NpmManifestIO) System() resolve.System { return resolve.NPM }
+func (NpmReadWriter) System() resolve.System { return resolve.NPM }
 
 type PackageJSON struct {
 	Name    string `json:"name"`
@@ -45,7 +45,7 @@ type PackageJSON struct {
 	// BundleDependencies   []string          `json:"bundleDependencies"`
 }
 
-func (rw NpmManifestIO) Read(f lockfile.DepFile) (Manifest, error) {
+func (rw NpmReadWriter) Read(f lockfile.DepFile) (Manifest, error) {
 	dec := json.NewDecoder(f)
 	var packagejson PackageJSON
 	if err := dec.Decode(&packagejson); err != nil {
@@ -194,7 +194,7 @@ func (rw NpmManifestIO) Read(f lockfile.DepFile) (Manifest, error) {
 	return manif, nil
 }
 
-func (rw NpmManifestIO) makeNPMReqVer(pkg, ver string) resolve.RequirementVersion {
+func (rw NpmReadWriter) makeNPMReqVer(pkg, ver string) resolve.RequirementVersion {
 	// TODO: URLs, Git, GitHub, `file:`
 	typ := dep.NewType() // don't use dep.NewType(dep.Dev) for devDeps to force the resolver to resolve them
 	realPkg, realVer := SplitNPMAlias(ver)
@@ -235,7 +235,7 @@ func (rw NpmManifestIO) makeNPMReqVer(pkg, ver string) resolve.RequirementVersio
 	}
 }
 
-func (NpmManifestIO) Write(r lockfile.DepFile, w io.Writer, patch Patch) error {
+func (NpmReadWriter) Write(r lockfile.DepFile, w io.Writer, patch Patch) error {
 	// Read the whole package.json into a string so we can use sjson to write in-place.
 	var buf strings.Builder
 	_, err := io.Copy(&buf, r)

--- a/internal/resolution/manifest/npm.go
+++ b/internal/resolution/manifest/npm.go
@@ -235,7 +235,7 @@ func (rw NpmManifestIO) makeNPMReqVer(pkg, ver string) resolve.RequirementVersio
 	}
 }
 
-func (NpmManifestIO) Write(r lockfile.DepFile, w io.Writer, patch ManifestPatch) error {
+func (NpmManifestIO) Write(r lockfile.DepFile, w io.Writer, patch Patch) error {
 	// Read the whole package.json into a string so we can use sjson to write in-place.
 	var buf strings.Builder
 	_, err := io.Copy(&buf, r)

--- a/internal/resolution/manifest/npm_test.go
+++ b/internal/resolution/manifest/npm_test.go
@@ -60,8 +60,8 @@ func TestNpmRead(t *testing.T) {
 	}
 	defer df.Close()
 
-	npmIO := manifest.NpmManifestIO{}
-	got, err := npmIO.Read(df)
+	npmRW := manifest.NpmReadWriter{}
+	got, err := npmRW.Read(df)
 	if err != nil {
 		t.Fatalf("failed to read file: %v", err)
 	}
@@ -122,8 +122,8 @@ func TestNpmWorkspaceRead(t *testing.T) {
 	}
 	defer df.Close()
 
-	npmIO := manifest.NpmManifestIO{}
-	got, err := npmIO.Read(df)
+	npmRW := manifest.NpmReadWriter{}
+	got, err := npmRW.Read(df)
 	if err != nil {
 		t.Fatalf("failed to read file: %v", err)
 	}
@@ -286,8 +286,8 @@ func TestNpmWrite(t *testing.T) {
 	}
 
 	buf := new(bytes.Buffer)
-	npmIO := manifest.NpmManifestIO{}
-	if err := npmIO.Write(df, buf, changes); err != nil {
+	npmRW := manifest.NpmReadWriter{}
+	if err := npmRW.Write(df, buf, changes); err != nil {
 		t.Fatalf("unable to update npm package.json: %v", err)
 	}
 	testutility.NewSnapshot().WithCRLFReplacement().MatchText(t, buf.String())

--- a/internal/resolution/manifest/npm_test.go
+++ b/internal/resolution/manifest/npm_test.go
@@ -222,7 +222,7 @@ func TestNpmWrite(t *testing.T) {
 	}
 	defer df.Close()
 
-	changes := manifest.ManifestPatch{
+	changes := manifest.Patch{
 		Deps: []manifest.DependencyPatch{
 			{
 				Pkg: resolve.PackageKey{

--- a/internal/resolution/resolve.go
+++ b/internal/resolution/resolve.go
@@ -228,8 +228,8 @@ func (res *Result) computeVulns(ctx context.Context, cl client.ResolutionClient)
 		}
 	}
 
-	// construct the ResolutionVulns
-	// TODO: This constructs a single ResolutionVuln per vulnerability ID.
+	// construct the resolution.Vulnerability
+	// TODO: This constructs a single resolution.Vulnerability per vulnerability ID.
 	// The scan action treats vulns with the same ID but affecting different versions of a package as distinct.
 	// TODO: Combine aliased IDs
 	for id, vuln := range vulnInfo {

--- a/internal/resolution/resolve_test.go
+++ b/internal/resolution/resolve_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/google/osv-scanner/internal/testutility"
 )
 
-func checkResult(t *testing.T, result *resolution.ResolutionResult) {
+func checkResult(t *testing.T, result *resolution.Result) {
 	t.Helper()
 	snap := testutility.NewSnapshot()
 	snap.MatchText(t, result.Graph.String())
@@ -29,7 +29,7 @@ func checkResult(t *testing.T, result *resolution.ResolutionResult) {
 	minVulns := make([]minimalVuln, len(result.Vulns))
 	for i, v := range result.Vulns {
 		minVulns[i] = minimalVuln{
-			ID:               v.Vulnerability.ID,
+			ID:               v.OSV.ID,
 			DevOnly:          v.DevOnly,
 			ProblemChains:    make([][]resolve.Edge, len(v.ProblemChains)),
 			NonProblemChains: make([][]resolve.Edge, len(v.NonProblemChains)),

--- a/internal/tui/in-place-info.go
+++ b/internal/tui/in-place-info.go
@@ -16,13 +16,14 @@ import (
 type inPlaceInfo struct {
 	table.Model
 
-	vulns        []*resolution.ResolutionVuln
+	vulns        []*resolution.Vulnerability
 	currVulnInfo ViewModel
 
 	width  int
 	height int
 }
 
+//revive:disable-next-line:unexported-return
 func NewInPlaceInfo(res remediation.InPlaceResult) *inPlaceInfo {
 	info := inPlaceInfo{width: ViewMinWidth, height: ViewMinHeight} // placeholder dimensions
 	cols := []table.Column{
@@ -44,7 +45,7 @@ func NewInPlaceInfo(res remediation.InPlaceResult) *inPlaceInfo {
 		row := table.Row{
 			patch.Pkg.Name,
 			fmt.Sprintf("%s → %s", patch.OrigVersion, patch.NewVersion),
-			patch.ResolvedVulns[0].Vulnerability.ID,
+			patch.ResolvedVulns[0].OSV.ID,
 		}
 		// Set each column to their widest element
 		for i, s := range row {
@@ -60,7 +61,7 @@ func NewInPlaceInfo(res remediation.InPlaceResult) *inPlaceInfo {
 			row := table.Row{
 				"",
 				"",
-				v.Vulnerability.ID,
+				v.OSV.ID,
 			}
 			rows = append(rows, row)
 			info.vulns = append(info.vulns, &patch.ResolvedVulns[i+1])

--- a/internal/tui/relock-info.go
+++ b/internal/tui/relock-info.go
@@ -19,7 +19,8 @@ type relockInfo struct {
 	addedFocused bool
 }
 
-func NewRelockInfo(change resolution.ResolutionDiff) *relockInfo {
+//revive:disable-next-line:unexported-return
+func NewRelockInfo(change resolution.Difference) *relockInfo {
 	info := relockInfo{fixedHeight: 1}
 	preamble := strings.Builder{}
 	preamble.WriteString("The following upgrades:\n")
@@ -28,7 +29,7 @@ func NewRelockInfo(change resolution.ResolutionDiff) *relockInfo {
 			dep.Pkg.Name, dep.OrigRequire, dep.OrigResolved, dep.NewRequire, dep.NewResolved))
 	}
 	preamble.WriteString("Will resolve the following:")
-	fixedVulns := make([]*resolution.ResolutionVuln, len(change.RemovedVulns))
+	fixedVulns := make([]*resolution.Vulnerability, len(change.RemovedVulns))
 	for i := range change.RemovedVulns {
 		fixedVulns[i] = &change.RemovedVulns[i]
 	}
@@ -39,7 +40,7 @@ func NewRelockInfo(change resolution.ResolutionDiff) *relockInfo {
 	}
 
 	// Create a second list showing introduced vulns
-	newVulns := make([]*resolution.ResolutionVuln, len(change.AddedVulns))
+	newVulns := make([]*resolution.Vulnerability, len(change.AddedVulns))
 	for i := range change.AddedVulns {
 		newVulns[i] = &change.AddedVulns[i]
 	}

--- a/internal/tui/vuln-info.go
+++ b/internal/tui/vuln-info.go
@@ -18,7 +18,7 @@ import (
 
 // ViewModel to display the details of a specific vulnerability
 type vulnInfo struct {
-	vuln        *resolution.ResolutionVuln
+	vuln        *resolution.Vulnerability
 	chainGraphs []ChainGraph
 
 	width  int
@@ -42,7 +42,8 @@ var (
 	highlightedVulnInfoHeadingStyle = vulnInfoHeadingStyle.Reverse(true)
 )
 
-func NewVulnInfo(vuln *resolution.ResolutionVuln) *vulnInfo {
+//revive:disable-next-line:unexported-return
+func NewVulnInfo(vuln *resolution.Vulnerability) *vulnInfo {
 	v := vulnInfo{
 		vuln:           vuln,
 		width:          ViewMinWidth,
@@ -134,9 +135,9 @@ func (v *vulnInfo) View() string {
 
 	detailWidth := v.width - (vulnInfoHeadingStyle.GetWidth() + vulnInfoHeadingStyle.GetMarginRight())
 
-	vID := v.vuln.Vulnerability.ID
-	sev := RenderSeverity(v.vuln.Vulnerability.Severity)
-	sum := wordwrap.String(v.vuln.Vulnerability.Summary, detailWidth)
+	vID := v.vuln.OSV.ID
+	sev := RenderSeverity(v.vuln.OSV.Severity)
+	sum := wordwrap.String(v.vuln.OSV.Summary, detailWidth)
 
 	var det string
 	r, err := glamour.NewTermRenderer(
@@ -144,7 +145,7 @@ func (v *vulnInfo) View() string {
 		glamour.WithWordWrap(detailWidth),
 	)
 	if err == nil {
-		det, err = r.Render(v.vuln.Vulnerability.Details)
+		det, err = r.Render(v.vuln.OSV.Details)
 	}
 	if err != nil {
 		det = v.fallbackDetails(detailWidth)
@@ -190,7 +191,7 @@ func (v *vulnInfo) detailsOnlyView() string {
 		glamour.WithWordWrap(v.width),
 	)
 	if err == nil {
-		det, err = r.Render(v.vuln.Vulnerability.Details)
+		det, err = r.Render(v.vuln.OSV.Details)
 	}
 	if err != nil {
 		det = v.fallbackDetails(v.width)
@@ -225,5 +226,5 @@ func (v *vulnInfo) headingStyle(idx int) lipgloss.Style {
 
 func (v *vulnInfo) fallbackDetails(width int) string {
 	// Use raw details if markdown rendering fails for whatever reason
-	return wordwrap.String(v.vuln.Vulnerability.Details, width)
+	return wordwrap.String(v.vuln.OSV.Details, width)
 }

--- a/internal/tui/vuln-list.go
+++ b/internal/tui/vuln-list.go
@@ -29,17 +29,18 @@ type vulnList struct {
 	blurred  bool              // whether the cursor should be hidden and input disabled
 }
 
-func NewVulnList(vulns []*resolution.ResolutionVuln, preamble string) *vulnList {
+//revive:disable-next-line:unexported-return
+func NewVulnList(vulns []*resolution.Vulnerability, preamble string) *vulnList {
 	vl := vulnList{preamble: preamble}
 	// Sort the vulns by descending severity, then ID
 	vulns = slices.Clone(vulns)
-	slices.SortFunc(vulns, func(a, b *resolution.ResolutionVuln) int {
-		aScoreFloat, aRating, _ := severity.CalculateOverallScore(a.Vulnerability.Severity)
+	slices.SortFunc(vulns, func(a, b *resolution.Vulnerability) int {
+		aScoreFloat, aRating, _ := severity.CalculateOverallScore(a.OSV.Severity)
 		aScore := int(aScoreFloat * 10) // CVSS scores are only to 1dp
 		if aRating == "UNKNOWN" {
 			aScore = 999 // Sort unknown before critical
 		}
-		bScoreFloat, bRating, _ := severity.CalculateOverallScore(b.Vulnerability.Severity)
+		bScoreFloat, bRating, _ := severity.CalculateOverallScore(b.OSV.Severity)
 		bScore := int(bScoreFloat * 10) // CVSS scores are only to 1dp
 		if bRating == "UNKNOWN" {
 			bScore = 999 // Sort unknown before critical
@@ -49,13 +50,13 @@ func NewVulnList(vulns []*resolution.ResolutionVuln, preamble string) *vulnList 
 			return -c
 		}
 
-		return cmp.Compare(a.Vulnerability.ID, b.Vulnerability.ID)
+		return cmp.Compare(a.OSV.ID, b.OSV.ID)
 	})
 	items := make([]list.Item, 0, len(vulns))
 	delegate := vulnListItemDelegate{idWidth: 0}
 	for _, v := range vulns {
 		items = append(items, vulnListItem{v})
-		if w := lipgloss.Width(v.Vulnerability.ID); w > delegate.idWidth {
+		if w := lipgloss.Width(v.OSV.ID); w > delegate.idWidth {
 			delegate.idWidth = w
 		}
 	}
@@ -115,7 +116,7 @@ func (v *vulnList) Update(msg tea.Msg) (ViewModel, tea.Cmd) {
 			return v, CloseViewModel
 		case key.Matches(msg, Keys.Select):
 			vuln := v.Model.SelectedItem().(vulnListItem)
-			v.currVulnInfo = NewVulnInfo(vuln.ResolutionVuln)
+			v.currVulnInfo = NewVulnInfo(vuln.Vulnerability)
 			v.currVulnInfo.Resize(v.Width(), v.Height())
 
 			return v, nil
@@ -152,11 +153,11 @@ func (v *vulnList) Focus() {
 
 // Helpers for the list.Model
 type vulnListItem struct {
-	*resolution.ResolutionVuln
+	*resolution.Vulnerability
 }
 
 func (v vulnListItem) FilterValue() string {
-	return v.Vulnerability.ID
+	return v.OSV.ID
 }
 
 type vulnListItemDelegate struct {
@@ -178,11 +179,11 @@ func (d vulnListItemDelegate) Render(w io.Writer, m list.Model, index int, listI
 		cursor = SelectedTextStyle.Render(">")
 		idStyle = idStyle.Inherit(SelectedTextStyle)
 	}
-	id := idStyle.Render(vuln.Vulnerability.ID)
-	severity := RenderSeverityShort(vuln.Vulnerability.Severity)
+	id := idStyle.Render(vuln.OSV.ID)
+	severity := RenderSeverityShort(vuln.OSV.Severity)
 	str := fmt.Sprintf("%s %s  %s  ", cursor, id, severity)
 	fmt.Fprint(w, str)
-	fmt.Fprint(w, truncate.StringWithTail(vuln.Vulnerability.Summary, uint(m.Width()-lipgloss.Width(str)), "…"))
+	fmt.Fprint(w, truncate.StringWithTail(vuln.OSV.Summary, uint(m.Width()-lipgloss.Width(str)), "…"))
 }
 
 // workaround item delegate wrapper to stop the selected item from being shown as selected
@@ -190,6 +191,6 @@ type blurredDelegate struct {
 	list.ItemDelegate
 }
 
-func (d blurredDelegate) Render(w io.Writer, m list.Model, index int, listItem list.Item) {
+func (d blurredDelegate) Render(w io.Writer, m list.Model, _ int, listItem list.Item) {
 	d.ItemDelegate.Render(w, m, -1, listItem)
 }

--- a/scripts/generate_mock_resolution_universe/main.go
+++ b/scripts/generate_mock_resolution_universe/main.go
@@ -39,7 +39,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-var remediationOpts = remediation.RemediationOptions{
+var remediationOpts = remediation.Options{
 	ResolveOpts: resolution.ResolveOpts{
 		MavenManagement: true,
 	},
@@ -48,7 +48,7 @@ var remediationOpts = remediation.RemediationOptions{
 	UpgradeConfig: upgrade.NewConfig(),
 }
 
-func doRelockRelax(ddCl *client.DepsDevClient, io manifest.ManifestIO, filename string) error {
+func doRelockRelax(ddCl *client.DepsDevClient, io manifest.IO, filename string) error {
 	cl := client.ResolutionClient{
 		VulnerabilityClient: client.NewOSVClient(),
 		DependencyClient:    ddCl,
@@ -65,7 +65,7 @@ func doRelockRelax(ddCl *client.DepsDevClient, io manifest.ManifestIO, filename 
 		return err
 	}
 
-	client.PreFetch(cl, context.Background(), manif.Requirements, manif.FilePath)
+	client.PreFetch(context.Background(), cl, manif.Requirements, manif.FilePath)
 	res, err := resolution.Resolve(context.Background(), cl, manif, remediationOpts.ResolveOpts)
 	if err != nil {
 		return err
@@ -75,7 +75,7 @@ func doRelockRelax(ddCl *client.DepsDevClient, io manifest.ManifestIO, filename 
 	return err
 }
 
-func doOverride(ddCl *client.DepsDevClient, io manifest.ManifestIO, filename string) error {
+func doOverride(ddCl *client.DepsDevClient, io manifest.IO, filename string) error {
 	cl := client.ResolutionClient{
 		VulnerabilityClient: client.NewOSVClient(),
 		DependencyClient:    ddCl,
@@ -92,7 +92,7 @@ func doOverride(ddCl *client.DepsDevClient, io manifest.ManifestIO, filename str
 		return err
 	}
 
-	client.PreFetch(cl, context.Background(), manif.Requirements, manif.FilePath)
+	client.PreFetch(context.Background(), cl, manif.Requirements, manif.FilePath)
 	res, err := resolution.Resolve(context.Background(), cl, manif, remediationOpts.ResolveOpts)
 	if err != nil {
 		return err
@@ -102,7 +102,7 @@ func doOverride(ddCl *client.DepsDevClient, io manifest.ManifestIO, filename str
 	return err
 }
 
-func doInPlace(ddCl *client.DepsDevClient, io lockfile.LockfileIO, filename string) error {
+func doInPlace(ddCl *client.DepsDevClient, io lockfile.IO, filename string) error {
 	cl := client.ResolutionClient{
 		VulnerabilityClient: client.NewOSVClient(),
 		DependencyClient:    ddCl,

--- a/scripts/generate_mock_resolution_universe/main.go
+++ b/scripts/generate_mock_resolution_universe/main.go
@@ -48,7 +48,7 @@ var remediationOpts = remediation.Options{
 	UpgradeConfig: upgrade.NewConfig(),
 }
 
-func doRelockRelax(ddCl *client.DepsDevClient, io manifest.IO, filename string) error {
+func doRelockRelax(ddCl *client.DepsDevClient, rw manifest.ReadWriter, filename string) error {
 	cl := client.ResolutionClient{
 		VulnerabilityClient: client.NewOSVClient(),
 		DependencyClient:    ddCl,
@@ -60,7 +60,7 @@ func doRelockRelax(ddCl *client.DepsDevClient, io manifest.IO, filename string) 
 	}
 	defer f.Close()
 
-	manif, err := io.Read(f)
+	manif, err := rw.Read(f)
 	if err != nil {
 		return err
 	}
@@ -75,7 +75,7 @@ func doRelockRelax(ddCl *client.DepsDevClient, io manifest.IO, filename string) 
 	return err
 }
 
-func doOverride(ddCl *client.DepsDevClient, io manifest.IO, filename string) error {
+func doOverride(ddCl *client.DepsDevClient, rw manifest.ReadWriter, filename string) error {
 	cl := client.ResolutionClient{
 		VulnerabilityClient: client.NewOSVClient(),
 		DependencyClient:    ddCl,
@@ -87,7 +87,7 @@ func doOverride(ddCl *client.DepsDevClient, io manifest.IO, filename string) err
 	}
 	defer f.Close()
 
-	manif, err := io.Read(f)
+	manif, err := rw.Read(f)
 	if err != nil {
 		return err
 	}
@@ -102,7 +102,7 @@ func doOverride(ddCl *client.DepsDevClient, io manifest.IO, filename string) err
 	return err
 }
 
-func doInPlace(ddCl *client.DepsDevClient, io lockfile.IO, filename string) error {
+func doInPlace(ddCl *client.DepsDevClient, rw lockfile.ReadWriter, filename string) error {
 	cl := client.ResolutionClient{
 		VulnerabilityClient: client.NewOSVClient(),
 		DependencyClient:    ddCl,
@@ -114,7 +114,7 @@ func doInPlace(ddCl *client.DepsDevClient, io lockfile.IO, filename string) erro
 	}
 	defer f.Close()
 
-	g, err := io.Read(f)
+	g, err := rw.Read(f)
 	if err != nil {
 		return err
 	}
@@ -290,7 +290,7 @@ func main() {
 
 	group := &errgroup.Group{}
 	for _, filename := range os.Args[1:] {
-		if io, err := manifest.GetManifestIO(filename); err == nil {
+		if io, err := manifest.GetReadWriter(filename); err == nil {
 			if remediation.SupportsRelax(io) {
 				group.Go(func() error {
 					err := doRelockRelax(cl, io, filename)
@@ -312,7 +312,7 @@ func main() {
 				})
 			}
 		}
-		if io, err := lockfile.GetLockfileIO(filename); err == nil {
+		if io, err := lockfile.GetReadWriter(filename); err == nil {
 			if remediation.SupportsInPlace(io) {
 				group.Go(func() error {
 					err := doInPlace(cl, io, filename)


### PR DESCRIPTION
Helping with #1257
Changed the guided remediation code (`cmd/osv-scanner/fix`, and `internal/resolution`, `remediation` and `tui`) to fix lint errors found when using `revive`'s default settings. All of this is internal, so there's no API breakages.

It was mostly `unexported-return` and stuttering complaints (e.g. `resolution.ResolutionResult` -> `resolution.Result`), so a bunch of structs have been renamed.