### PR TITLE
test: deduplicate `createTestDir` helper

### DIFF
--- a/pkg/lockfile/helpers_test.go
+++ b/pkg/lockfile/helpers_test.go
@@ -119,19 +119,6 @@ func expectPackages(t *testing.T, actualPackages []lockfile.PackageDetails, expe
 	}
 }
 
-func createTestDir(t *testing.T) (string, func()) {
-	t.Helper()
-
-	p, err := os.MkdirTemp("", "osv-scanner-test-*")
-	if err != nil {
-		t.Fatalf("could not create test directory: %v", err)
-	}
-
-	return p, func() {
-		_ = os.RemoveAll(p)
-	}
-}
-
 func copyFile(t *testing.T, from, to string) string {
 	t.Helper()
 

--- a/pkg/lockfile/node-modules_test.go
+++ b/pkg/lockfile/node-modules_test.go
@@ -5,27 +5,26 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/google/osv-scanner/v2/internal/testutility"
 	"github.com/google/osv-scanner/v2/pkg/lockfile"
 )
 
-func createTestDirWithNodeModulesDir(t *testing.T) (string, func()) {
+func createTestDirWithNodeModulesDir(t *testing.T) string {
 	t.Helper()
 
-	testDir, cleanupTestDir := createTestDir(t)
+	testDir := testutility.CreateTestDir(t)
 
 	if err := os.Mkdir(filepath.Join(testDir, "node_modules"), 0750); err != nil {
-		cleanupTestDir()
 		t.Fatalf("could not create node_modules directory: %v", err)
 	}
 
-	return testDir, cleanupTestDir
+	return testDir
 }
 
 func testParsingNodeModules(t *testing.T, fixture string) ([]lockfile.PackageDetails, error) {
 	t.Helper()
 
-	testDir, cleanupTestDir := createTestDirWithNodeModulesDir(t)
-	defer cleanupTestDir()
+	testDir := createTestDirWithNodeModulesDir(t)
 
 	file := copyFile(t, fixture, filepath.Join(testDir, "node_modules", ".package-lock.json"))
 


### PR DESCRIPTION
This test was landed around the same time that the utility was landed, and I forgot to go back and clean it up