### PR TITLE
chore: ignore `node_modules` in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 *.tar
 *.pprof
 .go-version
+node_modules


### PR DESCRIPTION
I think it's best to have this explicitly ignored since some of our fixtures are valid with npm/yarn/pnpm and `node_modules` is known for being a blackhole 😅 