### PR TITLE
feat: move offline flags out of experimental mode

### DIFF
--- a/cmd/osv-scanner/fix/main.go
+++ b/cmd/osv-scanner/fix/main.go
@@ -192,16 +192,16 @@ func Command(stdout, stderr io.Writer, r *reporter.Reporter) *cli.Command {
 			},
 			// Offline database flags, copied from osv-scanner scan
 			&cli.BoolFlag{
-				Name:    "experimental-offline-vulnerabilities",
-				Aliases: []string{"experimental-offline"},
+				Name:    "offline-vulnerabilities",
+				Aliases: []string{"offline"},
 				Usage:   "checks for vulnerabilities using local databases that are already cached",
 			},
 			&cli.BoolFlag{
-				Name:  "experimental-download-offline-databases",
+				Name:  "download-offline-databases",
 				Usage: "downloads vulnerability databases for offline comparison",
 			},
 			&cli.StringFlag{
-				Name:   "experimental-local-db-path",
+				Name:   "local-db-path",
 				Usage:  "sets the path that local databases should be stored",
 				Hidden: true,
 			},
@@ -308,12 +308,12 @@ func action(ctx *cli.Context, stdout, stderr io.Writer) (reporter.Reporter, erro
 	}
 
 	userAgent := "osv-scanner_fix/" + version.OSVVersion
