### PR TITLE
fix: Update test action to not fail on error

### DIFF
--- a/.github/workflows/test-action/action.yml
+++ b/.github/workflows/test-action/action.yml
@@ -32,4 +32,4 @@ runs:
       uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0
       with:
         token: ${{ inputs.codecov_token }}
-        fail_ci_if_error: true
+        fail_ci_if_error: false


### PR DESCRIPTION
Codecov has failed randomly quite a bit over the past year, it seems to have popped back up again. Going to turn off fail ci until it improves.