### PR TITLE
chore: use single quotes by default in Python scripts

### DIFF
--- a/scripts/generators/generate-debian-versions.py
+++ b/scripts/generators/generate-debian-versions.py
@@ -32,15 +32,15 @@ def is_unsupported_comparison(line):
 
 
 def uncomment(line):
-  if line.startswith("#"):
+  if line.startswith('#'):
     return line[1:]
-  if line.startswith("//"):
+  if line.startswith('//'):
     return line[2:]
   return line
 
 
 def download_debian_db():
-  urllib.request.urlretrieve("https://osv-vulnerabilities.storage.googleapis.com/Debian/all.zip", "debian-db.zip")
+  urllib.request.urlretrieve('https://osv-vulnerabilities.storage.googleapis.com/Debian/all.zip', 'debian-db.zip')
 
 
 def extract_packages_with_versions(osvs):
@@ -76,17 +76,17 @@ class DebianVersionComparer:
   def _load_cache(self):
     if self.cache_path:
       self.cache_path.touch()
-      with open(self.cache_path, "r") as f:
+      with open(self.cache_path, 'r') as f:
         lines = f.readlines()
 
         for line in lines:
           line = line.strip()
-          key, result = line.split(",")
+          key, result = line.split(',')
 
-          if result == "True":
+          if result == 'True':
             self.cache[key] = True
             continue
-          if result == "False":
+          if result == 'False':
             self.cache[key] = False
             continue
 
@@ -96,15 +96,15 @@ class DebianVersionComparer:
     self.cache[key] = result
     if self.cache_path:
       self.cache_path.touch()
-      with open(self.cache_path, "a") as f:
-        f.write(f"{key},{result}\n")
+      with open(self.cache_path, 'a') as f:
+        f.write(f'{key},{result}\n')
 
   def compare(self, a, op, b):
-    key = f"{a} {op} {b}"
+    key = f'{a} {op} {b}'
     if key in self.cache:
       return self.cache[key]
 
-    cmd = ["dpkg", "--compare-versions", a, op, b]
+    cmd = ['dpkg', '--compare-versions', a, op, b]
     out = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
     if out.stdout:
@@ -117,7 +117,7 @@ class DebianVersionComparer:
     return r
 
 
-debian_comparer = DebianVersionComparer("/tmp/debian-versions-generator-cache.csv")
+debian_comparer = DebianVersionComparer('/tmp/debian-versions-generator-cache.csv')
 
 
 class DebianVersion:
@@ -145,39 +145,39 @@ def compare(v1, relate, v2):
   return ops[relate](v1, v2)
 
 
-def compare_versions(lines, select="all"):
+def compare_versions(lines, select='all'):
   has_any_failed = False
 
   for line in lines:
     line = line.strip()
 
-    if line == "" or line.startswith('#') or line.startswith('//'):
+    if line == '' or line.startswith('#') or line.startswith('//'):
       maybe_unsupported = uncomment(line).strip()
 
       if is_unsupported_comparison(maybe_unsupported):
-        print(f"\033[96mS\033[0m: \033[93m{maybe_unsupported}\033[0m")
+        print(f'\033[96mS\033[0m: \033[93m{maybe_unsupported}\033[0m')
       continue
 
-    v1, op, v2 = line.strip().split(" ")
+    v1, op, v2 = line.strip().split(' ')
 
     r = compare(DebianVersion(v1), op, DebianVersion(v2))
 
     if not r:
       has_any_failed = r
 
-    if select == "failures" and r:
+    if select == 'failures' and r:
       continue
 
-    if select == "successes" and not r:
+    if select == 'successes' and not r:
       continue
 
     color = '\033[92m' if r else '\033[91m'
-    rs = "T" if r else "F"
-    print(f"{color}{rs}\033[0m: \033[93m{line}\033[0m")
+    rs = 'T' if r else 'F'
+    print(f'{color}{rs}\033[0m: \033[93m{line}\033[0m')
   return has_any_failed
 
 
-def compare_versions_in_file(filepath, select="all"):
+def compare_versions_in_file(filepath, select='all'):
   with open(filepath) as f:
     lines = f.readlines()
     return compare_versions(lines, select)
