### PR TITLE
feat: Add and fix vendored extractor

### DIFF
--- a/internal/scalibrextract/filesystem/vendored/vendored_test.go
+++ b/internal/scalibrextract/filesystem/vendored/vendored_test.go
@@ -3,6 +3,7 @@ package vendored_test
 import (
 	"context"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -100,12 +101,17 @@ func TestExtractor_Extract(t *testing.T) {
 		// TODO: Reenable when #657 is resolved.
 		testutility.Skip(t, "Temporarily disabled until #657 is resolved")
 	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	tests := []extracttest.TestTableEntry{
 		{
 			Name: "zlib test",
 			InputConfig: extracttest.ScanInputMockConfig{
-				Path: "testdata/thirdparty/zlib",
+				Path:         "testdata/thirdparty/zlib",
+				FakeScanRoot: cwd,
 			},
 			WantInventory: []*extractor.Inventory{
 				{

--- a/pkg/osvscanner/internal/scanners/walker.go
+++ b/pkg/osvscanner/internal/scanners/walker.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/osv-scanner/internal/customgitignore"
 	"github.com/google/osv-scanner/internal/output"
 	"github.com/google/osv-scanner/internal/scalibrextract"
+	"github.com/google/osv-scanner/internal/scalibrextract/filesystem/vendored"
 	"github.com/google/osv-scanner/internal/scalibrextract/vcs/gitrepo"
 	"github.com/google/osv-scanner/pkg/reporter"
 )
@@ -45,6 +46,8 @@ func ScanDir(r reporter.Reporter, dir string, skipGit bool, recursive bool, useG
 	}
 	relevantExtractors = append(relevantExtractors, lockfileExtractors...)
 	relevantExtractors = append(relevantExtractors, SBOMExtractors...)
+	// Only scan git directories if we are skipping the git extractor
+	relevantExtractors = append(relevantExtractors, vendored.Extractor{ScanGitDir: skipGit})
 	if pomExtractor != nil {
 		relevantExtractors = append(relevantExtractors, pomExtractor)
 	} else {
@@ -107,17 +110,6 @@ func ScanDir(r reporter.Reporter, dir string, skipGit bool, recursive bool, useG
 			// Always skip git repository directories
 			return filepath.SkipDir
 		}
-
-		// TODO(V2): Reenable vendored libs scanning
-		// if info.IsDir() && !compareOffline {
-		// 	if _, ok := vendoredLibNames[strings.ToLower(filepath.Base(path))]; ok {
-		// 		pkgs, err := ScanDirWithVendoredLibs(r, path)
-		// 		if err != nil {
-		// 			r.Infof("scan failed for dir containing vendored libs %s: %v\n", path, err)
-		// 		}
-		// 		scannedPackages = append(scannedPackages, pkgs...)
-		// 	}
-		// }
 
 		if !root && !recursive && info.IsDir() {
 			return filepath.SkipDir


### PR DESCRIPTION
Finish a TODO and use the vendored extractor. This also fixes an issue with the extractor using os.Open instead of the fsys open.