### PR TITLE
test: update case to reflect recent config parsing changes

### DIFF
--- a/pkg/config/config_internal_test.go
+++ b/pkg/config/config_internal_test.go
@@ -163,9 +163,9 @@ func Test_tryLoadConfig(t *testing.T) {
 				configPath: "./fixtures/testdatainner/osv-scanner-load-path.toml",
 			},
 			want: Config{
-				LoadPath: "./fixtures/testdatainner/osv-scanner-load-path.toml",
+				LoadPath: "",
 			},
-			wantErr: false,
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
This behaviour changed as a result of both #1252 (which makes `LoadPath` no longer a recognized config key) and #1249 (which causes the scanner to error when a config has an unknown key), but they didn't directly conflict with each other so got landed on `main` without this being picked up

(fwiw I'm not worried about this being a reoccurring thing that's worth guarding or preventing somehow as its usually pretty rare 🤷)