@@ -189,10 +189,10 @@ def generate_version_compares(versions):
     if i == 0:
       continue
 
-    comparison = f"{versions[i - 1]} < {version}\n"
+    comparison = f'{versions[i - 1]} < {version}\n'
 
     if is_unsupported_comparison(comparison.strip()):
-      comparison = "# " + comparison
+      comparison = '# ' + comparison
     comparisons.append(comparison)
   return comparisons
 
@@ -219,16 +219,16 @@ def fetch_packages_versions():
   return extract_packages_with_versions(osvs)
 
 
-outfile = "internal/semantic/fixtures/debian-versions-generated.txt"
+outfile = 'internal/semantic/fixtures/debian-versions-generated.txt'
 
 packs = fetch_packages_versions()
-with open(outfile, "w") as f:
+with open(outfile, 'w') as f:
   f.writelines(generate_package_compares(packs))
-  f.write("\n")
+  f.write('\n')
 
 # set this to either "failures" or "successes" to only have those comparison results
 # printed; setting it to anything else will have all comparison results printed
-show = os.environ.get("VERSION_GENERATOR_PRINT", "failures")
+show = os.environ.get('VERSION_GENERATOR_PRINT', 'failures')
 
 did_any_fail = compare_versions_in_file(outfile, show)
 

--- a/scripts/generators/generate-pypi-versions.py
+++ b/scripts/generators/generate-pypi-versions.py
@@ -25,15 +25,15 @@ def is_unsupported_comparison(line):
 
 
 def uncomment(line):
-  if line.startswith("#"):
+  if line.startswith('#'):
     return line[1:]
-  if line.startswith("//"):
+  if line.startswith('//'):
     return line[2:]
   return line
 
 
 def download_pypi_db():
-  urllib.request.urlretrieve("https://osv-vulnerabilities.storage.googleapis.com/PyPI/all.zip", "pypi-db.zip")
+  urllib.request.urlretrieve('https://osv-vulnerabilities.storage.googleapis.com/PyPI/all.zip', 'pypi-db.zip')
 
 
 def extract_packages_with_versions(osvs):
@@ -53,7 +53,7 @@ def extract_packages_with_versions(osvs):
         try:
           dict[package].append(packaging.version.parse(version))
         except packaging.version.InvalidVersion:
-          print(f"skipping invalid version {version} for {package}")
+          print(f'skipping invalid version {version} for {package}')
 
   # deduplicate and sort the versions for each package
   for package in dict:
@@ -67,39 +67,39 @@ def compare(v1, relate, v2):
   return ops[relate](v1, v2)
 
 
-def compare_versions(lines, select="all"):
+def compare_versions(lines, select='all'):
   has_any_failed = False
 
   for line in lines:
     line = line.strip()
 
-    if line == "" or line.startswith('#') or line.startswith('//'):
+    if line == '' or line.startswith('#') or line.startswith('//'):
       maybe_unsupported = uncomment(line).strip()
 
       if is_unsupported_comparison(maybe_unsupported):
-        print(f"\033[96mS\033[0m: \033[93m{maybe_unsupported}\033[0m")
+        print(f'\033[96mS\033[0m: \033[93m{maybe_unsupported}\033[0m')
       continue
 
-    v1, op, v2 = line.strip().split(" ")
+    v1, op, v2 = line.strip().split(' ')
 
     r = compare(packaging.version.parse(v1), op, packaging.version.parse(v2))
 
     if not r:
       has_any_failed = True
 
-    if select == "failures" and r:
+    if select == 'failures' and r:
       continue
 
-    if select == "successes" and not r:
+    if select == 'successes' and not r:
       continue
 
     color = '\033[92m' if r else '\033[91m'
-    rs = "T" if r else "F"
-    print(f"{color}{rs}\033[0m: \033[93m{line}\033[0m")
+    rs = 'T' if r else 'F'
+    print(f'{color}{rs}\033[0m: \033[93m{line}\033[0m')
   return has_any_failed
 
 
-def compare_versions_in_file(filepath, select="all"):
+def compare_versions_in_file(filepath, select='all'):
   with open(filepath) as f:
     lines = f.readlines()
     return compare_versions(lines, select)
