### PR TITLE
test: rewrite `models` to use snapshots and tables

### DIFF
--- a/pkg/models/__snapshots__/vulnerabilities_test.snap
+++ b/pkg/models/__snapshots__/vulnerabilities_test.snap
@@ -1,0 +1,34 @@
+
+[TestVulnerabilities_MarshalJSON/multiple_vulnerabilities - 1]
+[
+  {
+    "modified": "0001-01-01T00:00:00Z",
+    "id": "GHSA-1"
+  },
+  {
+    "modified": "0001-01-01T00:00:00Z",
+    "id": "GHSA-2"
+  },
+  {
+    "modified": "0001-01-01T00:00:00Z",
+    "id": "GHSA-3"
+  }
+]
+---
+
+[TestVulnerabilities_MarshalJSON/nil - 1]
+[]
+---
+
+[TestVulnerabilities_MarshalJSON/no_vulnerabilities - 1]
+[]
+---
+
+[TestVulnerabilities_MarshalJSON/one_vulnerability - 1]
+[
+  {
+    "modified": "0001-01-01T00:00:00Z",
+    "id": "GHSA-1"
+  }
+]
+---

--- a/pkg/models/__snapshots__/vulnerability_test.snap
+++ b/pkg/models/__snapshots__/vulnerability_test.snap
@@ -1,0 +1,122 @@
+
+[TestAffected_MarshalJSON/with_package - 1]
+{
+  "modified": "0001-01-01T00:00:00Z",
+  "id": "TEST-0000",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "requests"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ]
+}
+---
+
+[TestAffected_MarshalJSON/without_package - 1]
+{
+  "modified": "0001-01-01T00:00:00Z",
+  "id": "TEST-0000",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "requests"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ]
+}
+---
+
+[TestAffected_MarshalYAML/with_package - 1]
+id: TEST-0000
+modified: 0001-01-01T00:00:00Z
+affected:
+    - package:
+        ecosystem: PyPI
+        name: requests
+      versions:
+        - 1.0.0
+
+---
+
+[TestAffected_MarshalYAML/without_package - 1]
+id: TEST-0000
+modified: 0001-01-01T00:00:00Z
+affected:
+    - package:
+        ecosystem: PyPI
+        name: requests
+      versions:
+        - 1.0.0
+
+---
+
+[TestVulnerability_MarshalJSON_WithTimes/all_Los_Angeles - 1]
+{
+  "modified": "2023-12-01T20:30:30Z",
+  "published": "2021-06-30T08:00:00Z",
+  "withdrawn": "2022-01-16T07:59:59Z",
+  "id": "TEST-0000"
+}
+---
+
+[TestVulnerability_MarshalJSON_WithTimes/all_UTC - 1]
+{
+  "modified": "2023-12-01T12:30:30Z",
+  "published": "2021-06-30T01:00:00Z",
+  "withdrawn": "2022-01-15T23:59:59Z",
+  "id": "TEST-0000"
+}
+---
+
+[TestVulnerability_MarshalJSON_WithTimes/empty - 1]
+{
+  "modified": "0001-01-01T00:00:00Z",
+  "id": "TEST-0000"
+}
+---
+
+[TestVulnerability_MarshalJSON_WithTimes/no_withdraw - 1]
+{
+  "modified": "2023-12-01T12:30:30Z",
+  "published": "2021-06-30T01:00:00Z",
+  "id": "TEST-0000"
+}
+---
+
+[TestVulnerability_MarshalYAML_WithTimes/all_Los_Angeles - 1]
+id: TEST-0000
+modified: 2023-12-01T20:30:30Z
+published: 2021-06-30T08:00:00Z
+withdrawn: 2022-01-16T07:59:59Z
+
+---
+
+[TestVulnerability_MarshalYAML_WithTimes/all_UTC - 1]
+id: TEST-0000
+modified: 2023-12-01T12:30:30Z
+published: 2021-06-30T01:00:00Z
+withdrawn: 2022-01-15T23:59:59Z
+
+---
+
+[TestVulnerability_MarshalYAML_WithTimes/empty - 1]
+id: TEST-0000
+modified: 0001-01-01T00:00:00Z
+
+---
+
+[TestVulnerability_MarshalYAML_WithTimes/no_withdraw - 1]
+id: TEST-0000
+modified: 2023-12-01T12:30:30Z
+published: 2021-06-30T01:00:00Z
+
+---

