### PR TITLE
ci: ensure that `testutility.Skip` is used over `t.Skip` and friends

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -33,6 +33,12 @@ linters:
     - unused
 
 linters-settings:
+  forbidigo:
+    forbid:
+      - p: ^testing.T.Skip
+        pkg: ^testing$
+        msg: "go-snaps needs to know the test has been skipped, so use `testutility.Skip` instead"
+    analyze-types: true
   govet:
     settings:
       printf:


### PR DESCRIPTION
While it's not been a massive issue or anything, it's pretty easy to enforce and means one less thing for us maintainers to remember when reviewing