### PR TITLE
refactor(cmd): make function private

### DIFF
--- a/cmd/osv-scanner/scan/source/main.go
+++ b/cmd/osv-scanner/scan/source/main.go
@@ -92,14 +92,14 @@ func Command(stdout, stderr io.Writer, r *reporter.Reporter) *cli.Command {
 		ArgsUsage:   "[directory1 directory2...]",
 		Action: func(c *cli.Context) error {
 			var err error
-			*r, err = Action(c, stdout, stderr)
+			*r, err = action(c, stdout, stderr)
 
 			return err
 		},
 	}
 }
 
-func Action(context *cli.Context, stdout, stderr io.Writer) (reporter.Reporter, error) {
+func action(context *cli.Context, stdout, stderr io.Writer) (reporter.Reporter, error) {
 	format := context.String("format")
 
 	outputPath := context.String("output")


### PR DESCRIPTION
This doesn't need to be public so we might as well make it private like all our other command `action` functions