### PR TITLE
test: use skip instead of a condition so that `go-snaps` knows snapshots are not obsolete

### DIFF
--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -800,9 +800,11 @@ func TestRun_Docker(t *testing.T) {
 			t.Parallel()
 
 			// Only test on linux, and mac/windows CI/CD does not come with docker preinstalled
-			if runtime.GOOS == "linux" {
-				testCli(t, tt)
+			if runtime.GOOS != "linux" {
+				testutility.Skip(t, "Skipping Docker-based test as only Linux has Docker installed in CI")
 			}
+
+			testCli(t, tt)
 		})
 	}
 }


### PR DESCRIPTION
Currently, because we're not using `snaps.Skip` the Windows and MacOS test suites report obsolete snapshots that should be cleaned up 