### PR TITLE
build: upgrade to Go v1.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.23.6-alpine3.21@sha256:2c49857f2295e89b23b28386e57e018a86620a8fede5003900f2d138ba9c4037 AS builder
+FROM golang:1.24.0-alpine3.21@sha256:2d40d4fc278dad38be0777d5e2a88a2c6dee51b0b29c97a764fc6c6a11ca893c AS builder
 
 WORKDIR /src
 COPY ./go.mod ./go.sum ./

--- a/action.dockerfile
+++ b/action.dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.23.6-alpine3.21@sha256:2c49857f2295e89b23b28386e57e018a86620a8fede5003900f2d138ba9c4037
+FROM golang:1.24.0-alpine3.21@sha256:2d40d4fc278dad38be0777d5e2a88a2c6dee51b0b29c97a764fc6c6a11ca893c
 
 RUN mkdir /src
 WORKDIR /src

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -85,7 +85,7 @@ Alternatively, you can install this from source by running:
 go install github.com/google/osv-scanner/v2/cmd/osv-scanner@latest
 ```
 
-This requires Go 1.23.5+ to be installed.
+This requires Go 1.24.0+ to be installed.
 
 ## Build from source
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/osv-scanner/v2
 
-go 1.23.6
+go 1.24.0
 
 require (
 	deps.dev/api/v3 v3.0.0-20250210015309-e519ac173dde

--- a/renovate.json
+++ b/renovate.json
@@ -27,7 +27,7 @@
     }
   ],
   "constraints": {
-    "go": "1.23.5"
+    "go": "1.24.0"
   },
   "ignorePaths": ["**/fixtures/**", "**/fixtures-go/**"],
   "ignoreDeps": ["golang.org/x/vuln"]


### PR DESCRIPTION
This puts us on the latest version of Go, which should hopefully resolve the recent issues we've seen with `golangci-lint` and the `sourceanalysis` snapshots which I believe are due to CI using the current `stable` version of Go which is now v1.24.

In the long-run I think we might want to actually switch to using `oldstable` in our CI, but for now we can just upgrade since we're in a beta period - we can downgrade again if needed once we've gotten the Go version policy sorted out