### PR TITLE
feat: support `vulnerabilities.ignore` in package overrides

### DIFF
--- a/cmd/osv-scanner/__snapshots__/main_test.snap
+++ b/cmd/osv-scanner/__snapshots__/main_test.snap
@@ -368,6 +368,7 @@ Attempted to scan lockfile but failed: <rootdir>/fixtures/locks-many-with-invali
 ---
 
 [TestRun/config_file_can_be_broad - 1]
+Scanned <rootdir>/fixtures/locks-insecure/osv-scanner-flutter-deps.json file as a osv-scanner and found 3 packages
 Scanning dir ./fixtures/locks-many
 Scanned <rootdir>/fixtures/locks-many/Gemfile.lock file and found 1 package
 Scanned <rootdir>/fixtures/locks-many/alpine.cdx.xml as CycloneDX SBOM and found 14 packages
@@ -405,13 +406,16 @@ overriding license for package Packagist/league/flysystem/1.0.8 with 0BSD
 +-------------------------------------+------+-----------+------------------+---------+---------------------------------------+
 | https://osv.dev/GHSA-9f46-5r25-5wfm | 9.8  | Packagist | league/flysystem | 1.0.8   | fixtures/locks-insecure/composer.lock |
 +-------------------------------------+------+-----------+------------------+---------+---------------------------------------+
-+-------------------+-----------+------------------+---------+---------------------------------------+
-| LICENSE VIOLATION | ECOSYSTEM | PACKAGE          | VERSION | SOURCE                                |
-+-------------------+-----------+------------------+---------+---------------------------------------+
-| 0BSD              | Packagist | league/flysystem | 1.0.8   | fixtures/locks-insecure/composer.lock |
-| UNKNOWN           | RubyGems  | ast              | 2.4.2   | fixtures/locks-many/Gemfile.lock      |
-| 0BSD              | Packagist | sentry/sdk       | 2.0.4   | fixtures/locks-many/composer.lock     |
-+-------------------+-----------+------------------+---------+---------------------------------------+
++-------------------+-----------+------------------------------------------------+---------+-------------------------------------------------------+
+| LICENSE VIOLATION | ECOSYSTEM | PACKAGE                                        | VERSION | SOURCE                                                |
++-------------------+-----------+------------------------------------------------+---------+-------------------------------------------------------+
+| 0BSD              | Packagist | league/flysystem                               | 1.0.8   | fixtures/locks-insecure/composer.lock                 |
+| UNKNOWN           |           | https://github.com/flutter/buildroot.git       |         | fixtures/locks-insecure/osv-scanner-flutter-deps.json |
+| UNKNOWN           |           | https://github.com/brendan-duncan/archive.git  |         | fixtures/locks-insecure/osv-scanner-flutter-deps.json |
+| UNKNOWN           |           | https://chromium.googlesource.com/chromium/src |         | fixtures/locks-insecure/osv-scanner-flutter-deps.json |
+| UNKNOWN           | RubyGems  | ast                                            | 2.4.2   | fixtures/locks-many/Gemfile.lock                      |
+| 0BSD              | Packagist | sentry/sdk                                     | 2.0.4   | fixtures/locks-many/composer.lock                     |
++-------------------+-----------+------------------------------------------------+---------+-------------------------------------------------------+
 
 ---
 

--- a/cmd/osv-scanner/fixtures/osv-scanner-composite-config.toml
+++ b/cmd/osv-scanner/fixtures/osv-scanner-composite-config.toml
@@ -3,6 +3,10 @@ ecosystem = "npm"
 ignore = true
 
 [[PackageOverrides]]
