### PR TITLE
fix: A quick fix to handle symbolic links

### DIFF
--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -1082,6 +1082,13 @@ func patchPackageForRequest(pkg scannedPackage) scannedPackage {
 		}
 	}
 
+	// TODO: This should be done on the osv.dev side
+	// This is needed because Ubuntu ecosystem appends LTS
+	// but the scanner does not have this information.
+	if pkg.Ecosystem == "Ubuntu:20.04" {
+		pkg.Ecosystem = "Ubuntu:20.04:LTS"
+	}
+
 	return pkg
 }
 


### PR DESCRIPTION
Probably should not merge this PR directly, but this is a fix to allow osv-scanner to scan Ubuntu:20.04 based images (e.g. osv.dev workers)