### PR TITLE
feat: Update local matcher to the new requirements for resolve

### DIFF
--- a/cmd/osv-scanner/__snapshots__/main_test.snap
+++ b/cmd/osv-scanner/__snapshots__/main_test.snap
@@ -2404,7 +2404,11 @@ Filtered 1 local/unscannable package/s from the scan.
 ---
 
 [TestRun_LocalDatabases_AlwaysOffline/a_bunch_of_different_lockfiles_and_ecosystem - 2]
-could not find local databases for ecosystems: Alpine, Packagist, PyPI, RubyGems, npm
+could not load db for PyPI ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for RubyGems ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for Packagist ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for npm ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
 
 ---
 
@@ -2426,7 +2430,11 @@ Filtered 1 local/unscannable package/s from the scan.
 ---
 
 [TestRun_LocalDatabases_AlwaysOffline/a_bunch_of_different_lockfiles_and_ecosystem - 4]
-could not find local databases for ecosystems: Alpine, Packagist, PyPI, RubyGems, npm
+could not load db for PyPI ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for RubyGems ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for Alpine ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for Packagist ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
+could not load db for npm ecosystem: unable to fetch OSV database: no offline version of the OSV database is available
 
 ---
 

--- a/internal/clients/clientimpl/localmatcher/localmatcher.go
+++ b/internal/clients/clientimpl/localmatcher/localmatcher.go
@@ -45,7 +45,7 @@ func NewLocalMatcher(r reporter.Reporter, localDBPath string, downloadDB bool) (
 	}, nil
 }
 
