### PR TITLE
refactor(semantic): remove unneeded condition in PyPI version comparator

### DIFF
--- a/internal/semantic/version-pypi.go
+++ b/internal/semantic/version-pypi.go
@@ -225,10 +225,6 @@ func (pv PyPIVersion) comparePre(pw PyPIVersion) int {
 		ai := pv.preIndex()
 		bi := pw.preIndex()
 
-		if ai == bi {
-			return pv.pre.number.Cmp(pw.pre.number)
-		}
-
 		if ai > bi {
 			return +1
 		}
@@ -236,7 +232,7 @@ func (pv PyPIVersion) comparePre(pw PyPIVersion) int {
 			return -1
 		}
 
-		return 0
+		return pv.pre.number.Cmp(pw.pre.number)
 	}
 }
 


### PR DESCRIPTION
Currently this return is not covered because we're explicitly doing all three possible comparisons, so we might as well move the equality check to the end as the default