### PR TITLE
fix(offline): report all ecosystems without local databases in one single line

### DIFF
--- a/cmd/osv-scanner/__snapshots__/main_test.snap
+++ b/cmd/osv-scanner/__snapshots__/main_test.snap
@@ -2108,31 +2108,7 @@ Scanned <rootdir>/fixtures/locks-many/yarn.lock file and found 1 package
 ---
 
 [TestRun_LocalDatabases_AlwaysOffline/#00 - 2]
-could not load db for PyPI ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for PyPI ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for PyPI ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for PyPI ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for PyPI ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for PyPI ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for PyPI ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for RubyGems ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for Packagist ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for npm ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for npm ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not find local databases for ecosystems: Alpine, Packagist, PyPI, RubyGems, npm
 
 ---
 
@@ -2153,31 +2129,7 @@ Scanned <rootdir>/fixtures/locks-many/yarn.lock file and found 1 package
 ---
 
 [TestRun_LocalDatabases_AlwaysOffline/#00 - 4]
-could not load db for PyPI ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for PyPI ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for PyPI ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for PyPI ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for PyPI ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for PyPI ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for PyPI ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for RubyGems ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for Packagist ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for npm ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
-could not load db for npm ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not find local databases for ecosystems: Alpine, Packagist, PyPI, RubyGems, npm
 
 ---
 

--- a/cmd/osv-scanner/__snapshots__/main_test.snap
+++ b/cmd/osv-scanner/__snapshots__/main_test.snap
@@ -2091,6 +2091,96 @@ databases can only be downloaded when running in offline mode
 
 ---
 
+[TestRun_LocalDatabases_AlwaysOffline/#00 - 1]
+Scanning dir ./fixtures/locks-requirements
+Scanned <rootdir>/fixtures/locks-requirements/my-requirements.txt file and found 1 package
+Scanned <rootdir>/fixtures/locks-requirements/requirements-dev.txt file and found 1 package
+Scanned <rootdir>/fixtures/locks-requirements/requirements.prod.txt file and found 1 package
+Scanned <rootdir>/fixtures/locks-requirements/requirements.txt file and found 3 packages
+Scanned <rootdir>/fixtures/locks-requirements/the_requirements_for_test.txt file and found 1 package
+Scanning dir ./fixtures/locks-many
+Scanned <rootdir>/fixtures/locks-many/Gemfile.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/alpine.cdx.xml as CycloneDX SBOM and found 14 packages
+Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/yarn.lock file and found 1 package
+
+---
+
+[TestRun_LocalDatabases_AlwaysOffline/#00 - 2]
+could not load db for PyPI ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for PyPI ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for PyPI ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for PyPI ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for PyPI ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for PyPI ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for PyPI ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for RubyGems ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for Packagist ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for npm ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for npm ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+
+---
+
+[TestRun_LocalDatabases_AlwaysOffline/#00 - 3]
+Scanning dir ./fixtures/locks-requirements
+Scanned <rootdir>/fixtures/locks-requirements/my-requirements.txt file and found 1 package
+Scanned <rootdir>/fixtures/locks-requirements/requirements-dev.txt file and found 1 package
+Scanned <rootdir>/fixtures/locks-requirements/requirements.prod.txt file and found 1 package
+Scanned <rootdir>/fixtures/locks-requirements/requirements.txt file and found 3 packages
+Scanned <rootdir>/fixtures/locks-requirements/the_requirements_for_test.txt file and found 1 package
+Scanning dir ./fixtures/locks-many
+Scanned <rootdir>/fixtures/locks-many/Gemfile.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/alpine.cdx.xml as CycloneDX SBOM and found 14 packages
+Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/yarn.lock file and found 1 package
+
+---
+
+[TestRun_LocalDatabases_AlwaysOffline/#00 - 4]
+could not load db for PyPI ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for PyPI ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for PyPI ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for PyPI ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for PyPI ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for PyPI ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for PyPI ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for RubyGems ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for Packagist ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for npm ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for npm ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+
+---
+
 [TestRun_LockfileWithExplicitParseAs/#00 - 1]
 
 ---

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -641,6 +641,35 @@ func TestRun_LocalDatabases(t *testing.T) {
 	}
 }
 
+func TestRun_LocalDatabases_AlwaysOffline(t *testing.T) {
+	t.Parallel()
+
+	tests := []cliTestCase{
+		// a bunch of different lockfiles and ecosystem
+		{
+			name: "",
+			args: []string{"", "--config=./fixtures/osv-scanner-empty-config.toml", "--experimental-offline", "./fixtures/locks-requirements", "./fixtures/locks-many"},
+			exit: 127,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			testDir := testutility.CreateTestDir(t)
+			old := tt.args
+			tt.args = []string{"", "--experimental-local-db-path", testDir}
+			tt.args = append(tt.args, old[1:]...)
+
+			// run each test twice since they should provide the same output,
+			// and the second run should be fast as the db is already available
+			testCli(t, tt)
+			testCli(t, tt)
+		})
+	}
+}
+
 func TestRun_Licenses(t *testing.T) {
 	t.Parallel()
 	tests := []cliTestCase{


### PR DESCRIPTION
This reduces the amount of noise generated when using `--offline` if a database is not available for a particular ecosystem. While it was suggested that we could have some form of general error cache, for now I've just optimized for this specific case as really it's the one we expect the most and (in part) I think the nature of Go makes the more generic improvement a bit too faffy vs the gain.

Resolves #1005