### PR TITLE
feat: warn if a vulnerability is ignored multiple times in the same config

### DIFF
--- a/cmd/osv-scanner/__snapshots__/main_test.snap
+++ b/cmd/osv-scanner/__snapshots__/main_test.snap
@@ -395,6 +395,26 @@ unknown keys in config file: RustVersionOverride, PackageOverrides.skip, Package
 
 ---
 
+[TestRun/config_files_should_not_have_multiple_ignores_with_the_same_id - 1]
+warning: ./fixtures/osv-scanner-duplicate-config.toml has multiple ignores for GO-2022-0274 - only the first will be used!
+Scanning dir ./fixtures/locks-many
+Scanned <rootdir>/fixtures/locks-many/Gemfile.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/alpine.cdx.xml as CycloneDX SBOM and found 14 packages
+Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/yarn.lock file and found 1 package
++-------------------------------------+------+-----------+-----------+---------+---------------------------------------+
+| OSV URL                             | CVSS | ECOSYSTEM | PACKAGE   | VERSION | SOURCE                                |
++-------------------------------------+------+-----------+-----------+---------+---------------------------------------+
+| https://osv.dev/GHSA-whgm-jr23-g3j9 | 7.5  | npm       | ansi-html | 0.0.1   | fixtures/locks-many/package-lock.json |
++-------------------------------------+------+-----------+-----------+---------+---------------------------------------+
+
+---
+
+[TestRun/config_files_should_not_have_multiple_ignores_with_the_same_id - 2]
+
+---
+
 [TestRun/cyclonedx_1.4_output - 1]
 {
   "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",

--- a/cmd/osv-scanner/__snapshots__/main_test.snap
+++ b/cmd/osv-scanner/__snapshots__/main_test.snap
@@ -403,11 +403,9 @@ Scanned <rootdir>/fixtures/locks-many/alpine.cdx.xml as CycloneDX SBOM and found
 Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
 Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
 Scanned <rootdir>/fixtures/locks-many/yarn.lock file and found 1 package
-+-------------------------------------+------+-----------+-----------+---------+---------------------------------------+
-| OSV URL                             | CVSS | ECOSYSTEM | PACKAGE   | VERSION | SOURCE                                |
-+-------------------------------------+------+-----------+-----------+---------+---------------------------------------+
-| https://osv.dev/GHSA-whgm-jr23-g3j9 | 7.5  | npm       | ansi-html | 0.0.1   | fixtures/locks-many/package-lock.json |
-+-------------------------------------+------+-----------+-----------+---------+---------------------------------------+
+GHSA-whgm-jr23-g3j9 and 1 alias have been filtered out because: (no reason given)
+Filtered 1 vulnerability from output
+No issues found
 
 ---
 

--- a/cmd/osv-scanner/fixtures/osv-scanner-duplicate-config.toml
+++ b/cmd/osv-scanner/fixtures/osv-scanner-duplicate-config.toml
@@ -5,3 +5,6 @@ ignoreuntil = 2020-01-01
 [[IgnoredVulns]]
 id = "GO-2022-0274"
 ignoreuntil = 2022-01-01
+
+[[IgnoredVulns]]
+id = "GHSA-whgm-jr23-g3j9"

--- a/cmd/osv-scanner/fixtures/osv-scanner-duplicate-config.toml
+++ b/cmd/osv-scanner/fixtures/osv-scanner-duplicate-config.toml
@@ -1,0 +1,7 @@
+[[IgnoredVulns]]
+id = "GO-2022-0274"
+ignoreuntil = 2020-01-01
+
+[[IgnoredVulns]]
+id = "GO-2022-0274"
+ignoreuntil = 2022-01-01

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -359,6 +359,12 @@ func TestRun(t *testing.T) {
 			args: []string{"", "--config=./fixtures/osv-scanner-unknown-config.toml", "./fixtures/locks-many"},
 			exit: 127,
 		},
+		// config file with multiple ignores with the same id
+		{
+			name: "config files should not have multiple ignores with the same id",
+			args: []string{"", "--config=./fixtures/osv-scanner-duplicate-config.toml", "./fixtures/locks-many"},
+			exit: 0,
+		},
 		// a bunch of requirements.txt files with different names
 		{
 			name: "requirements.txt can have all kinds of names",

--- a/internal/config/config_internal_test.go
+++ b/internal/config/config_internal_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/osv-scanner/pkg/models"
+	"github.com/google/osv-scanner/pkg/reporter"
 )
 
 // Attempts to normalize any file paths in the given `output` so that they can
@@ -172,7 +173,7 @@ func Test_tryLoadConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := tryLoadConfig(tt.args.configPath)
+			got, err := tryLoadConfig(&reporter.VoidReporter{}, tt.args.configPath)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("tryLoadConfig() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -222,7 +223,7 @@ func TestTryLoadConfig_UnknownKeys(t *testing.T) {
 	}
 
 	for _, testData := range tests {
-		c, err := tryLoadConfig(testData.configPath)
+		c, err := tryLoadConfig(&reporter.VoidReporter{}, testData.configPath)
 
 		// we should always be returning an empty config on error
 		if diff := cmp.Diff(Config{}, c); diff != "" {

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -842,7 +842,7 @@ func DoScan(actions ScannerActions, r reporter.Reporter) (models.VulnerabilityRe
 	var scannedPackages []scannedPackage
 
 	if actions.ConfigOverridePath != "" {
-		err := configManager.UseOverride(actions.ConfigOverridePath)
+		err := configManager.UseOverride(r, actions.ConfigOverridePath)
 		if err != nil {
 			r.Errorf("Failed to read config file: %s\n", err)
 			return models.VulnerabilityResults{}, err


### PR DESCRIPTION
Currently if you have multiple ignores for a vulnerability, we just silently use the first one; this has us instead print a warning to make it more obvious when that occurs.

I've not had it error as it doesn't feel like a big enough deal to be worth erroring, though maybe that would be better as I can't think of an actual reason to have duplicate entries 🤔 

Resolves #1367