### PR TITLE
test: remove trailing whitespace and add end-of-file newline

### DIFF
--- a/cmd/osv-scanner/__snapshots__/fix_test.snap
+++ b/cmd/osv-scanner/__snapshots__/fix_test.snap
@@ -3886,7 +3886,7 @@ Rewriting <tempdir>/pom.xml...
 [TestRun_Fix/fix_non-interactive_json_override_pom.xml - 3]
 <project>
   <modelVersion>4.0.0</modelVersion>
- 
+
   <groupId>dev.osv</groupId>
   <artifactId>osv-fix</artifactId>
   <version>1</version>
@@ -3928,6 +3928,7 @@ Rewriting <tempdir>/pom.xml...
     </dependency>
   </dependencies>
 </project>
+
 ---
 
 [TestRun_Fix/fix_non-interactive_json_relax_package.json - 1]
@@ -4077,7 +4078,7 @@ Warning: `fix` exists as both a subcommand of OSV-Scanner and as a file on the f
 [TestRun_Fix/fix_non-interactive_override_pom.xml - 3]
 <project>
   <modelVersion>4.0.0</modelVersion>
- 
+
   <groupId>dev.osv</groupId>
   <artifactId>osv-fix</artifactId>
   <version>1</version>
@@ -4119,6 +4120,7 @@ Warning: `fix` exists as both a subcommand of OSV-Scanner and as a file on the f
     </dependency>
   </dependencies>
 </project>
+
 ---
 
 [TestRun_Fix/fix_non-interactive_relax_package.json - 1]

--- a/cmd/osv-scanner/fix/fixtures/override-maven/pom.xml
+++ b/cmd/osv-scanner/fix/fixtures/override-maven/pom.xml
@@ -1,6 +1,6 @@
 <project>
   <modelVersion>4.0.0</modelVersion>
- 
+
   <groupId>dev.osv</groupId>
   <artifactId>osv-fix</artifactId>
   <version>1</version>


### PR DESCRIPTION
My IDE found these while I was working on some bigger test stuff - I assume they're not load bearing for the actual tests, so this'll mean less noise in diffs