### PR TITLE
feat: Allow setting of the port number when using the --serve flag by adding a new --port (String) flag

### DIFF
--- a/cmd/osv-scanner/internal/helper/helper.go
+++ b/cmd/osv-scanner/internal/helper/helper.go
@@ -24,7 +24,7 @@ var OfflineFlags = map[string]string{
 
 // sets default port(8000) as a global variable
 var (
-    servePort = "8000"  // default port
+	servePort = "8000" // default port
 )
 
 var GlobalScanFlags = []cli.Flag{
@@ -54,9 +54,9 @@ var GlobalScanFlags = []cli.Flag{
 		Name:  "port",
 		Usage: "port number to use when serving HTML report (default: 8000)",
 		Action: func(_ *cli.Context, p string) error {
-            servePort = p
-            return nil
-        },
+			servePort = p
+			return nil
+		},
 	},
 	&cli.StringFlag{
 		Name:      "output",


### PR DESCRIPTION
changes are in file osv-scanner/cmd/osv-scanner/internal/helper/helper.go

1.Added a global variable servePort with a default value of "8000"

2.Added a new CLI flag --port that allows users to customize the port number used when serving the HTML report

3.Removed the hardcoded port number from the ServeHTML function, using the global servePort variable instead

4. The flag's Action function updates the global servePort variable when a custom port is specified

These changes allow users to specify a custom port using the --port flag when using the --serve option, while maintaining the default port 8000 if no custom port is specified.