-	if ctx.Bool("experimental-offline-vulnerabilities") {
+	if ctx.Bool("offline-vulnerabilities") {
 		matcher, err := localmatcher.NewLocalMatcher(
 			r,
-			ctx.String("experimental-local-db-path"),
+			ctx.String("local-db-path"),
 			userAgent,
-			ctx.Bool("experimental-download-offline-databases"),
+			ctx.Bool("download-offline-databases"),
 		)
 		if err != nil {
 			return nil, err

--- a/cmd/osv-scanner/internal/helper/helper.go
+++ b/cmd/osv-scanner/internal/helper/helper.go
@@ -104,7 +104,7 @@ var GlobalScanFlags = []cli.Flag{
 			for flag, value := range OfflineFlags {
 				// TODO(michaelkedar): do something if the flag was already explicitly set.
 
-				// Skip setting the flag if the current command doesn't have it."
+				// Skip setting the flag if the current command doesn't have it.
 				if !slices.ContainsFunc(ctx.Command.Flags, func(f cli.Flag) bool {
 					return slices.Contains(f.Names(), flag)
 				}) {

--- a/cmd/osv-scanner/internal/helper/helper.go
+++ b/cmd/osv-scanner/internal/helper/helper.go
@@ -22,10 +22,10 @@ import (
 // OfflineFlags is a map of flags which require network access to operate,
 // with the values to set them to in order to disable them
 var OfflineFlags = map[string]string{
-	"include-git-root":                     "true",
-	"experimental-offline-vulnerabilities": "true",
-	"experimental-no-resolve":              "true",
-	"experimental-licenses-summary":        "false",
+	"include-git-root":              "true",
+	"offline-vulnerabilities":       "true",
+	"experimental-no-resolve":       "true",
+	"experimental-licenses-summary": "false",
 	// "experimental-licenses": "", // StringSliceFlag has to be manually cleared.
 }
 
@@ -76,7 +76,7 @@ var GlobalScanFlags = []cli.Flag{
 		Value: "info",
 	},
 	&cli.BoolFlag{
-		Name:  "experimental-offline",
+		Name:  "offline",
 		Usage: "run in offline mode, disabling any features requiring network access",
 		Action: func(ctx *cli.Context, b bool) error {
 			if !b {
@@ -102,21 +102,21 @@ var GlobalScanFlags = []cli.Flag{
 		},
 	},
 	&cli.BoolFlag{
-		Name:  "experimental-offline-vulnerabilities",
+		Name:  "offline-vulnerabilities",
 		Usage: "checks for vulnerabilities using local databases that are already cached",
 	},
 	&cli.BoolFlag{
-		Name:  "experimental-download-offline-databases",
+		Name:  "download-offline-databases",
 		Usage: "downloads vulnerability databases for offline comparison",
+	},
+	&cli.StringFlag{
+		Name:   "local-db-path",
+		Usage:  "sets the path that local databases should be stored",
+		Hidden: true,
 	},
 	&cli.BoolFlag{
 		Name:  "experimental-no-resolve",
 		Usage: "disable transitive dependency resolution of manifest files",
-	},
-	&cli.StringFlag{
-		Name:   "experimental-local-db-path",
-		Usage:  "sets the path that local databases should be stored",
-		Hidden: true,
 	},
 	&cli.BoolFlag{
 		Name:  "experimental-all-packages",
@@ -187,7 +187,7 @@ func GetScanLicensesAllowlist(context *cli.Context) ([]string, error) {
 	}
 
 	scanLicensesAllowlist := context.StringSlice("experimental-licenses")
-	if context.Bool("experimental-offline") {
+	if context.Bool("offline") {
 		scanLicensesAllowlist = []string{}
 	}
 
@@ -225,9 +225,9 @@ func GetReporter(context *cli.Context, stdout, stderr io.Writer, outputPath, for
 
 func GetExperimentalScannerActions(context *cli.Context, scanLicensesAllowlist []string) osvscanner.ExperimentalScannerActions {
 	return osvscanner.ExperimentalScannerActions{
-		LocalDBPath:       context.String("experimental-local-db-path"),
-		DownloadDatabases: context.Bool("experimental-download-offline-databases"),
-		CompareOffline:    context.Bool("experimental-offline-vulnerabilities"),
+		LocalDBPath:       context.String("local-db-path"),
+		DownloadDatabases: context.Bool("download-offline-databases"),
+		CompareOffline:    context.Bool("offline-vulnerabilities"),
 		// License summary mode causes all
 		// packages to appear in the json as
 		// every package has a license - even

--- a/cmd/osv-scanner/internal/helper/helper.go
+++ b/cmd/osv-scanner/internal/helper/helper.go
@@ -22,7 +22,7 @@ import (
 // with the values to set them to in order to disable them
 var OfflineFlags = map[string]string{
 	"offline-vulnerabilities": "true",
-	"no-resolve":              "true",
+	"experimental-no-resolve": "true",
 }
 
 // sets default port(8000) as a global variable

--- a/cmd/osv-scanner/main.go
+++ b/cmd/osv-scanner/main.go
@@ -98,7 +98,7 @@ EXAMPLES:
 	$ {{.Name}} scan source -r <source_directory>
 
 	# Scan a source directory in offline mode
-	$ {{.Name}} scan source --offline -r <source_directory>
+	$ {{.Name}} scan source --offline-vulnerabilities --download-offline-database -r <source_directory>
 
 	# Scan a container image
 	$ {{.Name}} scan image <image_name>

--- a/cmd/osv-scanner/main.go
+++ b/cmd/osv-scanner/main.go
@@ -97,6 +97,9 @@ EXAMPLES:
 	# Scan a source directory
 	$ {{.Name}} scan source -r <source_directory>
 
+	# Scan a source directory in offline mode
+	$ {{.Name}} scan source --offline -r <source_directory>
+
 	# Scan a container image
 	$ {{.Name}} scan image <image_name>
 

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -232,7 +232,7 @@ func Test_run(t *testing.T) {
 		},
 		{
 			name: "PURL SBOM case sensitivity (local)",
-			args: []string{"", "--config=./fixtures/osv-scanner-empty-config.toml", "--experimental-offline", "--experimental-download-offline-databases", "--format", "table", "./fixtures/sbom-insecure/alpine.cdx.xml"},
+			args: []string{"", "--config=./fixtures/osv-scanner-empty-config.toml", "--offline", "--download-offline-databases", "--format", "table", "./fixtures/sbom-insecure/alpine.cdx.xml"},
 			exit: 1,
 		},
 		// Go project with an overridden go version
@@ -481,62 +481,62 @@ func Test_run_LocalDatabases(t *testing.T) {
 	tests := []cliTestCase{
 		{
 			name: "one specific supported lockfile",
-			args: []string{"", "--experimental-offline", "--experimental-download-offline-databases", "./fixtures/locks-many/composer.lock"},
+			args: []string{"", "--offline", "--download-offline-databases", "./fixtures/locks-many/composer.lock"},
 			exit: 0,
 		},
 		{
 			name: "one specific supported sbom with vulns",
-			args: []string{"", "--experimental-offline", "--experimental-download-offline-databases", "--config=./fixtures/osv-scanner-empty-config.toml", "./fixtures/sbom-insecure/postgres-stretch.cdx.xml"},
+			args: []string{"", "--offline", "--download-offline-databases", "--config=./fixtures/osv-scanner-empty-config.toml", "./fixtures/sbom-insecure/postgres-stretch.cdx.xml"},
 			exit: 1,
 		},
 		{
 			name: "one specific unsupported lockfile",
-			args: []string{"", "--experimental-offline", "--experimental-download-offline-databases", "./fixtures/locks-many/not-a-lockfile.toml"},
+			args: []string{"", "--offline", "--download-offline-databases", "./fixtures/locks-many/not-a-lockfile.toml"},
 			exit: 128,
 		},
 		{
 			name: "all supported lockfiles in the directory should be checked",
-			args: []string{"", "--experimental-offline", "--experimental-download-offline-databases", "./fixtures/locks-many"},
+			args: []string{"", "--offline", "--download-offline-databases", "./fixtures/locks-many"},
 			exit: 0,
 		},
 		{
 			name: "all supported lockfiles in the directory should be checked",
-			args: []string{"", "--experimental-offline", "--experimental-download-offline-databases", "./fixtures/locks-many-with-invalid"},
+			args: []string{"", "--offline", "--download-offline-databases", "./fixtures/locks-many-with-invalid"},
 			exit: 127,
 		},
 		{
 			name: "only the files in the given directories are checked by default (no recursion)",
-			args: []string{"", "--experimental-offline", "--experimental-download-offline-databases", "./fixtures/locks-one-with-nested"},
+			args: []string{"", "--offline", "--download-offline-databases", "./fixtures/locks-one-with-nested"},
 			exit: 0,
 		},
 		{
 			name: "nested directories are checked when `--recursive` is passed",
-			args: []string{"", "--experimental-offline", "--experimental-download-offline-databases", "--recursive", "./fixtures/locks-one-with-nested"},
+			args: []string{"", "--offline", "--download-offline-databases", "--recursive", "./fixtures/locks-one-with-nested"},
 			exit: 0,
 		},
 		{
 			name: ".gitignored files",
-			args: []string{"", "--experimental-offline", "--experimental-download-offline-databases", "--recursive", "./fixtures/locks-gitignore"},
+			args: []string{"", "--offline", "--download-offline-databases", "--recursive", "./fixtures/locks-gitignore"},
 			exit: 0,
 		},
 		{
 			name: "ignoring .gitignore",
-			args: []string{"", "--experimental-offline", "--experimental-download-offline-databases", "--recursive", "--no-ignore", "./fixtures/locks-gitignore"},
+			args: []string{"", "--offline", "--download-offline-databases", "--recursive", "--no-ignore", "./fixtures/locks-gitignore"},
 			exit: 0,
 		},
 		{
 			name: "output with json",
-			args: []string{"", "--experimental-offline", "--experimental-download-offline-databases", "--format", "json", "./fixtures/locks-many/composer.lock"},
+			args: []string{"", "--offline", "--download-offline-databases", "--format", "json", "./fixtures/locks-many/composer.lock"},
 			exit: 0,
 		},
 		{
 			name: "output format: markdown table",
-			args: []string{"", "--experimental-offline", "--experimental-download-offline-databases", "--format", "markdown", "./fixtures/locks-many/composer.lock"},
+			args: []string{"", "--offline", "--download-offline-databases", "--format", "markdown", "./fixtures/locks-many/composer.lock"},
 			exit: 0,
 		},
 		{
 			name: "database should be downloaded only when offline is set",
-			args: []string{"", "--experimental-download-offline-databases", "./fixtures/locks-many"},
+			args: []string{"", "--download-offline-databases", "./fixtures/locks-many"},
 			exit: 127,
 		},
 	}
@@ -548,7 +548,7 @@ func Test_run_LocalDatabases(t *testing.T) {
 			if testutility.IsAcceptanceTesting() {
 				testDir := testutility.CreateTestDir(t)
 				old := tt.args
-				tt.args = []string{"", "--experimental-local-db-path", testDir}
+				tt.args = []string{"", "--local-db-path", testDir}
 				tt.args = append(tt.args, old[1:]...)
 			}
 
@@ -566,7 +566,7 @@ func Test_run_LocalDatabases_AlwaysOffline(t *testing.T) {
 	tests := []cliTestCase{
 		{
 			name: "a bunch of different lockfiles and ecosystem",
-			args: []string{"", "--config=./fixtures/osv-scanner-empty-config.toml", "--experimental-offline", "./fixtures/locks-requirements", "./fixtures/locks-many"},
+			args: []string{"", "--config=./fixtures/osv-scanner-empty-config.toml", "--offline", "./fixtures/locks-requirements", "./fixtures/locks-many"},
 			exit: 127,
 		},
 	}
@@ -577,7 +577,7 @@ func Test_run_LocalDatabases_AlwaysOffline(t *testing.T) {
 
 			testDir := testutility.CreateTestDir(t)
 			old := tt.args
-			tt.args = []string{"", "--experimental-local-db-path", testDir}
+			tt.args = []string{"", "--local-db-path", testDir}
 			tt.args = append(tt.args, old[1:]...)
 
 			// run each test twice since they should provide the same output,
@@ -978,7 +978,7 @@ func Test_run_MavenTransitive(t *testing.T) {
 		{
 			// Direct dependencies do not have any vulnerability.
 			name: "does not scan transitive dependencies for pom.xml with offline mode",
-			args: []string{"", "--config=./fixtures/osv-scanner-empty-config.toml", "--experimental-offline", "--experimental-download-offline-databases", "./fixtures/maven-transitive/pom.xml"},
+			args: []string{"", "--config=./fixtures/osv-scanner-empty-config.toml", "--offline", "--download-offline-databases", "./fixtures/maven-transitive/pom.xml"},
 			exit: 0,
 		},
 		{

--- a/cmd/osv-scanner/scan/source/main.go
+++ b/cmd/osv-scanner/scan/source/main.go
@@ -125,8 +125,7 @@ func action(context *cli.Context, stdout, stderr io.Writer) (reporter.Reporter, 
 		return nil, err
 	}
 
-	var callAnalysisStates map[string]bool
-	callAnalysisStates = helper.CreateCallAnalysisStates(context.StringSlice("call-analysis"), context.StringSlice("no-call-analysis"))
+	callAnalysisStates := helper.CreateCallAnalysisStates(context.StringSlice("call-analysis"), context.StringSlice("no-call-analysis"))
 
 	experimentalScannerActions := helper.GetExperimentalScannerActions(context, scanLicensesAllowlist)
 	// Add `source` specific experimental configs

--- a/cmd/osv-scanner/scan/source/main.go
+++ b/cmd/osv-scanner/scan/source/main.go
@@ -70,11 +70,6 @@ var projectScanExperimentalFlags = []cli.Flag{
 		Name:  "experimental-maven-registry",
 		Usage: "URL of the default registry to fetch Maven metadata",
 	},
-	&cli.BoolFlag{
-		Name:  "experimental-call-analysis",
-		Usage: "[Deprecated] attempt call analysis on code to detect only active vulnerabilities",
-		Value: false,
-	},
 }
 
 func Command(stdout, stderr io.Writer, r *reporter.Reporter) *cli.Command {
@@ -131,12 +126,7 @@ func action(context *cli.Context, stdout, stderr io.Writer) (reporter.Reporter, 
 	}
 
 	var callAnalysisStates map[string]bool
-	if context.IsSet("experimental-call-analysis") {
-		callAnalysisStates = helper.CreateCallAnalysisStates([]string{"all"}, context.StringSlice("no-call-analysis"))
-		r.Infof("Warning: the experimental-call-analysis flag has been replaced. Please use the call-analysis and no-call-analysis flags instead.\n")
-	} else {
-		callAnalysisStates = helper.CreateCallAnalysisStates(context.StringSlice("call-analysis"), context.StringSlice("no-call-analysis"))
-	}
+	callAnalysisStates = helper.CreateCallAnalysisStates(context.StringSlice("call-analysis"), context.StringSlice("no-call-analysis"))
 
 	experimentalScannerActions := helper.GetExperimentalScannerActions(context, scanLicensesAllowlist)
 	// Add `source` specific experimental configs

--- a/docs/offline-mode.md
+++ b/docs/offline-mode.md
@@ -1,15 +1,12 @@
 ---
 layout: page
 title: Offline Mode
-permalink: /experimental/offline-mode/
-parent: Experimental Features
+permalink: /usage/offline-mode/
+parent: Usage
 nav_order: 1
 ---
 
 # Offline Mode
-
-Experimental
-{: .label }
 
 {: .no_toc }
 
@@ -22,10 +19,7 @@ Experimental
 {:toc}
 </details>
 
-OSV-Scanner now supports offline scanning as an experimental feature. Offline scanning checks your project against a local database instead of calling the OSV.dev API.
-
-{: .note }
-This feature is experimental and might change or be removed with only a minor version update.
+OSV-Scanner now supports offline scanning as an official feature. Offline scanning checks your project against a local database instead of calling the OSV.dev API.
 
 ## Specify database location
 
@@ -49,29 +43,29 @@ If the `OSV_SCANNER_LOCAL_DB_CACHE_DIRECTORY` environment variable is _not_ set,
 1. The location returned by [`os.UserCacheDir`](https://pkg.go.dev/os#UserCacheDir)
 2. The location returned by [`os.TempDir`](https://pkg.go.dev/os#TempDir)
 
-The database can be [downloaded manually](#manual-database-download) or by using the [`--experimental-download-offline-databases` flag](#download-offline-databases-option).
+The database can be [downloaded manually](#manual-database-download) or by using the [`--download-offline-databases` flag](#download-offline-databases-option).
 
 ## Offline option
 
-The offline database flag `--experimental-offline` causes OSV-Scanner to scan your project against a previously downloaded local database. OSV-Scanner will not download or update the local database, nor will it send any project or dependency information anywhere. When a local database is not present, you will get an error message. No network connection is required when using this flag.
+The offline database flag `--offline` causes OSV-Scanner to scan your project against a previously downloaded local database. OSV-Scanner will not download or update the local database, nor will it send any project or dependency information anywhere. When a local database is not present, you will get an error message. No network connection is required when using this flag.
 
 ```bash
-osv-scanner --experimental-offline ./path/to/your/dir
+osv-scanner --offline ./path/to/your/dir
 ```
 
-To use offline mode for just the vulnerability database, but allow other features to possibly make network requests (e.g. [transitive dependency scanning](./supported_languages_and_lockfiles.md/#transitive-dependency-scanning)), you can use the `--experimental-offline-vulnerabilities` flag instead.
+To use offline mode for just the vulnerability database, but allow other features to possibly make network requests (e.g. [transitive dependency scanning](./supported_languages_and_lockfiles.md/#transitive-dependency-scanning)), you can use the `--offline-vulnerabilities` flag instead.
 
 ## Download offline databases option
 
-The download offline databases flag `--experimental-download-offline-databases` allows OSV-Scanner to download or update your local database when running in offline mode, to make it easier to get started. This option only works when you also set the offline flag.
+The download offline databases flag `--download-offline-databases` allows OSV-Scanner to download or update your local database when running in offline mode, to make it easier to get started. This option only works when you also set the offline flag.
 
 ```bash
-osv-scanner --experimental-offline --experimental-download-offline-databases ./path/to/your/dir
+osv-scanner --offline-vulnerabilities --download-offline-databases ./path/to/your/dir
 ```
 
 ## Manual database download
 
-Instead of using the `--experimental-download-offline-databases` flag to download the database, it is possible to manually download the database.
+Instead of using the `--download-offline-databases` flag to download the database, it is possible to manually download the database.
 
 A downloadable copy of the OSV database is stored in a GCS bucket maintained by OSV:
 [`gs://osv-vulnerabilities`](https://osv-vulnerabilities.storage.googleapis.com)


### PR DESCRIPTION
This PR moves offline flags out of experimental mode and removes the deprecated `experimental-call-analysis` flag