### PR TITLE
refactor: merge duplicate class selectors

### DIFF
--- a/internal/output/html/style.html
+++ b/internal/output/html/style.html
@@ -103,9 +103,6 @@
     text-align: left;
     padding: 0 50px;
     display: none;
-  }
-
-  .vuln-details {
     border-bottom: 1px solid #eee;
     max-height: 400px;
     overflow: overlay;


### PR DESCRIPTION
The styles from both of these still get applied, but we might as well just use a single selector block 🤷 