### PR TITLE
chore: remove deprecated flags of `fix` subcommand

### DIFF
--- a/cmd/osv-scanner/fix/main.go
+++ b/cmd/osv-scanner/fix/main.go
@@ -158,19 +158,6 @@ func Command(stdout, stderr io.Writer, r *reporter.Reporter) *cli.Command {
 				Usage:       "the allowed package upgrades, in the format `[package-name:]level`. If package-name is omitted, level is applied to all packages. level must be one of (major, minor, patch, none).",
 				DefaultText: "major",
 			},
-			&cli.BoolFlag{
-				Category: upgradeCategory,
-				Name:     "disallow-major-upgrades",
-				Usage:    "disallow major version changes to dependencies",
-				Hidden:   true,
-			},
-			&cli.StringSliceFlag{
-				Category: upgradeCategory,
-				Name:     "disallow-package-upgrades",
-				Usage:    "list of packages to disallow version changes",
-				Hidden:   true,
-			},
-
 			&cli.IntFlag{
 				Category: vulnCategory,
 				Name:     "max-depth",
@@ -231,21 +218,6 @@ func Command(stdout, stderr io.Writer, r *reporter.Reporter) *cli.Command {
 
 func parseUpgradeConfig(ctx *cli.Context, r reporter.Reporter) upgrade.Config {
 	config := upgrade.NewConfig()
-
-	if ctx.IsSet("disallow-major-upgrades") {
-		r.Warnf("WARNING: `--disallow-major-upgrades` flag is deprecated, use `--upgrade-config minor` instead\n")
-		if ctx.Bool("disallow-major-upgrades") {
-			config.SetDefault(upgrade.Minor)
-		} else {
-			config.SetDefault(upgrade.Major)
-		}
-	}
-	if ctx.IsSet("disallow-package-upgrades") {
-		r.Warnf("WARNING: `--disallow-package-upgrades` flag is deprecated, use `--upgrade-config PKG:none` instead\n")
-		for _, pkg := range ctx.StringSlice("disallow-package-upgrades") {
-			config.Set(pkg, upgrade.None)
-		}
-	}
 
 	for _, spec := range ctx.StringSlice("upgrade-config") {
 		idx := strings.LastIndex(spec, ":")

--- a/cmd/osv-scanner/fix/main_test.go
+++ b/cmd/osv-scanner/fix/main_test.go
@@ -36,7 +36,7 @@ func parseFlags(t *testing.T, flags []string, arguments []string) (*cli.Context,
 
 func TestParseUpgradeConfig(t *testing.T) {
 	t.Parallel()
-	flags := []string{"upgrade-config", "disallow-major-upgrades", "disallow-package-upgrades"}
+	flags := []string{"upgrade-config"}
 
 	tests := []struct {
 		name string
@@ -101,20 +101,6 @@ func TestParseUpgradeConfig(t *testing.T) {
 				"none:patch":       upgrade.Minor,
 				"none":             upgrade.Patch,
 				"other":            upgrade.None,
-			},
-		},
-		{
-			name: "deprecated flag",
-			args: []string{
-				"--disallow-major-upgrades",
-				"--disallow-package-upgrades=pkg1,pkg2",
-				"--upgrade-config=pkg3:patch",
-			},
-			want: map[string]upgrade.Level{
-				"pkg1": upgrade.None,
-				"pkg2": upgrade.None,
-				"pkg3": upgrade.Patch,
-				"pkg4": upgrade.Minor,
 			},
 		},
 	}


### PR DESCRIPTION
Both flags have been deprecated for some time, V2 is a good opportunity to remove them.