### PR TITLE
Fix lock file parsing crash on malformed requirements.txt file

### DIFF
--- a/pkg/lockfile/parse-pnpm-lock.go
+++ b/pkg/lockfile/parse-pnpm-lock.go
@@ -88,6 +88,11 @@ func extractPnpmPackageNameAndVersion(dependencyPath string, lockfileVersion flo
 	}
 
 	parts := strings.Split(dependencyPath, "/")
+
+	if len(parts) == 1 {
+		return "", ""
+	}
+
 	var name string
 
 	parts = parts[1:]


### PR DESCRIPTION
Scalibr is crashing with a SIGSEGV while trying to parse this directory:

https://github.com/semgrep/semgrep/tree/develop/cli/tests/default/e2e/targets/dependency_aware

This is due to the lack of an array length check after the dependencyPath split.

2024/10/17 11:21:03 Starting filesystem walk for root: .
2024/10/17 11:21:03 Open(cli/tests/default/e2e/targets/dependency_aware/osv_parsing/requirements/file-format-example/other-requirements.txt): %!w(*fs.PathError=&{open cli/tests/default/e2e/targets/dependency_aware/osv_parsing/requirements/file-format-example/other-requirements.txt 2})
panic: runtime error: index out of range [0] with length 0
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x7503ac3]

goroutine 1 [running]:
github.com/google/osv-scalibr.Scanner.Scan.func1()
	vendor/github.com/google/osv-scalibr/scalibr.go:166 +0x23
panic({0x28e8260?, 0xc0024ef3f8?})
	go/1.23.2/linux_amd64/src/runtime/panic.go:785 +0x132
github.com/google/osv-scanner/pkg/lockfile.extractPnpmPackageNameAndVersion({0xc00254c9f0?, 0xb?}, 0x401599999999999a?)
	vendor/github.com/google/osv-scanner/pkg/lockfile/parse-pnpm-lock.go:95 +0x34f
github.com/google/osv-scanner/pkg/lockfile.parsePnpmLock({0xc001e5ea20?, 0xc00255a5a0?})
	vendor/github.com/google/osv-scanner/pkg/lockfile/parse-pnpm-lock.go:141 +0x145
github.com/google/osv-scanner/pkg/lockfile.PnpmLockExtractor.Extract({}, {0x39873e0, 0xc00112a1e0})
(...)
