### PR TITLE
fix: correct local-db-path name

### DIFF
--- a/cmd/osv-scanner/internal/helper/helper.go
+++ b/cmd/osv-scanner/internal/helper/helper.go
@@ -242,7 +242,7 @@ func GetScanLicensesAllowlist(context *cli.Context) ([]string, error) {
 
 func GetExperimentalScannerActions(context *cli.Context, scanLicensesAllowlist []string) osvscanner.ExperimentalScannerActions {
 	return osvscanner.ExperimentalScannerActions{
-		LocalDBPath:           context.String("experimental-local-db-path"),
+		LocalDBPath:           context.String("local-db-path"),
 		DownloadDatabases:     context.Bool("download-offline-databases"),
 		CompareOffline:        context.Bool("offline-vulnerabilities"),
 		ShowAllPackages:       context.Bool("experimental-all-packages"),


### PR DESCRIPTION
https://github.com/google/osv-scanner/pull/1664 missed one experimental flag