### PR TITLE
feat(updater): use version comparison workarounds in Maven updater

### DIFF
--- a/internal/remediation/override.go
+++ b/internal/remediation/override.go
@@ -257,7 +257,7 @@ func getVersionsGreater(ctx context.Context, cl client.DependencyClient, vk reso
 	if err != nil {
 		return nil, err
 	}
-	semvers :=  make(map[resolve.VersionKey]*semver.Version)
+	semvers := make(map[resolve.VersionKey]*semver.Version)
 	for _, ver := range versions {
 		parsed, err := semver.Maven.Parse(ver.Version)
 		if err != nil {
@@ -271,6 +271,7 @@ func getVersionsGreater(ctx context.Context, cl client.DependencyClient, vk reso
 		if vk.System == resolve.Maven {
 			return maven.CompareVersions(vk, semvers[a.VersionKey], semvers[b.VersionKey])
 		}
+
 		return vk.Semver().Compare(a.Version, b.Version)
 	}
 	slices.SortFunc(versions, cmpFunc)

--- a/internal/remediation/suggest/maven.go
+++ b/internal/remediation/suggest/maven.go
@@ -11,6 +11,7 @@ import (
 	"deps.dev/util/semver"
 	"github.com/google/osv-scanner/v2/internal/remediation/upgrade"
 	"github.com/google/osv-scanner/v2/internal/resolution/manifest"
+	"github.com/google/osv-scanner/v2/internal/utility/maven"
 	"golang.org/x/exp/slices"
 )
 
@@ -78,12 +79,12 @@ func suggestMavenVersion(ctx context.Context, cl resolve.Client, req resolve.Req
 	}
 	semvers := make([]*semver.Version, 0, len(versions))
 	for _, ver := range versions {
-		v, err := semver.Maven.Parse(ver.Version)
+		parsed, err := semver.Maven.Parse(ver.Version)
 		if err != nil {
-			log.Printf("parsing Maven version %s: %v", v, err)
+			log.Printf("parsing Maven version %s: %v", parsed, err)
 			continue
 		}
-		semvers = append(semvers, v)
+		semvers = append(semvers, parsed)
 	}
 
 	constraint, err := semver.Maven.ParseConstraint(req.Version)
@@ -109,12 +110,11 @@ func suggestMavenVersion(ctx context.Context, cl resolve.Client, req resolve.Req
 
 	var newReq *semver.Version
 	for _, v := range semvers {
-		if v.Compare(newReq) < 0 {
+		if maven.CompareVersions(req.VersionKey, v, newReq) < 0 {
 			// Skip versions smaller than the current requirement
 			continue
 		}
-		_, diff := v.Difference(current)
-		if !level.Allows(diff) {
+		if _, diff := v.Difference(current); !level.Allows(diff) {
 			continue
 		}
 		newReq = v

--- a/internal/utility/maven/maven.go
+++ b/internal/utility/maven/maven.go
@@ -162,6 +162,7 @@ func CompareVersions(vk resolve.VersionKey, a *semver.Version, b *semver.Version
 		if a == nil {
 			return -1
 		}
+
 		return 1
 	}
 

--- a/internal/utility/maven/maven.go
+++ b/internal/utility/maven/maven.go
@@ -155,7 +155,7 @@ func GetDependencyManagement(ctx context.Context, client *datasource.MavenRegist
 	return result.DependencyManagement, nil
 }
 
-// CompareVersions returns a version comparison function with special behaviour for specific packages,
+// CompareVersions compares two Maven semver versions with special behaviour for specific packages,
 // producing more desirable ordering using non-standard comparison.
 func CompareVersions(vk resolve.VersionKey, a *semver.Version, b *semver.Version) int {
 	if a == nil || b == nil {

--- a/internal/utility/maven/maven_test.go
+++ b/internal/utility/maven/maven_test.go
@@ -60,7 +60,79 @@ func TestParentPOMPath(t *testing.T) {
 	for _, tt := range tests {
 		got := maven.ParentPOMPath(tt.currentPath, tt.relativePath)
 		if got != tt.want {
-			t.Errorf("parentPOMPath(%s, %s): got %s, want %s", tt.currentPath, tt.relativePath, got, tt.want)
+			t.Errorf("ParentPOMPath(%s, %s): got %s, want %s", tt.currentPath, tt.relativePath, got, tt.want)
 		}
 	}
 }
+
+/*
+func TestCompareVersions(t *testing.T) {
+	t.Parallel()
+
+	versionKey := func(name string, version string) resolve.Version {
+		return resolve.Version{
+			VersionKey: resolve.VersionKey{
+				PackageKey: resolve.PackageKey{
+					System: resolve.Maven,
+					Name:   name,
+				},
+				Version: version,
+			},
+		}
+	}
+
+	tests := []struct {
+		a, b resolve.Version
+		want int
+	}{
+		{
+			versionKey("abc:xyz", "1.2.3"),
+			versionKey("abc:xyz", "2.3.4"),
+			-1,
+		},
+		{
+			versionKey("com.google.guava:guava", "1.2.3"),
+			versionKey("com.google.guava:guava", "2.3.4"),
+			-1,
+		},
+		{
+			versionKey("com.google.guava:guava", "1.2.3-jre"),
+			versionKey("com.google.guava:guava", "2.3.4-jre"),
+			-1,
+		},
+		{
+			versionKey("com.google.guava:guava", "1.2.3-android"),
+			versionKey("com.google.guava:guava", "2.3.4-android"),
+			-1,
+		},
+		{
+			// android flavours are always ordered earlier
+			versionKey("com.google.guava:guava", "1.2.3"),
+			versionKey("com.google.guava:guava", "2.3.4-android"),
+			1,
+		},
+		{
+			// jre flavours are always ordered later
+			versionKey("com.google.guava:guava", "1.2.3-jre"),
+			versionKey("com.google.guava:guava", "2.3.4"),
+			1,
+		},
+		{
+			versionKey("com.google.guava:guava", "1.2.3-jre"),
+			versionKey("com.google.guava:guava", "2.3.4-android"),
+			1,
+		},
+		{
+			versionKey("abc:xyz", "1.2.3"),
+			versionKey("abc:xyz", "2.3.4"),
+			-1,
+		},
+	}
+	for _, tt := range tests {
+		got := maven.CompareVersions(tt.a, tt.b)
+		if got != tt.want {
+			t.Errorf("CompareVersions(%v, %v): got %b, want %b", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+*/

--- a/internal/utility/maven/maven_test.go
+++ b/internal/utility/maven/maven_test.go
@@ -4,6 +4,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"deps.dev/util/resolve"
+	"deps.dev/util/semver"
 	"github.com/google/osv-scanner/v2/internal/utility/maven"
 )
 
@@ -65,74 +67,93 @@ func TestParentPOMPath(t *testing.T) {
 	}
 }
 
-/*
 func TestCompareVersions(t *testing.T) {
 	t.Parallel()
 
-	versionKey := func(name string, version string) resolve.Version {
-		return resolve.Version{
-			VersionKey: resolve.VersionKey{
-				PackageKey: resolve.PackageKey{
-					System: resolve.Maven,
-					Name:   name,
-				},
-				Version: version,
+	versionKey := func(name string, version string) resolve.VersionKey {
+		return resolve.VersionKey{
+			PackageKey: resolve.PackageKey{
+				System: resolve.Maven,
+				Name:   name,
 			},
+			Version: version,
 		}
+	}
+	semVer := func(version string) *semver.Version {
+		parsed, _ := resolve.Maven.Semver().Parse(version)
+		return parsed
 	}
 
 	tests := []struct {
-		a, b resolve.Version
+		vk   resolve.VersionKey
+		a, b *semver.Version
 		want int
 	}{
 		{
-			versionKey("abc:xyz", "1.2.3"),
-			versionKey("abc:xyz", "2.3.4"),
+			versionKey("abc:xyz", "1.0.0"),
+			semVer("1.2.3"),
+			semVer("1.2.3"),
+			0,
+		},
+		{
+			versionKey("abc:xyz", "1.0.0"),
+			semVer("1.2.3"),
+			semVer("2.3.4"),
 			-1,
 		},
 		{
-			versionKey("com.google.guava:guava", "1.2.3"),
-			versionKey("com.google.guava:guava", "2.3.4"),
+			versionKey("com.google.guava:guava", "1.0.0"),
+			semVer("1.2.3"),
+			semVer("2.3.4"),
 			-1,
 		},
 		{
-			versionKey("com.google.guava:guava", "1.2.3-jre"),
-			versionKey("com.google.guava:guava", "2.3.4-jre"),
+			versionKey("com.google.guava:guava", "1.0.0"),
+			semVer("1.2.3-jre"),
+			semVer("2.3.4-jre"),
 			-1,
 		},
 		{
-			versionKey("com.google.guava:guava", "1.2.3-android"),
-			versionKey("com.google.guava:guava", "2.3.4-android"),
+			versionKey("com.google.guava:guava", "1.0.0"),
+			semVer("1.2.3-android"),
+			semVer("2.3.4-android"),
 			-1,
 		},
 		{
-			// android flavours are always ordered earlier
-			versionKey("com.google.guava:guava", "1.2.3"),
-			versionKey("com.google.guava:guava", "2.3.4-android"),
+			versionKey("com.google.guava:guava", "1.0.0"),
+			semVer("2.3.4-android"),
+			semVer("1.2.3-jre"),
+			-1,
+		},
+		{
+			versionKey("com.google.guava:guava", "1.0.0-jre"),
+			semVer("1.2.3-android"),
+			semVer("1.2.3-jre"),
+			-1,
+		},
+		{
+			versionKey("com.google.guava:guava", "1.0.0-android"),
+			semVer("1.2.3-android"),
+			semVer("1.2.3-jre"),
 			1,
 		},
 		{
-			// jre flavours are always ordered later
-			versionKey("com.google.guava:guava", "1.2.3-jre"),
-			versionKey("com.google.guava:guava", "2.3.4"),
-			1,
-		},
-		{
-			versionKey("com.google.guava:guava", "1.2.3-jre"),
-			versionKey("com.google.guava:guava", "2.3.4-android"),
-			1,
-		},
-		{
-			versionKey("abc:xyz", "1.2.3"),
-			versionKey("abc:xyz", "2.3.4"),
+			versionKey("commons-io:commons-io", "1.0.0"),
+			semVer("1.2.3"),
+			semVer("2.3.4"),
 			-1,
+		},
+		{
+			versionKey("commons-io:commons-io", "1.0.0"),
+			semVer("1.2.3"),
+			semVer("20010101.000000"),
+			1,
 		},
 	}
 	for _, tt := range tests {
-		got := maven.CompareVersions(tt.a, tt.b)
+		got := maven.CompareVersions(tt.vk, tt.a, tt.b)
 		if got != tt.want {
-			t.Errorf("CompareVersions(%v, %v): got %b, want %b", tt.a, tt.b, got, tt.want)
+			t.Errorf("CompareVersions(%v, %v, %v): got %b, want %b", tt.vk, tt.a, tt.b, got, tt.want)
 		}
 	}
 }
-*/


### PR DESCRIPTION
This PR applies the Maven version comparison workarounds in the updater. To make the function reusable, moves the version comparison to `internal/utility/maven`.

Also considering that all version strings are parsed to semver first for comparison, this PR pre-parse the versions and store them in a map.