+name = "https://github.com/brendan-duncan/archive.git"
+vulnerability.ignore = true
+
+[[PackageOverrides]]
 ecosystem = "Maven"
 ignore = true
 reason = "it makes the table output really really long"

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -327,7 +327,7 @@ func TestRun(t *testing.T) {
 		// broad config file that overrides a whole ecosystem
 		{
 			name: "config file can be broad",
-			args: []string{"", "--config=./fixtures/osv-scanner-composite-config.toml", "--experimental-licenses", "MIT", "./fixtures/locks-many", "./fixtures/locks-insecure", "./fixtures/maven-transitive"},
+			args: []string{"", "--config=./fixtures/osv-scanner-composite-config.toml", "--experimental-licenses", "MIT", "-L", "osv-scanner:./fixtures/locks-insecure/osv-scanner-flutter-deps.json", "./fixtures/locks-many", "./fixtures/locks-insecure", "./fixtures/maven-transitive"},
 			exit: 1,
 		},
 		// ignored vulnerabilities and packages without a reason should be called out

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,9 +42,10 @@ ecosystem = "Go"
 group = "dev"
 
 # Actions to take for matching packages:
-ignore = true # Ignore this package completely, including license scanning
-license.ignore = true # Ignore the license of the package, if it is not already completely ignored at the top level
-license.override = ["MIT", "0BSD"] # Override the license of the package, if it is not ignored
+ignore = true # Ignore this package completely, including both reporting vulnerabilities and license violations
+vulnerability.ignore = true # Ignore vulnerabilities for this package, while still checking the license (if not also ignored)
+license.ignore = true # Ignore the license of the package, while still checking for vulnerabilities (if not also ignored)
+license.override = ["MIT", "0BSD"] # Override the license of the package, if it is not ignored from license scanning completely
 
 effectiveUntil = 2022-11-09 # Optional exception expiry date, after which the override will no longer apply
 reason = "abc" # Optional reason for the override, to explain why it was added

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -47,13 +47,14 @@ type IgnoreEntry struct {
 type PackageOverrideEntry struct {
 	Name string `toml:"name"`
 	// If the version is empty, the entry applies to all versions.
-	Version        string    `toml:"version"`
-	Ecosystem      string    `toml:"ecosystem"`
-	Group          string    `toml:"group"`
-	Ignore         bool      `toml:"ignore"`
-	License        License   `toml:"license"`
-	EffectiveUntil time.Time `toml:"effectiveUntil"`
-	Reason         string    `toml:"reason"`
+	Version        string        `toml:"version"`
+	Ecosystem      string        `toml:"ecosystem"`
+	Group          string        `toml:"group"`
+	Ignore         bool          `toml:"ignore"`
+	Vulnerability  Vulnerability `toml:"vulnerability"`
+	License        License       `toml:"license"`
+	EffectiveUntil time.Time     `toml:"effectiveUntil"`
+	Reason         string        `toml:"reason"`
 }
 
 func (e PackageOverrideEntry) matches(pkg models.PackageVulns) bool {
@@ -71,6 +72,10 @@ func (e PackageOverrideEntry) matches(pkg models.PackageVulns) bool {
 	}
 
 	return true
+}
+
+type Vulnerability struct {
+	Ignore bool `toml:"ignore"`
 }
 
 type License struct {
@@ -116,6 +121,15 @@ func (c *Config) ShouldIgnorePackageVersion(name, version, ecosystem string) (bo
 			Ecosystem: ecosystem,
 		},
 	})
+}
+
+// ShouldIgnorePackageVulnerabilities determines if the given package should have its vulnerabilities ignored based on override entries in the config
+func (c *Config) ShouldIgnorePackageVulnerabilities(pkg models.PackageVulns) bool {
+	overrides, _ := c.filterPackageVersionEntries(pkg, func(e PackageOverrideEntry) bool {
+		return e.Vulnerability.Ignore
+	})
+
+	return overrides
 }
 
 // ShouldOverridePackageLicense determines if the given package should have its license ignored or changed based on override entries in the config

--- a/pkg/config/config_internal_test.go
+++ b/pkg/config/config_internal_test.go
@@ -905,6 +905,100 @@ func TestConfig_ShouldIgnorePackageVersion(t *testing.T) {
 	}
 }
 
