### PR TITLE
test: use traditional `tt` variable name and remove unneeded loop-copy-var

### DIFF
--- a/internal/remediation/suggest/maven_test.go
+++ b/internal/remediation/suggest/maven_test.go
@@ -399,25 +399,25 @@ func TestSuggestVersion(t *testing.T) {
 		{"[1.0.0,2.0.0)", false, "2.3.4"},
 		{"[1.0.0,2.0.0)", true, "[1.0.0,2.0.0)"},
 	}
-	for _, test := range tests {
+	for _, tt := range tests {
 		vk := resolve.VersionKey{
 			PackageKey:  pk,
 			VersionType: resolve.Requirement,
-			Version:     test.requirement,
+			Version:     tt.requirement,
 		}
 		want := resolve.RequirementVersion{
 			VersionKey: resolve.VersionKey{
 				PackageKey:  pk,
 				VersionType: resolve.Requirement,
-				Version:     test.want,
+				Version:     tt.want,
 			},
 		}
-		got, err := suggestMavenVersion(ctx, lc, resolve.RequirementVersion{VersionKey: vk}, test.noMajorUpdates)
+		got, err := suggestMavenVersion(ctx, lc, resolve.RequirementVersion{VersionKey: vk}, tt.noMajorUpdates)
 		if err != nil {
 			t.Fatalf("fail to suggest a new version for %v: %v", vk, err)
 		}
 		if !reflect.DeepEqual(got, want) {
-			t.Errorf("suggestMavenVersion(%v, %t): got %s want %s", vk, test.noMajorUpdates, got, want)
+			t.Errorf("suggestMavenVersion(%v, %t): got %s want %s", vk, tt.noMajorUpdates, got, want)
 		}
 	}
 }

--- a/internal/resolution/manifest/maven_test.go
+++ b/internal/resolution/manifest/maven_test.go
@@ -973,10 +973,10 @@ func TestGeneratePropertyPatches(t *testing.T) {
 		{"${major}.2.3", "2.0.0", false, map[string]string{}},
 		{"1.${minor}.3", "2.0.0", false, map[string]string{}},
 	}
-	for _, test := range tests {
-		patches, ok := generatePropertyPatches(test.s1, test.s2)
-		if ok != test.possible || !reflect.DeepEqual(patches, test.patches) {
-			t.Errorf("generatePropertyPatches(%s, %s): got %v %v, want %v %v", test.s1, test.s2, patches, ok, test.patches, test.possible)
+	for _, tt := range tests {
+		patches, ok := generatePropertyPatches(tt.s1, tt.s2)
+		if ok != tt.possible || !reflect.DeepEqual(patches, tt.patches) {
+			t.Errorf("generatePropertyPatches(%s, %s): got %v %v, want %v %v", tt.s1, tt.s2, patches, ok, tt.patches, tt.possible)
 		}
 	}
 }

--- a/internal/utility/maven/maven_test.go
+++ b/internal/utility/maven/maven_test.go
@@ -62,10 +62,10 @@ func TestParentPOMPath(t *testing.T) {
 			want:         "",
 		},
 	}
-	for _, test := range tests {
-		got := maven.ParentPOMPath(test.currentPath, test.relativePath)
-		if got != test.want {
-			t.Errorf("parentPOMPath(%s, %s): got %s, want %s", test.currentPath, test.relativePath, got, test.want)
+	for _, tt := range tests {
+		got := maven.ParentPOMPath(tt.currentPath, tt.relativePath)
+		if got != tt.want {
+			t.Errorf("parentPOMPath(%s, %s): got %s, want %s", tt.currentPath, tt.relativePath, got, tt.want)
 		}
 	}
 }

--- a/internal/utility/vulns/vulnerability_test.go
+++ b/internal/utility/vulns/vulnerability_test.go
@@ -86,21 +86,21 @@ func TestOSV_AffectsEcosystem(t *testing.T) {
 		},
 	}
 
