### PR TITLE
chore: increase timeout for `golangci-lint`

### DIFF
--- a/.github/workflows/lint-action/action.yml
+++ b/.github/workflows/lint-action/action.yml
@@ -23,4 +23,4 @@ runs:
       with:
         # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
         version: v1.62.2
-        args: --timeout=2m
+        args: --timeout=5m

--- a/.github/workflows/lint-action/action.yml
+++ b/.github/workflows/lint-action/action.yml
@@ -23,3 +23,4 @@ runs:
       with:
         # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
         version: v1.62.2
+        args: --timeout=2m


### PR DESCRIPTION
Recently `golangci-lint` timeouts quite often, as suggested, increase the timeout to 5m.