### PR TITLE
fix: replace Debian package name with its source name

### DIFF
--- a/internal/image/scan.go
+++ b/internal/image/scan.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem/os/dpkg"
 	"github.com/google/osv-scanner/internal/lockfilescalibr"
 	"github.com/google/osv-scanner/pkg/lockfile"
 	"github.com/google/osv-scanner/pkg/models"
@@ -81,9 +82,24 @@ func ScanImage(r reporter.Reporter, imagePath string) (ScanResults, error) {
 			}
 		}
 
+		name := i.Name
+		version := i.Version
+
+		// Debian packages may have a different source name than their package name.
+		// OSV.dev matches vulnerabilities by source name.
+		// Convert the given package information to its source information if it is specified.
+		if metadata, ok := i.Metadata.(*dpkg.Metadata); ok {
+			if metadata.SourceName != "" {
+				name = metadata.SourceName
+			}
+			if metadata.SourceVersion != "" {
+				version = metadata.SourceVersion
+			}
+		}
+
 		pkg := lockfile.PackageDetails{
-			Name:      i.Name,
-			Version:   i.Version,
+			Name:      name,
+			Version:   version,
 			Ecosystem: lockfile.Ecosystem(i.Ecosystem()),
 			CompareAs: lockfile.Ecosystem(strings.Split(i.Ecosystem(), ":")[0]),
 		}


### PR DESCRIPTION
The current v2 container scanning doesn't report any Debian-related vulnerabilities. The reason is that the extractor takes the package name and package version to match against OSV records. But OSV records store records with the source name. Debian packages may have a different source name than their package name (also source version). For example: 
![image](https://github.com/user-attachments/assets/6c5cf9c9-7381-4f29-a887-5035b40c0efd)

The new change will convert the given package information to its corresponding source information for matching, if the source information is specified.