### PR TITLE
feat: migrate node-modules to a osv-scalibr extractor

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 **/fixtures/**
+**/testdata/**
 **/fixtures-go/**
 /docs/vendor/**
 /internal/output/html/*template.html

--- a/internal/image/pathtree/pathtree_test.go
+++ b/internal/image/pathtree/pathtree_test.go
@@ -191,7 +191,13 @@ func TestNode_GetChildren(t *testing.T) {
 			t.Parallel()
 
 			got := tt.tree.GetChildren(tt.key)
-			if diff := cmp.Diff(tt.want, got, cmp.AllowUnexported(testVal{})); diff != "" {
+			if diff := cmp.Diff(
+				tt.want,
+				got,
+				cmp.AllowUnexported(testVal{}),
+				cmpopts.SortSlices(func(a, b string) bool {
+					return strings.Compare(a, b) < 0
+				})); diff != "" {
 				t.Errorf("Node.GetChildren() (-want +got): %v", diff)
 			}
 		})

--- a/internal/lockfilescalibr/language/javascript/nodemodules/extractor.go
+++ b/internal/lockfilescalibr/language/javascript/nodemodules/extractor.go
@@ -1,0 +1,57 @@
+package nodemodules
+
+import (
+	"context"
+	"io/fs"
+	"path/filepath"
+
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/javascript/packagelockjson"
+	"github.com/google/osv-scalibr/plugin"
+	"github.com/google/osv-scalibr/purl"
+)
+
+type Extractor struct {
+	actualExtractor packagelockjson.Extractor
+}
+
+var _ filesystem.Extractor = Extractor{}
+
+// Name of the extractor.
+func (e Extractor) Name() string { return "javascript/nodemodules" }
+
+// Version of the extractor.
+func (e Extractor) Version() int { return 0 }
+
+// Requirements of the extractor.
+func (e Extractor) Requirements() *plugin.Capabilities {
+	return &plugin.Capabilities{}
+}
+
+// FileRequired returns true for .package-lock.json files under node_modules
+func (e Extractor) FileRequired(path string, _ fs.FileInfo) bool {
+	return filepath.Base(filepath.Dir(path)) == "node_modules" && filepath.Base(path) == ".package-lock.json"
+}
+
+// Extract extracts packages from yarn.lock files passed through the scan input.
+func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]*extractor.Inventory, error) {
+	return e.actualExtractor.Extract(ctx, input)
+}
+
+// ToPURL converts an inventory created by this extractor into a PURL.
+func (e Extractor) ToPURL(i *extractor.Inventory) (*purl.PackageURL, error) {
+	return e.actualExtractor.ToPURL(i)
+}
+
+// ToCPEs is not applicable as this extractor does not infer CPEs from the Inventory.
+func (e Extractor) ToCPEs(i *extractor.Inventory) ([]string, error) {
+	return e.actualExtractor.ToCPEs(i)
+}
+
+// Ecosystem returns the OSV ecosystem ('npm') of the software extracted by this extractor.
+func (e Extractor) Ecosystem(i *extractor.Inventory) string {
+	return e.actualExtractor.Ecosystem(i)
+}
+
+var _ filesystem.Extractor = Extractor{}


### PR DESCRIPTION
Ideally, node package extracts can be done with packagejson extractor directly (As every dir inside a node_modules directory has a package.json file), but that changes the image scanning snapshots too much to be part of this initial PR, and introduces new OS findings that are difficult to filter out. 

This keeps the existing solution of extracting directly with node_modules by implementing an extractor that wraps the `packagejsonlock` extractor to minimise snapshot changes. 