### PR TITLE
fix: remove redundant calls from `PreFetch`

### DIFF
--- a/internal/resolution/client/client.go
+++ b/internal/resolution/client/client.go
@@ -6,6 +6,7 @@ import (
 
 	pb "deps.dev/api/v3"
 	"deps.dev/util/resolve"
+	"deps.dev/util/resolve/dep"
 	"github.com/google/osv-scanner/internal/depsdev"
 	"github.com/google/osv-scanner/pkg/models"
 	"github.com/google/osv-scanner/pkg/osv"
@@ -62,6 +63,10 @@ func PreFetch(ctx context.Context, c DependencyClient, requirements []resolve.Re
 
 	// Use the deps.dev client to fetch complete dependency graphs of our direct imports
 	for _, im := range requirements {
+		// There are potentially a huge number of management/import dependencies.
+		if im.Type.HasAttr(dep.MavenDependencyOrigin) {
+			continue
+		}
 		// Get the preferred version of the import requirement
 		vks, err := c.MatchingVersions(ctx, im.VersionKey)
 		if err != nil || len(vks) == 0 {
@@ -109,6 +114,5 @@ func PreFetch(ctx context.Context, c DependencyClient, requirements []resolve.Re
 			go c.Versions(ctx, vk.PackageKey) //nolint:errcheck
 		}
 	}
-
 	// don't bother waiting for goroutines to finish.
 }

--- a/internal/resolution/client/client.go
+++ b/internal/resolution/client/client.go
@@ -108,20 +108,6 @@ func PreFetch(ctx context.Context, c DependencyClient, requirements []resolve.Re
 			go c.Version(ctx, vk)             //nolint:errcheck
 			go c.Versions(ctx, vk.PackageKey) //nolint:errcheck
 		}
-
-		for _, edge := range resp.GetEdges() {
-			req := edge.GetRequirement()
-			pbvk := nodes[edge.GetToNode()].GetVersionKey()
-			vk := resolve.VersionKey{
-				PackageKey: resolve.PackageKey{
-					System: resolve.System(pbvk.GetSystem()),
-					Name:   pbvk.GetName(),
-				},
-				Version:     req,
-				VersionType: resolve.Requirement,
-			}
-			go c.MatchingVersions(ctx, vk) //nolint:errcheck
-		}
 	}
 
 	// don't bother waiting for goroutines to finish.


### PR DESCRIPTION
In every `DependencyClient` we have, `MatchingVersions()` is just a call to `Versions()` plus semver matching, which is computationally expensive. It also was being called on every edge of the pre-fetched graphs.

Removed it to reduce CPU usage and hopefully improve performance with Maven resolution / Guided Remediation.

I've also skipped fetching things with `MavenDependencyOrigin` set (e.g. dependencyManagement dependencies) since there's potentially hundreds of them.