### PR TITLE
fix: renovatebot update golang version in config

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -77,7 +77,7 @@ Alternatively, you can install this from source by running:
 go install github.com/google/osv-scanner/cmd/osv-scanner@v1
 ```
 
-This requires Go 1.22.7+ to be installed.
+This requires Go 1.23.5+ to be installed.
 
 ## Build from source
 

--- a/renovate.json
+++ b/renovate.json
@@ -27,7 +27,7 @@
     }
   ],
   "constraints": {
-    "go": "1.22.7"
+    "go": "1.23.5"
   },
   "ignorePaths": ["**/fixtures/**", "**/fixtures-go/**"],
   "ignoreDeps": ["golang.org/x/vuln"]


### PR DESCRIPTION
This should unblock #1472 failing to run go mod tidy.