### PR TITLE
ci: upgrade golangci-lint to v1.64

### DIFF
--- a/.github/workflows/lint-action/action.yml
+++ b/.github/workflows/lint-action/action.yml
@@ -22,5 +22,5 @@ runs:
       uses: golangci/golangci-lint-action@e60da84bfae8c7920a47be973d75e15710aa8bd7 # v6.3.0
       with:
         # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-        version: v1.62.2
+        version: v1.64.4
         args: --timeout=5m

--- a/cmd/osv-scanner/fix/noninteractive.go
+++ b/cmd/osv-scanner/fix/noninteractive.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"slices"
 
 	"deps.dev/util/resolve"
@@ -18,7 +19,6 @@ import (
 	"github.com/google/osv-scanner/v2/internal/resolution/manifest"
 	"github.com/google/osv-scanner/v2/internal/resolution/util"
 	"github.com/google/osv-scanner/v2/pkg/lockfile"
-	"golang.org/x/exp/maps"
 )
 
 func autoInPlace(ctx context.Context, r *outputReporter, opts osvFixOptions, maxUpgrades int) error {
@@ -423,7 +423,7 @@ func makeResultVuln(vuln resolution.Vulnerability) vulnOutput {
 		vk := sg.Nodes[sg.Dependency].Version
 		affected[packageOutput{Name: vk.Name, Version: vk.Version}] = struct{}{}
 	}
-	v.Packages = maps.Keys(affected)
+	v.Packages = slices.Collect(maps.Keys(affected))
 	slices.SortFunc(v.Packages, func(a, b packageOutput) int {
 		if c := cmp.Compare(a.Name, b.Name); c != 0 {
 			return c
@@ -471,7 +471,7 @@ func populateResultVulns(outputResult *fixOutput, res *resolution.Result, allPat
 		}
 	}
 
-	outputResult.Vulnerabilities = maps.Values(vulns)
+	outputResult.Vulnerabilities = slices.Collect(maps.Values(vulns))
 	sortVulns(outputResult.Vulnerabilities)
 }
 

--- a/cmd/osv-scanner/fix/state-choose-strategy.go
+++ b/cmd/osv-scanner/fix/state-choose-strategy.go
@@ -2,6 +2,7 @@ package fix
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -11,7 +12,6 @@ import (
 	"github.com/google/osv-scanner/v2/internal/remediation"
 	"github.com/google/osv-scanner/v2/internal/resolution"
 	"github.com/google/osv-scanner/v2/internal/tui"
-	"golang.org/x/exp/slices"
 )
 
 type stateChooseStrategy struct {

--- a/cmd/osv-scanner/fix/state-in-place-result.go
+++ b/cmd/osv-scanner/fix/state-in-place-result.go
@@ -2,6 +2,7 @@ package fix
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/key"
@@ -10,7 +11,6 @@ import (
 	"github.com/google/osv-scanner/v2/internal/resolution"
 	lockf "github.com/google/osv-scanner/v2/internal/resolution/lockfile"
 	"github.com/google/osv-scanner/v2/internal/tui"
-	"golang.org/x/exp/slices"
 )
 
 type stateInPlaceResult struct {

--- a/cmd/osv-scanner/fix/state-relock-result.go
+++ b/cmd/osv-scanner/fix/state-relock-result.go
@@ -14,7 +14,6 @@ import (
 	"github.com/google/osv-scanner/v2/internal/resolution/client"
 	manif "github.com/google/osv-scanner/v2/internal/resolution/manifest"
 	"github.com/google/osv-scanner/v2/internal/tui"
-	"golang.org/x/exp/maps"
 )
 
 type stateRelockResult struct {
@@ -137,7 +136,7 @@ func (st *stateRelockResult) Update(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 			return errorAndExit(m, msg.err)
 		}
 		st.patches = msg.patches
-		maps.Clear(st.selectedPatches)
+		clear(st.selectedPatches)
 		st.buildPatchInfoViews(m)
 		st.patchesDone = true
 		if len(st.patches) > 0 {
@@ -155,7 +154,7 @@ func (st *stateRelockResult) Update(m model, msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.writing = false
 		m.relockBaseRes = st.currRes // relockBaseRes must match what is in the package.json
 		m.relockBaseResErrs = m.relockBaseRes.Errors()
-		maps.Clear(st.selectedPatches)
+		clear(st.selectedPatches)
 
 	case tui.ViewModelCloseMsg:
 		// info view wants to quit, just unfocus it

--- a/internal/datasource/npm_registry.go
+++ b/internal/datasource/npm_registry.go
@@ -5,12 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
+	"slices"
 	"sync"
 	"time"
 
 	"github.com/tidwall/gjson"
-	"golang.org/x/exp/maps"
 )
 
 type NpmRegistryAPIClient struct {
@@ -55,7 +56,7 @@ func (c *NpmRegistryAPIClient) Versions(ctx context.Context, pkg string) (NpmReg
 	}
 
 	return NpmRegistryVersions{
-		Versions: maps.Keys(pkgDetails.Versions),
+		Versions: slices.Collect(maps.Keys(pkgDetails.Versions)),
 		Tags:     pkgDetails.Tags,
 	}, nil
 }

--- a/internal/datasource/npm_registry_cache.go
+++ b/internal/datasource/npm_registry_cache.go
@@ -1,10 +1,9 @@
 package datasource
 
 import (
+	"maps"
 	"strings"
 	"time"
-
-	"golang.org/x/exp/maps"
 )
 
 type npmRegistryCache struct {

--- a/internal/grouper/grouper.go
+++ b/internal/grouper/grouper.go
@@ -1,10 +1,9 @@
 package grouper
 
 import (
+	"maps"
 	"slices"
 	"sort"
-
-	"golang.org/x/exp/maps"
 
 	"github.com/google/osv-scanner/v2/internal/identifiers"
 	"github.com/google/osv-scanner/v2/pkg/models"
@@ -51,7 +50,7 @@ func Group(vulns []IDAliases) []models.GroupInfo {
 	}
 
 	// Sort by group ID to maintain stable order for tests.
-	sortedKeys := maps.Keys(extractedGroups)
+	sortedKeys := slices.Collect(maps.Keys(extractedGroups))
 	sort.Ints(sortedKeys)
 
 	result := make([]models.GroupInfo, 0, len(sortedKeys))

--- a/internal/output/result.go
+++ b/internal/output/result.go
@@ -3,13 +3,13 @@ package output
 import (
 	"encoding/json"
 	"log"
+	"maps"
 	"os"
 	"slices"
 	"strings"
 
 	"github.com/google/osv-scanner/v2/internal/identifiers"
 	"github.com/google/osv-scanner/v2/pkg/models"
-	"golang.org/x/exp/maps"
 )
 
 type pkgWithSource struct {
@@ -22,7 +22,7 @@ type pkgSourceSet map[pkgWithSource]struct{}
 
 // StableKeys returns the pkgWithSource keys in a deterministic order
 func (pss *pkgSourceSet) StableKeys() []pkgWithSource {
-	pkgWithSrcKeys := maps.Keys(*pss)
+	pkgWithSrcKeys := slices.Collect(maps.Keys(*pss))
 
 	slices.SortFunc(pkgWithSrcKeys, func(a, b pkgWithSource) int {
 		// compare based on each field in descending priority

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -3,11 +3,11 @@ package output
 import (
 	"fmt"
 	"io"
+	"maps"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
-
-	"golang.org/x/exp/maps"
 
 	"github.com/google/osv-scanner/v2/internal/utility/results"
 	"github.com/google/osv-scanner/v2/internal/utility/severity"
@@ -298,7 +298,7 @@ func licenseSummaryTableBuilder(outputTable table.Writer, vulnResult *models.Vul
 		// No packages found.
 		return outputTable
 	}
-	licenses := maps.Keys(counts)
+	licenses := slices.Collect(maps.Keys(counts))
 	// Sort the license count in descending count order with the UNKNOWN
 	// license last.
 	sort.Slice(licenses, func(i, j int) bool {

--- a/internal/remediation/in_place.go
+++ b/internal/remediation/in_place.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"context"
 	"errors"
+	"maps"
 	"slices"
 
 	"deps.dev/util/resolve"
@@ -17,7 +18,6 @@ import (
 	"github.com/google/osv-scanner/v2/internal/resolution/util"
 	"github.com/google/osv-scanner/v2/internal/utility/vulns"
 	"github.com/google/osv-scanner/v2/pkg/models"
-	"golang.org/x/exp/maps"
 )
 
 type InPlacePatch struct {
@@ -123,7 +123,7 @@ func ComputeInPlacePatches(ctx context.Context, cl client.ResolutionClient, grap
 				}
 			}
 		}
-		set, err := buildConstraintSet(vk.Semver(), maps.Keys(reqVers))
+		set, err := buildConstraintSet(vk.Semver(), slices.Collect(maps.Keys(reqVers)))
 		if err != nil {
 			// TODO: log error?
 			continue

--- a/internal/remediation/in_place_test.go
+++ b/internal/remediation/in_place_test.go
@@ -3,6 +3,7 @@ package remediation_test
 import (
 	"cmp"
 	"context"
+	"maps"
 	"slices"
 	"testing"
 
@@ -15,7 +16,6 @@ import (
 	"github.com/google/osv-scanner/v2/internal/resolution/lockfile"
 	"github.com/google/osv-scanner/v2/internal/testutility"
 	lf "github.com/google/osv-scanner/v2/pkg/lockfile"
-	"golang.org/x/exp/maps"
 )
 
 func parseInPlaceFixture(t *testing.T, universePath, lockfilePath string) (*resolve.Graph, client.ResolutionClient) {
@@ -56,7 +56,7 @@ func checkInPlaceResults(t *testing.T, res remediation.InPlaceResult) {
 		for _, sg := range v.Subgraphs {
 			nodes[sg.Dependency] = struct{}{}
 		}
-		sortedNodes := maps.Keys(nodes)
+		sortedNodes := slices.Collect(maps.Keys(nodes))
 		slices.Sort(sortedNodes)
 
 		return minimalVuln{

--- a/internal/remediation/suggest/maven.go
+++ b/internal/remediation/suggest/maven.go
@@ -5,12 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"slices"
 
 	"deps.dev/util/resolve"
 	"deps.dev/util/semver"
 	"github.com/google/osv-scanner/v2/internal/resolution/manifest"
 	"github.com/google/osv-scanner/v2/pkg/lockfile"
-	"golang.org/x/exp/slices"
 )
 
 type MavenSuggester struct{}

--- a/internal/remediation/testhelpers_test.go
+++ b/internal/remediation/testhelpers_test.go
@@ -3,6 +3,7 @@ package remediation_test
 import (
 	"cmp"
 	"context"
+	"maps"
 	"slices"
 	"testing"
 
@@ -13,7 +14,6 @@ import (
 	"github.com/google/osv-scanner/v2/internal/resolution/manifest"
 	"github.com/google/osv-scanner/v2/internal/testutility"
 	lf "github.com/google/osv-scanner/v2/pkg/lockfile"
-	"golang.org/x/exp/maps"
 )
 
 func parseRemediationFixture(t *testing.T, universePath, manifestPath string, opts resolution.ResolveOpts) (*resolution.Result, client.ResolutionClient) {
@@ -61,7 +61,7 @@ func checkRemediationResults(t *testing.T, res []resolution.Difference) {
 		for _, sg := range v.Subgraphs {
 			nodes[sg.Dependency] = struct{}{}
 		}
-		sortedNodes := maps.Keys(nodes)
+		sortedNodes := slices.Collect(maps.Keys(nodes))
 		slices.Sort(sortedNodes)
 
 		return minimalVuln{

--- a/internal/resolution/lockfile/npm_v2.go
+++ b/internal/resolution/lockfile/npm_v2.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"context"
 	"errors"
+	"maps"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -15,7 +16,6 @@ import (
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/pretty"
 	"github.com/tidwall/sjson"
-	"golang.org/x/exp/maps"
 )
 
 // New-style (npm >= 7 / lockfileVersion 2+) structure
@@ -177,7 +177,7 @@ func (rw NpmReadWriter) makeNodeModuleDeps(pkg lockfile.NpmLockPackage, includeD
 }
 
 func (rw NpmReadWriter) packageNamesByNodeModuleDepth(packages map[string]lockfile.NpmLockPackage) []string {
-	keys := maps.Keys(packages)
+	keys := slices.Collect(maps.Keys(packages))
 	slices.SortFunc(keys, func(a, b string) int {
 		aSplit := strings.Split(a, "node_modules/")
 		bSplit := strings.Split(b, "node_modules/")

--- a/internal/scalibrextract/language/java/pomxmlnet/extractor.go
+++ b/internal/scalibrextract/language/java/pomxmlnet/extractor.go
@@ -4,9 +4,9 @@ package pomxmlnet
 import (
 	"context"
 	"fmt"
+	"maps"
 	"path/filepath"
-
-	"golang.org/x/exp/maps"
+	"slices"
 
 	mavenresolve "deps.dev/util/resolve/maven"
 	mavenutil "github.com/google/osv-scanner/v2/internal/utility/maven"
@@ -170,7 +170,7 @@ func (e Extractor) Extract(ctx context.Context, input *filesystem.ScanInput) ([]
 		details[inventory.Name] = &inventory
 	}
 
-	return maps.Values(details), nil
+	return slices.Collect(maps.Values(details)), nil
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.

--- a/internal/testutility/utility.go
+++ b/internal/testutility/utility.go
@@ -63,6 +63,7 @@ func ValueIfOnWindows(win, or string) string {
 func CreateTestDir(t *testing.T) string {
 	t.Helper()
 
+	//nolint:usetesting // we need to customize the directory name to replace in snapshots
 	p, err := os.MkdirTemp("", "osv-scanner-test-*")
 	if err != nil {
 		t.Fatalf("could not create test directory: %v", err)

--- a/internal/tui/dependency-graph.go
+++ b/internal/tui/dependency-graph.go
@@ -2,12 +2,12 @@ package tui
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"deps.dev/util/resolve"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/google/osv-scanner/v2/internal/resolution"
-	"golang.org/x/exp/slices"
 )
 
 type chainGraphNode struct {

--- a/pkg/lockfile/helpers_test.go
+++ b/pkg/lockfile/helpers_test.go
@@ -122,6 +122,7 @@ func expectPackages(t *testing.T, actualPackages []lockfile.PackageDetails, expe
 func createTestDir(t *testing.T) (string, func()) {
 	t.Helper()
 
+	//nolint:usetesting // we need to customize the directory name to replace in snapshots
 	p, err := os.MkdirTemp("", "osv-scanner-test-*")
 	if err != nil {
 		t.Fatalf("could not create test directory: %v", err)

--- a/pkg/lockfile/parse-go-lock.go
+++ b/pkg/lockfile/parse-go-lock.go
@@ -3,10 +3,11 @@ package lockfile
 import (
 	"fmt"
 	"io"
+	"maps"
 	"path/filepath"
+	"slices"
 	"strings"
 
-	"golang.org/x/exp/maps"
 	"golang.org/x/mod/modfile"
 )
 
@@ -92,7 +93,7 @@ func (e GoLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 		}
 	}
 
-	return maps.Values(deduplicatePackages(packages)), nil
+	return slices.Collect(maps.Values(deduplicatePackages(packages))), nil
 }
 
 var _ Extractor = GoLockExtractor{}

--- a/pkg/lockfile/parse-maven-lock.go
+++ b/pkg/lockfile/parse-maven-lock.go
@@ -3,12 +3,13 @@ package lockfile
 import (
 	"encoding/xml"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/google/osv-scanner/v2/internal/cachedregexp"
-	"golang.org/x/exp/maps"
 )
 
 type MavenLockDependency struct {
@@ -153,7 +154,7 @@ func (e MavenLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 		details[finalName] = pkgDetails
 	}
 
-	return maps.Values(details), nil
+	return slices.Collect(maps.Values(details)), nil
 }
 
 var _ Extractor = MavenLockExtractor{}

--- a/pkg/lockfile/parse-npm-lock.go
+++ b/pkg/lockfile/parse-npm-lock.go
@@ -3,12 +3,11 @@ package lockfile
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"path"
 	"path/filepath"
+	"slices"
 	"strings"
-
-	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 )
 
 type NpmLockDependency struct {
@@ -232,7 +231,7 @@ func (e NpmLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 		return []PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
 	}
 
-	return maps.Values(parseNpmLock(*parsedLockfile)), nil
+	return slices.Collect(maps.Values(parseNpmLock(*parsedLockfile))), nil
 }
 
 var _ Extractor = NpmLockExtractor{}

--- a/pkg/lockfile/parse-nuget-lock.go
+++ b/pkg/lockfile/parse-nuget-lock.go
@@ -3,9 +3,9 @@ package lockfile
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"path/filepath"
-
-	"golang.org/x/exp/maps"
+	"slices"
 )
 
 type NuGetLockPackage struct {
@@ -48,7 +48,7 @@ func parseNuGetLock(lockfile NuGetLockfile) ([]PackageDetails, error) {
 		}
 	}
 
-	return maps.Values(details), nil
+	return slices.Collect(maps.Values(details)), nil
 }
 
 type NuGetLockExtractor struct{}

--- a/pkg/lockfile/parse-pipenv-lock.go
+++ b/pkg/lockfile/parse-pipenv-lock.go
@@ -3,9 +3,9 @@ package lockfile
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"path/filepath"
-
-	"golang.org/x/exp/maps"
+	"slices"
 )
 
 type PipenvPackage struct {
@@ -39,7 +39,7 @@ func (e PipenvLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 	addPkgDetails(details, parsedLockfile.Packages, "")
 	addPkgDetails(details, parsedLockfile.PackagesDev, "dev")
 
-	return maps.Values(details), nil
+	return slices.Collect(maps.Values(details)), nil
 }
 
 func addPkgDetails(details map[string]PackageDetails, packages map[string]PipenvPackage, group string) {

--- a/pkg/lockfile/parse-requirements-txt.go
+++ b/pkg/lockfile/parse-requirements-txt.go
@@ -3,11 +3,12 @@ package lockfile
 import (
 	"bufio"
 	"fmt"
+	"maps"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/google/osv-scanner/v2/internal/cachedregexp"
-	"golang.org/x/exp/maps"
 )
 
 const PipEcosystem Ecosystem = "PyPI"
@@ -195,7 +196,7 @@ func parseRequirementsTxt(f DepFile, requiredAlready map[string]struct{}) ([]Pac
 		return []PackageDetails{}, fmt.Errorf("error while scanning %s: %w", f.Path(), err)
 	}
 
-	return maps.Values(packages), nil
+	return slices.Collect(maps.Values(packages)), nil
 }
 
 var _ Extractor = RequirementsTxtExtractor{}

--- a/pkg/lockfile/parse.go
+++ b/pkg/lockfile/parse.go
@@ -3,11 +3,11 @@ package lockfile
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
-
-	"golang.org/x/exp/maps"
 )
 
 func FindParser(pathToLockfile string, parseAs string) (PackageDetailsParser, string) {
@@ -67,7 +67,7 @@ func (ps Packages) Ecosystems() []Ecosystem {
 		ecosystems[pkg.Ecosystem] = struct{}{}
 	}
 
-	slicedEcosystems := maps.Keys(ecosystems)
+	slicedEcosystems := slices.Collect(maps.Keys(ecosystems))
 
 	sort.Slice(slicedEcosystems, func(i, j int) bool {
 		return slicedEcosystems[i] < slicedEcosystems[j]

--- a/scripts/generate_mock_resolution_universe/main.go
+++ b/scripts/generate_mock_resolution_universe/main.go
@@ -13,6 +13,7 @@ import (
 	"encoding/gob"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -39,7 +40,6 @@ import (
 	lf "github.com/google/osv-scanner/v2/pkg/lockfile"
 	"github.com/google/osv-scanner/v2/pkg/models"
 	"github.com/google/osv-scanner/v2/pkg/osv"
-	"golang.org/x/exp/maps"
 	"golang.org/x/sync/errgroup"
 	"gopkg.in/yaml.v3"
 )
@@ -210,7 +210,7 @@ func makeUniverse(cl *client.DepsDevClient) (clienttest.ResolutionUniverse, erro
 		return clienttest.ResolutionUniverse{}, err
 	}
 
-	pks := maps.Keys(pkgs)
+	pks := slices.Collect(maps.Keys(pkgs))
 	slices.SortFunc(pks, func(a, b resolve.PackageKey) int { return a.Compare(b) })
 
 	if len(pks) == 0 {

--- a/scripts/run_lints.sh
+++ b/scripts/run_lints.sh
@@ -2,4 +2,4 @@
 
 set -ex
 
-go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.2 run ./... --max-same-issues 0
+go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.4 run ./... --max-same-issues 0


### PR DESCRIPTION
I'm hoping this might fix the sudden linting failures we're getting - note that 9eb129a26b9a8449c3e05d391a2d216878121efe has been cherry-picked to #1620