### PR TITLE
fix: improve handling if `docker` exits with a non-zero code when trying to scan images

### DIFF
--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -618,14 +618,35 @@ func scanDebianDocker(r reporter.Reporter, dockerImageName string) ([]scannedPac
 		r.Errorf("Failed to get stdout: %s\n", err)
 		return nil, err
 	}
+	stderr, err := cmd.StderrPipe()
+
+	if err != nil {
+		r.Errorf("Failed to get stderr: %s\n", err)
+		return nil, err
+	}
+
 	err = cmd.Start()
 	if err != nil {
 		r.Errorf("Failed to start docker image: %s\n", err)
 		return nil, err
 	}
-	// TODO: Do error checking here
-	//nolint:errcheck
-	defer cmd.Wait()
+	defer func() {
+		var stderrlines []string
+
+		scanner := bufio.NewScanner(stderr)
+		for scanner.Scan() {
+			stderrlines = append(stderrlines, scanner.Text())
+		}
+
+		err := cmd.Wait()
+		if err != nil {
+			r.Errorf("Docker command exited with code %d\n", cmd.ProcessState.ExitCode())
+			for _, line := range stderrlines {
+				r.Errorf("> %s\n", line)
+			}
+		}
+	}()
+
 	scanner := bufio.NewScanner(stdout)
 	var packages []scannedPackage
 	for scanner.Scan() {


### PR DESCRIPTION
By capturing `stderr` and outputting it as an error when `docker` exits with a non-zero code, it should make it easier to catch and debug issues such as unsupported images, images that do not exist, or cannot be accessed due to lack of authentication.

Currently this just assumes the output from Docker will be helpful enough since we're not able to rely on a particular structure that'd let us parse and understand the actual error, but it should still be a lot better then the current behaviour of saying the docker image was scanned with no packages being found (which we do still do as changing that would be more complex).

Because we've not got any tests for this, here's some manual testing:

```
osv-scanner on  improve/docker-error-output [$?] via 🐹 v1.22.7 via  v20.11.0 took 4s
❯ osv-scanner --docker something --docker node:alpine
Scanned docker image with 0 packages
Docker command exited with code 125
> Unable to find image 'something:latest' locally
> docker: Error response from daemon: pull access denied for something, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.
> See 'docker run --help'.
Scanned docker image with 0 packages
Docker command exited with code 127
> docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "/usr/bin/dpkg-query": stat /usr/bin/dpkg-query: no such file or directory: unknown.
No package sources found, --help for usage information.
```

Note that since we're using `r.Errorf` this also means the scanner exits with a non-zero code.

Resolves #119