### PR TITLE
chore: update golangci-lint to version 1.62.2

### DIFF
--- a/.github/workflows/lint-action/action.yml
+++ b/.github/workflows/lint-action/action.yml
@@ -22,4 +22,4 @@ runs:
       uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
       with:
         # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-        version: v1.61.0
+        version: v1.62.2

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -13,7 +13,6 @@ linters:
     - lll              # line length is hard (g-rath)
     - godox            # to-do comments are fine (g-rath)
     - godot            # comments are fine without full stops (g-rath)
-    - gomnd            # not every number is magic (g-rath)
     - mnd              # not every number is magic (g-rath)
     - wsl              # disagree with, for now (g-rath)
     - ireturn          # disagree with, sort of (g-rath)

--- a/cmd/osv-scanner/fix/model.go
+++ b/cmd/osv-scanner/fix/model.go
@@ -19,6 +19,7 @@ import (
 	"golang.org/x/term"
 )
 
+//nolint:recvcheck
 type model struct {
 	//nolint:containedctx
 	ctx           context.Context         // Context, mostly used in deps.dev functions

--- a/pkg/models/results.go
+++ b/pkg/models/results.go
@@ -146,7 +146,7 @@ func (groupInfo *GroupInfo) IndexString() string {
 }
 
 // FixedVersions returns a map of fixed versions for each package, or a map of empty slices if no fixed versions are available
-func (v *Vulnerability) FixedVersions() map[Package][]string {
+func (v Vulnerability) FixedVersions() map[Package][]string {
 	output := map[Package][]string{}
 	for _, a := range v.Affected {
 		packageKey := a.Package

--- a/scripts/run_lints.sh
+++ b/scripts/run_lints.sh
@@ -2,4 +2,4 @@
 
 set -ex
 
-go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0 run ./... --max-same-issues 0
+go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.2 run ./... --max-same-issues 0


### PR DESCRIPTION
This PR updates `golangci-lint` to v1.62.2, and removes `gomnd` from the list of disabled linters since it is deprecated.