### PR TITLE
test: reduce noise in cmd cases using a custom `slog` handler

### DIFF
--- a/cmd/osv-scanner/testmain_test.go
+++ b/cmd/osv-scanner/testmain_test.go
@@ -43,10 +43,6 @@ func newMuffledHandler(w io.Writer) *muffledHandler {
 	return &muffledHandler{TextHandler: *slog.NewTextHandler(w, nil)}
 }
 
-func Test_FailThis(t *testing.T) {
-	t.Fail()
-}
-
 func TestMain(m *testing.M) {
 	slog.SetDefault(slog.New(newMuffledHandler(log.Writer())))
 

--- a/cmd/osv-scanner/testmain_test.go
+++ b/cmd/osv-scanner/testmain_test.go
@@ -25,6 +25,9 @@ func (c *muffledHandler) Handle(ctx context.Context, record slog.Record) error {
 		"End status: ",
 		"Neither CPE nor PURL found for package",
 		"Invalid PURL",
+		"os-release[ID] not set, fallback to",
+		"VERSION_ID not set in os-release",
+		"osrelease.ParseOsRelease(): file does not exist",
 	} {
 		if strings.HasPrefix(record.Message, prefix) {
 			return nil

--- a/cmd/osv-scanner/testmain_test.go
+++ b/cmd/osv-scanner/testmain_test.go
@@ -1,14 +1,46 @@
 package main
 
 import (
+	"context"
+	"io"
+	"log"
+	"log/slog"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/google/osv-scanner/v2/internal/testutility"
 )
 
+// muffledHandler eats certain log messages to reduce noise in the test output
+type muffledHandler struct {
+	slog.TextHandler
+}
+
+func (c *muffledHandler) Handle(ctx context.Context, record slog.Record) error {
+	// todo: work with the osv-scalibr team to see if we can reduce these
+	for _, prefix := range []string{
+		"Starting filesystem walk for root:",
+		"End status: ",
+		"Neither CPE nor PURL found for package",
+		"Invalid PURL",
+	} {
+		if strings.HasPrefix(record.Message, prefix) {
+			return nil
+		}
+	}
+
+	return c.TextHandler.Handle(ctx, record)
+}
+
+func newMuffledHandler(w io.Writer) *muffledHandler {
+	return &muffledHandler{TextHandler: *slog.NewTextHandler(w, nil)}
+}
+
 func TestMain(m *testing.M) {
+	slog.SetDefault(slog.New(newMuffledHandler(log.Writer())))
+
 	// ensure a git repository doesn't already exist in the fixtures directory,
 	// in case we didn't get a chance to clean-up properly in the last run
 	os.RemoveAll("./fixtures/.git")

--- a/cmd/osv-scanner/testmain_test.go
+++ b/cmd/osv-scanner/testmain_test.go
@@ -19,18 +19,20 @@ type muffledHandler struct {
 }
 
 func (c *muffledHandler) Handle(ctx context.Context, record slog.Record) error {
-	// todo: work with the osv-scalibr team to see if we can reduce these
-	for _, prefix := range []string{
-		"Starting filesystem walk for root:",
-		"End status: ",
-		"Neither CPE nor PURL found for package",
-		"Invalid PURL",
-		"os-release[ID] not set, fallback to",
-		"VERSION_ID not set in os-release",
-		"osrelease.ParseOsRelease(): file does not exist",
-	} {
-		if strings.HasPrefix(record.Message, prefix) {
-			return nil
+	if record.Level < slog.LevelError {
+		// todo: work with the osv-scalibr team to see if we can reduce these
+		for _, prefix := range []string{
+			"Starting filesystem walk for root:",
+			"End status: ",
+			"Neither CPE nor PURL found for package",
+			"Invalid PURL",
+			"os-release[ID] not set, fallback to",
+			"VERSION_ID not set in os-release",
+			"osrelease.ParseOsRelease(): file does not exist",
+		} {
+			if strings.HasPrefix(record.Message, prefix) {
+				return nil
+			}
 		}
 	}
 

--- a/cmd/osv-scanner/testmain_test.go
+++ b/cmd/osv-scanner/testmain_test.go
@@ -38,6 +38,10 @@ func newMuffledHandler(w io.Writer) *muffledHandler {
 	return &muffledHandler{TextHandler: *slog.NewTextHandler(w, nil)}
 }
 
+func Test_FailThis(t *testing.T) {
+	t.Fail()
+}
+
 func TestMain(m *testing.M) {
 	slog.SetDefault(slog.New(newMuffledHandler(log.Writer())))
 


### PR DESCRIPTION
Currently we got a lot of noise from `osv-scalibr` libraries which makes it hard to see what actually failed - since all of these are going through the `slog`, we can use our own custom handler to drop records with specific prefixes.

I believe there are some talks happening with the `osv-scalibr` team to see if some of these can be toned back, and also I think we will probably want to capture some of these at some point as part of valid tests, but short-term this should help make things more manageable.

I'm opening this as a draft as I don't know if we do actually want to land this, in part because I think this is going to almost immediately break as we've switching to `slog` ourselves which involves using a custom `slog` handler meaning this one will get overridden, but I still wanted to share the implementation either way as folks might like to cherry-pick it locally depending on what they're working on 🙂 