--- a/pkg/models/testmain_test.go
+++ b/pkg/models/testmain_test.go
@@ -1,0 +1,16 @@
+package models_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/google/osv-scanner/internal/testutility"
+)
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+
+	testutility.CleanSnapshots(m)
+
+	os.Exit(code)
+}

--- a/pkg/models/vulnerabilities_test.go
+++ b/pkg/models/vulnerabilities_test.go
@@ -1,62 +1,44 @@
 package models_test
 
 import (
-	"encoding/json"
 	"testing"
 
+	"github.com/google/osv-scanner/internal/testutility"
 	"github.com/google/osv-scanner/pkg/models"
 )
 
 func TestVulnerabilities_MarshalJSON(t *testing.T) {
 	t.Parallel()
 
-	osv := models.Vulnerability{ID: "GHSA-1"}
-	asJSON, err := json.Marshal(osv)
-
-	if err != nil {
-		t.Fatalf("Unable to marshal osv to JSON: %v", err)
-	}
-
 	tests := []struct {
 		name string
 		vs   models.Vulnerabilities
-		want string
 	}{
 		{
-			name: "",
+			name: "nil",
 			vs:   nil,
-			want: "[]",
 		},
 		{
-			name: "",
-			vs:   models.Vulnerabilities(nil),
-			want: "[]",
+			name: "no vulnerabilities",
+			vs:   models.Vulnerabilities{},
 		},
 		{
-			name: "",
-			vs:   models.Vulnerabilities{osv},
-			want: "[" + string(asJSON) + "]",
+			name: "one vulnerability",
+			vs:   models.Vulnerabilities{models.Vulnerability{ID: "GHSA-1"}},
 		},
 		{
-			name: "",
-			vs:   models.Vulnerabilities{osv, osv},
-			want: "[" + string(asJSON) + "," + string(asJSON) + "]",
+			name: "multiple vulnerabilities",
+			vs: models.Vulnerabilities{
+				models.Vulnerability{ID: "GHSA-1"},
+				models.Vulnerability{ID: "GHSA-2"},
+				models.Vulnerability{ID: "GHSA-3"},
+			},
 		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := tt.vs.MarshalJSON()
-			if err != nil {
-				t.Errorf("MarshalJSON() error = %v", err)
-
-				return
-			}
-
-			if gotStr := string(got); gotStr != tt.want {
-				t.Errorf("MarshalJSON() got = %v, want %v", gotStr, tt.want)
-			}
+			testutility.NewSnapshot().MatchJSON(t, tt.vs)
 		})
 	}
 }

--- a/pkg/models/vulnerability_test.go
+++ b/pkg/models/vulnerability_test.go
@@ -1,111 +1,103 @@
 package models_test
 
 import (
-	"encoding/json"
 	"testing"
 	"time"
 
+	"github.com/google/osv-scanner/internal/testutility"
 	"github.com/google/osv-scanner/pkg/models"
 	"gopkg.in/yaml.v3"
 )
 
