### PR TITLE
fix(guided remediation): handle extraneous/missing packages in package-lock.json more leniently

### DIFF
--- a/internal/resolution/lockfile/fixtures/npm_type_order/package-lock.json
+++ b/internal/resolution/lockfile/fixtures/npm_type_order/package-lock.json
@@ -1,0 +1,45 @@
+{
+  "name": "root",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "root",
+      "version": "1.0.0",
+      "peerDependencies": {
+        "a": "1.0.0",
+        "b": "1.0.0",
+        "c": "1.0.0",
+        "d": "1.0.0"
+      },
+      "dependencies": {
+        "a": "2.0.0",
+        "b": "2.0.0",
+        "c": "2.0.0"
+      },
+      "optionalDependencies": {
+        "a": "3.0.0",
+        "b": "3.0.0"
+      },
+      "devDependencies": {
+        "a": "4.0.0"
+      }
+    },
+    "node_modules/a": {
+      "version": "4.0.0",
+      "dev": true
+    },
+    "node_modules/b": {
+      "version": "3.0.0",
+      "optional": true
+    },
+    "node_modules/c": {
+      "version": "2.0.0"
+    },
+    "node_modules/d": {
+      "version": "1.0.0",
+      "peer": true
+    }
+  }
+}

--- a/internal/resolution/lockfile/npm.go
+++ b/internal/resolution/lockfile/npm.go
@@ -19,14 +19,17 @@ type NpmReadWriter struct{}
 
 func (NpmReadWriter) System() resolve.System { return resolve.NPM }
 
