### PR TITLE
refactor: replace experimental libraries with their std versions

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -22,7 +22,6 @@ linters:
     - err113           # will re-add later (another-rex)
     - nonamedreturns   # disagree with, for now (another-rex)
     - goconst          # not everything should be a constant
-    - exptostd         # will be enabled shortly
   presets:
     - bugs
     - comment

--- a/cmd/osv-scanner/fix/noninteractive.go
+++ b/cmd/osv-scanner/fix/noninteractive.go
@@ -423,7 +423,7 @@ func makeResultVuln(vuln resolution.Vulnerability) vulnOutput {
 		vk := sg.Nodes[sg.Dependency].Version
 		affected[packageOutput{Name: vk.Name, Version: vk.Version}] = struct{}{}
 	}
-	v.Packages = slices.Collect(maps.Keys(affected))
+	v.Packages = slices.AppendSeq(make([]packageOutput, 0, len(affected)), maps.Keys(affected))
 	slices.SortFunc(v.Packages, func(a, b packageOutput) int {
 		if c := cmp.Compare(a.Name, b.Name); c != 0 {
 			return c

--- a/cmd/osv-scanner/fix/noninteractive.go
+++ b/cmd/osv-scanner/fix/noninteractive.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"slices"
 
 	"deps.dev/util/resolve"
@@ -18,7 +19,6 @@ import (
 	lf "github.com/google/osv-scanner/v2/internal/resolution/lockfile"
 	"github.com/google/osv-scanner/v2/internal/resolution/manifest"
 	"github.com/google/osv-scanner/v2/internal/resolution/util"
-	"golang.org/x/exp/maps"
 )
 
 func autoInPlace(ctx context.Context, r *outputReporter, opts osvFixOptions, maxUpgrades int) error {
@@ -423,7 +423,7 @@ func makeResultVuln(vuln resolution.Vulnerability) vulnOutput {
 		vk := sg.Nodes[sg.Dependency].Version
 		affected[packageOutput{Name: vk.Name, Version: vk.Version}] = struct{}{}
 	}
-	v.Packages = maps.Keys(affected)
+	v.Packages = slices.Collect(maps.Keys(affected))
 	slices.SortFunc(v.Packages, func(a, b packageOutput) int {
 		if c := cmp.Compare(a.Name, b.Name); c != 0 {
 			return c
@@ -471,7 +471,7 @@ func populateResultVulns(outputResult *fixOutput, res *resolution.Result, allPat
 		}
 	}
 
-	outputResult.Vulnerabilities = maps.Values(vulns)
+	outputResult.Vulnerabilities = slices.Collect(maps.Values(vulns))
 	sortVulns(outputResult.Vulnerabilities)
 }
 

--- a/cmd/osv-scanner/fix/state-choose-strategy.go
+++ b/cmd/osv-scanner/fix/state-choose-strategy.go
@@ -2,6 +2,7 @@ package fix
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -11,7 +12,6 @@ import (
 	"github.com/google/osv-scanner/v2/internal/remediation"
 	"github.com/google/osv-scanner/v2/internal/resolution"
 	"github.com/google/osv-scanner/v2/internal/tui"
-	"golang.org/x/exp/slices"
 )
 
 type stateChooseStrategy struct {

--- a/cmd/osv-scanner/fix/state-in-place-result.go
+++ b/cmd/osv-scanner/fix/state-in-place-result.go
@@ -2,6 +2,7 @@ package fix
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/key"
@@ -10,7 +11,6 @@ import (
 	"github.com/google/osv-scanner/v2/internal/resolution"
 	lockf "github.com/google/osv-scanner/v2/internal/resolution/lockfile"
 	"github.com/google/osv-scanner/v2/internal/tui"
-	"golang.org/x/exp/slices"
 )
 
 type stateInPlaceResult struct {

--- a/cmd/osv-scanner/fix/state-relock-result.go
+++ b/cmd/osv-scanner/fix/state-relock-result.go
@@ -14,7 +14,6 @@ import (
 	"github.com/google/osv-scanner/v2/internal/resolution/client"
 	manif "github.com/google/osv-scanner/v2/internal/resolution/manifest"
 	"github.com/google/osv-scanner/v2/internal/tui"
-	"golang.org/x/exp/maps"
 )
 
 type stateRelockResult struct {
@@ -137,7 +136,7 @@ func (st *stateRelockResult) Update(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 			return errorAndExit(m, msg.err)
 		}
 		st.patches = msg.patches
-		maps.Clear(st.selectedPatches)
+		clear(st.selectedPatches)
 		st.buildPatchInfoViews(m)
 		st.patchesDone = true
 		if len(st.patches) > 0 {
@@ -155,7 +154,7 @@ func (st *stateRelockResult) Update(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.writing = false
 		m.relockBaseRes = st.currRes // relockBaseRes must match what is in the package.json
 		m.relockBaseResErrs = m.relockBaseRes.Errors()
-		maps.Clear(st.selectedPatches)
+		clear(st.selectedPatches)
 
 	case tui.ViewModelCloseMsg:
 		// info view wants to quit, just unfocus it

--- a/internal/clients/clientimpl/osvmatcher/cachedosvmatcher.go
+++ b/internal/clients/clientimpl/osvmatcher/cachedosvmatcher.go
@@ -82,7 +82,7 @@ func (matcher *CachedOSVMatcher) doQueries(ctx context.Context, invs []*extracto
 				toQuery[&osvdev.Query{Package: pkg}] = struct{}{}
 			}
 		}
-		queries = slices.Collect(maps.Keys(toQuery))
+		queries = slices.AppendSeq(make([]*osvdev.Query, 0, len(toQuery)), maps.Keys(toQuery))
 	}
 
 	if len(queries) == 0 {

--- a/internal/datasource/npm_registry.go
+++ b/internal/datasource/npm_registry.go
@@ -56,7 +56,7 @@ func (c *NpmRegistryAPIClient) Versions(ctx context.Context, pkg string) (NpmReg
 	}
 
 	return NpmRegistryVersions{
-		Versions: slices.Collect(maps.Keys(pkgDetails.Versions)),
+		Versions: slices.AppendSeq(make([]string, 0, len(pkgDetails.Versions)), maps.Keys(pkgDetails.Versions)),
 		Tags:     pkgDetails.Tags,
 	}, nil
 }

--- a/internal/datasource/npm_registry.go
+++ b/internal/datasource/npm_registry.go
@@ -5,12 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
+	"slices"
 	"sync"
 	"time"
 
 	"github.com/tidwall/gjson"
-	"golang.org/x/exp/maps"
 )
 
 type NpmRegistryAPIClient struct {
@@ -55,7 +56,7 @@ func (c *NpmRegistryAPIClient) Versions(ctx context.Context, pkg string) (NpmReg
 	}
 
 	return NpmRegistryVersions{
-		Versions: maps.Keys(pkgDetails.Versions),
+		Versions: slices.Collect(maps.Keys(pkgDetails.Versions)),
 		Tags:     pkgDetails.Tags,
 	}, nil
 }

--- a/internal/datasource/npm_registry_cache.go
+++ b/internal/datasource/npm_registry_cache.go
@@ -1,10 +1,9 @@
 package datasource
 
 import (
+	"maps"
 	"strings"
 	"time"
-
-	"golang.org/x/exp/maps"
 )
 
 type npmRegistryCache struct {

--- a/internal/grouper/grouper.go
+++ b/internal/grouper/grouper.go
@@ -50,7 +50,7 @@ func Group(vulns []IDAliases) []models.GroupInfo {
 	}
 
 	// Sort by group ID to maintain stable order for tests.
-	sortedKeys := slices.Collect(maps.Keys(extractedGroups))
+	sortedKeys := slices.AppendSeq(make([]int, 0, len(extractedGroups)), maps.Keys(extractedGroups))
 	sort.Ints(sortedKeys)
 
 	result := make([]models.GroupInfo, 0, len(sortedKeys))

--- a/internal/grouper/grouper.go
+++ b/internal/grouper/grouper.go
@@ -1,10 +1,9 @@
 package grouper
 
 import (
+	"maps"
 	"slices"
 	"sort"
-
-	"golang.org/x/exp/maps"
 
 	"github.com/google/osv-scanner/v2/internal/identifiers"
 	"github.com/google/osv-scanner/v2/pkg/models"
@@ -51,7 +50,7 @@ func Group(vulns []IDAliases) []models.GroupInfo {
 	}
 
 	// Sort by group ID to maintain stable order for tests.
-	sortedKeys := maps.Keys(extractedGroups)
+	sortedKeys := slices.Collect(maps.Keys(extractedGroups))
 	sort.Ints(sortedKeys)
 
 	result := make([]models.GroupInfo, 0, len(sortedKeys))

--- a/internal/output/result.go
+++ b/internal/output/result.go
@@ -24,7 +24,7 @@ type pkgSourceSet map[pkgWithSource]struct{}
 
 // StableKeys returns the pkgWithSource keys in a deterministic order
 func (pss *pkgSourceSet) StableKeys() []pkgWithSource {
-	pkgWithSrcKeys := slices.Collect(maps.Keys(*pss))
+	pkgWithSrcKeys := slices.AppendSeq(make([]pkgWithSource, 0, len(*pss)), maps.Keys(*pss))
 
 	slices.SortFunc(pkgWithSrcKeys, func(a, b pkgWithSource) int {
 		// compare based on each field in descending priority

--- a/internal/output/result.go
+++ b/internal/output/result.go
@@ -3,6 +3,7 @@ package output
 import (
 	"encoding/json"
 	"log"
+	"maps"
 	"os"
 	"slices"
 	"strings"
@@ -11,7 +12,6 @@ import (
 	"github.com/google/osv-scanner/v2/internal/utility/vulns"
 	"github.com/google/osv-scanner/v2/pkg/models"
 	"github.com/ossf/osv-schema/bindings/go/osvschema"
-	"golang.org/x/exp/maps"
 )
 
 type pkgWithSource struct {
@@ -24,7 +24,7 @@ type pkgSourceSet map[pkgWithSource]struct{}
 
 // StableKeys returns the pkgWithSource keys in a deterministic order
 func (pss *pkgSourceSet) StableKeys() []pkgWithSource {
-	pkgWithSrcKeys := maps.Keys(*pss)
+	pkgWithSrcKeys := slices.Collect(maps.Keys(*pss))
 
 	slices.SortFunc(pkgWithSrcKeys, func(a, b pkgWithSource) int {
 		// compare based on each field in descending priority

--- a/internal/remediation/in_place.go
+++ b/internal/remediation/in_place.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"context"
 	"errors"
+	"maps"
 	"slices"
 
 	"deps.dev/util/resolve"
@@ -17,7 +18,6 @@ import (
 	"github.com/google/osv-scanner/v2/internal/resolution/util"
 	"github.com/google/osv-scanner/v2/internal/utility/vulns"
 	"github.com/ossf/osv-schema/bindings/go/osvschema"
-	"golang.org/x/exp/maps"
 )
 
 type InPlacePatch struct {
@@ -123,7 +123,7 @@ func ComputeInPlacePatches(ctx context.Context, cl client.ResolutionClient, grap
 				}
 			}
 		}
-		set, err := buildConstraintSet(vk.Semver(), maps.Keys(reqVers))
+		set, err := buildConstraintSet(vk.Semver(), slices.Collect(maps.Keys(reqVers)))
 		if err != nil {
 			// TODO: log error?
 			continue

--- a/internal/remediation/in_place.go
+++ b/internal/remediation/in_place.go
@@ -123,7 +123,7 @@ func ComputeInPlacePatches(ctx context.Context, cl client.ResolutionClient, grap
 				}
 			}
 		}
-		set, err := buildConstraintSet(vk.Semver(), slices.Collect(maps.Keys(reqVers)))
+		set, err := buildConstraintSet(vk.Semver(), slices.AppendSeq(make([]string, 0, len(reqVers)), maps.Keys(reqVers)))
 		if err != nil {
 			// TODO: log error?
 			continue

--- a/internal/remediation/in_place_test.go
+++ b/internal/remediation/in_place_test.go
@@ -3,6 +3,7 @@ package remediation_test
 import (
 	"cmp"
 	"context"
+	"maps"
 	"slices"
 	"testing"
 
@@ -15,7 +16,6 @@ import (
 	"github.com/google/osv-scanner/v2/internal/resolution/depfile"
 	"github.com/google/osv-scanner/v2/internal/resolution/lockfile"
 	"github.com/google/osv-scanner/v2/internal/testutility"
-	"golang.org/x/exp/maps"
 )
 
 func parseInPlaceFixture(t *testing.T, universePath, lockfilePath string) (*resolve.Graph, client.ResolutionClient) {
@@ -56,7 +56,7 @@ func checkInPlaceResults(t *testing.T, res remediation.InPlaceResult) {
 		for _, sg := range v.Subgraphs {
 			nodes[sg.Dependency] = struct{}{}
 		}
-		sortedNodes := maps.Keys(nodes)
+		sortedNodes := slices.Collect(maps.Keys(nodes))
 		slices.Sort(sortedNodes)
 
 		return minimalVuln{

--- a/internal/remediation/in_place_test.go
+++ b/internal/remediation/in_place_test.go
@@ -56,7 +56,7 @@ func checkInPlaceResults(t *testing.T, res remediation.InPlaceResult) {
 		for _, sg := range v.Subgraphs {
 			nodes[sg.Dependency] = struct{}{}
 		}
-		sortedNodes := slices.Collect(maps.Keys(nodes))
+		sortedNodes := slices.AppendSeq(make([]resolve.NodeID, 0, len(nodes)), maps.Keys(nodes))
 		slices.Sort(sortedNodes)
 
 		return minimalVuln{

--- a/internal/remediation/suggest/maven.go
+++ b/internal/remediation/suggest/maven.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"slices"
 	"strings"
 
 	"deps.dev/util/resolve"
@@ -12,7 +13,6 @@ import (
 	"github.com/google/osv-scanner/v2/internal/remediation/upgrade"
 	"github.com/google/osv-scanner/v2/internal/resolution/manifest"
 	"github.com/google/osv-scanner/v2/internal/utility/maven"
-	"golang.org/x/exp/slices"
 )
 
 type MavenSuggester struct{}

--- a/internal/remediation/testhelpers_test.go
+++ b/internal/remediation/testhelpers_test.go
@@ -3,6 +3,7 @@ package remediation_test
 import (
 	"cmp"
 	"context"
+	"maps"
 	"slices"
 	"testing"
 
@@ -13,7 +14,6 @@ import (
 	"github.com/google/osv-scanner/v2/internal/resolution/depfile"
 	"github.com/google/osv-scanner/v2/internal/resolution/manifest"
 	"github.com/google/osv-scanner/v2/internal/testutility"
-	"golang.org/x/exp/maps"
 )
 
 func parseRemediationFixture(t *testing.T, universePath, manifestPath string, opts resolution.ResolveOpts) (*resolution.Result, client.ResolutionClient) {
@@ -61,7 +61,7 @@ func checkRemediationResults(t *testing.T, res []resolution.Difference) {
 		for _, sg := range v.Subgraphs {
 			nodes[sg.Dependency] = struct{}{}
 		}
-		sortedNodes := maps.Keys(nodes)
+		sortedNodes := slices.Collect(maps.Keys(nodes))
 		slices.Sort(sortedNodes)
 
 		return minimalVuln{

--- a/internal/remediation/testhelpers_test.go
+++ b/internal/remediation/testhelpers_test.go
@@ -61,7 +61,7 @@ func checkRemediationResults(t *testing.T, res []resolution.Difference) {
 		for _, sg := range v.Subgraphs {
 			nodes[sg.Dependency] = struct{}{}
 		}
-		sortedNodes := slices.Collect(maps.Keys(nodes))
+		sortedNodes := slices.AppendSeq(make([]resolve.NodeID, 0, len(nodes)), maps.Keys(nodes))
 		slices.Sort(sortedNodes)
 
 		return minimalVuln{

--- a/internal/resolution/lockfile/npm_v2.go
+++ b/internal/resolution/lockfile/npm_v2.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"context"
 	"errors"
+	"maps"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -14,7 +15,6 @@ import (
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/pretty"
 	"github.com/tidwall/sjson"
-	"golang.org/x/exp/maps"
 )
 
 // New-style (npm >= 7 / lockfileVersion 2+) structure
@@ -176,7 +176,7 @@ func (rw NpmReadWriter) makeNodeModuleDeps(pkg npmLockPackage, includeDev bool) 
 }
 
 func (rw NpmReadWriter) packageNamesByNodeModuleDepth(packages map[string]npmLockPackage) []string {
-	keys := maps.Keys(packages)
+	keys := slices.Collect(maps.Keys(packages))
 	slices.SortFunc(keys, func(a, b string) int {
 		aSplit := strings.Split(a, "node_modules/")
 		bSplit := strings.Split(b, "node_modules/")

--- a/internal/resolution/lockfile/npm_v2.go
+++ b/internal/resolution/lockfile/npm_v2.go
@@ -176,7 +176,7 @@ func (rw NpmReadWriter) makeNodeModuleDeps(pkg npmLockPackage, includeDev bool) 
 }
 
 func (rw NpmReadWriter) packageNamesByNodeModuleDepth(packages map[string]npmLockPackage) []string {
-	keys := slices.Collect(maps.Keys(packages))
+	keys := slices.AppendSeq(make([]string, 0, len(packages)), maps.Keys(packages))
 	slices.SortFunc(keys, func(a, b string) int {
 		aSplit := strings.Split(a, "node_modules/")
 		bSplit := strings.Split(b, "node_modules/")

--- a/internal/tui/dependency-graph.go
+++ b/internal/tui/dependency-graph.go
@@ -2,12 +2,12 @@ package tui
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"deps.dev/util/resolve"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/google/osv-scanner/v2/internal/resolution"
-	"golang.org/x/exp/slices"
 )
 
 type chainGraphNode struct {

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"os"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -33,7 +35,6 @@ import (
 	"github.com/google/osv-scanner/v2/pkg/osvscanner/internal/scanners"
 	"github.com/google/osv-scanner/v2/pkg/reporter"
 	"github.com/ossf/osv-schema/bindings/go/osvschema"
-	"golang.org/x/exp/maps"
 )
 
 type ScannerActions struct {
@@ -411,7 +412,7 @@ func buildLicenseSummary(scanResult *results.ScanResults) []models.LicenseCount 
 		return []models.LicenseCount{}
 	}
 
-	licenses := maps.Keys(counts)
+	licenses := slices.Collect(maps.Keys(counts))
 
 	// Sort the license count in descending count order with the UNKNOWN
 	// license last.

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -412,7 +412,7 @@ func buildLicenseSummary(scanResult *results.ScanResults) []models.LicenseCount 
 		return []models.LicenseCount{}
 	}
 
-	licenses := slices.Collect(maps.Keys(counts))
+	licenses := slices.AppendSeq(make([]models.License, 0, len(counts)), maps.Keys(counts))
 
 	// Sort the license count in descending count order with the UNKNOWN
 	// license last.

--- a/scripts/generate_mock_resolution_universe/main.go
+++ b/scripts/generate_mock_resolution_universe/main.go
@@ -13,6 +13,7 @@ import (
 	"encoding/gob"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -38,7 +39,6 @@ import (
 	"github.com/google/osv-scanner/v2/internal/resolution/util"
 	"github.com/google/osv-scanner/v2/internal/version"
 	"github.com/ossf/osv-schema/bindings/go/osvschema"
-	"golang.org/x/exp/maps"
 	"golang.org/x/sync/errgroup"
 	"gopkg.in/yaml.v3"
 )
@@ -209,7 +209,7 @@ func makeUniverse(cl *client.DepsDevClient) (clienttest.ResolutionUniverse, erro
 		return clienttest.ResolutionUniverse{}, err
 	}
 
-	pks := maps.Keys(pkgs)
+	pks := slices.Collect(maps.Keys(pkgs))
 	slices.SortFunc(pks, func(a, b resolve.PackageKey) int { return a.Compare(b) })
 
 	if len(pks) == 0 {

--- a/scripts/generate_mock_resolution_universe/main.go
+++ b/scripts/generate_mock_resolution_universe/main.go
@@ -209,7 +209,7 @@ func makeUniverse(cl *client.DepsDevClient) (clienttest.ResolutionUniverse, erro
 		return clienttest.ResolutionUniverse{}, err
 	}
 
-	pks := slices.Collect(maps.Keys(pkgs))
+	pks := slices.AppendSeq(make([]resolve.PackageKey, 0, len(pkgs)), maps.Keys(pkgs))
 	slices.SortFunc(pks, func(a, b resolve.PackageKey) int { return a.Compare(b) })
 
 	if len(pks) == 0 {


### PR DESCRIPTION
These became stable in Go v1.21, so we can stop using the `x/exp` versions

(this will be enforced by the `expotostd` linter which is being introduced in the next version of golanglint-ci)