-	for i, test := range tests {
+	for i, tt := range tests {
 		vuln := models.Vulnerability{
 			ID:        "1",
 			Published: time.Time{},
 			Modified:  time.Time{},
 			Details:   "This is an open source vulnerability!",
-			Affected:  test.Affected,
+			Affected:  tt.Affected,
 		}
 
-		if vulns.AffectsEcosystem(vuln, test.Ecosystem) != test.Expected {
+		if vulns.AffectsEcosystem(vuln, tt.Ecosystem) != tt.Expected {
 			t.Errorf(
 				"Test #%d: Expected OSV to return %t but it returned %t",
 				i,
-				test.Expected,
-				!test.Expected,
+				tt.Expected,
+				!tt.Expected,
 			)
 		}
 	}

--- a/pkg/lockfile/parse-pdm-lock_test.go
+++ b/pkg/lockfile/parse-pdm-lock_test.go
@@ -52,14 +52,13 @@ func TestPdmExtractor_ShouldExtract(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		tst := test
-		t.Run(tst.name, func(t *testing.T) {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ext := lockfile.PdmLockExtractor{}
-			should := ext.ShouldExtract(tst.path)
-			if should != tst.want {
-				t.Errorf("ShouldExtract() - got %v, expected %v", should, tst.want)
+			should := ext.ShouldExtract(tt.path)
+			if should != tt.want {
+				t.Errorf("ShouldExtract() - got %v, expected %v", should, tt.want)
 			}
 		})
 	}

--- a/pkg/models/vulnerability_test.go
+++ b/pkg/models/vulnerability_test.go
@@ -153,16 +153,15 @@ func TestVulnerability_MarshalJSONTimes(t *testing.T) {
 			want: `{"modified":"2023-12-01T20:30:30Z","published":"2021-06-30T08:00:00Z","withdrawn":"2022-01-16T07:59:59Z","id":"TEST-0000"}`,
 		},
 	}
-	for _, test := range tests {
-		innerTest := test
-		t.Run(innerTest.name, func(t *testing.T) {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := json.Marshal(innerTest.vuln)
+			got, err := json.Marshal(tt.vuln)
 			if err != nil {
 				t.Fatalf("Marshal() = %v; want no error", err)
 			}
-			if string(got) != innerTest.want {
-				t.Errorf("Marshal() = %v; want %v", string(got), innerTest.want)
+			if string(got) != tt.want {
+				t.Errorf("Marshal() = %v; want %v", string(got), tt.want)
 			}
 		})
 	}
@@ -217,16 +216,15 @@ func TestVulnerability_MarshalYAMLTimes(t *testing.T) {
 			want: "id: TEST-0000\nmodified: 2023-12-01T20:30:30Z\npublished: 2021-06-30T08:00:00Z\nwithdrawn: 2022-01-16T07:59:59Z\n",
 		},
 	}
-	for _, test := range tests {
-		innerTest := test
-		t.Run(innerTest.name, func(t *testing.T) {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := yaml.Marshal(innerTest.vuln)
+			got, err := yaml.Marshal(tt.vuln)
 			if err != nil {
 				t.Fatalf("Marshal() = %v; want no error", err)
 			}
-			if string(got) != innerTest.want {
-				t.Errorf("Marshal() = %v; want %v", string(got), innerTest.want)
+			if string(got) != tt.want {
+				t.Errorf("Marshal() = %v; want %v", string(got), tt.want)
 			}
 		})
 	}

--- a/pkg/reporter/cyclonedx_test.go
+++ b/pkg/reporter/cyclonedx_test.go
@@ -20,9 +20,9 @@ func TestCycloneDXReporter_Errorf(t *testing.T) {
 	}
 
 	text := "hello world!"
-	for _, test := range tests {
+	for _, tt := range tests {
 		writer := &bytes.Buffer{}
-		r := reporter.NewCycloneDXReporter(io.Discard, writer, test.version, reporter.ErrorLevel)
+		r := reporter.NewCycloneDXReporter(io.Discard, writer, tt.version, reporter.ErrorLevel)
 
 		r.Errorf("%s", text)
 
@@ -50,14 +50,14 @@ func TestCycloneDXReporter_Warnf(t *testing.T) {
 		{lvl: reporter.ErrorLevel, expectedPrintout: "", version: models.CycloneDXVersion15},
 	}
 
-	for _, test := range tests {
+	for _, tt := range tests {
 		writer := &bytes.Buffer{}
-		r := reporter.NewCycloneDXReporter(io.Discard, writer, test.version, test.lvl)
+		r := reporter.NewCycloneDXReporter(io.Discard, writer, tt.version, tt.lvl)
 
 		r.Warnf("%s", text)
 
-		if writer.String() != test.expectedPrintout {
-			t.Errorf("expected \"%s\", got \"%s\"", test.expectedPrintout, writer.String())
+		if writer.String() != tt.expectedPrintout {
+			t.Errorf("expected \"%s\", got \"%s\"", tt.expectedPrintout, writer.String())
 		}
 	}
 }
@@ -77,14 +77,14 @@ func TestCycloneDXReporter_Infof(t *testing.T) {
 		{lvl: reporter.WarnLevel, expectedPrintout: "", version: models.CycloneDXVersion15},
 	}
 
-	for _, test := range tests {
+	for _, tt := range tests {
 		writer := &bytes.Buffer{}
-		r := reporter.NewCycloneDXReporter(io.Discard, writer, test.version, test.lvl)
+		r := reporter.NewCycloneDXReporter(io.Discard, writer, tt.version, tt.lvl)
 
 		r.Infof("%s", text)
 
-		if writer.String() != test.expectedPrintout {
-			t.Errorf("expected \"%s\", got \"%s\"", test.expectedPrintout, writer.String())
+		if writer.String() != tt.expectedPrintout {
+			t.Errorf("expected \"%s\", got \"%s\"", tt.expectedPrintout, writer.String())
 		}
 	}
 }
@@ -119,14 +119,14 @@ func TestCycloneDXReporter_Verbosef(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
+	for _, tt := range tests {
 		writer := &bytes.Buffer{}
-		r := reporter.NewCycloneDXReporter(io.Discard, writer, test.version, test.lvl)
+		r := reporter.NewCycloneDXReporter(io.Discard, writer, tt.version, tt.lvl)
 
 		r.Verbosef("%s", text)
 
-		if writer.String() != test.expectedPrintout {
-			t.Errorf("expected \"%s\", got \"%s\"", test.expectedPrintout, writer.String())
+		if writer.String() != tt.expectedPrintout {
+			t.Errorf("expected \"%s\", got \"%s\"", tt.expectedPrintout, writer.String())
 		}
 	}
 }

--- a/pkg/reporter/gh-annotations_reporter_test.go
+++ b/pkg/reporter/gh-annotations_reporter_test.go
@@ -37,14 +37,14 @@ func TestGHAnnotationsReporter_Warnf(t *testing.T) {
 		{lvl: reporter.ErrorLevel, expectedPrintout: ""},
 	}
 
-	for _, test := range tests {
+	for _, tt := range tests {
 		writer := &bytes.Buffer{}
-		r := reporter.NewGHAnnotationsReporter(io.Discard, writer, test.lvl)
+		r := reporter.NewGHAnnotationsReporter(io.Discard, writer, tt.lvl)
 
 		r.Warnf("%s", text)
 
-		if writer.String() != test.expectedPrintout {
-			t.Errorf("expected \"%s\", got \"%s\"", test.expectedPrintout, writer.String())
+		if writer.String() != tt.expectedPrintout {
+			t.Errorf("expected \"%s\", got \"%s\"", tt.expectedPrintout, writer.String())
 		}
 	}
 }

--- a/pkg/reporter/json_reporter_test.go
+++ b/pkg/reporter/json_reporter_test.go
@@ -37,14 +37,14 @@ func TestJSONReporter_Warnf(t *testing.T) {
 		{lvl: reporter.ErrorLevel, expectedPrintout: ""},
 	}
 
-	for _, test := range tests {
+	for _, tt := range tests {
 		writer := &bytes.Buffer{}
-		r := reporter.NewJSONReporter(io.Discard, writer, test.lvl)
+		r := reporter.NewJSONReporter(io.Discard, writer, tt.lvl)
 
 		r.Warnf("%s", text)
 
-		if writer.String() != test.expectedPrintout {
-			t.Errorf("expected \"%s\", got \"%s\"", test.expectedPrintout, writer.String())
+		if writer.String() != tt.expectedPrintout {
+			t.Errorf("expected \"%s\", got \"%s\"", tt.expectedPrintout, writer.String())
 		}
 	}
 }
@@ -61,14 +61,14 @@ func TestJSONReporter_Infof(t *testing.T) {
 		{lvl: reporter.WarnLevel, expectedPrintout: ""},
 	}
 
-	for _, test := range tests {
+	for _, tt := range tests {
 		writer := &bytes.Buffer{}
-		r := reporter.NewJSONReporter(io.Discard, writer, test.lvl)
+		r := reporter.NewJSONReporter(io.Discard, writer, tt.lvl)
 
 		r.Infof("%s", text)
 
-		if writer.String() != test.expectedPrintout {
-			t.Errorf("expected \"%s\", got \"%s\"", test.expectedPrintout, writer.String())
+		if writer.String() != tt.expectedPrintout {
+			t.Errorf("expected \"%s\", got \"%s\"", tt.expectedPrintout, writer.String())
 		}
 	}
 }
@@ -85,14 +85,14 @@ func TestJSONReporter_Verbosef(t *testing.T) {
 		{lvl: reporter.InfoLevel, expectedPrintout: ""},
 	}
 
-	for _, test := range tests {
+	for _, tt := range tests {
 		writer := &bytes.Buffer{}
-		r := reporter.NewJSONReporter(io.Discard, writer, test.lvl)
+		r := reporter.NewJSONReporter(io.Discard, writer, tt.lvl)
 
 		r.Verbosef("%s", text)
 
-		if writer.String() != test.expectedPrintout {
-			t.Errorf("expected \"%s\", got \"%s\"", test.expectedPrintout, writer.String())
+		if writer.String() != tt.expectedPrintout {
+			t.Errorf("expected \"%s\", got \"%s\"", tt.expectedPrintout, writer.String())
 		}
 	}
 }

--- a/pkg/reporter/sarif_reporter_test.go
+++ b/pkg/reporter/sarif_reporter_test.go
@@ -37,14 +37,14 @@ func TestSarifReporter_Warnf(t *testing.T) {
 		{lvl: reporter.ErrorLevel, expectedPrintout: ""},
 	}
 
-	for _, test := range tests {
+	for _, tt := range tests {
 		writer := &bytes.Buffer{}
-		r := reporter.NewSarifReporter(io.Discard, writer, test.lvl)
+		r := reporter.NewSarifReporter(io.Discard, writer, tt.lvl)
 
 		r.Warnf("%s", text)
 
-		if writer.String() != test.expectedPrintout {
-			t.Errorf("expected \"%s\", got \"%s\"", test.expectedPrintout, writer.String())
+		if writer.String() != tt.expectedPrintout {
+			t.Errorf("expected \"%s\", got \"%s\"", tt.expectedPrintout, writer.String())
 		}
 	}
 }
@@ -61,14 +61,14 @@ func TestSarifReporter_Infof(t *testing.T) {
 		{lvl: reporter.WarnLevel, expectedPrintout: ""},
 	}
 
-	for _, test := range tests {
+	for _, tt := range tests {
 		writer := &bytes.Buffer{}
-		r := reporter.NewSarifReporter(io.Discard, writer, test.lvl)
+		r := reporter.NewSarifReporter(io.Discard, writer, tt.lvl)
 
 		r.Infof("%s", text)
 
-		if writer.String() != test.expectedPrintout {
-			t.Errorf("expected \"%s\", got \"%s\"", test.expectedPrintout, writer.String())
+		if writer.String() != tt.expectedPrintout {
+			t.Errorf("expected \"%s\", got \"%s\"", tt.expectedPrintout, writer.String())
 		}
 	}
 }
@@ -85,14 +85,14 @@ func TestSarifReporter_Verbosef(t *testing.T) {
 		{lvl: reporter.InfoLevel, expectedPrintout: ""},
 	}
 
-	for _, test := range tests {
+	for _, tt := range tests {
 		writer := &bytes.Buffer{}
-		r := reporter.NewSarifReporter(io.Discard, writer, test.lvl)
+		r := reporter.NewSarifReporter(io.Discard, writer, tt.lvl)
 
 		r.Verbosef("%s", text)
 
-		if writer.String() != test.expectedPrintout {
-			t.Errorf("expected \"%s\", got \"%s\"", test.expectedPrintout, writer.String())
+		if writer.String() != tt.expectedPrintout {
+			t.Errorf("expected \"%s\", got \"%s\"", tt.expectedPrintout, writer.String())
 		}
 	}
 }

--- a/pkg/reporter/table_reporter_test.go
+++ b/pkg/reporter/table_reporter_test.go
@@ -37,14 +37,14 @@ func TestTableReporter_Warnf(t *testing.T) {
 		{lvl: reporter.ErrorLevel, expectedPrintout: ""},
 	}
 
-	for _, test := range tests {
+	for _, tt := range tests {
 		writer := &bytes.Buffer{}
-		r := reporter.NewTableReporter(writer, io.Discard, test.lvl, false, 0)
+		r := reporter.NewTableReporter(writer, io.Discard, tt.lvl, false, 0)
 
 		r.Warnf("%s", text)
 
-		if writer.String() != test.expectedPrintout {
-			t.Errorf("expected \"%s\", got \"%s\"", test.expectedPrintout, writer.String())
+		if writer.String() != tt.expectedPrintout {
+			t.Errorf("expected \"%s\", got \"%s\"", tt.expectedPrintout, writer.String())
 		}
 	}
 }
@@ -61,14 +61,14 @@ func TestTableReporter_Infof(t *testing.T) {
 		{lvl: reporter.WarnLevel, expectedPrintout: ""},
 	}
 
-	for _, test := range tests {
+	for _, tt := range tests {
 		writer := &bytes.Buffer{}
-		r := reporter.NewTableReporter(writer, io.Discard, test.lvl, false, 0)
+		r := reporter.NewTableReporter(writer, io.Discard, tt.lvl, false, 0)
 
 		r.Infof("%s", text)
 
-		if writer.String() != test.expectedPrintout {
-			t.Errorf("expected \"%s\", got \"%s\"", test.expectedPrintout, writer.String())
+		if writer.String() != tt.expectedPrintout {
+			t.Errorf("expected \"%s\", got \"%s\"", tt.expectedPrintout, writer.String())
 		}
 	}
 }
@@ -85,14 +85,14 @@ func TestTableReporter_Verbosef(t *testing.T) {
 		{lvl: reporter.InfoLevel, expectedPrintout: ""},
 	}
 
-	for _, test := range tests {
+	for _, tt := range tests {
 		writer := &bytes.Buffer{}
-		r := reporter.NewTableReporter(writer, io.Discard, test.lvl, false, 0)
+		r := reporter.NewTableReporter(writer, io.Discard, tt.lvl, false, 0)
 
 		r.Verbosef("%s", text)
 
-		if writer.String() != test.expectedPrintout {
-			t.Errorf("expected \"%s\", got \"%s\"", test.expectedPrintout, writer.String())
+		if writer.String() != tt.expectedPrintout {
+			t.Errorf("expected \"%s\", got \"%s\"", tt.expectedPrintout, writer.String())
 		}
 	}
 }

--- a/pkg/reporter/vertical_reporter_test.go
+++ b/pkg/reporter/vertical_reporter_test.go
@@ -37,14 +37,14 @@ func TestVerticalReporter_Warnf(t *testing.T) {
 		{lvl: reporter.ErrorLevel, expectedPrintout: ""},
 	}
 
-	for _, test := range tests {
+	for _, tt := range tests {
 		writer := &bytes.Buffer{}
-		r := reporter.NewVerticalReporter(writer, io.Discard, test.lvl, false, 0)
+		r := reporter.NewVerticalReporter(writer, io.Discard, tt.lvl, false, 0)
 
 		r.Warnf("%s", text)
 
-		if writer.String() != test.expectedPrintout {
-			t.Errorf("expected \"%s\", got \"%s\"", test.expectedPrintout, writer.String())
+		if writer.String() != tt.expectedPrintout {
+			t.Errorf("expected \"%s\", got \"%s\"", tt.expectedPrintout, writer.String())
 		}
 	}
 }


### PR DESCRIPTION
Typically with table tests the inner variable is called `tt`, which we're doing in most places already but not everywhere - and as a result, this lead to linting picking up a few `copyloopvar` violations that were previously ignored due to the different variable name