### PR TITLE
fix: Ignore linux source packages

### DIFF
--- a/pkg/osvscanner/filter.go
+++ b/pkg/osvscanner/filter.go
@@ -35,6 +35,28 @@ func filterUnscannablePackages(r reporter.Reporter, scanResults *results.ScanRes
 	scanResults.PackageScanResults = packageResults
 }
 
+// filterNonContainerRelevantPackages removes packages that are not relevant when doing container scanning
+func filterNonContainerRelevantPackages(r reporter.Reporter, scanResults *results.ScanResults) {
+	packageResults := make([]imodels.PackageScanResult, 0, len(scanResults.PackageScanResults))
+	for _, psr := range scanResults.PackageScanResults {
+		p := psr.PackageInfo
+
+		// Almost all packages with linux as a SourceName are kernel packages
+		// which does not apply within a container, as containers use the host's kernel
+		if p.Name() == "linux" {
+			continue
+		}
+
+		packageResults = append(packageResults, psr)
+	}
+
+	if len(packageResults) != len(scanResults.PackageScanResults) {
+		r.Infof("Filtered %d non container relevant package/s from the scan.\n", len(scanResults.PackageScanResults)-len(packageResults))
+	}
+
+	scanResults.PackageScanResults = packageResults
+}
+
 // filterIgnoredPackages removes ignore scanned packages according to config. Returns filtered scanned packages.
 func filterIgnoredPackages(r reporter.Reporter, scanResults *results.ScanResults) {
 	configManager := &scanResults.ConfigManager

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -356,6 +356,8 @@ func DoContainerScan(actions ScannerActions, r reporter.Reporter) (models.Vulner
 	// ----- Filtering -----
 	filterUnscannablePackages(r, &scanResult)
 
+	filterNonContainerRelevantPackages(r, &scanResult)
+
 	// --- Make Vulnerability Requests ---
 	if accessors.VulnMatcher != nil {
 		err = makeVulnRequestWithMatcher(r, scanResult.PackageScanResults, accessors.VulnMatcher)


### PR DESCRIPTION
Linux source packages are likely to be kernel packages, which generally do not apply in a container context, 