@@ -111,10 +111,10 @@ def generate_version_compares(versions):
     if i == 0:
       continue
 
-    comparison = f"{versions[i - 1]} < {version}\n"
+    comparison = f'{versions[i - 1]} < {version}\n'
 
     if is_unsupported_comparison(comparison.strip()):
-      comparison = "# " + comparison
+      comparison = '# ' + comparison
     comparisons.append(comparison)
   return comparisons
 
@@ -141,16 +141,16 @@ def fetch_packages_versions():
   return extract_packages_with_versions(osvs)
 
 
-outfile = "internal/semantic/fixtures/pypi-versions-generated.txt"
+outfile = 'internal/semantic/fixtures/pypi-versions-generated.txt'
 
 packs = fetch_packages_versions()
-with open(outfile, "w") as f:
+with open(outfile, 'w') as f:
   f.writelines(generate_package_compares(packs))
-  f.write("\n")
+  f.write('\n')
 
 # set this to either "failures" or "successes" to only have those comparison results
 # printed; setting it to anything else will have all comparison results printed
-show = os.environ.get("VERSION_GENERATOR_PRINT", "failures")
+show = os.environ.get('VERSION_GENERATOR_PRINT', 'failures')
 
 did_any_fail = compare_versions_in_file(outfile, show)
 

--- a/scripts/generators/generate-redhat-versions.py
+++ b/scripts/generators/generate-redhat-versions.py
@@ -36,15 +36,15 @@ def is_unsupported_comparison(line):
 
 
 def uncomment(line):
-  if line.startswith("#"):
+  if line.startswith('#'):
     return line[1:]
-  if line.startswith("//"):
+  if line.startswith('//'):
     return line[2:]
   return line
 
 
 def download_redhat_db():
-  urllib.request.urlretrieve("https://osv-vulnerabilities.storage.googleapis.com/Red%20Hat/all.zip", "redhat-db.zip")
+  urllib.request.urlretrieve('https://osv-vulnerabilities.storage.googleapis.com/Red%20Hat/all.zip', 'redhat-db.zip')
 
 
 def extract_packages_with_versions(osvs):
@@ -87,17 +87,17 @@ class RedHatVersionComparer:
   def _load_cache(self):
     if self.cache_path:
       self.cache_path.touch()
-      with open(self.cache_path, "r") as f:
+      with open(self.cache_path, 'r') as f:
         lines = f.readlines()
 
         for line in lines:
           line = line.strip()
-          key, result = line.split(",")
+          key, result = line.split(',')
 
-          if result == "True":
+          if result == 'True':
             self.cache[key] = True
             continue
-          if result == "False":
+          if result == 'False':
             self.cache[key] = False
             continue
 
@@ -107,49 +107,49 @@ class RedHatVersionComparer:
     self.cache[key] = result
     if self.cache_path:
       self.cache_path.touch()
-      with open(self.cache_path, "a") as f:
-        f.write(f"{key},{result}\n")
+      with open(self.cache_path, 'a') as f:
+        f.write(f'{key},{result}\n')
 
   def _compare1(self, a, op, b):
-    cmd = ["rpm", "--eval", f"%{{lua:print(rpm.vercmp('{a}', '{b}'))}}"]
+    cmd = ['rpm', '--eval', f'%{{lua:print(rpm.vercmp("{a}", "{b}"))}}']
     out = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
     if out.returncode != 0 or out.stderr:
-      raise Exception(f"rpm did not like comparing {a} {op} {b}: {out.stderr.decode('utf-8')}")
+      raise Exception(f'rpm did not like comparing {a} {op} {b}: {out.stderr.decode("utf-8")}')
 
     r = out.stdout.decode('utf-8').strip()
 
-    if r == "0" and op == "=":
+    if r == '0' and op == '=':
       return True
-    elif r == "1" and op == ">":
+    elif r == '1' and op == '>':
       return True
-    elif r == "-1" and op == "<":
+    elif r == '-1' and op == '<':
       return True
 
     return False
 
   def _compare2(self, a, op, b):