-func TestAffected_MarshalJSONWithPackage(t *testing.T) {
+func TestAffected_MarshalJSON(t *testing.T) {
 	t.Parallel()
-	v := models.Vulnerability{
-		ID: "TEST-0000",
-		Affected: []models.Affected{
-			{
-				Package:  models.Package{Ecosystem: models.EcosystemPyPI, Name: "requests"},
-				Versions: []string{"1.0.0"},
+
+	tests := []struct {
+		name string
+		vuln models.Vulnerability
+	}{
+		{
+			name: "with package",
+			vuln: models.Vulnerability{
+				ID: "TEST-0000",
+				Affected: []models.Affected{
+					{
+						Package:  models.Package{Ecosystem: models.EcosystemPyPI, Name: "requests"},
+						Versions: []string{"1.0.0"},
+					},
+				},
+			},
+		},
+		{
+			name: "without package",
+			vuln: models.Vulnerability{
+				ID: "TEST-0000",
+				Affected: []models.Affected{
+					{
+						Package:  models.Package{Ecosystem: models.EcosystemPyPI, Name: "requests"},
+						Versions: []string{"1.0.0"},
+					},
+				},
 			},
 		},
 	}
-	got, err := json.Marshal(v)
-	if err != nil {
-		t.Fatalf("Marshal() = %v; want no error", err)
-	}
-	want := `{"modified":"0001-01-01T00:00:00Z","id":"TEST-0000","affected":[{"package":{"ecosystem":"PyPI","name":"requests"},"versions":["1.0.0"]}]}`
-	if string(got) != want {
-		t.Errorf("Marshal() = %v; want %v", string(got), want)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			testutility.NewSnapshot().MatchJSON(t, tt.vuln)
+		})
 	}
 }
 
-func TestAffected_MarshalJSONWithoutPackage(t *testing.T) {
+func TestAffected_MarshalYAML(t *testing.T) {
 	t.Parallel()
-	v := models.Vulnerability{
-		ID: "TEST-0000",
-		Affected: []models.Affected{
-			{
-				Versions: []string{"1.0.0"},
+
+	tests := []struct {
+		name string
+		vuln models.Vulnerability
+	}{
+		{
+			name: "with package",
+			vuln: models.Vulnerability{
+				ID: "TEST-0000",
+				Affected: []models.Affected{
+					{
+						Package:  models.Package{Ecosystem: models.EcosystemPyPI, Name: "requests"},
+						Versions: []string{"1.0.0"},
+					},
+				},
+			},
+		},
+		{
+			name: "without package",
+			vuln: models.Vulnerability{
+				ID: "TEST-0000",
+				Affected: []models.Affected{
+					{
+						Package:  models.Package{Ecosystem: models.EcosystemPyPI, Name: "requests"},
+						Versions: []string{"1.0.0"},
+					},
+				},
 			},
 		},
 	}
-	got, err := json.Marshal(v)
-	if err != nil {
-		t.Fatalf("Marshal() = %v; want no error", err)
-	}
-	want := `{"modified":"0001-01-01T00:00:00Z","id":"TEST-0000","affected":[{"versions":["1.0.0"]}]}`
-	if string(got) != want {
-		t.Errorf("Marshal() = %v; want %v", string(got), want)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := yaml.Marshal(tt.vuln)
+			if err != nil {
+				t.Fatalf("Marshal() = %v; want no error", err)
+			}
+			testutility.NewSnapshot().MatchText(t, string(got))
+		})
 	}
 }
 
-func TestAffected_MarshalYAMLWithPackage(t *testing.T) {
+func TestVulnerability_MarshalJSON_WithTimes(t *testing.T) {
 	t.Parallel()
-	v := models.Vulnerability{
-		ID: "TEST-0000",
-		Affected: []models.Affected{
-			{
-				Package:  models.Package{Ecosystem: models.EcosystemPyPI, Name: "requests"},
-				Versions: []string{"1.0.0"},
-			},
-		},
-	}
-	got, err := yaml.Marshal(v)
-	if err != nil {
-		t.Fatalf("Marshal() = %v; want no error", err)
-	}
-	want := `id: TEST-0000
-modified: 0001-01-01T00:00:00Z
-affected:
-    - package:
-        ecosystem: PyPI
-        name: requests
-      versions:
-        - 1.0.0
-`
-	if string(got) != want {
-		t.Errorf("Marshal() = %v; want %v", string(got), want)
-	}
-}
 
-func TestAffected_MarshalYAMLWithoutPackage(t *testing.T) {
-	t.Parallel()
-	v := models.Vulnerability{
-		ID: "TEST-0000",
-		Affected: []models.Affected{
-			{
-				Versions: []string{"1.0.0"},
-			},
-		},
-	}
-	got, err := yaml.Marshal(v)
-	if err != nil {
-		t.Fatalf("Marshal() = %v; want no error", err)
-	}
-	want := `id: TEST-0000
-modified: 0001-01-01T00:00:00Z
-affected:
-    - versions:
-        - 1.0.0
-`
-	if string(got) != want {
-		t.Errorf("Marshal() = %v; want %v", string(got), want)
-	}
-}
-
-func TestVulnerability_MarshalJSONTimes(t *testing.T) {
-	t.Parallel()
 	losAngeles, err := time.LoadLocation("America/Los_Angeles")
 	if err != nil {
 		panic(err)
@@ -156,19 +148,15 @@ func TestVulnerability_MarshalJSONTimes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := json.Marshal(tt.vuln)
-			if err != nil {
-				t.Fatalf("Marshal() = %v; want no error", err)
-			}
-			if string(got) != tt.want {
-				t.Errorf("Marshal() = %v; want %v", string(got), tt.want)
-			}
+
+			testutility.NewSnapshot().MatchJSON(t, tt.vuln)
 		})
 	}
 }
 
-func TestVulnerability_MarshalYAMLTimes(t *testing.T) {
+func TestVulnerability_MarshalYAML_WithTimes(t *testing.T) {
 	t.Parallel()
+
 	losAngeles, err := time.LoadLocation("America/Los_Angeles")
 	if err != nil {
 		panic(err)
@@ -177,14 +165,12 @@ func TestVulnerability_MarshalYAMLTimes(t *testing.T) {
 	tests := []struct {
 		name string
 		vuln models.Vulnerability
-		want string
 	}{
 		{
 			name: "empty",
 			vuln: models.Vulnerability{
 				ID: "TEST-0000",
 			},
-			want: "id: TEST-0000\nmodified: 0001-01-01T00:00:00Z\n",
 		},
 		{
 			name: "no withdraw",
@@ -193,7 +179,6 @@ func TestVulnerability_MarshalYAMLTimes(t *testing.T) {
 				Modified:  time.Date(2023, 12, 1, 12, 30, 30, 0, time.UTC),
 				Published: time.Date(2021, 6, 30, 1, 0, 0, 0, time.UTC),
 			},
-			want: "id: TEST-0000\nmodified: 2023-12-01T12:30:30Z\npublished: 2021-06-30T01:00:00Z\n",
 		},
 		{
 			name: "all UTC",
@@ -203,7 +188,6 @@ func TestVulnerability_MarshalYAMLTimes(t *testing.T) {
 				Published: time.Date(2021, 6, 30, 1, 0, 0, 0, time.UTC),
 				Withdrawn: time.Date(2022, 1, 15, 23, 59, 59, 0, time.UTC),
 			},
-			want: "id: TEST-0000\nmodified: 2023-12-01T12:30:30Z\npublished: 2021-06-30T01:00:00Z\nwithdrawn: 2022-01-15T23:59:59Z\n",
 		},
 		{
 			name: "all Los Angeles",
@@ -213,19 +197,17 @@ func TestVulnerability_MarshalYAMLTimes(t *testing.T) {
 				Published: time.Date(2021, 6, 30, 1, 0, 0, 0, losAngeles),
 				Withdrawn: time.Date(2022, 1, 15, 23, 59, 59, 0, losAngeles),
 			},
-			want: "id: TEST-0000\nmodified: 2023-12-01T20:30:30Z\npublished: 2021-06-30T08:00:00Z\nwithdrawn: 2022-01-16T07:59:59Z\n",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+
 			got, err := yaml.Marshal(tt.vuln)
 			if err != nil {
 				t.Fatalf("Marshal() = %v; want no error", err)
 			}
-			if string(got) != tt.want {
-				t.Errorf("Marshal() = %v; want %v", string(got), tt.want)
-			}
+			testutility.NewSnapshot().MatchText(t, string(got))
 		})
 	}
 }


### PR DESCRIPTION
This should make it easier to maintain since we won't need to edit raw JSON - I wouldn't say this is strictly better as some of the tests were small enough that I'd argue the initial overhead of using snapshots makes it less of a win, but ultimately these don't change often so I think it's still better to be consistent with the rest of the codebase

(I've also got a fix or two coming up in this section which'll be made easier by this)