### PR TITLE
test: don't skip acceptance tests when targeted with `-run`

### DIFF
--- a/internal/testutility/utility.go
+++ b/internal/testutility/utility.go
@@ -1,6 +1,7 @@
 package testutility
 
 import (
+	"flag"
 	"os"
 	"runtime"
 	"strings"
@@ -34,16 +35,30 @@ func Skip(t *testing.T, args ...any) {
 	snaps.Skip(t, args...)
 }
 
+// isThisTestRunTarget tries to determine if the currently running test has been
+// targeted with the -run flag, by comparing the flags value to [testing.T.Name]
+//
+// Since this just does a direct comparison, it will not match for regex patterns
+func isThisTestRunTarget(t *testing.T) bool {
+	t.Helper()
+
+	runOnly := flag.Lookup("test.run").Value.String()
+
+	return runOnly == t.Name()
+}
+
 // IsAcceptanceTesting returns true if the test suite is being run with acceptance tests enabled
 func IsAcceptanceTesting() bool {
 	return os.Getenv("TEST_ACCEPTANCE") == "true"
 }
 
 // SkipIfNotAcceptanceTesting marks the test as skipped unless the test suite is
-// being run with acceptance tests enabled, as indicated by IsAcceptanceTesting
+// being run with acceptance tests enabled, as indicated by IsAcceptanceTesting,
+// or the test is being run specifically with the -run flag
 func SkipIfNotAcceptanceTesting(t *testing.T, reason string) {
 	t.Helper()
-	if !IsAcceptanceTesting() {
+
+	if !IsAcceptanceTesting() && !isThisTestRunTarget(t) {
 		Skip(t, "Skipping extended test: ", reason)
 	}
 }


### PR DESCRIPTION
This is a neat little trick I thought of while cleaning up the snapshots - all its saving us from is having to stick `TEST_ACCEPTANCE=true` in front of our `go test` calls, but I think it's nice to have the test suite not require that when you're running a specific acceptance test.

Credit to `go-snaps` for proving it must be possible, since this is what it does to determine if a snapshot is obsolete or that the tests have just not been run.

I've gone with the slightly awkward name `isThisTestRunTarget` as I felt it was less ambiguous than `isThisTestRunning` and similar, since yes the test must be running if the function is being called... 😅 