### PR TITLE
refactor: use relative path to get Maven parent path

### DIFF
--- a/internal/utility/maven/maven.go
+++ b/internal/utility/maven/maven.go
@@ -45,20 +45,22 @@ func MergeParents(ctx context.Context, mavenClient *datasource.MavenRegistryAPIC
 
 		var proj maven.Project
 		parentFound := false
-		if parentPath := ParentPOMPath(currentPath, string(current.RelativePath)); allowLocal && parentPath != "" {
-			currentPath = parentPath
-			f, err := os.Open(parentPath)
-			if err != nil {
-				return fmt.Errorf("failed to open parent file %s: %w", parentPath, err)
-			}
-			err = datasource.NewMavenDecoder(f).Decode(&proj)
-			f.Close()
-			if err != nil {
-				return fmt.Errorf("failed to unmarshal project: %w", err)
-			}
-			if ProjectKey(proj) == current.ProjectKey && proj.Packaging == "pom" {
-				// Only mark parent is found when the identifiers and packaging are exptected.
-				parentFound = true
+		if allowLocal {
+			if parentPath := ParentPOMPath(currentPath, string(current.RelativePath)); parentPath != "" {
+				currentPath = parentPath
+				f, err := os.Open(parentPath)
+				if err != nil {
+					return fmt.Errorf("failed to open parent file %s: %w", parentPath, err)
+				}
+				err = datasource.NewMavenDecoder(f).Decode(&proj)
+				f.Close()
+				if err != nil {
+					return fmt.Errorf("failed to unmarshal project: %w", err)
+				}
+				if ProjectKey(proj) == current.ProjectKey && proj.Packaging == "pom" {
+					// Only mark parent is found when the identifiers and packaging are exptected.
+					parentFound = true
+				}
 			}
 		}
 		if !parentFound {

--- a/internal/utility/maven/maven_test.go
+++ b/internal/utility/maven/maven_test.go
@@ -1,7 +1,6 @@
 package maven_test
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -10,10 +9,6 @@ import (
 
 func TestParentPOMPath(t *testing.T) {
 	t.Parallel()
-	dir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("failed to get current directory: %v", err)
-	}
 	tests := []struct {
 		currentPath, relativePath string
 		want                      string
@@ -27,37 +22,37 @@ func TestParentPOMPath(t *testing.T) {
 		// |- pom.xml
 		{
 			// Parent path is specified correctly.
-			currentPath:  filepath.Join(dir, "fixtures", "my-app", "pom.xml"),
+			currentPath:  filepath.Join("fixtures", "my-app", "pom.xml"),
 			relativePath: "../parent/pom.xml",
-			want:         filepath.Join(dir, "fixtures", "parent", "pom.xml"),
+			want:         filepath.Join("fixtures", "parent", "pom.xml"),
 		},
 		{
 			// Wrong file name is specified in relative path.
-			currentPath:  filepath.Join(dir, "fixtures", "my-app", "pom.xml"),
+			currentPath:  filepath.Join("fixtures", "my-app", "pom.xml"),
 			relativePath: "../parent/abc.xml",
 			want:         "",
 		},
 		{
 			// Wrong directory is specified in relative path.
-			currentPath:  filepath.Join(dir, "fixtures", "my-app", "pom.xml"),
+			currentPath:  filepath.Join("fixtures", "my-app", "pom.xml"),
 			relativePath: "../not-found/pom.xml",
 			want:         "",
 		},
 		{
 			// Only directory is specified.
-			currentPath:  filepath.Join(dir, "fixtures", "my-app", "pom.xml"),
+			currentPath:  filepath.Join("fixtures", "my-app", "pom.xml"),
 			relativePath: "../parent",
-			want:         filepath.Join(dir, "fixtures", "parent", "pom.xml"),
+			want:         filepath.Join("fixtures", "parent", "pom.xml"),
 		},
 		{
 			// Parent relative path is default to '../pom.xml'.
-			currentPath:  filepath.Join(dir, "fixtures", "my-app", "pom.xml"),
+			currentPath:  filepath.Join("fixtures", "my-app", "pom.xml"),
 			relativePath: "",
-			want:         filepath.Join(dir, "fixtures", "pom.xml"),
+			want:         filepath.Join("fixtures", "pom.xml"),
 		},
 		{
 			// No pom.xml is found even in the default path.
-			currentPath:  filepath.Join(dir, "fixtures", "pom.xml"),
+			currentPath:  filepath.Join("fixtures", "pom.xml"),
 			relativePath: "",
 			want:         "",
 		},


### PR DESCRIPTION
To align with how we scan in OSV-Scalibr, change `ParentPOMPath` to be based on relative path.
Also only call this function for local scans - we don't need to know parent path for upstream pom.xml.