### PR TITLE
feat(output): show package view for container scanning table result

### DIFF
--- a/cmd/osv-scanner/__snapshots__/main_test.snap
+++ b/cmd/osv-scanner/__snapshots__/main_test.snap
@@ -2589,7 +2589,9 @@ Scanned <rootdir>/fixtures/maven-transitive/pom.xml file and found 3 packages
 
 [TestRun_OCIImage/Alpine_3.10_image_tar_with_3.18_version_file - 1]
 Scanning image ../../internal/image/fixtures/test-alpine.tar
-Total 1 packages affected by 2 vulnerabilities (1 Critical, 1 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystems, 2 have fixes available
+Total 1 packages affected by 2 vulnerabilities (1 Critical, 1 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystems.
+2 vulnerabilities have fixes available
+
 Alpine:v3.18
 +----------------------------------------------------------+
 | Source:docker:../../internal/image/fixtures/test-alpine. |
@@ -2599,6 +2601,7 @@ Alpine:v3.18
 +---------+-------------------+---------------+------------+
 | zlib    | 1.2.11-r1         | Fix Available |          2 |
 +---------+-------------------+---------------+------------+
+
 For the most comprehensive scan results, we recommend using the HTML output: `osv-scanner --format html --output results.html`.
 You can also view the full vulnerability list in your terminal with: `osv-scanner --format vertical`
 
@@ -2620,7 +2623,9 @@ failed to load image ./fixtures/oci-image/no-file-here.tar: open ./fixtures/oci-
 
 [TestRun_OCIImage/scanning_node_modules_using_npm_with_no_packages - 1]
 Scanning image ../../internal/image/fixtures/test-node_modules-npm-empty.tar
-Total 1 packages affected by 4 vulnerabilities (0 Critical, 0 High, 4 Medium, 0 Low, 0 Unknown) from 1 ecosystems, 4 have fixes available
+Total 1 packages affected by 4 vulnerabilities (0 Critical, 0 High, 4 Medium, 0 Low, 0 Unknown) from 1 ecosystems.
+4 vulnerabilities have fixes available
+
 Alpine:v3.19
 +----------------------------------------------------------+
 | Source:docker:../../internal/image/fixtures/test-node_mo |
@@ -2630,6 +2635,7 @@ Alpine:v3.19
 +---------+-------------------+---------------+------------+
 | busybox | 1.36.1-r15        | Fix Available |          4 |
 +---------+-------------------+---------------+------------+
+
 For the most comprehensive scan results, we recommend using the HTML output: `osv-scanner --format html --output results.html`.
 You can also view the full vulnerability list in your terminal with: `osv-scanner --format vertical`
 
@@ -2641,7 +2647,9 @@ You can also view the full vulnerability list in your terminal with: `osv-scanne
 
 [TestRun_OCIImage/scanning_node_modules_using_npm_with_some_packages - 1]
 Scanning image ../../internal/image/fixtures/test-node_modules-npm-full.tar
-Total 3 packages affected by 6 vulnerabilities (2 Critical, 0 High, 4 Medium, 0 Low, 0 Unknown) from 2 ecosystems, 5 have fixes available
+Total 3 packages affected by 6 vulnerabilities (2 Critical, 0 High, 4 Medium, 0 Low, 0 Unknown) from 2 ecosystems.
+5 vulnerabilities have fixes available
+
 npm
 +--------------------------------------------------------------+
 | Source:docker:../../internal/image/fixtures/test-node_module |
@@ -2661,6 +2669,7 @@ Alpine:v3.19
 +---------+-------------------+---------------+------------+
 | busybox | 1.36.1-r15        | Fix Available |          4 |
 +---------+-------------------+---------------+------------+
+
 For the most comprehensive scan results, we recommend using the HTML output: `osv-scanner --format html --output results.html`.
 You can also view the full vulnerability list in your terminal with: `osv-scanner --format vertical`
 
@@ -2672,7 +2681,9 @@ You can also view the full vulnerability list in your terminal with: `osv-scanne
 
 [TestRun_OCIImage/scanning_node_modules_using_pnpm_with_no_packages - 1]
 Scanning image ../../internal/image/fixtures/test-node_modules-pnpm-empty.tar
-Total 1 packages affected by 4 vulnerabilities (0 Critical, 0 High, 4 Medium, 0 Low, 0 Unknown) from 1 ecosystems, 4 have fixes available
+Total 1 packages affected by 4 vulnerabilities (0 Critical, 0 High, 4 Medium, 0 Low, 0 Unknown) from 1 ecosystems.
+4 vulnerabilities have fixes available
+
 Alpine:v3.19
 +----------------------------------------------------------+
 | Source:docker:../../internal/image/fixtures/test-node_mo |
@@ -2682,6 +2693,7 @@ Alpine:v3.19
 +---------+-------------------+---------------+------------+
 | busybox | 1.36.1-r15        | Fix Available |          4 |
 +---------+-------------------+---------------+------------+
+
 For the most comprehensive scan results, we recommend using the HTML output: `osv-scanner --format html --output results.html`.
 You can also view the full vulnerability list in your terminal with: `osv-scanner --format vertical`
 
@@ -2693,7 +2705,9 @@ You can also view the full vulnerability list in your terminal with: `osv-scanne
 
 [TestRun_OCIImage/scanning_node_modules_using_pnpm_with_some_packages - 1]
 Scanning image ../../internal/image/fixtures/test-node_modules-pnpm-full.tar
-Total 1 packages affected by 4 vulnerabilities (0 Critical, 0 High, 4 Medium, 0 Low, 0 Unknown) from 1 ecosystems, 4 have fixes available
+Total 1 packages affected by 4 vulnerabilities (0 Critical, 0 High, 4 Medium, 0 Low, 0 Unknown) from 1 ecosystems.
+4 vulnerabilities have fixes available
+
 Alpine:v3.19
 +----------------------------------------------------------+
 | Source:docker:../../internal/image/fixtures/test-node_mo |
@@ -2703,6 +2717,7 @@ Alpine:v3.19
 +---------+-------------------+---------------+------------+
 | busybox | 1.36.1-r15        | Fix Available |          4 |
 +---------+-------------------+---------------+------------+
+
 For the most comprehensive scan results, we recommend using the HTML output: `osv-scanner --format html --output results.html`.
 You can also view the full vulnerability list in your terminal with: `osv-scanner --format vertical`
 
@@ -2714,7 +2729,9 @@ You can also view the full vulnerability list in your terminal with: `osv-scanne
 
 [TestRun_OCIImage/scanning_node_modules_using_yarn_with_no_packages - 1]
 Scanning image ../../internal/image/fixtures/test-node_modules-yarn-empty.tar
-Total 1 packages affected by 4 vulnerabilities (0 Critical, 0 High, 4 Medium, 0 Low, 0 Unknown) from 1 ecosystems, 4 have fixes available
+Total 1 packages affected by 4 vulnerabilities (0 Critical, 0 High, 4 Medium, 0 Low, 0 Unknown) from 1 ecosystems.
+4 vulnerabilities have fixes available
+
 Alpine:v3.19
 +----------------------------------------------------------+
 | Source:docker:../../internal/image/fixtures/test-node_mo |
@@ -2724,6 +2741,7 @@ Alpine:v3.19
 +---------+-------------------+---------------+------------+
 | busybox | 1.36.1-r15        | Fix Available |          4 |
 +---------+-------------------+---------------+------------+
+
 For the most comprehensive scan results, we recommend using the HTML output: `osv-scanner --format html --output results.html`.
 You can also view the full vulnerability list in your terminal with: `osv-scanner --format vertical`
 
@@ -2735,7 +2753,9 @@ You can also view the full vulnerability list in your terminal with: `osv-scanne
 
 [TestRun_OCIImage/scanning_node_modules_using_yarn_with_some_packages - 1]
 Scanning image ../../internal/image/fixtures/test-node_modules-yarn-full.tar
-Total 1 packages affected by 4 vulnerabilities (0 Critical, 0 High, 4 Medium, 0 Low, 0 Unknown) from 1 ecosystems, 4 have fixes available
+Total 1 packages affected by 4 vulnerabilities (0 Critical, 0 High, 4 Medium, 0 Low, 0 Unknown) from 1 ecosystems.
+4 vulnerabilities have fixes available
+
 Alpine:v3.19
 +----------------------------------------------------------+
 | Source:docker:../../internal/image/fixtures/test-node_mo |
@@ -2745,6 +2765,7 @@ Alpine:v3.19
 +---------+-------------------+---------------+------------+
 | busybox | 1.36.1-r15        | Fix Available |          4 |
 +---------+-------------------+---------------+------------+
+
 For the most comprehensive scan results, we recommend using the HTML output: `osv-scanner --format html --output results.html`.
 You can also view the full vulnerability list in your terminal with: `osv-scanner --format vertical`
 

--- a/cmd/osv-scanner/__snapshots__/main_test.snap
+++ b/cmd/osv-scanner/__snapshots__/main_test.snap
@@ -2590,7 +2590,7 @@ Scanned <rootdir>/fixtures/maven-transitive/pom.xml file and found 3 packages
 [TestRun_OCIImage/Alpine_3.10_image_tar_with_3.18_version_file - 1]
 Scanning image ../../internal/image/fixtures/test-alpine.tar
 Total 1 packages affected by 2 vulnerabilities (1 Critical, 1 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystems.
-2 vulnerabilities have fixes available
+2 vulnerabilities have fixes available.
 
 Alpine:v3.18
 +----------------------------------------------------------+
@@ -2603,7 +2603,7 @@ Alpine:v3.18
 +---------+-------------------+---------------+------------+
 
 For the most comprehensive scan results, we recommend using the HTML output: `osv-scanner --format html --output results.html`.
-You can also view the full vulnerability list in your terminal with: `osv-scanner --format vertical`
+You can also view the full vulnerability list in your terminal with: `osv-scanner --format vertical`.
 
 ---
 
@@ -2624,7 +2624,7 @@ failed to load image ./fixtures/oci-image/no-file-here.tar: open ./fixtures/oci-
 [TestRun_OCIImage/scanning_node_modules_using_npm_with_no_packages - 1]
 Scanning image ../../internal/image/fixtures/test-node_modules-npm-empty.tar
 Total 1 packages affected by 4 vulnerabilities (0 Critical, 0 High, 4 Medium, 0 Low, 0 Unknown) from 1 ecosystems.
-4 vulnerabilities have fixes available
+4 vulnerabilities have fixes available.
 
 Alpine:v3.19
 +----------------------------------------------------------+
@@ -2637,7 +2637,7 @@ Alpine:v3.19
 +---------+-------------------+---------------+------------+
 
 For the most comprehensive scan results, we recommend using the HTML output: `osv-scanner --format html --output results.html`.
-You can also view the full vulnerability list in your terminal with: `osv-scanner --format vertical`
+You can also view the full vulnerability list in your terminal with: `osv-scanner --format vertical`.
 
 ---
 
@@ -2648,7 +2648,7 @@ You can also view the full vulnerability list in your terminal with: `osv-scanne
 [TestRun_OCIImage/scanning_node_modules_using_npm_with_some_packages - 1]
 Scanning image ../../internal/image/fixtures/test-node_modules-npm-full.tar
 Total 3 packages affected by 6 vulnerabilities (2 Critical, 0 High, 4 Medium, 0 Low, 0 Unknown) from 2 ecosystems.
-5 vulnerabilities have fixes available
+5 vulnerabilities have fixes available.
 
 npm
 +--------------------------------------------------------------+
@@ -2671,7 +2671,7 @@ Alpine:v3.19
 +---------+-------------------+---------------+------------+
 
 For the most comprehensive scan results, we recommend using the HTML output: `osv-scanner --format html --output results.html`.
-You can also view the full vulnerability list in your terminal with: `osv-scanner --format vertical`
+You can also view the full vulnerability list in your terminal with: `osv-scanner --format vertical`.
 
 ---
 
@@ -2682,7 +2682,7 @@ You can also view the full vulnerability list in your terminal with: `osv-scanne
 [TestRun_OCIImage/scanning_node_modules_using_pnpm_with_no_packages - 1]
 Scanning image ../../internal/image/fixtures/test-node_modules-pnpm-empty.tar
 Total 1 packages affected by 4 vulnerabilities (0 Critical, 0 High, 4 Medium, 0 Low, 0 Unknown) from 1 ecosystems.
-4 vulnerabilities have fixes available
+4 vulnerabilities have fixes available.
 
 Alpine:v3.19
 +----------------------------------------------------------+
@@ -2695,7 +2695,7 @@ Alpine:v3.19
 +---------+-------------------+---------------+------------+
 
 For the most comprehensive scan results, we recommend using the HTML output: `osv-scanner --format html --output results.html`.
-You can also view the full vulnerability list in your terminal with: `osv-scanner --format vertical`
+You can also view the full vulnerability list in your terminal with: `osv-scanner --format vertical`.
 
 ---
 
@@ -2706,7 +2706,7 @@ You can also view the full vulnerability list in your terminal with: `osv-scanne
 [TestRun_OCIImage/scanning_node_modules_using_pnpm_with_some_packages - 1]
 Scanning image ../../internal/image/fixtures/test-node_modules-pnpm-full.tar
 Total 1 packages affected by 4 vulnerabilities (0 Critical, 0 High, 4 Medium, 0 Low, 0 Unknown) from 1 ecosystems.
-4 vulnerabilities have fixes available
+4 vulnerabilities have fixes available.
 
 Alpine:v3.19
 +----------------------------------------------------------+
@@ -2719,7 +2719,7 @@ Alpine:v3.19
 +---------+-------------------+---------------+------------+
 
 For the most comprehensive scan results, we recommend using the HTML output: `osv-scanner --format html --output results.html`.
-You can also view the full vulnerability list in your terminal with: `osv-scanner --format vertical`
+You can also view the full vulnerability list in your terminal with: `osv-scanner --format vertical`.
 
 ---
 
@@ -2730,7 +2730,7 @@ You can also view the full vulnerability list in your terminal with: `osv-scanne
 [TestRun_OCIImage/scanning_node_modules_using_yarn_with_no_packages - 1]
 Scanning image ../../internal/image/fixtures/test-node_modules-yarn-empty.tar
 Total 1 packages affected by 4 vulnerabilities (0 Critical, 0 High, 4 Medium, 0 Low, 0 Unknown) from 1 ecosystems.
-4 vulnerabilities have fixes available
+4 vulnerabilities have fixes available.
 
 Alpine:v3.19
 +----------------------------------------------------------+
@@ -2743,7 +2743,7 @@ Alpine:v3.19
 +---------+-------------------+---------------+------------+
 
 For the most comprehensive scan results, we recommend using the HTML output: `osv-scanner --format html --output results.html`.
-You can also view the full vulnerability list in your terminal with: `osv-scanner --format vertical`
+You can also view the full vulnerability list in your terminal with: `osv-scanner --format vertical`.
 
 ---
 
@@ -2754,7 +2754,7 @@ You can also view the full vulnerability list in your terminal with: `osv-scanne
 [TestRun_OCIImage/scanning_node_modules_using_yarn_with_some_packages - 1]
 Scanning image ../../internal/image/fixtures/test-node_modules-yarn-full.tar
 Total 1 packages affected by 4 vulnerabilities (0 Critical, 0 High, 4 Medium, 0 Low, 0 Unknown) from 1 ecosystems.
-4 vulnerabilities have fixes available
+4 vulnerabilities have fixes available.
 
 Alpine:v3.19
 +----------------------------------------------------------+
@@ -2767,7 +2767,7 @@ Alpine:v3.19
 +---------+-------------------+---------------+------------+
 
 For the most comprehensive scan results, we recommend using the HTML output: `osv-scanner --format html --output results.html`.
-You can also view the full vulnerability list in your terminal with: `osv-scanner --format vertical`
+You can also view the full vulnerability list in your terminal with: `osv-scanner --format vertical`.
 
 ---
 

--- a/cmd/osv-scanner/__snapshots__/main_test.snap
+++ b/cmd/osv-scanner/__snapshots__/main_test.snap
@@ -2589,12 +2589,18 @@ Scanned <rootdir>/fixtures/maven-transitive/pom.xml file and found 3 packages
 
 [TestRun_OCIImage/Alpine_3.10_image_tar_with_3.18_version_file - 1]
 Scanning image ../../internal/image/fixtures/test-alpine.tar
-+--------------------------------+------+--------------+---------+-----------+---------------------------------------------------------------------+
-| OSV URL                        | CVSS | ECOSYSTEM    | PACKAGE | VERSION   | SOURCE                                                              |
-+--------------------------------+------+--------------+---------+-----------+---------------------------------------------------------------------+
-| https://osv.dev/CVE-2018-25032 | 7.5  | Alpine:v3.18 | zlib    | 1.2.11-r1 | ../../internal/image/fixtures/test-alpine.tar:/lib/apk/db/installed |
-| https://osv.dev/CVE-2022-37434 | 9.8  | Alpine:v3.18 | zlib    | 1.2.11-r1 | ../../internal/image/fixtures/test-alpine.tar:/lib/apk/db/installed |
-+--------------------------------+------+--------------+---------+-----------+---------------------------------------------------------------------+
+Total 1 packages affected by 2 vulnerabilities (1 Critical, 1 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystems, 2 have fixes available
+Alpine:v3.18
++----------------------------------------------------------+
+| Source:docker:../../internal/image/fixtures/test-alpine. |
+| tar:/lib/apk/db/installed                                |
++---------+-------------------+---------------+------------+
+| PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT |
++---------+-------------------+---------------+------------+
+| zlib    | 1.2.11-r1         | Fix Available |          2 |
++---------+-------------------+---------------+------------+
+For the most comprehensive scan results, we recommend using the HTML output: `osv-scanner --format html --output results.html`.
+You can also view the full vulnerability list in your terminal with: `osv-scanner --format vertical`
 
 ---
 
@@ -2614,14 +2620,18 @@ failed to load image ./fixtures/oci-image/no-file-here.tar: open ./fixtures/oci-
 
 [TestRun_OCIImage/scanning_node_modules_using_npm_with_no_packages - 1]
 Scanning image ../../internal/image/fixtures/test-node_modules-npm-empty.tar
-+--------------------------------+------+--------------+---------+------------+-------------------------------------------------------------------------------------+
-| OSV URL                        | CVSS | ECOSYSTEM    | PACKAGE | VERSION    | SOURCE                                                                              |
-+--------------------------------+------+--------------+---------+------------+-------------------------------------------------------------------------------------+
-| https://osv.dev/CVE-2023-42363 | 5.5  | Alpine:v3.19 | busybox | 1.36.1-r15 | ../../internal/image/fixtures/test-node_modules-npm-empty.tar:/lib/apk/db/installed |
-| https://osv.dev/CVE-2023-42364 | 5.5  | Alpine:v3.19 | busybox | 1.36.1-r15 | ../../internal/image/fixtures/test-node_modules-npm-empty.tar:/lib/apk/db/installed |
-| https://osv.dev/CVE-2023-42365 | 5.5  | Alpine:v3.19 | busybox | 1.36.1-r15 | ../../internal/image/fixtures/test-node_modules-npm-empty.tar:/lib/apk/db/installed |
-| https://osv.dev/CVE-2023-42366 | 5.5  | Alpine:v3.19 | busybox | 1.36.1-r15 | ../../internal/image/fixtures/test-node_modules-npm-empty.tar:/lib/apk/db/installed |
-+--------------------------------+------+--------------+---------+------------+-------------------------------------------------------------------------------------+
+Total 1 packages affected by 4 vulnerabilities (0 Critical, 0 High, 4 Medium, 0 Low, 0 Unknown) from 1 ecosystems, 4 have fixes available
+Alpine:v3.19
++----------------------------------------------------------+
+| Source:docker:../../internal/image/fixtures/test-node_mo |
+| dules-npm-empty.tar:/lib/apk/db/installed                |
++---------+-------------------+---------------+------------+
+| PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT |
++---------+-------------------+---------------+------------+
+| busybox | 1.36.1-r15        | Fix Available |          4 |
++---------+-------------------+---------------+------------+
+For the most comprehensive scan results, we recommend using the HTML output: `osv-scanner --format html --output results.html`.
+You can also view the full vulnerability list in your terminal with: `osv-scanner --format vertical`
 
 ---
 
@@ -2631,17 +2641,28 @@ Scanning image ../../internal/image/fixtures/test-node_modules-npm-empty.tar
 
 [TestRun_OCIImage/scanning_node_modules_using_npm_with_some_packages - 1]
 Scanning image ../../internal/image/fixtures/test-node_modules-npm-full.tar
-+-------------------------------------+------+--------------+----------+------------+-------------------------------------------------------------------------------------------------------+
-| OSV URL                             | CVSS | ECOSYSTEM    | PACKAGE  | VERSION    | SOURCE                                                                                                |
-+-------------------------------------+------+--------------+----------+------------+-------------------------------------------------------------------------------------------------------+
-| https://osv.dev/CVE-2023-42363      | 5.5  | Alpine:v3.19 | busybox  | 1.36.1-r15 | ../../internal/image/fixtures/test-node_modules-npm-full.tar:/lib/apk/db/installed                    |
-| https://osv.dev/CVE-2023-42364      | 5.5  | Alpine:v3.19 | busybox  | 1.36.1-r15 | ../../internal/image/fixtures/test-node_modules-npm-full.tar:/lib/apk/db/installed                    |
-| https://osv.dev/CVE-2023-42365      | 5.5  | Alpine:v3.19 | busybox  | 1.36.1-r15 | ../../internal/image/fixtures/test-node_modules-npm-full.tar:/lib/apk/db/installed                    |
-| https://osv.dev/CVE-2023-42366      | 5.5  | Alpine:v3.19 | busybox  | 1.36.1-r15 | ../../internal/image/fixtures/test-node_modules-npm-full.tar:/lib/apk/db/installed                    |
-| https://osv.dev/GHSA-38f5-ghc2-fcmv | 9.8  | npm          | cryo     | 0.0.6      | ../../internal/image/fixtures/test-node_modules-npm-full.tar:/usr/app/node_modules/.package-lock.json |
-| https://osv.dev/GHSA-vh95-rmgr-6w4m | 9.8  | npm          | minimist | 0.0.8      | ../../internal/image/fixtures/test-node_modules-npm-full.tar:/usr/app/node_modules/.package-lock.json |
-| https://osv.dev/GHSA-xvch-5gv4-984h |      |              |          |            |                                                                                                       |
-+-------------------------------------+------+--------------+----------+------------+-------------------------------------------------------------------------------------------------------+
+Total 3 packages affected by 6 vulnerabilities (2 Critical, 0 High, 4 Medium, 0 Low, 0 Unknown) from 2 ecosystems, 5 have fixes available
+npm
++--------------------------------------------------------------+
+| Source:docker:../../internal/image/fixtures/test-node_module |
+| s-npm-full.tar:/usr/app/node_modules/.package-lock.json      |
++----------+-------------------+------------------+------------+
+| PACKAGE  | INSTALLED VERSION | FIX AVAILABLE    | VULN COUNT |
++----------+-------------------+------------------+------------+
+| cryo     | 0.0.6             | No fix available |          1 |
+| minimist | 0.0.8             | Fix Available    |          1 |
++----------+-------------------+------------------+------------+
+Alpine:v3.19
++----------------------------------------------------------+
+| Source:docker:../../internal/image/fixtures/test-node_mo |
+| dules-npm-full.tar:/lib/apk/db/installed                 |
++---------+-------------------+---------------+------------+
+| PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT |
++---------+-------------------+---------------+------------+
+| busybox | 1.36.1-r15        | Fix Available |          4 |
++---------+-------------------+---------------+------------+
+For the most comprehensive scan results, we recommend using the HTML output: `osv-scanner --format html --output results.html`.
+You can also view the full vulnerability list in your terminal with: `osv-scanner --format vertical`
 
 ---
 
@@ -2651,14 +2672,18 @@ Scanning image ../../internal/image/fixtures/test-node_modules-npm-full.tar
 
 [TestRun_OCIImage/scanning_node_modules_using_pnpm_with_no_packages - 1]
 Scanning image ../../internal/image/fixtures/test-node_modules-pnpm-empty.tar
-+--------------------------------+------+--------------+---------+------------+--------------------------------------------------------------------------------------+
-| OSV URL                        | CVSS | ECOSYSTEM    | PACKAGE | VERSION    | SOURCE                                                                               |
-+--------------------------------+------+--------------+---------+------------+--------------------------------------------------------------------------------------+
-| https://osv.dev/CVE-2023-42363 | 5.5  | Alpine:v3.19 | busybox | 1.36.1-r15 | ../../internal/image/fixtures/test-node_modules-pnpm-empty.tar:/lib/apk/db/installed |
-| https://osv.dev/CVE-2023-42364 | 5.5  | Alpine:v3.19 | busybox | 1.36.1-r15 | ../../internal/image/fixtures/test-node_modules-pnpm-empty.tar:/lib/apk/db/installed |
-| https://osv.dev/CVE-2023-42365 | 5.5  | Alpine:v3.19 | busybox | 1.36.1-r15 | ../../internal/image/fixtures/test-node_modules-pnpm-empty.tar:/lib/apk/db/installed |
-| https://osv.dev/CVE-2023-42366 | 5.5  | Alpine:v3.19 | busybox | 1.36.1-r15 | ../../internal/image/fixtures/test-node_modules-pnpm-empty.tar:/lib/apk/db/installed |
-+--------------------------------+------+--------------+---------+------------+--------------------------------------------------------------------------------------+
+Total 1 packages affected by 4 vulnerabilities (0 Critical, 0 High, 4 Medium, 0 Low, 0 Unknown) from 1 ecosystems, 4 have fixes available
+Alpine:v3.19
++----------------------------------------------------------+
+| Source:docker:../../internal/image/fixtures/test-node_mo |
+| dules-pnpm-empty.tar:/lib/apk/db/installed               |
++---------+-------------------+---------------+------------+
+| PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT |
++---------+-------------------+---------------+------------+
+| busybox | 1.36.1-r15        | Fix Available |          4 |
++---------+-------------------+---------------+------------+
+For the most comprehensive scan results, we recommend using the HTML output: `osv-scanner --format html --output results.html`.
+You can also view the full vulnerability list in your terminal with: `osv-scanner --format vertical`
 
 ---
 
@@ -2668,14 +2693,18 @@ Scanning image ../../internal/image/fixtures/test-node_modules-pnpm-empty.tar
 
 [TestRun_OCIImage/scanning_node_modules_using_pnpm_with_some_packages - 1]
 Scanning image ../../internal/image/fixtures/test-node_modules-pnpm-full.tar
-+--------------------------------+------+--------------+---------+------------+-------------------------------------------------------------------------------------+
-| OSV URL                        | CVSS | ECOSYSTEM    | PACKAGE | VERSION    | SOURCE                                                                              |
-+--------------------------------+------+--------------+---------+------------+-------------------------------------------------------------------------------------+
-| https://osv.dev/CVE-2023-42363 | 5.5  | Alpine:v3.19 | busybox | 1.36.1-r15 | ../../internal/image/fixtures/test-node_modules-pnpm-full.tar:/lib/apk/db/installed |
-| https://osv.dev/CVE-2023-42364 | 5.5  | Alpine:v3.19 | busybox | 1.36.1-r15 | ../../internal/image/fixtures/test-node_modules-pnpm-full.tar:/lib/apk/db/installed |
-| https://osv.dev/CVE-2023-42365 | 5.5  | Alpine:v3.19 | busybox | 1.36.1-r15 | ../../internal/image/fixtures/test-node_modules-pnpm-full.tar:/lib/apk/db/installed |
-| https://osv.dev/CVE-2023-42366 | 5.5  | Alpine:v3.19 | busybox | 1.36.1-r15 | ../../internal/image/fixtures/test-node_modules-pnpm-full.tar:/lib/apk/db/installed |
-+--------------------------------+------+--------------+---------+------------+-------------------------------------------------------------------------------------+
+Total 1 packages affected by 4 vulnerabilities (0 Critical, 0 High, 4 Medium, 0 Low, 0 Unknown) from 1 ecosystems, 4 have fixes available
+Alpine:v3.19
++----------------------------------------------------------+
+| Source:docker:../../internal/image/fixtures/test-node_mo |
+| dules-pnpm-full.tar:/lib/apk/db/installed                |
++---------+-------------------+---------------+------------+
+| PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT |
++---------+-------------------+---------------+------------+
+| busybox | 1.36.1-r15        | Fix Available |          4 |
++---------+-------------------+---------------+------------+
+For the most comprehensive scan results, we recommend using the HTML output: `osv-scanner --format html --output results.html`.
+You can also view the full vulnerability list in your terminal with: `osv-scanner --format vertical`
 
 ---
 
@@ -2685,14 +2714,18 @@ Scanning image ../../internal/image/fixtures/test-node_modules-pnpm-full.tar
 
 [TestRun_OCIImage/scanning_node_modules_using_yarn_with_no_packages - 1]
 Scanning image ../../internal/image/fixtures/test-node_modules-yarn-empty.tar
-+--------------------------------+------+--------------+---------+------------+--------------------------------------------------------------------------------------+
-| OSV URL                        | CVSS | ECOSYSTEM    | PACKAGE | VERSION    | SOURCE                                                                               |
-+--------------------------------+------+--------------+---------+------------+--------------------------------------------------------------------------------------+
-| https://osv.dev/CVE-2023-42363 | 5.5  | Alpine:v3.19 | busybox | 1.36.1-r15 | ../../internal/image/fixtures/test-node_modules-yarn-empty.tar:/lib/apk/db/installed |
-| https://osv.dev/CVE-2023-42364 | 5.5  | Alpine:v3.19 | busybox | 1.36.1-r15 | ../../internal/image/fixtures/test-node_modules-yarn-empty.tar:/lib/apk/db/installed |
-| https://osv.dev/CVE-2023-42365 | 5.5  | Alpine:v3.19 | busybox | 1.36.1-r15 | ../../internal/image/fixtures/test-node_modules-yarn-empty.tar:/lib/apk/db/installed |
-| https://osv.dev/CVE-2023-42366 | 5.5  | Alpine:v3.19 | busybox | 1.36.1-r15 | ../../internal/image/fixtures/test-node_modules-yarn-empty.tar:/lib/apk/db/installed |
-+--------------------------------+------+--------------+---------+------------+--------------------------------------------------------------------------------------+
+Total 1 packages affected by 4 vulnerabilities (0 Critical, 0 High, 4 Medium, 0 Low, 0 Unknown) from 1 ecosystems, 4 have fixes available
+Alpine:v3.19
++----------------------------------------------------------+
+| Source:docker:../../internal/image/fixtures/test-node_mo |
+| dules-yarn-empty.tar:/lib/apk/db/installed               |
++---------+-------------------+---------------+------------+
+| PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT |
++---------+-------------------+---------------+------------+
+| busybox | 1.36.1-r15        | Fix Available |          4 |
++---------+-------------------+---------------+------------+
+For the most comprehensive scan results, we recommend using the HTML output: `osv-scanner --format html --output results.html`.
+You can also view the full vulnerability list in your terminal with: `osv-scanner --format vertical`
 
 ---
 
@@ -2702,14 +2735,18 @@ Scanning image ../../internal/image/fixtures/test-node_modules-yarn-empty.tar
 
 [TestRun_OCIImage/scanning_node_modules_using_yarn_with_some_packages - 1]
 Scanning image ../../internal/image/fixtures/test-node_modules-yarn-full.tar
-+--------------------------------+------+--------------+---------+------------+-------------------------------------------------------------------------------------+
-| OSV URL                        | CVSS | ECOSYSTEM    | PACKAGE | VERSION    | SOURCE                                                                              |
-+--------------------------------+------+--------------+---------+------------+-------------------------------------------------------------------------------------+
-| https://osv.dev/CVE-2023-42363 | 5.5  | Alpine:v3.19 | busybox | 1.36.1-r15 | ../../internal/image/fixtures/test-node_modules-yarn-full.tar:/lib/apk/db/installed |
-| https://osv.dev/CVE-2023-42364 | 5.5  | Alpine:v3.19 | busybox | 1.36.1-r15 | ../../internal/image/fixtures/test-node_modules-yarn-full.tar:/lib/apk/db/installed |
-| https://osv.dev/CVE-2023-42365 | 5.5  | Alpine:v3.19 | busybox | 1.36.1-r15 | ../../internal/image/fixtures/test-node_modules-yarn-full.tar:/lib/apk/db/installed |
-| https://osv.dev/CVE-2023-42366 | 5.5  | Alpine:v3.19 | busybox | 1.36.1-r15 | ../../internal/image/fixtures/test-node_modules-yarn-full.tar:/lib/apk/db/installed |
-+--------------------------------+------+--------------+---------+------------+-------------------------------------------------------------------------------------+
+Total 1 packages affected by 4 vulnerabilities (0 Critical, 0 High, 4 Medium, 0 Low, 0 Unknown) from 1 ecosystems, 4 have fixes available
+Alpine:v3.19
++----------------------------------------------------------+
+| Source:docker:../../internal/image/fixtures/test-node_mo |
+| dules-yarn-full.tar:/lib/apk/db/installed                |
++---------+-------------------+---------------+------------+
+| PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT |
++---------+-------------------+---------------+------------+
+| busybox | 1.36.1-r15        | Fix Available |          4 |
++---------+-------------------+---------------+------------+
+For the most comprehensive scan results, we recommend using the HTML output: `osv-scanner --format html --output results.html`.
+You can also view the full vulnerability list in your terminal with: `osv-scanner --format vertical`
 
 ---
 

--- a/internal/output/__snapshots__/output_result_test.snap
+++ b/internal/output/__snapshots__/output_result_test.snap
@@ -256,9 +256,13 @@
   "IsContainerScanning": false,
   "AllLayers": [],
   "VulnTypeCount": {
-    "All": 4,
+    "All": 6,
     "OS": 0,
-    "Project": 4,
+    "Project": 6,
+    "Uncalled": 0
+  },
+  "PackageTypeCount": {
+    "Called": 4,
     "Uncalled": 0
   },
   "VulnCount": {
@@ -539,9 +543,13 @@
   "IsContainerScanning": false,
   "AllLayers": [],
   "VulnTypeCount": {
-    "All": 4,
+    "All": 6,
     "OS": 0,
-    "Project": 4,
+    "Project": 6,
+    "Uncalled": 0
+  },
+  "PackageTypeCount": {
+    "Called": 4,
     "Uncalled": 0
   },
   "VulnCount": {
@@ -812,6 +820,10 @@
     "All": 0,
     "OS": 0,
     "Project": 0,
+    "Uncalled": 0
+  },
+  "PackageTypeCount": {
+    "Called": 0,
     "Uncalled": 0
   },
   "VulnCount": {
@@ -1120,6 +1132,10 @@
     "Project": 3,
     "Uncalled": 0
   },
+  "PackageTypeCount": {
+    "Called": 3,
+    "Uncalled": 0
+  },
   "VulnCount": {
     "CallAnalysisCount": {
       "Called": 3,
@@ -1404,9 +1420,13 @@
   "IsContainerScanning": false,
   "AllLayers": [],
   "VulnTypeCount": {
-    "All": 4,
+    "All": 6,
     "OS": 0,
-    "Project": 4,
+    "Project": 6,
+    "Uncalled": 0
+  },
+  "PackageTypeCount": {
+    "Called": 4,
     "Uncalled": 0
   },
   "VulnCount": {
@@ -1694,9 +1714,13 @@
   "IsContainerScanning": false,
   "AllLayers": [],
   "VulnTypeCount": {
-    "All": 4,
+    "All": 5,
     "OS": 0,
-    "Project": 4,
+    "Project": 5,
+    "Uncalled": 1
+  },
+  "PackageTypeCount": {
+    "Called": 4,
     "Uncalled": 1
   },
   "VulnCount": {
@@ -1816,6 +1840,10 @@
     "Project": 0,
     "Uncalled": 0
   },
+  "PackageTypeCount": {
+    "Called": 0,
+    "Uncalled": 0
+  },
   "VulnCount": {
     "CallAnalysisCount": {
       "Called": 0,
@@ -1846,6 +1874,10 @@
     "All": 0,
     "OS": 0,
     "Project": 0,
+    "Uncalled": 0
+  },
+  "PackageTypeCount": {
+    "Called": 0,
     "Uncalled": 0
   },
   "VulnCount": {
@@ -1911,6 +1943,10 @@
     "All": 0,
     "OS": 0,
     "Project": 0,
+    "Uncalled": 0
+  },
+  "PackageTypeCount": {
+    "Called": 0,
     "Uncalled": 0
   },
   "VulnCount": {
@@ -2007,6 +2043,10 @@
     "All": 0,
     "OS": 0,
     "Project": 0,
+    "Uncalled": 0
+  },
+  "PackageTypeCount": {
+    "Called": 0,
     "Uncalled": 0
   },
   "VulnCount": {
@@ -2129,6 +2169,10 @@
     "Project": 1,
     "Uncalled": 1
   },
+  "PackageTypeCount": {
+    "Called": 1,
+    "Uncalled": 1
+  },
   "VulnCount": {
     "CallAnalysisCount": {
       "Called": 1,
@@ -2235,6 +2279,10 @@
     "All": 1,
     "OS": 0,
     "Project": 1,
+    "Uncalled": 0
+  },
+  "PackageTypeCount": {
+    "Called": 1,
     "Uncalled": 0
   },
   "VulnCount": {
@@ -2345,6 +2393,10 @@
     "Project": 0,
     "Uncalled": 1
   },
+  "PackageTypeCount": {
+    "Called": 0,
+    "Uncalled": 1
+  },
   "VulnCount": {
     "CallAnalysisCount": {
       "Called": 0,
@@ -2453,6 +2505,10 @@
     "Project": 1,
     "Uncalled": 0
   },
+  "PackageTypeCount": {
+    "Called": 1,
+    "Uncalled": 0
+  },
   "VulnCount": {
     "CallAnalysisCount": {
       "Called": 1,
@@ -2559,6 +2615,10 @@
     "All": 1,
     "OS": 0,
     "Project": 1,
+    "Uncalled": 0
+  },
+  "PackageTypeCount": {
+    "Called": 1,
     "Uncalled": 0
   },
   "VulnCount": {
@@ -2673,6 +2733,10 @@
     "Project": 0,
     "Uncalled": 1
   },
+  "PackageTypeCount": {
+    "Called": 0,
+    "Uncalled": 1
+  },
   "VulnCount": {
     "CallAnalysisCount": {
       "Called": 0,
@@ -2783,6 +2847,10 @@
     "All": 1,
     "OS": 0,
     "Project": 1,
+    "Uncalled": 0
+  },
+  "PackageTypeCount": {
+    "Called": 1,
     "Uncalled": 0
   },
   "VulnCount": {
@@ -2933,6 +3001,10 @@
     "All": 2,
     "OS": 0,
     "Project": 2,
+    "Uncalled": 0
+  },
+  "PackageTypeCount": {
+    "Called": 2,
     "Uncalled": 0
   },
   "VulnCount": {
@@ -3098,6 +3170,10 @@
     "All": 1,
     "OS": 0,
     "Project": 1,
+    "Uncalled": 0
+  },
+  "PackageTypeCount": {
+    "Called": 1,
     "Uncalled": 0
   },
   "VulnCount": {
@@ -3275,6 +3351,10 @@
     "All": 2,
     "OS": 0,
     "Project": 2,
+    "Uncalled": 0
+  },
+  "PackageTypeCount": {
+    "Called": 2,
     "Uncalled": 0
   },
   "VulnCount": {

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -133,7 +133,7 @@ func printContainerScanningResult(result Result, outputWriter io.Writer, termina
 	}
 
 	const promptMessage = "For the most comprehensive scan results, we recommend using the HTML output: " +
-		"`osv-scanner --format html --output results.html`. \n" +
+		"`osv-scanner --format html --output results.html`.\n" +
 		"You can also view the full vulnerability list in your terminal with: " +
 		"`osv-scanner --format vertical`"
 	fmt.Fprintln(outputWriter, promptMessage)

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -92,7 +92,8 @@ func tableBuilder(outputTable table.Writer, vulnResult *models.VulnerabilityResu
 
 func printContainerScanningResult(result Result, outputWriter io.Writer, terminalWidth int) {
 	summary := fmt.Sprintf(
-		"Total %[1]d packages affected by %[2]d vulnerabilities (%[3]d Critical, %[4]d High, %[5]d Medium, %[6]d Low, %[7]d Unknown) from %[8]d ecosystems, %[9]d have fixes available",
+		"Total %[1]d packages affected by %[2]d vulnerabilities (%[3]d Critical, %[4]d High, %[5]d Medium, %[6]d Low, %[7]d Unknown) from %[8]d ecosystems.\n"+
+			"%[9]d vulnerabilities have fixes available",
 		result.PackageTypeCount.Called,
 		result.VulnTypeCount.All,
 		result.VulnCount.SeverityCount.Critical,
@@ -104,6 +105,8 @@ func printContainerScanningResult(result Result, outputWriter io.Writer, termina
 		result.VulnCount.FixableCount.Fixed,
 	)
 	fmt.Fprintln(outputWriter, summary)
+	// Add a newline
+	fmt.Fprintln(outputWriter)
 
 	for _, ecosystem := range result.Ecosystems {
 		fmt.Fprintln(outputWriter, ecosystem.Name)
@@ -131,6 +134,8 @@ func printContainerScanningResult(result Result, outputWriter io.Writer, termina
 			outputTable.Render()
 		}
 	}
+	// Add a newline
+	fmt.Fprintln(outputWriter)
 
 	const promptMessage = "For the most comprehensive scan results, we recommend using the HTML output: " +
 		"`osv-scanner --format html --output results.html`.\n" +

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -28,11 +28,17 @@ func PrintTableResults(vulnResult *models.VulnerabilityResults, outputWriter io.
 		text.DisableColors()
 	}
 
+	outputResult := BuildResults(vulnResult)
+
 	// Render the vulnerabilities.
-	outputTable := newTable(outputWriter, terminalWidth)
-	outputTable = tableBuilder(outputTable, vulnResult)
-	if outputTable.Length() != 0 {
-		outputTable.Render()
+	if outputResult.IsContainerScanning {
+		printContainerScanningResult(outputResult, outputWriter, terminalWidth)
+	} else {
+		outputTable := newTable(outputWriter, terminalWidth)
+		outputTable = tableBuilder(outputTable, vulnResult)
+		if outputTable.Length() != 0 {
+			outputTable.Render()
+		}
 	}
 
 	// Render the licenses if any.
@@ -82,6 +88,55 @@ func tableBuilder(outputTable table.Writer, vulnResult *models.VulnerabilityResu
 	}
 
 	return outputTable
+}
+
+func printContainerScanningResult(result Result, outputWriter io.Writer, terminalWidth int) {
+	summary := fmt.Sprintf(
+		"Total %[1]d packages affected by %[2]d vulnerabilities (%[3]d Critical, %[4]d High, %[5]d Medium, %[6]d Low, %[7]d Unknown) from %[8]d ecosystems, %[9]d have fixes available",
+		result.PackageTypeCount.Called,
+		result.VulnTypeCount.All,
+		result.VulnCount.SeverityCount.Critical,
+		result.VulnCount.SeverityCount.High,
+		result.VulnCount.SeverityCount.Medium,
+		result.VulnCount.SeverityCount.Low,
+		result.VulnCount.SeverityCount.Unknown,
+		len(result.Ecosystems),
+		result.VulnCount.FixableCount.Fixed,
+	)
+	fmt.Fprintln(outputWriter, summary)
+
+	for _, ecosystem := range result.Ecosystems {
+		fmt.Fprintln(outputWriter, ecosystem.Name)
+
+		for _, source := range ecosystem.Sources {
+			outputTable := newTable(outputWriter, terminalWidth)
+			outputTable.SetTitle("Source:" + source.Name)
+			outputTable.AppendHeader(table.Row{"Package", "Installed Version", "Fix available", "Vuln count"})
+			for _, pkg := range source.Packages {
+				outputRow := table.Row{}
+				totalCount := pkg.VulnCount.CallAnalysisCount.Called
+				var fixAvailable string
+				if pkg.FixedVersion == UnfixedDescription {
+					fixAvailable = UnfixedDescription
+				} else {
+					if pkg.VulnCount.FixableCount.UnFixed > 0 {
+						fixAvailable = "Partial fixes Available"
+					} else {
+						fixAvailable = "Fix Available"
+					}
+				}
+				outputRow = append(outputRow, pkg.Name, pkg.InstalledVersion, fixAvailable, totalCount)
+				outputTable.AppendRow(outputRow)
+			}
+			outputTable.Render()
+		}
+	}
+
+	const promptMessage = "For the most comprehensive scan results, we recommend using the HTML output: " +
+		"`osv-scanner --format html --output results.html`. \n" +
+		"You can also view the full vulnerability list in your terminal with: " +
+		"`osv-scanner --format vertical`"
+	fmt.Fprintln(outputWriter, promptMessage)
 }
 
 type tbInnerResponse struct {

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -93,7 +93,7 @@ func tableBuilder(outputTable table.Writer, vulnResult *models.VulnerabilityResu
 func printContainerScanningResult(result Result, outputWriter io.Writer, terminalWidth int) {
 	summary := fmt.Sprintf(
 		"Total %[1]d packages affected by %[2]d vulnerabilities (%[3]d Critical, %[4]d High, %[5]d Medium, %[6]d Low, %[7]d Unknown) from %[8]d ecosystems.\n"+
-			"%[9]d vulnerabilities have fixes available",
+			"%[9]d vulnerabilities have fixes available.",
 		result.PackageTypeCount.Called,
 		result.VulnTypeCount.All,
 		result.VulnCount.SeverityCount.Critical,
@@ -140,7 +140,7 @@ func printContainerScanningResult(result Result, outputWriter io.Writer, termina
 	const promptMessage = "For the most comprehensive scan results, we recommend using the HTML output: " +
 		"`osv-scanner --format html --output results.html`.\n" +
 		"You can also view the full vulnerability list in your terminal with: " +
-		"`osv-scanner --format vertical`"
+		"`osv-scanner --format vertical`."
 	fmt.Fprintln(outputWriter, promptMessage)
 }
 


### PR DESCRIPTION
Fixes #1315

For container scanning, instead of listing hundreds of vulnerabilities, the output now shows the affected packages.

**Changes:**
- Added a summary listing the number of affected packages and vulnerabilities, including severity counts and the number of fixable vulnerabilities.
- Grouped results by ecosystem and source.
- Added a prompt message to inform users about the HTML and vertical output options.

**Future Plans (to be implemented after the comprehensive layer and base image information are available):**

- Add a layer info summary.
- Add base image information.

**Sample output:**
![Screenshot 2024-11-19 at 4 53 49 PM](https://github.com/user-attachments/assets/970c2beb-9d10-4803-a81a-9dc5b768fc5b)
![Screenshot 2024-11-19 at 4 53 58 PM](https://github.com/user-attachments/assets/627363bf-00cc-4a9e-9984-315dc2c9752a)