-    if op == "=":
-      op = "=="  # lua uses == for equality
+    if op == '=':
+      op = '=='  # lua uses == for equality
 
-    cmd = ["rpm", "--eval", f"%{{lua:print(rpm.ver('{a}') {op} rpm.ver('{b}'))}}"]
+    cmd = ['rpm', '--eval', f'%{{lua:print(rpm.ver("{a}") {op} rpm.ver("{b}"))}}']
     out = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
     if out.returncode != 0 or out.stderr:
-      raise Exception(f"rpm did not like comparing {a} {op} {b}: {out.stderr.decode('utf-8')}")
+      raise Exception(f'rpm did not like comparing {a} {op} {b}: {out.stderr.decode("utf-8")}')
 
     r = out.stdout.decode('utf-8').strip()
 
-    if r == "true":
+    if r == 'True':
       return True
-    elif r == "false":
+    elif r == 'False':
       return False
 
-    raise Exception(f"unexpected result from rpm: {r}")
+    raise Exception(f'unexpected result from rpm: {r}')
 
 
   def compare(self, a, op, b):
-    key = f"{a} {op} {b}"
+    key = f'{a} {op} {b}'
     if key in self.cache:
       return self.cache[key]
 
@@ -160,7 +160,7 @@ class RedHatVersionComparer:
     return r
 
 
-redhat_comparer = RedHatVersionComparer("/tmp/redhat-versions-generator-cache.csv")
+redhat_comparer = RedHatVersionComparer('/tmp/redhat-versions-generator-cache.csv')
 
 
 class RedHatVersion:
@@ -188,39 +188,39 @@ def compare(v1, relate, v2):
   return ops[relate](v1, v2)
 
 
-def compare_versions(lines, select="all"):
+def compare_versions(lines, select='all'):
   has_any_failed = False
 
   for line in lines:
     line = line.strip()
 
-    if line == "" or line.startswith('#') or line.startswith('//'):
+    if line == '' or line.startswith('#') or line.startswith('//'):
       maybe_unsupported = uncomment(line).strip()
 
       if is_unsupported_comparison(maybe_unsupported):
-        print(f"\033[96mS\033[0m: \033[93m{maybe_unsupported}\033[0m")
+        print(f'\033[96mS\033[0m: \033[93m{maybe_unsupported}\033[0m')
       continue
 
-    v1, op, v2 = line.strip().split(" ")
+    v1, op, v2 = line.strip().split(' ')
 
     r = compare(RedHatVersion(v1), op, RedHatVersion(v2))
 
     if not r:
       has_any_failed = r
 
-    if select == "failures" and r:
+    if select == 'failures' and r:
       continue
 
-    if select == "successes" and not r:
+    if select == 'successes' and not r:
       continue
 
     color = '\033[92m' if r else '\033[91m'
-    rs = "T" if r else "F"
-    print(f"{color}{rs}\033[0m: \033[93m{line}\033[0m")
+    rs = 'T' if r else 'F'
+    print(f'{color}{rs}\033[0m: \033[93m{line}\033[0m')
   return has_any_failed
 
 
-def compare_versions_in_file(filepath, select="all"):
+def compare_versions_in_file(filepath, select='all'):
   with open(filepath) as f:
     lines = f.readlines()
     return compare_versions(lines, select)
@@ -232,10 +232,10 @@ def generate_version_compares(versions):
     if i == 0:
       continue
 
-    comparison = f"{versions[i - 1]} < {version}\n"
+    comparison = f'{versions[i - 1]} < {version}\n'
 
     if is_unsupported_comparison(comparison.strip()):
-      comparison = "# " + comparison
+      comparison = '# ' + comparison
     comparisons.append(comparison)
   return comparisons
 
@@ -262,16 +262,16 @@ def fetch_packages_versions():
   return extract_packages_with_versions(osvs)
 
 
-outfile = "internal/semantic/fixtures/redhat-versions-generated.txt"
+outfile = 'internal/semantic/fixtures/redhat-versions-generated.txt'
 
 packs = fetch_packages_versions()
-with open(outfile, "w") as f:
+with open(outfile, 'w') as f:
   f.writelines(generate_package_compares(packs))
