### PR TITLE
docs: corrected field names in osv scanner results in the JSON doc

### DIFF
--- a/docs/output.md
+++ b/docs/output.md
@@ -105,7 +105,7 @@ osv-scanner --format json -L path/to/lockfile > /path/to/file.json
 {
   "results": [
     {
-      "packageSource": {
+      "source": {
         "path": "/absolute/path/to/go.mod",
         // One of: lockfile, sbom, git, docker
         "type": "lockfile"
@@ -148,7 +148,7 @@ osv-scanner --format json -L path/to/lockfile > /path/to/file.json
       ]
     },
     {
-      "packageSource": {
+      "source": {
         "path": "/absolute/path/to/Cargo.lock",
         "type": "lockfile"
       },


### PR DESCRIPTION
Corrected JSON field names in the osv-scanner documentation. Previously, one key was incorrectly called `sourcePackage` and was changed to `source`.

Closes https://github.com/google/osv-scanner/issues/1391