### PR TITLE
fix: Update constraint to not be pinned to minor version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -27,7 +27,7 @@
     }
   ],
   "constraints": {
-    "go": "1.23.5"
+    "go": "1.23"
   },
   "ignorePaths": ["**/fixtures/**", "**/fixtures-go/**"],
   "ignoreDeps": ["golang.org/x/vuln"]


### PR DESCRIPTION
Renovatebot PR seems to be failing because of the constraint.