### PR TITLE
feat: move transitive scanning flags from experimental

### DIFF
--- a/cmd/osv-scanner/fix/main.go
+++ b/cmd/osv-scanner/fix/main.go
@@ -58,8 +58,8 @@ type osvFixOptions struct {
 func Command(stdout, stderr io.Writer, r *reporter.Reporter) *cli.Command {
 	return &cli.Command{
 		Name:        "fix",
-		Usage:       "scans a manifest and/or lockfile for vulnerabilities and suggests changes for remediating them",
-		Description: "scans a manifest and/or lockfile for vulnerabilities and suggests changes for remediating them",
+		Usage:       "[EXPERIMENTAL] scans a manifest and/or lockfile for vulnerabilities and suggests changes for remediating them",
+		Description: "[EXPERIMENTAL] scans a manifest and/or lockfile for vulnerabilities and suggests changes for remediating them",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:      "manifest",

--- a/cmd/osv-scanner/fix/main.go
+++ b/cmd/osv-scanner/fix/main.go
@@ -58,8 +58,8 @@ type osvFixOptions struct {
 func Command(stdout, stderr io.Writer, r *reporter.Reporter) *cli.Command {
 	return &cli.Command{
 		Name:        "fix",
-		Usage:       "[EXPERIMENTAL] scans a manifest and/or lockfile for vulnerabilities and suggests changes for remediating them",
-		Description: "[EXPERIMENTAL] scans a manifest and/or lockfile for vulnerabilities and suggests changes for remediating them",
+		Usage:       "scans a manifest and/or lockfile for vulnerabilities and suggests changes for remediating them",
+		Description: "scans a manifest and/or lockfile for vulnerabilities and suggests changes for remediating them",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:      "manifest",

--- a/cmd/osv-scanner/internal/helper/helper.go
+++ b/cmd/osv-scanner/internal/helper/helper.go
@@ -23,7 +23,7 @@ import (
 var OfflineFlags = map[string]string{
 	"include-git-root":                     "true",
 	"experimental-offline-vulnerabilities": "true",
-	"experimental-no-resolve":              "true",
+	"no-resolve":                           "true",
 }
 
 // sets default port(8000) as a global variable
@@ -129,7 +129,7 @@ var GlobalScanFlags = []cli.Flag{
 		Usage: "downloads vulnerability databases for offline comparison",
 	},
 	&cli.BoolFlag{
-		Name:  "experimental-no-resolve",
+		Name:  "no-resolve",
 		Usage: "disable transitive dependency resolution of manifest files",
 	},
 	&cli.StringFlag{

--- a/cmd/osv-scanner/internal/helper/helper.go
+++ b/cmd/osv-scanner/internal/helper/helper.go
@@ -127,14 +127,14 @@ var GlobalScanFlags = []cli.Flag{
 		Name:  "download-offline-databases",
 		Usage: "downloads vulnerability databases for offline comparison",
 	},
-	&cli.BoolFlag{
-		Name:  "no-resolve",
-		Usage: "disable transitive dependency resolution of manifest files",
-	},
 	&cli.StringFlag{
 		Name:   "local-db-path",
 		Usage:  "sets the path that local databases should be stored",
 		Hidden: true,
+	},
+	&cli.BoolFlag{
+		Name:  "no-resolve",
+		Usage: "disable transitive dependency resolution of manifest files",
 	},
 	&cli.BoolFlag{
 		Name:  "experimental-all-packages",

--- a/cmd/osv-scanner/internal/helper/helper.go
+++ b/cmd/osv-scanner/internal/helper/helper.go
@@ -22,7 +22,7 @@ import (
 // with the values to set them to in order to disable them
 var OfflineFlags = map[string]string{
 	"offline-vulnerabilities": "true",
-	"no-resolve":                           "true",
+	"no-resolve":              "true",
 }
 
 // sets default port(8000) as a global variable

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -989,7 +989,7 @@ func Test_run_MavenTransitive(t *testing.T) {
 		{
 			// Direct dependencies do not have any vulnerability.
 			name: "does not scan transitive dependencies for pom.xml with no-resolve",
-			args: []string{"", "--config=./fixtures/osv-scanner-empty-config.toml", "--experimental-no-resolve", "./fixtures/maven-transitive/pom.xml"},
+			args: []string{"", "--config=./fixtures/osv-scanner-empty-config.toml", "--no-resolve", "./fixtures/maven-transitive/pom.xml"},
 			exit: 0,
 		},
 		{
@@ -999,7 +999,7 @@ func Test_run_MavenTransitive(t *testing.T) {
 		},
 		{
 			name: "resolve transitive dependencies with native data source",
-			args: []string{"", "--config=./fixtures/osv-scanner-empty-config.toml", "--experimental-resolution-data-source=native", "-L", "pom.xml:./fixtures/maven-transitive/registry.xml"},
+			args: []string{"", "--config=./fixtures/osv-scanner-empty-config.toml", "--data-source=native", "-L", "pom.xml:./fixtures/maven-transitive/registry.xml"},
 			exit: 1,
 		},
 	}

--- a/cmd/osv-scanner/scan/source/main.go
+++ b/cmd/osv-scanner/scan/source/main.go
@@ -55,7 +55,7 @@ var projectScanFlags = []cli.Flag{
 
 var projectScanExperimentalFlags = []cli.Flag{
 	&cli.StringFlag{
-		Name:  "experimental-resolution-data-source",
+		Name:  "data-source",
 		Usage: "source to fetch package information from; value can be: deps.dev, native",
 		Value: "deps.dev",
 		Action: func(_ *cli.Context, s string) error {
@@ -67,7 +67,7 @@ var projectScanExperimentalFlags = []cli.Flag{
 		},
 	},
 	&cli.StringFlag{
-		Name:  "experimental-maven-registry",
+		Name:  "maven-registry",
 		Usage: "URL of the default registry to fetch Maven metadata",
 	},
 	&cli.BoolFlag{
@@ -141,9 +141,9 @@ func action(context *cli.Context, stdout, stderr io.Writer) (reporter.Reporter, 
 	experimentalScannerActions := helper.GetExperimentalScannerActions(context, scanLicensesAllowlist)
 	// Add `source` specific experimental configs
 	experimentalScannerActions.TransitiveScanningActions = osvscanner.TransitiveScanningActions{
-		Disabled:         context.Bool("experimental-no-resolve"),
-		NativeDataSource: context.String("experimental-resolution-data-source") == "native",
-		MavenRegistry:    context.String("experimental-maven-registry"),
+		Disabled:         context.Bool("no-resolve"),
+		NativeDataSource: context.String("data-source") == "native",
+		MavenRegistry:    context.String("maven-registry"),
 	}
 
 	scannerAction := osvscanner.ScannerActions{

--- a/cmd/osv-scanner/scan/source/main.go
+++ b/cmd/osv-scanner/scan/source/main.go
@@ -51,9 +51,6 @@ var projectScanFlags = []cli.Flag{
 		Usage: "include scanning git root (non-submoduled) repositories",
 		Value: false,
 	},
-}
-
-var projectScanExperimentalFlags = []cli.Flag{
 	&cli.StringFlag{
 		Name:  "data-source",
 		Usage: "source to fetch package information from; value can be: deps.dev, native",
@@ -73,11 +70,9 @@ var projectScanExperimentalFlags = []cli.Flag{
 }
 
 func Command(stdout, stderr io.Writer, r *reporter.Reporter) *cli.Command {
-	flags := make([]cli.Flag, 0, len(projectScanFlags)+len(helper.GetScanGlobalFlags())+len(projectScanExperimentalFlags))
+	flags := make([]cli.Flag, 0, len(projectScanFlags)+len(helper.GetScanGlobalFlags()))
 	flags = append(flags, projectScanFlags...)
 	flags = append(flags, helper.GetScanGlobalFlags()...)
-	// Make sure all experimental flags show after regular flags
-	flags = append(flags, projectScanExperimentalFlags...)
 
 	return &cli.Command{
 		Name:        "source",

--- a/docs/supported_languages_and_lockfiles.md
+++ b/docs/supported_languages_and_lockfiles.md
@@ -82,7 +82,7 @@ Vendored dependencies have been directly copied into the project folder, but do 
 
 ## Transitive dependency scanning
 
-OSV-Scanner supports transitive dependency scanning for Maven pom.xml. This feature is enabled by default when scanning, but it can be disabled using the `--experimental-no-resolve` flag. It is also disabled in the [offline mode](./offline-mode.md).
+OSV-Scanner supports transitive dependency scanning for Maven pom.xml. This feature is enabled by default when scanning, but it can be disabled using the `--no-resolve` flag. It is also disabled in the [offline mode](./offline-mode.md).
 
 OSV-Scanner uses [deps.dev’s resolver library](https://pkg.go.dev/deps.dev/util/resolve) to compute the dependency graph of a project. This graph includes all of the direct and transitive dependencies. By default, [deps.dev API](https://docs.deps.dev/api/v3/index.html) is queried for package versions and requirements. The support for private registries is [coming soon](https://github.com/google/osv-scanner/issues/1045).
 
@@ -95,9 +95,9 @@ Test dependencies are not supported yet in the computed dependency graph for Mav
 
 By default, we use the [deps.dev API](https://docs.deps.dev/api/v3/) to find version and dependency information of packages during transitive scanning.
 
-If instead you'd like to fetch data from [Maven Central](https://repo.maven.apache.org/maven2/), you can use the `--experimental-resolution-data-source=native` flag.
+If instead you'd like to fetch data from [Maven Central](https://repo.maven.apache.org/maven2/), you can use the `--data-source=native` flag.
 
-If your project uses mirrored or private registries, in addition to setting `--experimental-resolution-data-source=native`, you will need to use the `--experimental-maven-registry=<full-registry-url>` flag to specify the registry (e.g. `--experimental-maven-registry=https://repo.maven.apache.org/maven2/`).
+If your project uses mirrored or private registries, in addition to setting `--data-source=native`, you will need to use the `--maven-registry=<full-registry-url>` flag to specify the registry (e.g. `--maven-registry=https://repo.maven.apache.org/maven2/`).
 
 ## Custom Lockfiles
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -102,7 +102,7 @@ Several experimental features are available through flags. See their respective 
 
 - [`--experimental-offline-vulnerabilities`](./offline-mode.md)
 - [`--experimental-licenses`](./license-scanning.md)
-- `--experimental-no-resolve`: Disables transitive dependency resolution.
+- `--no-resolve`: Disables transitive dependency resolution.
 - `experimental-all-packages`: Outputs all packages in JSON format (make sure to set `--format=json`).
 
 ## Pre-Commit Integration


### PR DESCRIPTION
This PR moves a few transitive scanning flags from experimental and aligns with `fix`:
 - `experimental-no-resolve` -> `no-resolve`
 - `experimental-resolution-data-source` -> `data-source`
 - `experimental-maven-registry` -> `maven-registry`