### PR TITLE
chore: enable `usetesting` linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -23,7 +23,6 @@ linters:
     - nonamedreturns   # disagree with, for now (another-rex)
     - goconst          # not everything should be a constant
     - exptostd         # will be enabled shortly
-    - usetesting       # will be enabled shortly
   presets:
     - bugs
     - comment

--- a/internal/testutility/utility.go
+++ b/internal/testutility/utility.go
@@ -63,6 +63,7 @@ func ValueIfOnWindows(win, or string) string {
 func CreateTestDir(t *testing.T) string {
 	t.Helper()
 
+	//nolint:usetesting // we need to customize the directory name to replace in snapshots
 	p, err := os.MkdirTemp("", "osv-scanner-test-*")
 	if err != nil {
 		t.Fatalf("could not create test directory: %v", err)


### PR DESCRIPTION
The only violation we have of this currently is expected due to a limitation of `t.TempDir`

Cherry-picked from #1622