### PR TITLE
chore: configure `golangci-lint` to always show all issues from all linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -117,6 +117,8 @@ linters-settings:
     block-size: 2
 
 issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
   exclude-rules:
     - path: pkg/reporter
       linters:

--- a/scripts/run_lints.sh
+++ b/scripts/run_lints.sh
@@ -2,4 +2,4 @@
 
 set -ex
 
-go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.4 run ./... --max-same-issues 0
+go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.4 run ./...


### PR DESCRIPTION
This should help ensure that linting results are consistent regardless of how the linter is being run