### PR TITLE
fix: remove usage of `pkg/lockfile` from guided remediation

### DIFF
--- a/cmd/osv-scanner/fix/model.go
+++ b/cmd/osv-scanner/fix/model.go
@@ -14,9 +14,9 @@ import (
 	"github.com/google/osv-scanner/v2/internal/remediation"
 	"github.com/google/osv-scanner/v2/internal/resolution"
 	"github.com/google/osv-scanner/v2/internal/resolution/client"
+	"github.com/google/osv-scanner/v2/internal/resolution/depfile"
 	manif "github.com/google/osv-scanner/v2/internal/resolution/manifest"
 	"github.com/google/osv-scanner/v2/internal/tui"
-	osvLockfile "github.com/google/osv-scanner/v2/pkg/lockfile"
 	"golang.org/x/term"
 )
 
@@ -184,7 +184,7 @@ type inPlaceResolutionMsg struct {
 }
 
 func doInPlaceResolution(ctx context.Context, cl client.ResolutionClient, opts osvFixOptions) tea.Msg {
-	lf, err := osvLockfile.OpenLocalDepFile(opts.Lockfile)
+	lf, err := depfile.OpenLocalDepFile(opts.Lockfile)
 	if err != nil {
 		return inPlaceResolutionMsg{err: err}
 	}
@@ -219,7 +219,7 @@ func doRelock(ctx context.Context, cl client.ResolutionClient, m manif.Manifest,
 }
 
 func doInitialRelock(ctx context.Context, opts osvFixOptions) tea.Msg {
-	f, err := osvLockfile.OpenLocalDepFile(opts.Manifest)
+	f, err := depfile.OpenLocalDepFile(opts.Manifest)
 	if err != nil {
 		return doRelockMsg{err: err}
 	}

--- a/cmd/osv-scanner/fix/noninteractive.go
+++ b/cmd/osv-scanner/fix/noninteractive.go
@@ -14,10 +14,10 @@ import (
 	"github.com/google/osv-scanner/v2/internal/remediation"
 	"github.com/google/osv-scanner/v2/internal/resolution"
 	"github.com/google/osv-scanner/v2/internal/resolution/client"
+	"github.com/google/osv-scanner/v2/internal/resolution/depfile"
 	lf "github.com/google/osv-scanner/v2/internal/resolution/lockfile"
 	"github.com/google/osv-scanner/v2/internal/resolution/manifest"
 	"github.com/google/osv-scanner/v2/internal/resolution/util"
-	"github.com/google/osv-scanner/v2/pkg/lockfile"
 	"golang.org/x/exp/maps"
 )
 
@@ -32,7 +32,7 @@ func autoInPlace(ctx context.Context, r *outputReporter, opts osvFixOptions, max
 	outputResult.Ecosystem = util.OSVEcosystem[opts.LockfileRW.System()]
 	outputResult.Strategy = strategyInPlace
 
-	f, err := lockfile.OpenLocalDepFile(opts.Lockfile)
+	f, err := depfile.OpenLocalDepFile(opts.Lockfile)
 	if err != nil {
 		return err
 	}
@@ -132,7 +132,7 @@ func autoRelax(ctx context.Context, r *outputReporter, opts osvFixOptions, maxUp
 	outputResult.Ecosystem = util.OSVEcosystem[opts.ManifestRW.System()]
 	outputResult.Strategy = strategyRelax
 
-	f, err := lockfile.OpenLocalDepFile(opts.Manifest)
+	f, err := depfile.OpenLocalDepFile(opts.Manifest)
 	if err != nil {
 		return err
 	}
@@ -267,7 +267,7 @@ func autoOverride(ctx context.Context, r *outputReporter, opts osvFixOptions, ma
 	outputResult.Path = opts.Manifest
 	outputResult.Ecosystem = util.OSVEcosystem[opts.ManifestRW.System()]
 	outputResult.Strategy = strategyOverride
-	f, err := lockfile.OpenLocalDepFile(opts.Manifest)
+	f, err := depfile.OpenLocalDepFile(opts.Manifest)
 	if err != nil {
 		return err
 	}

--- a/cmd/osv-scanner/update/main.go
+++ b/cmd/osv-scanner/update/main.go
@@ -9,9 +9,9 @@ import (
 	"github.com/google/osv-scanner/v2/internal/depsdev"
 	"github.com/google/osv-scanner/v2/internal/remediation/suggest"
 	"github.com/google/osv-scanner/v2/internal/resolution/client"
+	"github.com/google/osv-scanner/v2/internal/resolution/depfile"
 	"github.com/google/osv-scanner/v2/internal/resolution/manifest"
 	"github.com/google/osv-scanner/v2/internal/version"
-	"github.com/google/osv-scanner/v2/pkg/lockfile"
 	"github.com/google/osv-scanner/v2/pkg/reporter"
 	"github.com/urfave/cli/v2"
 )
@@ -84,7 +84,7 @@ func action(ctx *cli.Context, stdout, stderr io.Writer) (reporter.Reporter, erro
 		return nil, err
 	}
 
-	df, err := lockfile.OpenLocalDepFile(options.Manifest)
+	df, err := depfile.OpenLocalDepFile(options.Manifest)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/remediation/in_place_test.go
+++ b/internal/remediation/in_place_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/google/osv-scanner/v2/internal/resolution"
 	"github.com/google/osv-scanner/v2/internal/resolution/client"
 	"github.com/google/osv-scanner/v2/internal/resolution/clienttest"
+	"github.com/google/osv-scanner/v2/internal/resolution/depfile"
 	"github.com/google/osv-scanner/v2/internal/resolution/lockfile"
 	"github.com/google/osv-scanner/v2/internal/testutility"
-	lf "github.com/google/osv-scanner/v2/pkg/lockfile"
 	"golang.org/x/exp/maps"
 )
 
@@ -26,7 +26,7 @@ func parseInPlaceFixture(t *testing.T, universePath, lockfilePath string) (*reso
 		t.Fatalf("Failed to get ReadWriter: %v", err)
 	}
 
-	f, err := lf.OpenLocalDepFile(lockfilePath)
+	f, err := depfile.OpenLocalDepFile(lockfilePath)
 	if err != nil {
 		t.Fatalf("Failed to open lockfile: %v", err)
 	}

--- a/internal/remediation/suggest/maven.go
+++ b/internal/remediation/suggest/maven.go
@@ -9,7 +9,6 @@ import (
 	"deps.dev/util/resolve"
 	"deps.dev/util/semver"
 	"github.com/google/osv-scanner/v2/internal/resolution/manifest"
-	"github.com/google/osv-scanner/v2/pkg/lockfile"
 	"golang.org/x/exp/slices"
 )
 
@@ -29,7 +28,8 @@ func (ms *MavenSuggester) Suggest(ctx context.Context, client resolve.Client, mf
 		if slices.Contains(opts.NoUpdates, req.Name) {
 			continue
 		}
-		if opts.IgnoreDev && lockfile.MavenEcosystem.IsDevGroup(mf.Groups[manifest.MakeRequirementKey(req)]) {
+
+		if opts.IgnoreDev && slices.Contains(mf.Groups[manifest.MakeRequirementKey(req)], "test") {
 			// Skip the update if the dependency is of development group
 			// and updates on development dependencies are not desired
 			continue

--- a/internal/remediation/testhelpers_test.go
+++ b/internal/remediation/testhelpers_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/google/osv-scanner/v2/internal/resolution"
 	"github.com/google/osv-scanner/v2/internal/resolution/client"
 	"github.com/google/osv-scanner/v2/internal/resolution/clienttest"
+	"github.com/google/osv-scanner/v2/internal/resolution/depfile"
 	"github.com/google/osv-scanner/v2/internal/resolution/manifest"
 	"github.com/google/osv-scanner/v2/internal/testutility"
-	lf "github.com/google/osv-scanner/v2/pkg/lockfile"
 	"golang.org/x/exp/maps"
 )
 
@@ -24,7 +24,7 @@ func parseRemediationFixture(t *testing.T, universePath, manifestPath string, op
 		t.Fatalf("Failed to get ReadWriter: %v", err)
 	}
 
-	f, err := lf.OpenLocalDepFile(manifestPath)
+	f, err := depfile.OpenLocalDepFile(manifestPath)
 	if err != nil {
 		t.Fatalf("Failed to open manifest: %v", err)
 	}

--- a/internal/resolution/client/client.go
+++ b/internal/resolution/client/client.go
@@ -10,7 +10,7 @@ import (
 	"deps.dev/util/semver"
 	"github.com/google/osv-scanner/v2/internal/clients/clientinterfaces"
 	"github.com/google/osv-scanner/v2/internal/depsdev"
-	"github.com/google/osv-scanner/v2/pkg/osv"
+	"github.com/google/osv-scanner/v2/internal/version"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )
@@ -42,10 +42,9 @@ func PreFetch(ctx context.Context, c DependencyClient, requirements []resolve.Re
 		return
 	}
 	creds := credentials.NewClientTLSFromCert(certPool, "")
-	dialOpts := []grpc.DialOption{grpc.WithTransportCredentials(creds)}
-
-	if osv.RequestUserAgent != "" {
-		dialOpts = append(dialOpts, grpc.WithUserAgent(osv.RequestUserAgent))
+	dialOpts := []grpc.DialOption{
+		grpc.WithTransportCredentials(creds),
+		grpc.WithUserAgent("osv-scanner/" + version.OSVVersion),
 	}
 
 	conn, err := grpc.NewClient(depsdev.DepsdevAPI, dialOpts...)

--- a/internal/resolution/client/npm_registry_client.go
+++ b/internal/resolution/client/npm_registry_client.go
@@ -15,7 +15,7 @@ import (
 	"deps.dev/util/semver"
 	"github.com/google/osv-scanner/v2/internal/datasource"
 	"github.com/google/osv-scanner/v2/internal/depsdev"
-	"github.com/google/osv-scanner/v2/pkg/osv"
+	"github.com/google/osv-scanner/v2/internal/version"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )
@@ -41,10 +41,9 @@ func NewNpmRegistryClient(workdir string) (*NpmRegistryClient, error) {
 		return nil, fmt.Errorf("getting system cert pool: %w", err)
 	}
 	creds := credentials.NewClientTLSFromCert(certPool, "")
-	dialOpts := []grpc.DialOption{grpc.WithTransportCredentials(creds)}
-
-	if osv.RequestUserAgent != "" {
-		dialOpts = append(dialOpts, grpc.WithUserAgent(osv.RequestUserAgent))
+	dialOpts := []grpc.DialOption{
+		grpc.WithTransportCredentials(creds),
+		grpc.WithUserAgent("osv-scanner_fix/" + version.OSVVersion),
 	}
 
 	conn, err := grpc.NewClient(depsdev.DepsdevAPI, dialOpts...)

--- a/internal/resolution/depfile/depfile.go
+++ b/internal/resolution/depfile/depfile.go
@@ -1,0 +1,63 @@
+// TODO(michaelkedar):
+// Temporarily retaining the deprecated DepFile interface internally for guided remediation,
+// so it be removed from the OSV-Scanner v2 library.
+// This will be removed when the migration of guided remediation to OSV-Scalibr is completed.
+package depfile
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// DepFile is an abstraction for a file that has been opened for extraction,
+// and that knows how to open other DepFiles relative to itself.
+type DepFile interface {
+	io.Reader
+
+	// Open opens an NestedDepFile based on the path of the
+	// current DepFile if the provided path is relative.
+	//
+	// If the path is an absolute path, then it is opened absolutely.
+	Open(path string) (NestedDepFile, error)
+
+	Path() string
+}
+
+// NestedDepFile is an abstraction for a file that has been opened while extracting another file,
+// and would need to be closed.
+type NestedDepFile interface {
+	io.Closer
+	DepFile
+}
+
+// A LocalFile represents a file that exists on the local filesystem.
+type LocalFile struct {
+	// TODO(rexpan): This should be *os.File, as that would allow us to access other underlying functions that definitely will exist
+	io.ReadCloser
+
+	path string
+}
+
+func (f LocalFile) Open(path string) (NestedDepFile, error) {
+	if filepath.IsAbs(path) {
+		return OpenLocalDepFile(path)
+	}
+
+	return OpenLocalDepFile(filepath.Join(filepath.Dir(f.path), path))
+}
+
+func (f LocalFile) Path() string { return f.path }
+
+func OpenLocalDepFile(path string) (NestedDepFile, error) {
+	r, err := os.Open(path)
+
+	if err != nil {
+		return LocalFile{}, err
+	}
+
+	// Very unlikely to have Abs return an error if the file opens correctly
+	path, _ = filepath.Abs(path)
+
+	return LocalFile{r, path}, nil
+}

--- a/internal/resolution/lockfile/lockfile.go
+++ b/internal/resolution/lockfile/lockfile.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 
 	"deps.dev/util/resolve"
-	"github.com/google/osv-scanner/v2/pkg/lockfile"
+	"github.com/google/osv-scanner/v2/internal/resolution/depfile"
 )
 
 type DependencyPatch struct {
@@ -21,14 +21,14 @@ type ReadWriter interface {
 	// System returns which ecosystem this ReadWriter is for.
 	System() resolve.System
 	// Read parses a lockfile into a resolved graph
-	Read(file lockfile.DepFile) (*resolve.Graph, error)
+	Read(file depfile.DepFile) (*resolve.Graph, error)
 	// Write applies the DependencyPatches to the lockfile, with minimal changes to the file.
 	// `original` is the original lockfile to read from. The updated lockfile is written to `output`.
-	Write(original lockfile.DepFile, output io.Writer, patches []DependencyPatch) error
+	Write(original depfile.DepFile, output io.Writer, patches []DependencyPatch) error
 }
 
 func Overwrite(rw ReadWriter, filename string, patches []DependencyPatch) error {
-	r, err := lockfile.OpenLocalDepFile(filename)
+	r, err := depfile.OpenLocalDepFile(filename)
 	if err != nil {
 		return err
 	}

--- a/internal/resolution/lockfile/npm.go
+++ b/internal/resolution/lockfile/npm.go
@@ -11,8 +11,8 @@ import (
 	"deps.dev/util/resolve"
 	"deps.dev/util/resolve/dep"
 	"github.com/google/osv-scanner/v2/internal/datasource"
+	"github.com/google/osv-scanner/v2/internal/resolution/depfile"
 	"github.com/google/osv-scanner/v2/internal/resolution/manifest"
-	"github.com/google/osv-scanner/v2/pkg/lockfile"
 )
 
 type NpmReadWriter struct{}
@@ -73,7 +73,7 @@ func (n npmNodeModule) IsAliased() bool {
 	return len(n.ActualName) > 0
 }
 
-func (rw NpmReadWriter) Read(file lockfile.DepFile) (*resolve.Graph, error) {
+func (rw NpmReadWriter) Read(file depfile.DepFile) (*resolve.Graph, error) {
 	dec := json.NewDecoder(file)
 	var lockJSON npmLockfile
 	if err := dec.Decode(&lockJSON); err != nil {
@@ -177,7 +177,7 @@ func (rw NpmReadWriter) reVersionAliasedDeps(deps map[string]npmDependencyVersio
 	}
 }
 
-func (rw NpmReadWriter) Write(original lockfile.DepFile, output io.Writer, patches []DependencyPatch) error {
+func (rw NpmReadWriter) Write(original depfile.DepFile, output io.Writer, patches []DependencyPatch) error {
 	var buf strings.Builder
 	_, err := io.Copy(&buf, original)
 	if err != nil {

--- a/internal/resolution/lockfile/npm_test.go
+++ b/internal/resolution/lockfile/npm_test.go
@@ -9,9 +9,9 @@ import (
 	"deps.dev/util/resolve"
 	"deps.dev/util/resolve/schema"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/osv-scanner/v2/internal/resolution/depfile"
 	"github.com/google/osv-scanner/v2/internal/resolution/lockfile"
 	"github.com/google/osv-scanner/v2/internal/testutility"
-	lf "github.com/google/osv-scanner/v2/pkg/lockfile"
 )
 
 func TestNpmReadV2(t *testing.T) {
@@ -19,7 +19,7 @@ func TestNpmReadV2(t *testing.T) {
 
 	// This lockfile was generated using a private registry with https://verdaccio.org/
 	// Mock packages were published to it and installed with npm.
-	df, err := lf.OpenLocalDepFile("./fixtures/npm_v2/package-lock.json")
+	df, err := depfile.OpenLocalDepFile("./fixtures/npm_v2/package-lock.json")
 	if err != nil {
 		t.Fatalf("failed to open file: %v", err)
 	}
@@ -70,7 +70,7 @@ func TestNpmReadV1(t *testing.T) {
 
 	// This lockfile was generated using a private registry with https://verdaccio.org/
 	// Mock packages were published to it and installed with npm.
-	df, err := lf.OpenLocalDepFile("./fixtures/npm_v1/package-lock.json")
+	df, err := depfile.OpenLocalDepFile("./fixtures/npm_v1/package-lock.json")
 	if err != nil {
 		t.Fatalf("failed to open file: %v", err)
 	}
@@ -119,7 +119,7 @@ func TestNpmReadTypeOrder(t *testing.T) {
 	// Empirically, devDependencies > optionalDependencies > dependencies > peerDependencies
 
 	// This lockfile was manually constructed.
-	df, err := lf.OpenLocalDepFile("./fixtures/npm_type_order/package-lock.json")
+	df, err := depfile.OpenLocalDepFile("./fixtures/npm_type_order/package-lock.json")
 	if err != nil {
 		t.Fatalf("failed to open file: %v", err)
 	}
@@ -202,7 +202,7 @@ func TestNpmWrite(t *testing.T) {
 		},
 	}
 
-	df, err := lf.OpenLocalDepFile(file)
+	df, err := depfile.OpenLocalDepFile(file)
 	if err != nil {
 		t.Fatalf("failed to open file: %v", err)
 	}

--- a/internal/resolution/lockfile/npm_v1.go
+++ b/internal/resolution/lockfile/npm_v1.go
@@ -11,7 +11,6 @@ import (
 	"deps.dev/util/resolve/dep"
 	"github.com/google/osv-scanner/v2/internal/datasource"
 	"github.com/google/osv-scanner/v2/internal/resolution/manifest"
-	"github.com/google/osv-scanner/v2/pkg/lockfile"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
@@ -21,7 +20,7 @@ import (
 // Installed packages stored in recursive "dependencies" object
 // with "requires" field listing direct dependencies, and each possibly having their own "dependencies"
 // No dependency information package-lock.json for the root node, so we must also have the package.json
-func (rw NpmReadWriter) nodesFromDependencies(lockJSON lockfile.NpmLockfile, manifestFile io.Reader) (*resolve.Graph, *npmNodeModule, error) {
+func (rw NpmReadWriter) nodesFromDependencies(lockJSON npmLockfile, manifestFile io.Reader) (*resolve.Graph, *npmNodeModule, error) {
 	// Need to grab the root requirements from the package.json, since it's not in the lockfile
 	var manifestJSON manifest.PackageJSON
 	if err := json.NewDecoder(manifestFile).Decode(&manifestJSON); err != nil {
@@ -66,7 +65,7 @@ func (rw NpmReadWriter) nodesFromDependencies(lockJSON lockfile.NpmLockfile, man
 	return &g, nodeModuleTree, err
 }
 
-func (rw NpmReadWriter) computeDependenciesRecursive(g *resolve.Graph, parent *npmNodeModule, deps map[string]lockfile.NpmLockDependency) error {
+func (rw NpmReadWriter) computeDependenciesRecursive(g *resolve.Graph, parent *npmNodeModule, deps map[string]npmLockDependency) error {
 	for name, d := range deps {
 		actualName, version := manifest.SplitNPMAlias(d.Version)
 		nID := g.AddNode(resolve.VersionKey{

--- a/internal/resolution/lockfile/npm_v2.go
+++ b/internal/resolution/lockfile/npm_v2.go
@@ -11,7 +11,6 @@ import (
 	"deps.dev/util/resolve"
 	"deps.dev/util/resolve/dep"
 	"github.com/google/osv-scanner/v2/internal/datasource"
-	"github.com/google/osv-scanner/v2/pkg/lockfile"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/pretty"
 	"github.com/tidwall/sjson"
@@ -23,7 +22,7 @@ import (
 // Installed packages are in the flat "packages" object, keyed by the install path
 // e.g. "node_modules/foo/node_modules/bar"
 // packages contain most information from their own manifests.
-func (rw NpmReadWriter) nodesFromPackages(lockJSON lockfile.NpmLockfile) (*resolve.Graph, *npmNodeModule, error) {
+func (rw NpmReadWriter) nodesFromPackages(lockJSON npmLockfile) (*resolve.Graph, *npmNodeModule, error) {
 	var g resolve.Graph
 	// Create graph nodes and reconstruct the node_modules folder structure in memory
 	root, ok := lockJSON.Packages[""]
@@ -147,7 +146,7 @@ func (rw NpmReadWriter) nodesFromPackages(lockJSON lockfile.NpmLockfile) (*resol
 	return &g, nodeModuleTree, nil
 }
 
-func (rw NpmReadWriter) makeNodeModuleDeps(pkg lockfile.NpmLockPackage, includeDev bool) *npmNodeModule {
+func (rw NpmReadWriter) makeNodeModuleDeps(pkg npmLockPackage, includeDev bool) *npmNodeModule {
 	nm := npmNodeModule{
 		Children: make(map[string]*npmNodeModule),
 		Deps:     make(map[string]npmDependencyVersionSpec),
@@ -176,7 +175,7 @@ func (rw NpmReadWriter) makeNodeModuleDeps(pkg lockfile.NpmLockPackage, includeD
 	return &nm
 }
 
-func (rw NpmReadWriter) packageNamesByNodeModuleDepth(packages map[string]lockfile.NpmLockPackage) []string {
+func (rw NpmReadWriter) packageNamesByNodeModuleDepth(packages map[string]npmLockPackage) []string {
 	keys := maps.Keys(packages)
 	slices.SortFunc(keys, func(a, b string) int {
 		aSplit := strings.Split(a, "node_modules/")

--- a/internal/resolution/manifest/manifest.go
+++ b/internal/resolution/manifest/manifest.go
@@ -11,7 +11,7 @@ import (
 
 	"deps.dev/util/resolve"
 	"deps.dev/util/resolve/dep"
-	"github.com/google/osv-scanner/v2/pkg/lockfile"
+	"github.com/google/osv-scanner/v2/internal/resolution/depfile"
 )
 
 type Manifest struct {
@@ -63,16 +63,16 @@ type ReadWriter interface {
 	// System returns which ecosystem this ReadWriter is for.
 	System() resolve.System
 	// Read parses a manifest file into a Manifest, possibly recursively following references to other local manifest files
-	Read(file lockfile.DepFile) (Manifest, error)
+	Read(file depfile.DepFile) (Manifest, error)
 	// Write applies the Patch to the manifest, with minimal changes to the file.
 	// `original` is the original manifest file to read from. The updated manifest is written to `output`.
-	Write(original lockfile.DepFile, output io.Writer, patches Patch) error
+	Write(original depfile.DepFile, output io.Writer, patches Patch) error
 }
 
 // Overwrite applies the ManifestPatch to the manifest at filename.
 // Used so as to not have the same file open for reading and writing at the same time.
 func Overwrite(rw ReadWriter, filename string, p Patch) error {
-	r, err := lockfile.OpenLocalDepFile(filename)
+	r, err := depfile.OpenLocalDepFile(filename)
 	if err != nil {
 		return err
 	}

--- a/internal/resolution/manifest/maven.go
+++ b/internal/resolution/manifest/maven.go
@@ -15,9 +15,9 @@ import (
 	"deps.dev/util/resolve"
 	"deps.dev/util/resolve/dep"
 	"github.com/google/osv-scanner/v2/internal/datasource"
+	"github.com/google/osv-scanner/v2/internal/resolution/depfile"
 	internalxml "github.com/google/osv-scanner/v2/internal/thirdparty/xml"
 	mavenutil "github.com/google/osv-scanner/v2/internal/utility/maven"
-	"github.com/google/osv-scanner/v2/pkg/lockfile"
 )
 
 func mavenRequirementKey(requirement resolve.RequirementVersion) RequirementKey {
@@ -67,7 +67,7 @@ type DependencyWithOrigin struct {
 	Origin string // Origin indicates where the dependency comes from
 }
 
-func (m MavenReadWriter) Read(df lockfile.DepFile) (Manifest, error) {
+func (m MavenReadWriter) Read(df depfile.DepFile) (Manifest, error) {
 	ctx := context.Background()
 
 	var project maven.Project
@@ -290,7 +290,7 @@ func mavenOrigin(list ...string) string {
 	return result
 }
 
-func (MavenReadWriter) Write(df lockfile.DepFile, w io.Writer, patch Patch) error {
+func (MavenReadWriter) Write(df depfile.DepFile, w io.Writer, patch Patch) error {
 	specific, ok := patch.Manifest.EcosystemSpecific.(MavenManifestSpecific)
 	if !ok {
 		return errors.New("invalid MavenManifestSpecific data")
@@ -351,7 +351,7 @@ func (MavenReadWriter) Write(df lockfile.DepFile, w io.Writer, patch Patch) erro
 			continue
 		}
 		// TODO: investigate how to test parent manifests are updated.
-		depFile, err := lockfile.OpenLocalDepFile(path)
+		depFile, err := depfile.OpenLocalDepFile(path)
 		if err != nil {
 			return err
 		}

--- a/internal/resolution/manifest/maven_test.go
+++ b/internal/resolution/manifest/maven_test.go
@@ -13,8 +13,8 @@ import (
 	"deps.dev/util/resolve/dep"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/osv-scanner/v2/internal/datasource"
+	"github.com/google/osv-scanner/v2/internal/resolution/depfile"
 	"github.com/google/osv-scanner/v2/internal/testutility"
-	"github.com/google/osv-scanner/v2/pkg/lockfile"
 )
 
 var (
@@ -103,7 +103,7 @@ func TestMavenReadWrite(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get current directory: %v", err)
 	}
-	df, err := lockfile.OpenLocalDepFile(filepath.Join(dir, "fixtures", "maven", "my-app", "pom.xml"))
+	df, err := depfile.OpenLocalDepFile(filepath.Join(dir, "fixtures", "maven", "my-app", "pom.xml"))
 	if err != nil {
 		t.Fatalf("failed to open file: %v", err)
 	}
@@ -412,7 +412,7 @@ func TestMavenReadWrite(t *testing.T) {
 	}
 
 	// Re-open the file for writing.
-	df, err = lockfile.OpenLocalDepFile(filepath.Join(dir, "fixtures", "maven", "my-app", "pom.xml"))
+	df, err = depfile.OpenLocalDepFile(filepath.Join(dir, "fixtures", "maven", "my-app", "pom.xml"))
 	if err != nil {
 		t.Fatalf("failed to open file: %v", err)
 	}
@@ -433,7 +433,7 @@ func TestMavenWrite(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get current directory: %v", err)
 	}
-	df, err := lockfile.OpenLocalDepFile(filepath.Join(dir, "fixtures", "maven", "my-app", "pom.xml"))
+	df, err := depfile.OpenLocalDepFile(filepath.Join(dir, "fixtures", "maven", "my-app", "pom.xml"))
 	if err != nil {
 		t.Fatalf("fail to open file: %v", err)
 	}
@@ -545,7 +545,7 @@ func TestMavenWriteDM(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get current directory: %v", err)
 	}
-	df, err := lockfile.OpenLocalDepFile(filepath.Join(dir, "fixtures", "maven", "no-dependency-management.xml"))
+	df, err := depfile.OpenLocalDepFile(filepath.Join(dir, "fixtures", "maven", "no-dependency-management.xml"))
 	if err != nil {
 		t.Fatalf("fail to open file: %v", err)
 	}

--- a/internal/resolution/manifest/npm.go
+++ b/internal/resolution/manifest/npm.go
@@ -10,7 +10,7 @@ import (
 
 	"deps.dev/util/resolve"
 	"deps.dev/util/resolve/dep"
-	"github.com/google/osv-scanner/v2/pkg/lockfile"
+	"github.com/google/osv-scanner/v2/internal/resolution/depfile"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
@@ -45,7 +45,7 @@ type PackageJSON struct {
 	// BundleDependencies   []string          `json:"bundleDependencies"`
 }
 
-func (rw NpmReadWriter) Read(f lockfile.DepFile) (Manifest, error) {
+func (rw NpmReadWriter) Read(f depfile.DepFile) (Manifest, error) {
 	dec := json.NewDecoder(f)
 	var packagejson PackageJSON
 	if err := dec.Decode(&packagejson); err != nil {
@@ -235,7 +235,7 @@ func (rw NpmReadWriter) makeNPMReqVer(pkg, ver string) resolve.RequirementVersio
 	}
 }
 
-func (NpmReadWriter) Write(r lockfile.DepFile, w io.Writer, patch Patch) error {
+func (NpmReadWriter) Write(r depfile.DepFile, w io.Writer, patch Patch) error {
 	// Read the whole package.json into a string so we can use sjson to write in-place.
 	var buf strings.Builder
 	_, err := io.Copy(&buf, r)

--- a/internal/resolution/manifest/npm_test.go
+++ b/internal/resolution/manifest/npm_test.go
@@ -8,9 +8,9 @@ import (
 
 	"deps.dev/util/resolve"
 	"deps.dev/util/resolve/dep"
+	"github.com/google/osv-scanner/v2/internal/resolution/depfile"
 	"github.com/google/osv-scanner/v2/internal/resolution/manifest"
 	"github.com/google/osv-scanner/v2/internal/testutility"
-	"github.com/google/osv-scanner/v2/pkg/lockfile"
 )
 
 func aliasType(t *testing.T, aliasedName string) dep.Type {
@@ -54,7 +54,7 @@ func npmReqKey(t *testing.T, name, knownAs string) manifest.RequirementKey {
 func TestNpmRead(t *testing.T) {
 	t.Parallel()
 
-	df, err := lockfile.OpenLocalDepFile("./fixtures/package.json")
+	df, err := depfile.OpenLocalDepFile("./fixtures/package.json")
 	if err != nil {
 		t.Fatalf("failed to open file: %v", err)
 	}
@@ -116,7 +116,7 @@ func TestNpmRead(t *testing.T) {
 func TestNpmWorkspaceRead(t *testing.T) {
 	t.Parallel()
 
-	df, err := lockfile.OpenLocalDepFile("./fixtures/npm-workspaces/package.json")
+	df, err := depfile.OpenLocalDepFile("./fixtures/npm-workspaces/package.json")
 	if err != nil {
 		t.Fatalf("failed to open file: %v", err)
 	}
@@ -216,7 +216,7 @@ func TestNpmWorkspaceRead(t *testing.T) {
 func TestNpmWrite(t *testing.T) {
 	t.Parallel()
 
-	df, err := lockfile.OpenLocalDepFile("./fixtures/package.json")
+	df, err := depfile.OpenLocalDepFile("./fixtures/package.json")
 	if err != nil {
 		t.Fatalf("failed to open file: %v", err)
 	}

--- a/scripts/generate_mock_resolution_universe/main.go
+++ b/scripts/generate_mock_resolution_universe/main.go
@@ -32,11 +32,11 @@ import (
 	"github.com/google/osv-scanner/v2/internal/resolution"
 	"github.com/google/osv-scanner/v2/internal/resolution/client"
 	"github.com/google/osv-scanner/v2/internal/resolution/clienttest"
+	"github.com/google/osv-scanner/v2/internal/resolution/depfile"
 	"github.com/google/osv-scanner/v2/internal/resolution/lockfile"
 	"github.com/google/osv-scanner/v2/internal/resolution/manifest"
 	"github.com/google/osv-scanner/v2/internal/resolution/util"
 	"github.com/google/osv-scanner/v2/internal/version"
-	lf "github.com/google/osv-scanner/v2/pkg/lockfile"
 	"github.com/google/osv-scanner/v2/pkg/models"
 	"github.com/google/osv-scanner/v2/pkg/osv"
 	"golang.org/x/exp/maps"
@@ -75,7 +75,7 @@ func doRelockRelax(ddCl *client.DepsDevClient, rw manifest.ReadWriter, filename 
 		DependencyClient:     ddCl,
 	}
 
-	f, err := lf.OpenLocalDepFile(filename)
+	f, err := depfile.OpenLocalDepFile(filename)
 	if err != nil {
 		return err
 	}
@@ -102,7 +102,7 @@ func doOverride(ddCl *client.DepsDevClient, rw manifest.ReadWriter, filename str
 		DependencyClient:     ddCl,
 	}
 
-	f, err := lf.OpenLocalDepFile(filename)
+	f, err := depfile.OpenLocalDepFile(filename)
 	if err != nil {
 		return err
 	}
@@ -129,7 +129,7 @@ func doInPlace(ddCl *client.DepsDevClient, rw lockfile.ReadWriter, filename stri
 		DependencyClient:     ddCl,
 	}
 
-	f, err := lf.OpenLocalDepFile(filename)
+	f, err := depfile.OpenLocalDepFile(filename)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
To unblock removing `pkg/lockfile` for the full v2 release.
Just copied the necessary parts into the internal directories. Guided remediation is being moved into OSV-Scalibr, so I'll do a proper refactor as part of that move.

There's still one usage left with [`VKToPackageDetails`](https://github.com/google/osv-scanner/blob/3bd1565fd31266b9899747840b8223ab6b7ed225/internal/resolution/util/depsdev.go#L15), which is needed in calls to [`vulns.IsAffected()`](https://github.com/google/osv-scanner/blob/3bd1565fd31266b9899747840b8223ab6b7ed225/internal/utility/vulns/vulnerability.go#L144).