### PR TITLE
refactor: rename test helper for clarity

### DIFF
--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -667,7 +667,7 @@ func TestRun_LocalDatabases(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			if testutility.IsAcceptanceTest() {
+			if testutility.IsAcceptanceTesting() {
 				testDir := testutility.CreateTestDir(t)
 				old := tt.args
 				tt.args = []string{"", "--experimental-local-db-path", testDir}

--- a/internal/testutility/utility.go
+++ b/internal/testutility/utility.go
@@ -34,16 +34,16 @@ func Skip(t *testing.T, args ...any) {
 	snaps.Skip(t, args...)
 }
 
-// IsAcceptanceTest returns true if the test suite is being run with acceptance tests enabled
-func IsAcceptanceTest() bool {
+// IsAcceptanceTesting returns true if the test suite is being run with acceptance tests enabled
+func IsAcceptanceTesting() bool {
 	return os.Getenv("TEST_ACCEPTANCE") == "true"
 }
 
 // SkipIfNotAcceptanceTesting marks the test as skipped unless the test suite is
-// being run with acceptance tests enabled, as indicated by IsAcceptanceTest
+// being run with acceptance tests enabled, as indicated by IsAcceptanceTesting
 func SkipIfNotAcceptanceTesting(t *testing.T, reason string) {
 	t.Helper()
-	if !IsAcceptanceTest() {
+	if !IsAcceptanceTesting() {
 		Skip(t, "Skipping extended test: ", reason)
 	}
 }


### PR DESCRIPTION
I think there are even better names we could use for both of these helpers, but given we're not using them that much for now I've just fixed the most immediate issue with the current name