### PR TITLE
feat: add `--experimental-offline-vulnerabilities` and `--experimental-no-resolve` flags

### DIFF
--- a/cmd/osv-scanner/__snapshots__/main_test.snap
+++ b/cmd/osv-scanner/__snapshots__/main_test.snap
@@ -2372,6 +2372,17 @@ Scanned <rootdir>/fixtures/locks-insecure/composer.lock file and found 1 package
 
 ---
 
+[TestRun_MavenTransitive/does_not_scan_transitive_dependencies_for_pom.xml_with_no-resolve - 1]
+Scanning dir ./fixtures/maven-transitive/pom.xml
+Scanned <rootdir>/fixtures/maven-transitive/pom.xml file and found 1 package
+No issues found
+
+---
+
+[TestRun_MavenTransitive/does_not_scan_transitive_dependencies_for_pom.xml_with_no-resolve - 2]
+
+---
+
 [TestRun_MavenTransitive/does_not_scan_transitive_dependencies_for_pom.xml_with_offline_mode - 1]
 Scanning dir ./fixtures/maven-transitive/pom.xml
 Scanned <rootdir>/fixtures/maven-transitive/pom.xml file and found 1 package

--- a/cmd/osv-scanner/fix/main.go
+++ b/cmd/osv-scanner/fix/main.go
@@ -171,8 +171,9 @@ func Command(stdout, stderr io.Writer, r *reporter.Reporter) *cli.Command {
 			},
 			// Offline database flags, copied from osv-scanner scan
 			&cli.BoolFlag{
-				Name:  "experimental-offline",
-				Usage: "checks for vulnerabilities using local databases that are already cached",
+				Name:    "experimental-offline-vulnerabilities",
+				Aliases: []string{"experimental-offline"},
+				Usage:   "checks for vulnerabilities using local databases that are already cached",
 			},
 			&cli.BoolFlag{
 				Name:  "experimental-download-offline-databases",
@@ -327,7 +328,7 @@ func action(ctx *cli.Context, stdout, stderr io.Writer) (reporter.Reporter, erro
 		}
 	}
 
-	if ctx.Bool("experimental-offline") {
+	if ctx.Bool("experimental-offline-vulnerabilities") {
 		var err error
 		opts.Client.VulnerabilityClient, err = client.NewOSVOfflineClient(
 			r,

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -912,6 +912,12 @@ func TestRun_MavenTransitive(t *testing.T) {
 			exit: 0,
 		},
 		{
+			// Direct dependencies do not have any vulnerability.
+			name: "does not scan transitive dependencies for pom.xml with no-resolve",
+			args: []string{"", "--config=./fixtures/osv-scanner-empty-config.toml", "--experimental-no-resolve", "./fixtures/maven-transitive/pom.xml"},
+			exit: 0,
+		},
+		{
 			name: "scans dependencies from multiple registries",
 			args: []string{"", "--config=./fixtures/osv-scanner-empty-config.toml", "-L", "pom.xml:./fixtures/maven-transitive/registry.xml"},
 			exit: 1,

--- a/docs/guided-remediation.md
+++ b/docs/guided-remediation.md
@@ -264,7 +264,7 @@ If your project uses mirrored or private registries, you will need to use `--dat
 
 ### Offline Vulnerability Database
 
-The `fix` subcommand supports the `--experimental-offline` and `--experimental-download-offline-databases` flags.
+The `fix` subcommand supports the `--experimental-offline-vulnerabilities` and `--experimental-download-offline-databases` flags.
 
 For more information, see [Offline Mode](./offline-mode.md).
 

--- a/docs/offline-mode.md
+++ b/docs/offline-mode.md
@@ -59,6 +59,8 @@ The offline database flag `--experimental-offline` causes OSV-Scanner to scan yo
 osv-scanner --experimental-offline ./path/to/your/dir
 ```
 
+To use offline mode for just the vulnerability database, but allow other features to possibly make network requests (e.g. [transitive dependency scanning](./supported_languages_and_lockfiles.md/#transitive-dependency-scanning)), you can use the `--experimental-offline-vulnerabilities` flag instead.
+
 ## Download offline databases option
 
 The download offline databases flag `--experimental-download-offline-databases` allows OSV-Scanner to download or update your local database when running in offline mode, to make it easier to get started. This option only works when you also set the offline flag.

--- a/docs/supported_languages_and_lockfiles.md
+++ b/docs/supported_languages_and_lockfiles.md
@@ -72,7 +72,7 @@ Vendored dependencies have been directly copied into the project folder, but do 
 
 ## Transitive dependency scanning
 
-OSV-Scanner supports transitive dependency scanning for Maven pom.xml. This feature is enabled by default when scanning, but it is disabled in the [offline mode](./offline-mode.md).
+OSV-Scanner supports transitive dependency scanning for Maven pom.xml. This feature is enabled by default when scanning, but it can be disabled using the `--experimental-no-resolve` flag. It is also disabled in the [offline mode](./offline-mode.md).
 
 OSV-Scanner uses [deps.dev’s resolver library](https://pkg.go.dev/deps.dev/util/resolve) to compute the dependency graph of a project. This graph includes all of the direct and transitive dependencies. By default, [deps.dev API](https://docs.deps.dev/api/v3/index.html) is queried for package versions and requirements. The support for private registries is [coming soon](https://github.com/google/osv-scanner/issues/1045).
 


### PR DESCRIPTION
Closes #1339 and closes #1121 
Adds flags to use offline mode for vulnerabilities (`--experimental-offline-vulnerabilities`) and transitive resolution separately (`--experimental-no-resolve`)

The original `--experimental-offline` flag retains the same behaviour by functionally setting both of these flags.