-func (matcher *LocalMatcher) Match(ctx context.Context, invs []*extractor.Inventory) ([][]*models.Vulnerability, error) {
+func (matcher *LocalMatcher) MatchVulnerabilities(ctx context.Context, invs []*extractor.Inventory) ([][]*models.Vulnerability, error) {
 	results := make([][]*models.Vulnerability, 0, len(invs))
 
 	for _, inv := range invs {
@@ -102,6 +102,7 @@ func (matcher *LocalMatcher) loadDBFromCache(ctx context.Context, ecosystem ecos
 	if err != nil {
 		matcher.failedDBs[ecosystem.Ecosystem] = err
 		matcher.r.Errorf("could not load db for %s ecosystem: %v\n", ecosystem.Ecosystem, err)
+
 		return nil, err
 	}
 

--- a/internal/clients/clientimpl/localmatcher/localmatcher.go
+++ b/internal/clients/clientimpl/localmatcher/localmatcher.go
@@ -41,6 +41,7 @@ func NewLocalMatcher(r reporter.Reporter, localDBPath string, downloadDB bool) (
 		dbs:        make(map[osvschema.Ecosystem]*ZipDB),
 		downloadDB: downloadDB,
 		r:          r,
+		failedDBs:  make(map[osvschema.Ecosystem]error),
 	}, nil
 }
 

--- a/internal/clients/clientimpl/localmatcher/localmatcher.go
+++ b/internal/clients/clientimpl/localmatcher/localmatcher.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"slices"
-	"strings"
 
 	"github.com/google/osv-scalibr/extractor"
 	"github.com/google/osv-scanner/internal/imodels"
@@ -26,6 +24,8 @@ type LocalMatcher struct {
 	dbBasePath string
 	dbs        map[osvschema.Ecosystem]*ZipDB
 	downloadDB bool
+	// failedDBs keeps track of the errors when getting databases for each ecosystem
+	failedDBs map[osvschema.Ecosystem]error
 	// TODO(v2 logging): Remove this reporter
 	r reporter.Reporter
 }
@@ -46,9 +46,6 @@ func NewLocalMatcher(r reporter.Reporter, localDBPath string, downloadDB bool) (
 
 func (matcher *LocalMatcher) Match(ctx context.Context, invs []*extractor.Inventory) ([][]*models.Vulnerability, error) {
 	results := make([][]*models.Vulnerability, 0, len(invs))
-
-	// slice to track ecosystems that did not have an offline database available
-	var missingDBs []string
 
 	for _, inv := range invs {
 		if ctx.Err() != nil {
@@ -73,31 +70,21 @@ func (matcher *LocalMatcher) Match(ctx context.Context, invs []*extractor.Invent
 		db, err := matcher.loadDBFromCache(ctx, pkg.Ecosystem)
 
 		if err != nil {
-			if errors.Is(err, ErrOfflineDatabaseNotFound) {
-				missingDBs = append(missingDBs, string(pkg.Ecosystem.Ecosystem))
-			} else {
-				// TODO(V2 logging):
-				// the most likely error at this point is that the PURL could not be parsed
-				matcher.r.Errorf("could not load db for %s ecosystem: %v\n", pkg.Ecosystem, err)
-			}
-
-			results = append(results, []*models.Vulnerability{})
-
 			continue
 		}
 
 		results = append(results, db.VulnerabilitiesAffectingPackage(pkg))
 	}
 
-	if len(missingDBs) > 0 {
-		missingDBs = slices.Compact(missingDBs)
-		slices.Sort(missingDBs)
-
-		// TODO(v2 logging):
-		matcher.r.Errorf("could not find local databases for ecosystems: %s\n", strings.Join(missingDBs, ", "))
-	}
-
 	return results, nil
+}
+
+// LoadEcosystem tries to preload the ecosystem into the cache, and returns an error if the ecosystem
+// cannot be loaded.
+func (matcher *LocalMatcher) LoadEcosystem(ctx context.Context, ecosystem ecosystem.Parsed) error {
+	_, err := matcher.loadDBFromCache(ctx, ecosystem)
+
+	return err
 }
 
 func (matcher *LocalMatcher) loadDBFromCache(ctx context.Context, ecosystem ecosystem.Parsed) (*ZipDB, error) {
@@ -105,9 +92,15 @@ func (matcher *LocalMatcher) loadDBFromCache(ctx context.Context, ecosystem ecos
 		return db, nil
 	}
 
+	if matcher.failedDBs[ecosystem.Ecosystem] != nil {
+		return nil, matcher.failedDBs[ecosystem.Ecosystem]
+	}
+
 	db, err := NewZippedDB(ctx, matcher.dbBasePath, string(ecosystem.Ecosystem), fmt.Sprintf("%s/%s/all.zip", zippedDBRemoteHost, ecosystem.Ecosystem), !matcher.downloadDB)
 
 	if err != nil {
+		matcher.failedDBs[ecosystem.Ecosystem] = err
+		matcher.r.Errorf("could not load db for %s ecosystem: %v\n", ecosystem.Ecosystem, err)
 		return nil, err
 	}
 

--- a/internal/clients/clientimpl/osvmatcher/osvmatcher.go
+++ b/internal/clients/clientimpl/osvmatcher/osvmatcher.go
@@ -30,7 +30,7 @@ type OSVMatcher struct {
 	InitialQueryTimeout time.Duration
 }
 
-func (matcher *OSVMatcher) Match(ctx context.Context, pkgs []*extractor.Inventory) ([][]*models.Vulnerability, error) {
+func (matcher *OSVMatcher) MatchVulnerabilities(ctx context.Context, pkgs []*extractor.Inventory) ([][]*models.Vulnerability, error) {
 	var batchResp *osvdev.BatchedResponse
 	deadlineExceeded := false
 

--- a/internal/clients/clientinterfaces/vulnerabilitymatcher.go
+++ b/internal/clients/clientinterfaces/vulnerabilitymatcher.go
@@ -8,5 +8,5 @@ import (
 )
 
 type VulnerabilityMatcher interface {
-	Match(ctx context.Context, invs []*extractor.Inventory) ([][]*models.Vulnerability, error)
+	MatchVulnerabilities(ctx context.Context, invs []*extractor.Inventory) ([][]*models.Vulnerability, error)
 }

--- a/internal/imodels/ecosystem/ecosystem.go
+++ b/internal/imodels/ecosystem/ecosystem.go
@@ -94,6 +94,12 @@ func MustParse(str string) Parsed {
 
 // Parse parses a string into a constants.Ecosystem and an optional suffix specified with a ":"
 func Parse(str string) (Parsed, error) {
+	// Special case to return an empty ecosystem if str is empty
+	// This is not considered an error.
+	if str == "" {
+		return Parsed{}, nil
+	}
+
 	ecosystem, suffix, _ := strings.Cut(str, ":")
 
 	// Always return the full parsed value even if it might be invalid

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -207,7 +207,7 @@ func makeRequestWithMatcher(
 		invs = append(invs, pkgs.PackageInfo.OriginalInventory)
 	}
 
-	res, err := matcher.Match(context.Background(), invs)
+	res, err := matcher.MatchVulnerabilities(context.Background(), invs)
 	if err != nil {
 		// TODO: Handle error here
 		r.Errorf("error when retrieving vulns: %v", err)


### PR DESCRIPTION
Sets up logging to only return one error log per database that fails to load, and also adds a LoadEcosystem function to preload/preerror databases

imodels.go part can be safely ignored as that is removed in a followup PR.