### PR TITLE
feat: Update scalibr and add support for bun.lock

### DIFF
--- a/cmd/osv-scanner/__snapshots__/main_test.snap
+++ b/cmd/osv-scanner/__snapshots__/main_test.snap
@@ -339,16 +339,19 @@ Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
 Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
 Scanned <rootdir>/fixtures/locks-many/yarn.lock file and found 1 package
 Scanning dir ./fixtures/locks-insecure
+Scanned <rootdir>/fixtures/locks-insecure/bun.lock file and found 2 packages
 Scanned <rootdir>/fixtures/locks-insecure/composer.lock file and found 1 package
 Scanning dir ./fixtures/maven-transitive
 Scanned <rootdir>/fixtures/maven-transitive/pom.xml file and found 3 packages
 Filtered 1 local/unscannable package/s from the scan.
 Package npm/ansi-html/0.0.1 has been filtered out because: (no reason given)
 Package npm/balanced-match/1.0.2 has been filtered out because: (no reason given)
+Package npm/has-flag/4.0.0 has been filtered out because: (no reason given)
+Package npm/wrappy/1.0.2 has been filtered out because: (no reason given)
 Package Maven/org.apache.logging.log4j:log4j-api/2.14.1 has been filtered out because: it makes the table output really really long
 Package Maven/org.apache.logging.log4j:log4j-core/2.14.1 has been filtered out because: it makes the table output really really long
 Package Maven/org.apache.logging.log4j:log4j-web/2.14.1 has been filtered out because: it makes the table output really really long
-Filtered 5 ignored package/s from the scan.
+Filtered 7 ignored package/s from the scan.
 overriding license for package Alpine/alpine-baselayout/3.4.0-r0 with MIT
 overriding license for package Alpine/alpine-baselayout-data/3.4.0-r0 with MIT
 overriding license for package Alpine/alpine-keys/2.4-r1 with MIT
@@ -453,6 +456,22 @@ No issues found
       "version": "1.0.8",
       "licenses": [],
       "purl": "pkg:composer/league/flysystem@1.0.8"
