### PR TITLE
feat: move license scanning and all package flags out of experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,26 +83,26 @@ $ osv-scanner scan image my-image-name:tag
 
 ![screencast of html output of container scanning](https://github.com/user-attachments/assets/8bb95366-27ec-45d1-86ed-e42890f2fb46)
 
-### [License Scanning](https://google.github.io/osv-scanner/experimental/license-scanning/) (Experimental)
+### [License Scanning](https://google.github.io/osv-scanner/experimental/license-scanning/)
 
 Check your dependencies' licenses using deps.dev data. For a summary:
 
 ```bash
-osv-scanner --experimental-licenses-summary path/to/repository
+osv-scanner --licenses path/to/repository
 ```
 
 To check against an allowed license list (SPDX format):
 
 ```bash
-osv-scanner --experimental-licenses="MIT,Apache-2.0" path/to/directory
+osv-scanner --licenses="MIT,Apache-2.0" path/to/directory
 ```
 
-### [Offline Scanning](https://google.github.io/osv-scanner/experimental/offline-mode/) (Experimental)
+### [Offline Scanning](https://google.github.io/osv-scanner/experimental/offline-mode/)
 
 Scan your project against a local OSV database. No network connection is required after the initial database download. The database can also be manually downloaded.
 
 ```bash
-osv-scanner --experimental-offline --experimental-download-offline-databases ./path/to/your/dir
+osv-scanner --offline --download-offline-databases ./path/to/your/dir
 ```
 
 ### [Guided Remediation](https://google.github.io/osv-scanner/experimental/guided-remediation/) (Experimental)

--- a/cmd/osv-scanner/internal/helper/helper.go
+++ b/cmd/osv-scanner/internal/helper/helper.go
@@ -138,11 +138,11 @@ func GetScanGlobalFlags() []cli.Flag {
 			Usage: "disable transitive dependency resolution of manifest files",
 		},
 		&cli.BoolFlag{
-			Name:  "experimental-all-packages",
+			Name:  "all-packages",
 			Usage: "when json output is selected, prints all packages",
 		},
 		&cli.GenericFlag{
-			Name:  "experimental-licenses",
+			Name:  "licenses",
 			Usage: "report on licenses based on an allowlist",
 			Value: &licenseGenericFlag{
 				allowList: "",
@@ -220,9 +220,9 @@ func GetReporter(context *cli.Context, stdout, stderr io.Writer, outputPath, for
 }
 
 func GetScanLicensesAllowlist(context *cli.Context) ([]string, error) {
-	allowlist := strings.Split(context.Generic("experimental-licenses").(*licenseGenericFlag).String(), ",")
+	allowlist := strings.Split(context.Generic("licenses").(*licenseGenericFlag).String(), ",")
 
-	if !context.IsSet("experimental-licenses") {
+	if !context.IsSet("licenses") {
 		return []string{}, nil
 	}
 
@@ -232,7 +232,7 @@ func GetScanLicensesAllowlist(context *cli.Context) ([]string, error) {
 	}
 
 	if unrecognized := spdx.Unrecognized(allowlist); len(unrecognized) > 0 {
-		return nil, fmt.Errorf("--experimental-licenses requires comma-separated spdx licenses. The following license(s) are not recognized as spdx: %s", strings.Join(unrecognized, ","))
+		return nil, fmt.Errorf("--licenses requires comma-separated spdx licenses. The following license(s) are not recognized as spdx: %s", strings.Join(unrecognized, ","))
 	}
 
 	if context.Bool("offline") {
@@ -247,8 +247,8 @@ func GetExperimentalScannerActions(context *cli.Context, scanLicensesAllowlist [
 		LocalDBPath:           context.String("local-db-path"),
 		DownloadDatabases:     context.Bool("download-offline-databases"),
 		CompareOffline:        context.Bool("offline-vulnerabilities"),
-		ShowAllPackages:       context.Bool("experimental-all-packages"),
-		ScanLicensesSummary:   context.IsSet("experimental-licenses"),
+		ShowAllPackages:       context.Bool("all-packages"),
+		ScanLicensesSummary:   context.IsSet("licenses"),
 		ScanLicensesAllowlist: scanLicensesAllowlist,
 	}
 }

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -184,7 +184,7 @@ func Test_run(t *testing.T) {
 		},
 		{
 			name: "cyclonedx 1.4 output",
-			args: []string{"", "--config=./fixtures/osv-scanner-empty-config.toml", "--format", "cyclonedx-1-4", "--experimental-all-packages", "./fixtures/locks-insecure"},
+			args: []string{"", "--config=./fixtures/osv-scanner-empty-config.toml", "--format", "cyclonedx-1-4", "--all-packages", "./fixtures/locks-insecure"},
 			exit: 1,
 		},
 		// output format: cyclonedx 1.5
@@ -195,7 +195,7 @@ func Test_run(t *testing.T) {
 		},
 		{
 			name: "cyclonedx 1.5 output",
-			args: []string{"", "--config=./fixtures/osv-scanner-empty-config.toml", "--format", "cyclonedx-1-5", "--experimental-all-packages", "./fixtures/locks-insecure"},
+			args: []string{"", "--config=./fixtures/osv-scanner-empty-config.toml", "--format", "cyclonedx-1-5", "--all-packages", "./fixtures/locks-insecure"},
 			exit: 1,
 		},
 		// output format: unsupported
@@ -250,7 +250,7 @@ func Test_run(t *testing.T) {
 		// broad config file that overrides a whole ecosystem
 		{
 			name: "config file can be broad",
-			args: []string{"", "--config=./fixtures/osv-scanner-composite-config.toml", "--experimental-licenses=MIT", "-L", "osv-scanner:./fixtures/locks-insecure/osv-scanner-flutter-deps.json", "./fixtures/locks-many", "./fixtures/locks-insecure", "./fixtures/maven-transitive"},
+			args: []string{"", "--config=./fixtures/osv-scanner-composite-config.toml", "--licenses=MIT", "-L", "osv-scanner:./fixtures/locks-insecure/osv-scanner-flutter-deps.json", "./fixtures/locks-many", "./fixtures/locks-insecure", "./fixtures/maven-transitive"},
 			exit: 1,
 		},
 		// ignored vulnerabilities and packages without a reason should be called out
@@ -593,67 +593,67 @@ func Test_run_Licenses(t *testing.T) {
 	tests := []cliTestCase{
 		{
 			name: "No vulnerabilities with license summary",
-			args: []string{"", "--experimental-licenses", "./fixtures/locks-many"},
+			args: []string{"", "--licenses", "./fixtures/locks-many"},
 			exit: 0,
 		},
 		{
 			name: "No vulnerabilities with license summary in markdown",
-			args: []string{"", "--experimental-licenses", "--format=markdown", "./fixtures/locks-many"},
+			args: []string{"", "--licenses", "--format=markdown", "./fixtures/locks-many"},
 			exit: 0,
 		},
 		{
 			name: "Vulnerabilities and license summary",
-			args: []string{"", "--experimental-licenses", "--config=./fixtures/osv-scanner-empty-config.toml", "./fixtures/locks-many/package-lock.json"},
+			args: []string{"", "--licenses", "--config=./fixtures/osv-scanner-empty-config.toml", "./fixtures/locks-many/package-lock.json"},
 			exit: 1,
 		},
 		{
 			name: "Vulnerabilities and license violations with allowlist",
-			args: []string{"", "--experimental-licenses=MIT", "--config=./fixtures/osv-scanner-empty-config.toml", "./fixtures/locks-many/package-lock.json"},
+			args: []string{"", "--licenses=MIT", "--config=./fixtures/osv-scanner-empty-config.toml", "./fixtures/locks-many/package-lock.json"},
 			exit: 1,
 		},
 		{
 			name: "Vulnerabilities and all license violations allowlisted",
-			args: []string{"", "--experimental-licenses=Apache-2.0", "--config=./fixtures/osv-scanner-empty-config.toml", "./fixtures/locks-many/package-lock.json"},
+			args: []string{"", "--licenses=Apache-2.0", "--config=./fixtures/osv-scanner-empty-config.toml", "./fixtures/locks-many/package-lock.json"},
 			exit: 1,
 		},
 		{
 			name: "Some packages with license violations and show-all-packages in json",
-			args: []string{"", "--format=json", "--experimental-licenses=MIT", "--experimental-all-packages", "./fixtures/locks-licenses/package-lock.json"},
+			args: []string{"", "--format=json", "--licenses=MIT", "--all-packages", "./fixtures/locks-licenses/package-lock.json"},
 			exit: 1,
 		},
 		{
 			name: "Some packages with ignored licenses",
-			args: []string{"", "--config=./fixtures/osv-scanner-complex-licenses-config.toml", "--experimental-licenses=MIT", "./fixtures/locks-many", "./fixtures/locks-insecure"},
+			args: []string{"", "--config=./fixtures/osv-scanner-complex-licenses-config.toml", "--licenses=MIT", "./fixtures/locks-many", "./fixtures/locks-insecure"},
 			exit: 1,
 		},
 		{
 			name: "Some packages with license violations in json",
-			args: []string{"", "--format=json", "--experimental-licenses=MIT", "./fixtures/locks-licenses/package-lock.json"},
+			args: []string{"", "--format=json", "--licenses=MIT", "./fixtures/locks-licenses/package-lock.json"},
 			exit: 1,
 		},
 		{
 			name: "No license violations and show-all-packages in json",
-			args: []string{"", "--format=json", "--experimental-licenses=MIT,Apache-2.0", "--experimental-all-packages", "./fixtures/locks-licenses/package-lock.json"},
+			args: []string{"", "--format=json", "--licenses=MIT,Apache-2.0", "--all-packages", "./fixtures/locks-licenses/package-lock.json"},
 			exit: 0,
 		},
 		{
 			name: "Show all Packages with license summary in json",
-			args: []string{"", "--format=json", "--experimental-licenses", "--experimental-all-packages", "./fixtures/locks-licenses/package-lock.json"},
+			args: []string{"", "--format=json", "--licenses", "--all-packages", "./fixtures/locks-licenses/package-lock.json"},
 			exit: 0,
 		},
 		{
 			name: "Licenses in summary mode json",
-			args: []string{"", "--format=json", "--experimental-licenses", "./fixtures/locks-licenses/package-lock.json"},
+			args: []string{"", "--format=json", "--licenses", "./fixtures/locks-licenses/package-lock.json"},
 			exit: 0,
 		},
 		{
 			name: "Licenses with expressions",
-			args: []string{"", "--config=./fixtures/osv-scanner-expressive-licenses-config.toml", "--experimental-licenses=MIT,BSD-3-Clause", "./fixtures/locks-licenses/package-lock.json"},
+			args: []string{"", "--config=./fixtures/osv-scanner-expressive-licenses-config.toml", "--licenses=MIT,BSD-3-Clause", "./fixtures/locks-licenses/package-lock.json"},
 			exit: 1,
 		},
 		{
 			name: "Licenses with invalid expression",
-			args: []string{"", "--config=./fixtures/osv-scanner-invalid-licenses-config.toml", "--experimental-licenses=MIT,BSD-3-Clause", "./fixtures/locks-licenses/package-lock.json"},
+			args: []string{"", "--config=./fixtures/osv-scanner-invalid-licenses-config.toml", "--licenses=MIT,BSD-3-Clause", "./fixtures/locks-licenses/package-lock.json"},
 			exit: 1,
 		},
 	}
@@ -835,7 +835,7 @@ func Test_run_OCIImageAllPackagesJSON(t *testing.T) {
 		},
 		{
 			name: "scanning image with go binary",
-			args: []string{"", "scan", "image", "--archive", "--experimental-all-packages", "--format=json", "../../internal/image/fixtures/test-go-binary.tar"},
+			args: []string{"", "scan", "image", "--archive", "--all-packages", "--format=json", "../../internal/image/fixtures/test-go-binary.tar"},
 			exit: 1,
 			replaceRules: []testutility.JSONReplaceRule{
 				testutility.GroupsAsArrayLen,

--- a/docs/guided-remediation.md
+++ b/docs/guided-remediation.md
@@ -775,7 +775,7 @@ If your project uses mirrored or private registries, you will need to use `--dat
 
 ### Offline Vulnerability Database
 
-The `fix` subcommand supports the `--experimental-offline-vulnerabilities` and `--experimental-download-offline-databases` flags.
+The `fix` subcommand supports the `--offline-vulnerabilities` and `--download-offline-databases` flags.
 
 For more information, see [Offline Mode](./offline-mode.md).
 

--- a/docs/license-scanning.md
+++ b/docs/license-scanning.md
@@ -29,6 +29,8 @@ To also display violations, you can provide an allowlist of permitted licenses a
 ```bash
 # Show license summary only
 osv-scanner --licenses path/to/repository
+
+# Show the license summary and violations against an allowlist (provide the list after the = sign):
 osv-scanner --licenses="comma-separated list of allowed licenses" path/to/directory
 ```
 

--- a/docs/license-scanning.md
+++ b/docs/license-scanning.md
@@ -1,15 +1,12 @@
 ---
 layout: page
 title: License Scanning
-permalink: /experimental/license-scanning/
-parent: Experimental Features
-nav_order: 2
+permalink: /usage/license-scanning/
+parent: Usage
+nav_order: 3
 ---
 
 # License Scanning
-
-Experimental
-{: .label }
 
 {: .no_toc }
 
@@ -22,25 +19,17 @@ Experimental
 {:toc}
 </details>
 
-OSV-Scanner supports license checking as an experimental feature. The data comes from the [deps.dev API](https://docs.deps.dev/api/).
+OSV-Scanner supports license checking as an official feature. The data comes from the [deps.dev API](https://docs.deps.dev/api/).
 
-{: .note }
-This feature is experimental and might change or be removed with only a minor version update.
+## License Summary and Violations
 
-## License summary
-
-If you want a summary of your dependencies licenses, use the `--experimental-licenses-summary` flag:
+The `--licenses` flag provides a summary of the licenses used by your dependencies.
+To also display violations, you can provide an allowlist of permitted licenses as an argument:
 
 ```bash
-osv-scanner --experimental-licenses-summary path/to/repository
-```
-
-## License violations
-
-To set an allowed license list and see the details of packages that do not conform, use the `--experimental-licenses` flag:
-
-```bash
-osv-scanner --experimental-licenses="comma-separated list of allowed licenses" path/to/directory
+# Show license summary only
+osv-scanner --licenses path/to/repository
+osv-scanner --licenses="comma-separated list of allowed licenses" path/to/directory
 ```
 
 Include your allowed licenses as a comma-separated list. OSV-Scanner recognizes licenses in SPDX format. Please indicate your allowed licenses using [SPDX license](https://spdx.org/licenses/) identifiers.
@@ -56,7 +45,7 @@ If you wanted to allow the following licenses:
 Your command would be in this form:
 
 ```bash
-osv-scanner --experimental-licenses="BSD-3-Clause,Apache-2.0,MIT" path/to/directory
+osv-scanner --licenses="BSD-3-Clause,Apache-2.0,MIT" path/to/directory
 ```
 
 ## Override License

--- a/docs/offline-mode.md
+++ b/docs/offline-mode.md
@@ -3,7 +3,7 @@ layout: page
 title: Offline Mode
 permalink: /usage/offline-mode/
 parent: Usage
-nav_order: 1
+nav_order: 4
 ---
 
 # Offline Mode

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -132,7 +132,7 @@ osv-scanner --all-packages --format=json path/to/repository
 
 Several other features are available through flags. See their respective documentation pages for more details:
 
-- `--no-resolve`: Disables [transitive dependency resolution](./supported_languages_and_lockfiles.md).
+- `--no-resolve`: Disables [transitive dependency resolution](./supported_languages_and_lockfiles.md#transitive-dependency-scanning).
 
 ## Pre-Commit Integration
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -96,14 +96,43 @@ The `--serve` flag is a helper flag to set the output format to HTML, and serve 
 osv-scanner scan -L package-lock.json --serve
 ```
 
+### Offline vulnerability match
+
+The `--offline-vulnerabilities` flag can be used to check for vulnerabilities using local databases that are already cached
+
+```bash
+osv-scanner --offline-vulnerabilities --download-offline-databases ./path/to/your/dir
+```
+
+See [offline vulnerabilities](./offline-mode.md) for more details.
+
+### Licenses scanning
+
+The `--licenses` flag can be used to report license violations based on an allowlist
+
+```bash
+# Show license summary only
+osv-scanner --licenses path/to/repository
+
+# Show the license summary and violations against an allowlist (provide the list after the = sign):
+osv-scanner --licenses="comma-separated list of allowed licenses" path/to/directory
+```
+
+See [licenses scanning](./license-scanning.md) for more details.
+
+### Show all packages
+
+The `--all-packages` flag can be used to output all packages in JSON format (make sure to set `--format=json`).
+
+```bash
+osv-scanner --all-packages --format=json path/to/repository
+```
+
 ### Other features
 
 Several other features are available through flags. See their respective documentation pages for more details:
 
-- [`--offline-vulnerabilities`](./offline-mode.md)
-- [`--licenses`](./license-scanning.md)
-- `--no-resolve`: Disables transitive dependency resolution.
-- `--all-packages`: Outputs all packages in JSON format (make sure to set `--format=json`).
+- [`--no-resolve`](./supported_languages_and_lockfiles.md): Disables transitive dependency resolution.
 
 ## Pre-Commit Integration
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -96,14 +96,14 @@ The `--serve` flag is a helper flag to set the output format to HTML, and serve 
 osv-scanner scan -L package-lock.json --serve
 ```
 
-### Experimental features
+### Other features
 
-Several experimental features are available through flags. See their respective documentation pages for more details:
+Several other features are available through flags. See their respective documentation pages for more details:
 
-- [`--experimental-offline-vulnerabilities`](./offline-mode.md)
-- [`--experimental-licenses`](./license-scanning.md)
-- `--experimental-no-resolve`: Disables transitive dependency resolution.
-- `experimental-all-packages`: Outputs all packages in JSON format (make sure to set `--format=json`).
+- [`--offline-vulnerabilities`](./offline-mode.md)
+- [`--licenses`](./license-scanning.md)
+- `--no-resolve`: Disables transitive dependency resolution.
+- `--all-packages`: Outputs all packages in JSON format (make sure to set `--format=json`).
 
 ## Pre-Commit Integration
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -132,7 +132,7 @@ osv-scanner --all-packages --format=json path/to/repository
 
 Several other features are available through flags. See their respective documentation pages for more details:
 
-- [`--no-resolve`](./supported_languages_and_lockfiles.md): Disables transitive dependency resolution.
+- `--no-resolve`: Disables [transitive dependency resolution](./supported_languages_and_lockfiles.md).
 
 ## Pre-Commit Integration
 


### PR DESCRIPTION
This PR moves the `--licenses` and `--all-packages` flags out of experimental mode. Along with [PR 1668](https://github.com/google/osv-scanner/pull/1668), all our flags are now out of experimental mode.