### PR TITLE
feat(performance): parallelize batch query sending

### DIFF
--- a/pkg/osv/osv.go
+++ b/pkg/osv/osv.go
@@ -239,8 +239,8 @@ func MakeRequestWithClient(request BatchedQuery, client *http.Client) (*BatchedR
 	}
 
 	var totalOsvResp BatchedResponse
-	for _, resutls := range totalOsvRespResults {
-		totalOsvResp.Results = append(totalOsvResp.Results, resutls...)
+	for _, results := range totalOsvRespResults {
+		totalOsvResp.Results = append(totalOsvResp.Results, results...)
 	}
 
 	return &totalOsvResp, nil


### PR DESCRIPTION
Resolves https://github.com/google/osv-scanner/issues/1411#event-15601233836

This change parallelizes BatchQuery sending with the maximum concurrent number set at 10.

Performance improvement: Using `rocket.chat.json` as an example (3 BatchQuery sending), it reduces the scanning time from 26 seconds to 17 seconds.