### PR TITLE
fix: use the same sorting logic everywhere for sorting OSVs by their IDs

### DIFF
--- a/cmd/osv-scanner/fix/noninteractive.go
+++ b/cmd/osv-scanner/fix/noninteractive.go
@@ -10,6 +10,7 @@ import (
 	"deps.dev/util/resolve"
 	"deps.dev/util/resolve/dep"
 	"github.com/google/osv-scanner/v2/internal/datasource"
+	"github.com/google/osv-scanner/v2/internal/identifiers"
 	"github.com/google/osv-scanner/v2/internal/remediation"
 	"github.com/google/osv-scanner/v2/internal/resolution"
 	"github.com/google/osv-scanner/v2/internal/resolution/client"
@@ -408,7 +409,7 @@ func autoChooseOverridePatches(diffs []resolution.Difference, maxUpgrades int, o
 
 func sortVulns(vulns []vulnOutput) {
 	slices.SortFunc(vulns, func(a, b vulnOutput) int {
-		return cmp.Compare(a.ID, b.ID)
+		return identifiers.IDSortFunc(a.ID, b.ID)
 	})
 }
 

--- a/internal/output/output_result.go
+++ b/internal/output/output_result.go
@@ -479,7 +479,7 @@ func getVulnList(vulnMap map[string]VulnResult) []VulnResult {
 
 	// Sort projectResults to ensure consistent output
 	slices.SortFunc(vulnList, func(a, b VulnResult) int {
-		return cmp.Compare(a.ID, b.ID)
+		return identifiers.IDSortFunc(a.ID, b.ID)
 	})
 
 	return vulnList


### PR DESCRIPTION
I'm not sure if this ever actually matters, but I assume we want to always be using this function whenever we "sort OSVs by their IDs" for consistency