### PR TITLE
chore: update Go to version 1.23.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/osv-scanner
 
-go 1.22.7
+go 1.23.2
 
 require (
 	deps.dev/api/v3 v3.0.0-20241010035105-b3ba03369df1


### PR DESCRIPTION
we're getting a lot of errors when scanning 1.23.2 [kuma codebase](https://github.com/kumahq/kuma/):

```
Scanned ./projects/kuma/go.mod file and found 222 packages
2024/10/30 08:38:53 internal error: error "package requires newer Go version go1.23" (*errors.errorString) without position
2024/10/30 08:38:53 internal error: error "package requires newer Go version go1.23" (*errors.errorString) without position
...
```