+    },
+    {
+      "bom-ref": "pkg:npm/has-flag@4.0.0",
+      "type": "library",
+      "name": "has-flag",
+      "version": "4.0.0",
+      "licenses": [],
+      "purl": "pkg:npm/has-flag@4.0.0"
+    },
+    {
+      "bom-ref": "pkg:npm/wrappy@1.0.2",
+      "type": "library",
+      "name": "wrappy",
+      "version": "1.0.2",
+      "licenses": [],
+      "purl": "pkg:npm/wrappy@1.0.2"
     }
   ],
   "vulnerabilities": [
@@ -498,6 +517,7 @@ No issues found
 
 [TestRun/cyclonedx_1.4_output - 2]
 Scanning dir ./fixtures/locks-insecure
+Scanned <rootdir>/fixtures/locks-insecure/bun.lock file and found 2 packages
 Scanned <rootdir>/fixtures/locks-insecure/composer.lock file and found 1 package
 
 ---
@@ -516,6 +536,22 @@ Scanned <rootdir>/fixtures/locks-insecure/composer.lock file and found 1 package
       "version": "1.0.8",
       "licenses": [],
       "purl": "pkg:composer/league/flysystem@1.0.8"
+    },
+    {
+      "bom-ref": "pkg:npm/has-flag@4.0.0",
+      "type": "library",
+      "name": "has-flag",
+      "version": "4.0.0",
+      "licenses": [],
+      "purl": "pkg:npm/has-flag@4.0.0"
+    },
+    {
+      "bom-ref": "pkg:npm/wrappy@1.0.2",
+      "type": "library",
+      "name": "wrappy",
+      "version": "1.0.2",
+      "licenses": [],
+      "purl": "pkg:npm/wrappy@1.0.2"
     }
   ],
   "vulnerabilities": [
@@ -561,6 +597,7 @@ Scanned <rootdir>/fixtures/locks-insecure/composer.lock file and found 1 package
 
 [TestRun/cyclonedx_1.5_output - 2]
 Scanning dir ./fixtures/locks-insecure
+Scanned <rootdir>/fixtures/locks-insecure/bun.lock file and found 2 packages
 Scanned <rootdir>/fixtures/locks-insecure/composer.lock file and found 1 package
 
 ---
@@ -1631,11 +1668,14 @@ Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
 Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
 Scanned <rootdir>/fixtures/locks-many/yarn.lock file and found 1 package
 Scanning dir ./fixtures/locks-insecure
+Scanned <rootdir>/fixtures/locks-insecure/bun.lock file and found 2 packages
 Scanned <rootdir>/fixtures/locks-insecure/composer.lock file and found 1 package
 Filtered 1 local/unscannable package/s from the scan.
 Package npm/ansi-html/0.0.1 has been filtered out because: (no reason given)
 Package npm/balanced-match/1.0.2 has been filtered out because: (no reason given)
-Filtered 2 ignored package/s from the scan.
+Package npm/has-flag/4.0.0 has been filtered out because: (no reason given)
+Package npm/wrappy/1.0.2 has been filtered out because: (no reason given)
+Filtered 4 ignored package/s from the scan.
 ignoring license for package Alpine/alpine-baselayout/3.4.0-r0
 ignoring license for package Alpine/alpine-baselayout-data/3.4.0-r0
 ignoring license for package Alpine/alpine-keys/2.4-r1
@@ -2747,6 +2787,7 @@ stat <rootdir>/path/to/my:project/package-lock.json: no such file or directory
 Scanned <rootdir>/fixtures/locks-insecure/my-package-lock.json file as a package-lock.json and found 1 package
 Scanned <rootdir>/fixtures/locks-insecure/my-yarn.lock file as a yarn.lock and found 1 package
 Scanning dir ./fixtures/locks-insecure
+Scanned <rootdir>/fixtures/locks-insecure/bun.lock file and found 2 packages
 Scanned <rootdir>/fixtures/locks-insecure/composer.lock file and found 1 package
 +-------------------------------------+------+-----------+------------------+---------+----------------------------------------------+
 | OSV URL                             | CVSS | ECOSYSTEM | PACKAGE          | VERSION | SOURCE                                       |
@@ -2766,6 +2807,7 @@ Scanned <rootdir>/fixtures/locks-insecure/composer.lock file and found 1 package
 Scanned <rootdir>/fixtures/locks-insecure/my-yarn.lock file as a yarn.lock and found 1 package
 Scanned <rootdir>/fixtures/locks-insecure/my-package-lock.json file as a package-lock.json and found 1 package
 Scanning dir ./fixtures/locks-insecure
+Scanned <rootdir>/fixtures/locks-insecure/bun.lock file and found 2 packages
 Scanned <rootdir>/fixtures/locks-insecure/composer.lock file and found 1 package
 +-------------------------------------+------+-----------+------------------+---------+----------------------------------------------+
 | OSV URL                             | CVSS | ECOSYSTEM | PACKAGE          | VERSION | SOURCE                                       |
@@ -2813,6 +2855,7 @@ could not determine extractor, requested my-file
 [TestRun_LockfileWithExplicitParseAs/when_an_explicit_parse-as_is_given,_it's_applied_to_that_file - 1]
 Scanned <rootdir>/fixtures/locks-insecure/my-package-lock.json file as a package-lock.json and found 1 package
 Scanning dir ./fixtures/locks-insecure
+Scanned <rootdir>/fixtures/locks-insecure/bun.lock file and found 2 packages
 Scanned <rootdir>/fixtures/locks-insecure/composer.lock file and found 1 package
 +-------------------------------------+------+-----------+------------------+---------+----------------------------------------------+
 | OSV URL                             | CVSS | ECOSYSTEM | PACKAGE          | VERSION | SOURCE                                       |

--- a/cmd/osv-scanner/fixtures/locks-insecure/bun.lock
+++ b/cmd/osv-scanner/fixtures/locks-insecure/bun.lock
@@ -1,0 +1,17 @@
+{
+  "lockfileVersion": 0,
+  "workspaces": {
+    "": {
+      "name": "bun-lockfile",
+      "dependencies": {
+        "has-flag": "*",
+        "wrappy": "^1.0.0",
+      },
+    },
+  },
+  "packages": {
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+  }
+}

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/go-git/go-billy/v5 v5.6.2
 	github.com/go-git/go-git/v5 v5.13.2
 	github.com/google/go-cmp v0.6.0
-	github.com/google/osv-scalibr v0.1.6-0.20250204042239-1e0c0f48841d
+	github.com/google/osv-scalibr v0.1.7-0.20250205161050-34e66e88be2f
 	github.com/ianlancetaylor/demangle v0.0.0-20240912202439-0a2b6291aafd
 	github.com/jedib0t/go-pretty/v6 v6.6.5
 	github.com/muesli/reflow v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -184,6 +184,8 @@ github.com/google/go-containerregistry v0.20.2 h1:B1wPJ1SN/S7pB+ZAimcciVD+r+yV/l
 github.com/google/go-containerregistry v0.20.2/go.mod h1:z38EKdKh4h7IP2gSfUUqEvalZBqs6AoLeWfUy34nQC8=
 github.com/google/osv-scalibr v0.1.6-0.20250204042239-1e0c0f48841d h1:QoncpqAA6ehwjH6Zu9OV/TouftSIPChGH7cOPorzjWQ=
 github.com/google/osv-scalibr v0.1.6-0.20250204042239-1e0c0f48841d/go.mod h1:G4uAYcj3eBCWG0k7q8z5n9B4zcjT5iAZqQj2DbSeIoY=
+github.com/google/osv-scalibr v0.1.7-0.20250205161050-34e66e88be2f h1:wbB8jN6eUdQXS89gykLjjsybNG4KAAB9dCoUN6xlNPQ=
+github.com/google/osv-scalibr v0.1.7-0.20250205161050-34e66e88be2f/go.mod h1:QIEHZfY/muD9/oouPNaUQKpeZKr87pKOTNpXQxpVnoE=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/pkg/osvscanner/internal/scanners/extractorbuilder.go
+++ b/pkg/osvscanner/internal/scanners/extractorbuilder.go
@@ -5,7 +5,6 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/language/cpp/conanlock"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/dart/pubspec"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/dotnet/depsjson"
-	"github.com/google/osv-scalibr/extractor/filesystem/language/dotnet/packageslockjson"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/erlang/mixlock"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/golang/gobinary"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/golang/gomod"
@@ -15,6 +14,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/language/java/gradlelockfile"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/java/gradleverificationmetadataxml"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/java/pomxml"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/javascript/bunlock"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/javascript/packagelockjson"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/javascript/pnpmlock"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/javascript/yarnlock"
@@ -48,26 +48,51 @@ var sbomExtractors = []filesystem.Extractor{
 }
 
 var lockfileExtractors = []filesystem.Extractor{
+	// C
 	conanlock.Extractor{},
-	packageslockjson.Extractor{},
+
+	// Erlang
 	mixlock.Extractor{},
+
+	// Flutter
 	pubspec.Extractor{},
+
+	// Go
 	gomod.Extractor{},
+
+	// Java
 	gradlelockfile.Extractor{},
 	gradleverificationmetadataxml.Extractor{},
+
+	// Javascript
 	packagelockjson.Extractor{},
 	pnpmlock.Extractor{},
 	yarnlock.Extractor{},
+	bunlock.Extractor{},
+
+	// PHP
 	composerlock.Extractor{},
+
+	// Python
 	pipfilelock.Extractor{},
 	pdmlock.Extractor{},
 	poetrylock.Extractor{},
 	requirements.Extractor{},
-	renvlock.Extractor{},
-	gemfilelock.Extractor{},
-	cargolock.Extractor{},
 	uvlock.Extractor{},
+
+	// R
+	renvlock.Extractor{},
+
+	// Ruby
+	gemfilelock.Extractor{},
+
+	// Rust
+	cargolock.Extractor{},
+
+	// NuGet
 	depsjson.Extractor{},
+
+	// Haskell
 	cabal.Extractor{},
 	stacklock.Extractor{},
 	// TODO: map the extracted packages to SwiftURL in OSV.dev

--- a/pkg/osvscanner/internal/scanners/lockfile.go
+++ b/pkg/osvscanner/internal/scanners/lockfile.go
@@ -40,6 +40,7 @@ var lockfileExtractorMapping = map[string]string{
 	"packages.lock.json":          "dotnet/packageslockjson",
 	"conan.lock":                  "cpp/conanlock",
 	"go.mod":                      "go/gomod",
+	"bun.lock":                    "javascript/bunlock",
 	"Gemfile.lock":                "ruby/gemfilelock",
 	"cabal.project.freeze":        "haskell/cabal",
 	"stack.yaml.lock":             "haskell/stacklock",


### PR DESCRIPTION
Also reorder all the extractors so it's easier to read

We actually had a duplicate extractor defined in there.

This also fixes the issue with SBOM extraction discussed here: https://github.com/google/osv-scanner/discussions/1529#discussioncomment-12017733 

Though we still need to follow up with documentation updates.