### PR TITLE
test: only check parent test name when deciding if an acceptance testis being targeted with `-run`

### DIFF
--- a/internal/testutility/utility.go
+++ b/internal/testutility/utility.go
@@ -42,7 +42,7 @@ func Skip(t *testing.T, args ...any) {
 func isThisTestRunTarget(t *testing.T) bool {
 	t.Helper()
 
-	runOnly := flag.Lookup("test.run").Value.String()
+	runOnly, _, _ := strings.Cut(flag.Lookup("test.run").Value.String(), "/")
 
 	return runOnly == t.Name()
 }


### PR DESCRIPTION
This improves on #1630 so that now attempting to run a specific child test should result in it always running regardless of if its an acceptance test or not, e.g.

```
go test ./cmd/osv-scanner/ -run 'Test_run_OCIImage/Invalid_path'
```

Technically, this implementation will only work when the helper is used at the parent level even though the helper itself should work in the parent or child test functions, but all of our current usages are at the parent level and I couldn't think of any advantage to moving this to the child so I've not bothered supporting the inverse even though it should be trivial to do.