### PR TITLE
fix: add "slices" import back in

### DIFF
--- a/pkg/osvscanner/vulnerability_result.go
+++ b/pkg/osvscanner/vulnerability_result.go
@@ -1,6 +1,7 @@
 package osvscanner
 
 import (
+	"slices"
 	"sort"
 	"strings"
 


### PR DESCRIPTION
#1329 removed the slices import in `vulnerability_result.go`, because it was no longer using it.
At the same time, #1385 added a new usage of the module.

Add the import back to make osv-scanner build again.