### PR TITLE
chore: exclude all third-party packages from linting

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -128,4 +128,4 @@ issues:
       linters:
         - paralleltest
   exclude-dirs:
-    - internal/thirdparty/xml
+    - internal/thirdparty/


### PR DESCRIPTION
There's no actual linting violations currently in the `internal/thirdparty/ar` package, but we might as well exclude all packages 🤷 