### PR TITLE
fix(javareach): handle cases where META-INF/services classes can't be found

### DIFF
--- a/experimental/javareach/cmd/reachable/main.go
+++ b/experimental/javareach/cmd/reachable/main.go
@@ -130,6 +130,7 @@ func enumerateReachabilityForJar(jarPath string) error {
 	// Look inside META-INF/services, which is used by
 	// https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html
 	servicesDir := filepath.Join(tmpDir, "META-INF/services")
+	var serviceClasses []string
 	if _, err := os.Stat(servicesDir); err == nil {
 		var entries []string
 
@@ -172,7 +173,7 @@ func enumerateReachabilityForJar(jarPath string) error {
 				}
 
 				slog.Debug("adding META-INF/services provider", "provider", provider, "from", entry)
-				mainClasses = append(mainClasses, strings.ReplaceAll(provider, ".", "/"))
+				serviceClasses = append(serviceClasses, strings.ReplaceAll(provider, ".", "/"))
 			}
 			if err := scanner.Err(); err != nil {
 				return err
@@ -183,7 +184,7 @@ func enumerateReachabilityForJar(jarPath string) error {
 	// Enumerate reachable classes.
 	// TODO: Look inside more static files (e.g. XML beans configurations).
 	enumerator := javareach.NewReachabilityEnumerator(classPaths, classFinder, javareach.AssumeAllClassesReachable, javareach.AssumeAllClassesReachable)
-	result, err := enumerator.EnumerateReachabilityFromClasses(mainClasses)
+	result, err := enumerator.EnumerateReachabilityFromClasses(mainClasses, serviceClasses)
 	if err != nil {
 		return err
 	}

--- a/experimental/javareach/cmd/reachable/main.go
+++ b/experimental/javareach/cmd/reachable/main.go
@@ -130,7 +130,7 @@ func enumerateReachabilityForJar(jarPath string) error {
 	// Look inside META-INF/services, which is used by
 	// https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html
 	servicesDir := filepath.Join(tmpDir, "META-INF/services")
-	var serviceClasses []string
+	var optionalRootClasses []string
 	if _, err := os.Stat(servicesDir); err == nil {
 		var entries []string
 
@@ -173,7 +173,7 @@ func enumerateReachabilityForJar(jarPath string) error {
 				}
 
 				slog.Debug("adding META-INF/services provider", "provider", provider, "from", entry)
-				serviceClasses = append(serviceClasses, strings.ReplaceAll(provider, ".", "/"))
+				optionalRootClasses = append(optionalRootClasses, strings.ReplaceAll(provider, ".", "/"))
 			}
 			if err := scanner.Err(); err != nil {
 				return err
@@ -184,7 +184,7 @@ func enumerateReachabilityForJar(jarPath string) error {
 	// Enumerate reachable classes.
 	// TODO: Look inside more static files (e.g. XML beans configurations).
 	enumerator := javareach.NewReachabilityEnumerator(classPaths, classFinder, javareach.AssumeAllClassesReachable, javareach.AssumeAllClassesReachable)
-	result, err := enumerator.EnumerateReachabilityFromClasses(mainClasses, serviceClasses)
+	result, err := enumerator.EnumerateReachabilityFromClasses(mainClasses, optionalRootClasses)
 	if err != nil {
 		return err
 	}

--- a/experimental/javareach/reachable.go
+++ b/experimental/javareach/reachable.go
@@ -59,12 +59,21 @@ func NewReachabilityEnumerator(
 	}
 }
 
-func (r *ReachabilityEnumerator) EnumerateReachabilityFromClasses(mainClasses []string) (*ReachabilityResult, error) {
+func (r *ReachabilityEnumerator) EnumerateReachabilityFromClasses(mainClasses []string, serviceClasses []string) (*ReachabilityResult, error) {
 	var roots []*ClassFile
 	for _, mainClass := range mainClasses {
 		cf, err := r.findClass(r.ClassPaths, mainClass)
 		if err != nil {
-			return nil, fmt.Errorf("failed to find class %s: %v", mainClass, err)
+			return nil, fmt.Errorf("failed to find main class %s: %v", mainClass, err)
+		}
+		roots = append(roots, cf)
+	}
+
+	// ServiceClasses are those from META-INF/services. They might not exist in the Jar.
+	for _, serviceClass := range serviceClasses {
+		cf, err := r.findClass(r.ClassPaths, serviceClass)
+		if err != nil {
+			continue
 		}
 		roots = append(roots, cf)
 	}

--- a/experimental/javareach/reachable.go
+++ b/experimental/javareach/reachable.go
@@ -59,7 +59,7 @@ func NewReachabilityEnumerator(
 	}
 }
 
-func (r *ReachabilityEnumerator) EnumerateReachabilityFromClasses(mainClasses []string, serviceClasses []string) (*ReachabilityResult, error) {
+func (r *ReachabilityEnumerator) EnumerateReachabilityFromClasses(mainClasses []string, optionalRootClasses []string) (*ReachabilityResult, error) {
 	var roots []*ClassFile
 	for _, mainClass := range mainClasses {
 		cf, err := r.findClass(r.ClassPaths, mainClass)
@@ -69,8 +69,8 @@ func (r *ReachabilityEnumerator) EnumerateReachabilityFromClasses(mainClasses []
 		roots = append(roots, cf)
 	}
 
-	// ServiceClasses are those from META-INF/services. They might not exist in the Jar.
-	for _, serviceClass := range serviceClasses {
+	// optionalRootClasses include those from META-INF/services. They might not exist in the Jar.
+	for _, serviceClass := range optionalRootClasses {
 		cf, err := r.findClass(r.ClassPaths, serviceClass)
 		if err != nil {
 			continue


### PR DESCRIPTION
Classes defined in META-INF/services might not exists in the JAR.