### PR TITLE
feat(guided remediation): Add flag to exclude patches that would introduce new vulns

### DIFF
--- a/cmd/osv-scanner/fix/main.go
+++ b/cmd/osv-scanner/fix/main.go
@@ -39,12 +39,13 @@ const (
 
 type osvFixOptions struct {
 	remediation.Options
-	Client     client.ResolutionClient
-	Manifest   string
-	ManifestRW manifest.ReadWriter
-	Lockfile   string
-	LockfileRW lockfile.ReadWriter
-	RelockCmd  string
+	Client      client.ResolutionClient
+	Manifest    string
+	ManifestRW  manifest.ReadWriter
+	Lockfile    string
+	LockfileRW  lockfile.ReadWriter
+	RelockCmd   string
+	NoIntroduce bool
 }
 
 func Command(stdout, stderr io.Writer, r *reporter.Reporter) *cli.Command {
@@ -140,6 +141,11 @@ func Command(stdout, stderr io.Writer, r *reporter.Reporter) *cli.Command {
 				Name:     "apply-top",
 				Usage:    "apply the top N patches",
 				Value:    -1,
+			},
+			&cli.BoolFlag{
+				Category: autoModeCategory,
+				Name:     "no-introduce",
+				Usage:    "exclude patches that would introduce new vulnerabilities",
 			},
 
 			&cli.StringSliceFlag{
@@ -302,9 +308,10 @@ func action(ctx *cli.Context, stdout, stderr io.Writer) (reporter.Reporter, erro
 			MaxDepth:      ctx.Int("max-depth"),
 			UpgradeConfig: parseUpgradeConfig(ctx, r),
 		},
-		Manifest:  ctx.String("manifest"),
-		Lockfile:  ctx.String("lockfile"),
-		RelockCmd: ctx.String("relock-cmd"),
+		Manifest:    ctx.String("manifest"),
+		Lockfile:    ctx.String("lockfile"),
+		RelockCmd:   ctx.String("relock-cmd"),
+		NoIntroduce: ctx.Bool("no-introduce"),
 	}
 
 	system := resolve.UnknownSystem

--- a/docs/guided-remediation.md
+++ b/docs/guided-remediation.md
@@ -324,6 +324,7 @@ The following flags may be used when running in non-interactive mode only:
 
   For example, `--apply-top=1` will only apply one patch, and `--apply-top=2` would apply the two best compatible patches. This flag is particularly useful when scripting to test the outcome of specific patches. Setting `--apply-top=-1` will apply every possible patch (default behavior).
 
+- `--no-introduce`: Set to exclude patches that would introduce new vulnerabilities if applied.
 - `--format=` `text` OR `json`. The [output format](#output-formats) to use for results.
 
 ### Vulnerability selection


### PR DESCRIPTION
Adds a `--no-introduce` flag to `osv-scanner fix --non-interactive` to remove patches from consideration if they introduce new vulnerabilities.

(I haven't actually tested this because I'm struggling to find a project that would introduce vulns...)