### PR TITLE
test(semantic): include ecosystems not supported by `lockfile`

### DIFF
--- a/internal/semantic/parse_test.go
+++ b/internal/semantic/parse_test.go
@@ -14,8 +14,7 @@ func TestParse(t *testing.T) {
 
 	ecosystems := lockfile.KnownEcosystems()
 
-	// todo: remove once CRAN is supported by lockfile
-	ecosystems = append(ecosystems, "CRAN")
+	ecosystems = append(ecosystems, "Alpine", "Debian", "Ubuntu")
 
 	for _, ecosystem := range ecosystems {
 		_, err := semantic.Parse("", models.Ecosystem(ecosystem))
@@ -37,8 +36,7 @@ func TestMustParse(t *testing.T) {
 
 	ecosystems := lockfile.KnownEcosystems()
 
-	// todo: remove once CRAN is supported by lockfile
-	ecosystems = append(ecosystems, "CRAN")
+	ecosystems = append(ecosystems, "Alpine", "Debian", "Ubuntu")
 
 	for _, ecosystem := range ecosystems {
 		semantic.MustParse("", models.Ecosystem(ecosystem))


### PR DESCRIPTION
Notably this adds coverage over the Ubuntu entry, since that reuses Debian so we don't have any explicit tests for that in the comparison tests.

We also no longer need to be manually adding `CRAN` since `lockfile` supports it
