### PR TITLE
refactor(semantic): sort ecosystems by name

### DIFF
--- a/internal/semantic/parse.go
+++ b/internal/semantic/parse.go
@@ -22,36 +22,36 @@ func MustParse(str string, ecosystem models.Ecosystem) Version {
 func Parse(str string, ecosystem models.Ecosystem) (Version, error) {
 	//nolint:exhaustive // Using strings to specify ecosystem instead of lockfile types
 	switch ecosystem {
-	case "npm":
+	case "Alpine":
+		return parseAlpineVersion(str), nil
+	case "ConanCenter":
 		return parseSemverVersion(str), nil
+	case "CRAN":
+		return parseCRANVersion(str), nil
 	case "crates.io":
 		return parseSemverVersion(str), nil
 	case "Debian":
 		return parseDebianVersion(str), nil
-	case "Ubuntu":
-		return parseDebianVersion(str), nil
-	case "Alpine":
-		return parseAlpineVersion(str), nil
-	case "RubyGems":
-		return parseRubyGemsVersion(str), nil
-	case "NuGet":
-		return parseNuGetVersion(str), nil
-	case "Packagist":
-		return parsePackagistVersion(str), nil
 	case "Go":
 		return parseSemverVersion(str), nil
 	case "Hex":
 		return parseSemverVersion(str), nil
 	case "Maven":
 		return parseMavenVersion(str), nil
-	case "PyPI":
-		return parsePyPIVersion(str), nil
+	case "npm":
+		return parseSemverVersion(str), nil
+	case "NuGet":
+		return parseNuGetVersion(str), nil
+	case "Packagist":
+		return parsePackagistVersion(str), nil
 	case "Pub":
 		return parseSemverVersion(str), nil
-	case "ConanCenter":
-		return parseSemverVersion(str), nil
-	case "CRAN":
-		return parseCRANVersion(str), nil
+	case "PyPI":
+		return parsePyPIVersion(str), nil
+	case "RubyGems":
+		return parseRubyGemsVersion(str), nil
+	case "Ubuntu":
+		return parseDebianVersion(str), nil
 	}
 
 	return nil, fmt.Errorf("%w %s", ErrUnsupportedEcosystem, ecosystem)


### PR DESCRIPTION
Having ecosystems sorted by their name makes it easier to review this section of code