+type npmDependencyVersionSpec struct {
+	Version string
+	DepType dep.Type
+}
+
 type npmNodeModule struct {
-	NodeID       resolve.NodeID
-	Parent       *npmNodeModule
-	Children     map[string]*npmNodeModule // keyed on package name
-	Deps         map[string]string
-	OptionalDeps map[string]string
-	DevDeps      map[string]string // dev dependencies are also included in Deps
-	ActualName   string            // set if the node is an alias, the real package name this refers to
+	NodeID     resolve.NodeID
+	Parent     *npmNodeModule
+	Children   map[string]*npmNodeModule // keyed on package name
+	Deps       map[string]npmDependencyVersionSpec
+	ActualName string // set if the node is an alias, the real package name this refers to
 }
 
 func (n npmNodeModule) IsAliased() bool {
@@ -85,27 +88,17 @@ func (rw NpmReadWriter) Read(file lockfile.DepFile) (*resolve.Graph, error) {
 		}
 
 		// Add edges to the correct dependency nodes
-		for depName, depVer := range node.Deps {
+		for depName, depSpec := range node.Deps {
 			depNode := rw.findDependencyNode(node, depName)
 			if depNode == -1 {
-				return nil, fmt.Errorf("required dependency not found in package-lock file: %s", depName)
-			}
-			var typ dep.Type
-			if node.DevDeps[depName] == depVer {
-				typ = dep.NewType(dep.Dev)
-			}
-			if err := g.AddEdge(node.NodeID, depNode, depVer, typ); err != nil {
-				return nil, err
-			}
-		}
-		for depName, depVer := range node.OptionalDeps {
-			depNode := rw.findDependencyNode(node, depName)
-			// don't error if an optional dependency is not installed
-			if depNode == -1 {
+				// The dependency is apparently not in the package-lock.json.
+				// This probably means the lockfile is malformed, and npm would usually error installing this.
+				// But there are some cases (with workspaces) that npm doesn't error.
+				// We just always ignore the error to make it work.
+				// TODO: g.AddError(...)
 				continue
 			}
-			typ := dep.NewType(dep.Opt)
-			if err := g.AddEdge(node.NodeID, depNode, depVer, typ); err != nil {
+			if err := g.AddEdge(node.NodeID, depNode, depSpec.Version, depSpec.DepType); err != nil {
 				return nil, err
 			}
 		}
@@ -139,10 +132,11 @@ func (rw NpmReadWriter) findDependencyNode(node *npmNodeModule, depName string) 
 	return resolve.NodeID(-1)
 }
 
-func (rw NpmReadWriter) reVersionAliasedDeps(deps map[string]string) {
+func (rw NpmReadWriter) reVersionAliasedDeps(deps map[string]npmDependencyVersionSpec) {
 	// for the dependency maps, change versions from "npm:pkg@version" to "version"
 	for k, v := range deps {
-		_, deps[k] = manifest.SplitNPMAlias(v)
+		_, v.Version = manifest.SplitNPMAlias(v.Version)
+		deps[k] = v
 	}
 }
 

--- a/internal/resolution/lockfile/npm.go
+++ b/internal/resolution/lockfile/npm.go
@@ -58,7 +58,7 @@ func (rw NpmReadWriter) Read(file lockfile.DepFile) (*resolve.Graph, error) {
 		return nil, errors.New("no dependencies in package-lock.json")
 	}
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error when parsing package-lock.json: %w", err)
 	}
 
 	// Traverse the graph (somewhat inefficiently) to add edges between nodes
@@ -87,6 +87,9 @@ func (rw NpmReadWriter) Read(file lockfile.DepFile) (*resolve.Graph, error) {
 		// Add edges to the correct dependency nodes
 		for depName, depVer := range node.Deps {
 			depNode := rw.findDependencyNode(node, depName)
+			if depNode == -1 {
+				return nil, fmt.Errorf("required dependency not found in package-lock file: %s", depName)
+			}
 			var typ dep.Type
 			if node.DevDeps[depName] == depVer {
 				typ = dep.NewType(dep.Dev)

--- a/internal/resolution/lockfile/npm_test.go
+++ b/internal/resolution/lockfile/npm_test.go
@@ -44,7 +44,7 @@ r 1.0.0
 		@fake-registry/b@^2.0.0 2.0.0
 			c: @fake-registry/c@^1.0.0 1.1.1
 				# peerDependency becomes optional
-				Opt|$d@^2.0.0
+				Scope peer|$d@^2.0.0
 			d: @fake-registry/d@^2.0.0 2.2.2
 	# workspace
 	w@* 1.0.0
@@ -90,14 +90,14 @@ func TestNpmReadV1(t *testing.T) {
 	want, err := schema.ParseResolve(`
 r 1.0.0
 	@fake-registry/a@^1.2.3 1.2.3
-		Opt|$b@^1.0.0
+		$b@^1.0.0
 	b: @fake-registry/b@^1.0.1 1.0.1
 	Dev KnownAs a-dev|@fake-registry/a@^2.3.4 2.3.4
-		# all indirect dependencies become optional because it's impossible to tell in v1
-		Opt|@fake-registry/b@^2.0.0 2.0.0
-			Opt|@fake-registry/c@^1.0.0 1.1.1
+		# all indirect dependencies become regular because it's impossible to tell type in v1
+		@fake-registry/b@^2.0.0 2.0.0
+			@fake-registry/c@^1.0.0 1.1.1
 				# peerDependencies are not supported in v1
-			Opt|@fake-registry/d@^2.0.0 2.2.2
+			@fake-registry/d@^2.0.0 2.2.2
 	# v1 does not support workspaces
 `, resolve.NPM)
 	if err != nil {

--- a/internal/resolution/lockfile/npm_test.go
+++ b/internal/resolution/lockfile/npm_test.go
@@ -43,7 +43,6 @@ r 1.0.0
 	Dev KnownAs a-dev|@fake-registry/a@^2.3.4 2.3.4
 		@fake-registry/b@^2.0.0 2.0.0
 			c: @fake-registry/c@^1.0.0 1.1.1
-				# peerDependency becomes optional
 				Scope peer|$d@^2.0.0
 			d: @fake-registry/d@^2.0.0 2.2.2
 	# workspace
@@ -99,6 +98,49 @@ r 1.0.0
 				# peerDependencies are not supported in v1
 			@fake-registry/d@^2.0.0 2.2.2
 	# v1 does not support workspaces
+`, resolve.NPM)
+	if err != nil {
+		t.Fatalf("error parsing want graph: %v", err)
+	}
+
+	if err := want.Canon(); err != nil {
+		t.Fatalf("failed canonicalizing want graph: %v", err)
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("npm lockfile mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestNpmReadTypeOrder(t *testing.T) {
+	t.Parallel()
+
+	// Testing the behavior when a package is included in multiple dependency type fields.
+	// Empirically, devDependencies > optionalDependencies > dependencies > peerDependencies
+
+	// This lockfile was manually constructed.
+	df, err := lf.OpenLocalDepFile("./fixtures/npm_type_order/package-lock.json")
+	if err != nil {
+		t.Fatalf("failed to open file: %v", err)
+	}
+	defer df.Close()
+
+	npmRW := lockfile.NpmReadWriter{}
+	got, err := npmRW.Read(df)
+	if err != nil {
+		t.Fatalf("failed to read file: %v", err)
+	}
+
+	if err := got.Canon(); err != nil {
+		t.Fatalf("failed canonicalizing got graph: %v", err)
+	}
+
+	want, err := schema.ParseResolve(`
+root 1.0.0
+	Dev|a@4.0.0 4.0.0
+	Opt|b@3.0.0 3.0.0
+	c@2.0.0 2.0.0
+	Scope peer|d@1.0.0 1.0.0
 `, resolve.NPM)
 	if err != nil {
 		t.Fatalf("error parsing want graph: %v", err)


### PR DESCRIPTION
Changes two things for package-lock.json parsing:
1. Made it so packages installed in unknown locations (e.g. under a non-existent package) are ignored (following npm's behaviour), instead of triggering a panic.
2. Made missing dependencies in the lockfile *not* cause an error. npm would typically raise an error here, *unless* the missing dependency under a workspace's dependency graph. I think it's ok if we're more lenient than npm here.