-  f.write("\n")
+  f.write('\n')
 
 # set this to either "failures" or "successes" to only have those comparison results
 # printed; setting it to anything else will have all comparison results printed
-show = os.environ.get("VERSION_GENERATOR_PRINT", "failures")
+show = os.environ.get('VERSION_GENERATOR_PRINT', 'failures')
 
 did_any_fail = compare_versions_in_file(outfile, show)
 

--- a/scripts/report_uncleaned_snapshots.py
+++ b/scripts/report_uncleaned_snapshots.py
@@ -5,15 +5,15 @@ import glob
 
 
 def annotate_file(file, msg):
-  if os.getenv("CI") is not None:
-    print(f"::error file={file} msg={msg}")
+  if os.getenv('CI') is not None:
+    print(f'::error file={file} msg={msg}')
 
 
 def does_clean_snapshots(pkg_dir):
   try:
-    with open(f"{pkg_dir}/testmain_test.go", 'r') as file:
+    with open(f'{pkg_dir}/testmain_test.go', 'r') as file:
       for _, line in enumerate(file):
-        if "	testutility.CleanSnapshots(m)" in line:
+        if '	testutility.CleanSnapshots(m)' in line:
           return True
     return False
   except FileNotFoundError:
@@ -21,21 +21,21 @@ def does_clean_snapshots(pkg_dir):
 
 
 def report_lack_of_snapshot_cleaning(directory):
-  if os.path.exists(f"{directory}/testmain_test.go"):
-    file = f"{directory}/testmain_test.go"
+  if os.path.exists(f'{directory}/testmain_test.go'):
+    file = f'{directory}/testmain_test.go'
 
-    annotate_file(file, "Make sure that `TestMain` is calling `testutility.CleanSnapshots(m)` after the tests have been run")
-    print(f"{file} is not calling `testutility.CleanSnapshots(m)`")
+    annotate_file(file, 'Make sure that `TestMain` is calling `testutility.CleanSnapshots(m)` after the tests have been run')
+    print(f'{file} is not calling `testutility.CleanSnapshots(m)`')
   else:
-    file = list(glob.iglob(os.path.join(directory, "*_test.go")))[0]
+    file = list(glob.iglob(os.path.join(directory, '*_test.go')))[0]
 
-    annotate_file(file, "Please add a `testmain_test.go` file with a `TestMain` function that calls `testutility.CleanSnapshots(m)` after the tests have been run")
-    print(f"{directory} does not have a `testmain_test.go` file with a `TestMain` function that calls `testutility.CleanSnapshots(m)` after the tests have been run")
+    annotate_file(file, 'Please add a `testmain_test.go` file with a `TestMain` function that calls `testutility.CleanSnapshots(m)` after the tests have been run')
+    print(f'{directory} does not have a `testmain_test.go` file with a `TestMain` function that calls `testutility.CleanSnapshots(m)` after the tests have been run')
   pass
 
 
 uncleaned_snapshots = False
-for snapshot_dir in glob.iglob("**/__snapshots__/", recursive=True):
+for snapshot_dir in glob.iglob('**/__snapshots__/', recursive=True):
   parent_dir = os.path.dirname(snapshot_dir[:-1])
 
   if does_clean_snapshots(parent_dir):
@@ -45,7 +45,7 @@ for snapshot_dir in glob.iglob("**/__snapshots__/", recursive=True):
   uncleaned_snapshots = True
 
 if uncleaned_snapshots:
-  print("")
+  print('')
   print("one or more packages are using snapshots but not ensuring they're cleaned up")
-  print("make sure these packages have a testmain_test.go file that defines a TestMain function that calls testutility.CleanSnapshots(m)")
+  print('make sure these packages have a testmain_test.go file that defines a TestMain function that calls testutility.CleanSnapshots(m)')
   exit(1)


### PR DESCRIPTION
Apparently I've not been as consistent on this as I thought I was, so as punishment I've gone through all the scripts and made sure they're using single quotes by default - aside from still being used within `f` strings due to how that syntax works for string literals within interopolations, I have retained the usage of double quotes in four `print` calls which have single quotes in them to avoid doing an escape