### PR TITLE
fix: apply go version override to _all_ instances of the `stdlib`

### DIFF
--- a/cmd/osv-scanner/__snapshots__/main_test.snap
+++ b/cmd/osv-scanner/__snapshots__/main_test.snap
@@ -186,6 +186,47 @@ Scanned <rootdir>/fixtures/go-project/go.mod file and found 1 package
 
 ---
 
+[TestRun/Go_project_with_an_overridden_go_version,_recursive - 1]
+Scanning dir ./fixtures/go-project
+Scanned <rootdir>/fixtures/go-project/go.mod file and found 1 package
+Scanned <rootdir>/fixtures/go-project/nested/go.mod file and found 1 package
++------------------------------+------+-----------+---------+---------+-----------------------------------+
+| OSV URL                      | CVSS | ECOSYSTEM | PACKAGE | VERSION | SOURCE                            |
++------------------------------+------+-----------+---------+---------+-----------------------------------+
+| Uncalled vulnerabilities     |      |           |         |         |                                   |
++------------------------------+------+-----------+---------+---------+-----------------------------------+
+| https://osv.dev/GO-2024-2598 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod        |
+| https://osv.dev/GO-2024-2599 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod        |
+| https://osv.dev/GO-2024-2600 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod        |
+| https://osv.dev/GO-2024-2609 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod        |
+| https://osv.dev/GO-2024-2610 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod        |
+| https://osv.dev/GO-2024-2687 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod        |
+| https://osv.dev/GO-2024-2887 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod        |
+| https://osv.dev/GO-2024-2888 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod        |
+| https://osv.dev/GO-2024-2963 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod        |
+| https://osv.dev/GO-2024-3105 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod        |
+| https://osv.dev/GO-2024-3106 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod        |
+| https://osv.dev/GO-2024-3107 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod        |
+| https://osv.dev/GO-2024-2598 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/nested/go.mod |
+| https://osv.dev/GO-2024-2599 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/nested/go.mod |
+| https://osv.dev/GO-2024-2600 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/nested/go.mod |
+| https://osv.dev/GO-2024-2609 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/nested/go.mod |
+| https://osv.dev/GO-2024-2610 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/nested/go.mod |
+| https://osv.dev/GO-2024-2687 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/nested/go.mod |
+| https://osv.dev/GO-2024-2887 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/nested/go.mod |
+| https://osv.dev/GO-2024-2888 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/nested/go.mod |
+| https://osv.dev/GO-2024-2963 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/nested/go.mod |
+| https://osv.dev/GO-2024-3105 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/nested/go.mod |
+| https://osv.dev/GO-2024-3106 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/nested/go.mod |
+| https://osv.dev/GO-2024-3107 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/nested/go.mod |
++------------------------------+------+-----------+---------+---------+-----------------------------------+
+
+---
+
+[TestRun/Go_project_with_an_overridden_go_version,_recursive - 2]
+
+---
+
 [TestRun/PURL_SBOM_case_sensitivity_(api) - 1]
 Scanning dir ./fixtures/sbom-insecure/alpine.cdx.xml
 Scanned <rootdir>/fixtures/sbom-insecure/alpine.cdx.xml as CycloneDX SBOM and found 14 packages

--- a/cmd/osv-scanner/fixtures/go-project/nested/go-version-config.toml
+++ b/cmd/osv-scanner/fixtures/go-project/nested/go-version-config.toml
@@ -1,0 +1,1 @@
+GoVersionOverride = "1.21.7"

--- a/cmd/osv-scanner/fixtures/go-project/nested/go.mod
+++ b/cmd/osv-scanner/fixtures/go-project/nested/go.mod
@@ -1,0 +1,3 @@
+module github.com/ossf-tests/osv-e2e
+
+go 1.19

--- a/cmd/osv-scanner/fixtures/go-project/nested/osv-scanner.toml
+++ b/cmd/osv-scanner/fixtures/go-project/nested/osv-scanner.toml
@@ -1,0 +1,5 @@
+[[PackageOverrides]]
+name = "stdlib"
+ecosystem = "Go"
+ignore = true
+reason = "This is an intentionally vulnerable test project"

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -312,6 +312,12 @@ func TestRun(t *testing.T) {
 			args: []string{"", "--config=./fixtures/go-project/go-version-config.toml", "./fixtures/go-project"},
 			exit: 0,
 		},
+		// Go project with an overridden go version, recursive
+		{
+			name: "Go project with an overridden go version, recursive",
+			args: []string{"", "--config=./fixtures/go-project/go-version-config.toml", "-r", "./fixtures/go-project"},
+			exit: 0,
+		},
 		// broad config file that overrides a whole ecosystem
 		{
 			name: "config file can be broad",

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -1107,7 +1107,7 @@ func overrideGoVersion(r reporter.Reporter, packages []scannedPackage, configMan
 				packages[i].Version = configToUse.GoVersionOverride
 			}
 
-			break
+			continue
 		}
 	}
 }


### PR DESCRIPTION
Currently we assume that there'll only ever be one occurence of `stdlib` when overriding the Go version but really there can be an occurrence _per `go.mod`_ file

Resolves #1273