+func TestConfig_ShouldIgnorePackageVulnerabilities(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		config Config
+		args   models.PackageVulns
+		wantOk bool
+	}{
+		{
+			name: "Exact version entry exists with ignore",
+			config: Config{
+				PackageOverrides: []PackageOverrideEntry{
+					{
+						Name:      "lib1",
+						Version:   "1.0.0",
+						Ecosystem: "Go",
+						Vulnerability: Vulnerability{
+							Ignore: true,
+						},
+						Reason: "abc",
+					},
+				},
+			},
+			args: models.PackageVulns{
+				Package: models.PackageInfo{
+					Name:      "lib1",
+					Version:   "1.0.0",
+					Ecosystem: "Go",
+				},
+			},
+			wantOk: true,
+		},
+		{
+			name: "Version entry doesn't exist with ignore",
+			config: Config{
+				PackageOverrides: []PackageOverrideEntry{
+					{
+						Name:      "lib1",
+						Version:   "1.0.0",
+						Ecosystem: "Go",
+						Vulnerability: Vulnerability{
+							Ignore: true,
+						},
+						Reason: "abc",
+					},
+				},
+			},
+			args: models.PackageVulns{
+				Package: models.PackageInfo{
+					Name:      "lib1",
+					Version:   "1.0.1",
+					Ecosystem: "Go",
+				},
+			},
+			wantOk: false,
+		},
+		{
+			name: "Name matches with ignore",
+			config: Config{
+				PackageOverrides: []PackageOverrideEntry{
+					{
+						Name:      "lib1",
+						Ecosystem: "Go",
+						Vulnerability: Vulnerability{
+							Ignore: true,
+						},
+						Reason: "abc",
+					},
+				},
+			},
+			args: models.PackageVulns{
+				Package: models.PackageInfo{
+					Name:      "lib1",
+					Version:   "1.0.1",
+					Ecosystem: "Go",
+				},
+			},
+			wantOk: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotOk := tt.config.ShouldIgnorePackageVulnerabilities(tt.args)
+			if gotOk != tt.wantOk {
+				t.Errorf("ShouldIgnorePackageVulnerabilities() gotOk = %v, wantOk %v", gotOk, tt.wantOk)
+			}
+		})
+	}
+}
+
 func TestConfig_ShouldOverridePackageLicense(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/osvscanner/vulnerability_result.go
+++ b/pkg/osvscanner/vulnerability_result.go
@@ -59,11 +59,14 @@ func buildVulnerabilityResults(
 		pkg.DepGroups = rawPkg.DepGroups
 
 		if len(vulnsResp.Results[i].Vulns) > 0 {
-			includePackage = true
-			pkg.Vulnerabilities = vulnsResp.Results[i].Vulns
-			pkg.Groups = grouper.Group(grouper.ConvertVulnerabilityToIDAliases(pkg.Vulnerabilities))
-			for i, group := range pkg.Groups {
-				pkg.Groups[i].MaxSeverity = output.MaxSeverity(group, pkg)
+			configToUse := configManager.Get(r, rawPkg.Source.Path)
+			if !configToUse.ShouldIgnorePackageVulnerabilities(pkg) {
+				includePackage = true
+				pkg.Vulnerabilities = vulnsResp.Results[i].Vulns
+				pkg.Groups = grouper.Group(grouper.ConvertVulnerabilityToIDAliases(pkg.Vulnerabilities))
+				for i, group := range pkg.Groups {
+					pkg.Groups[i].MaxSeverity = output.MaxSeverity(group, pkg)
+				}
 			}
 		}
 		if actions.ScanLicensesSummary || len(actions.ScanLicensesAllowlist) > 0 {


### PR DESCRIPTION
This implements the ability to ignore vulnerabilities in a matching group of packages while still reporting license violations, as the inverse to `license.ignore`.

Resolves #1226