### PR TITLE
fix(semantic): support parsing versions without a numeric component

### DIFF
--- a/internal/semantic/fixtures/alpine-versions.txt
+++ b/internal/semantic/fixtures/alpine-versions.txt
@@ -47,6 +47,14 @@
 1.2_svn1 > 1.2_csv2
 1.2_cvs1 > 1.2_blah
 
+# technically invalid, but "apk version -t" still accepts them
+.1 < 1
+1 > .1
+.2 > .1
+a < b
+c > b
+c = c
+
 # from https://raw.githubusercontent.com/alpinelinux/apk-tools/master/tests/version.data
 2.34 > 0.1.0_alpha
 # todo: this might be invalid?

--- a/internal/semantic/version-alpine.go
+++ b/internal/semantic/version-alpine.go
@@ -223,6 +223,10 @@ func (v AlpineVersion) CompareStr(str string) int {
 func parseAlpineNumberComponents(v *AlpineVersion, str string) string {
 	sub := cachedregexp.MustCompile(`^((\d+)\.?)*`).FindString(str)
 
+	if sub == "" {
+		return str
+	}
+
 	for i, d := range strings.Split(sub, ".") {
 		v.components = append(v.components, alpineNumberComponent{
 			value:    convertToBigIntOrPanic(d),


### PR DESCRIPTION
While I'm pretty these are technically invalid, they're easy to support and without this Alpine is the only comparator that panics when parsing an empty string which I think is a little sad.