### PR TITLE
fix(javareach): maven validation and correct manifest class name parsing

### DIFF
--- a/experimental/javareach/cmd/reachable/main.go
+++ b/experimental/javareach/cmd/reachable/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"archive/zip"
 	"bufio"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -20,9 +21,15 @@ import (
 	"github.com/google/osv-scanner/experimental/javareach"
 )
 
-const MavenDepDirPath = "META-INF/maven"
-const ManifestFilePath = "META-INF/MANIFEST.MF"
-const ServiceDirPath = "META-INF/services"
+const MetaDirPath = "META-INF"
+
+var (
+	ManifestFilePath = filepath.Join(MetaDirPath, "MANIFEST.MF")
+	MavenDepDirPath  = filepath.Join(MetaDirPath, "maven")
+	ServiceDirPath   = filepath.Join(MetaDirPath, "services")
+
+	ErrMavenDependencyNotFound = errors.New(MavenDepDirPath + " directory not found")
+)
 
 // Usage:
 //
@@ -108,7 +115,7 @@ func enumerateReachabilityForJar(jarPath string) error {
 	_, err = os.Stat(filepath.Join(tmpDir, MavenDepDirPath))
 	if err != nil {
 		slog.Error("reachability analysis is only supported for JARs built with Maven.")
-		return err
+		return ErrMavenDependencyNotFound
 	}
 
 	// Build .class -> Maven group ID:artifact ID mappings.

--- a/experimental/javareach/jar.go
+++ b/experimental/javareach/jar.go
@@ -314,11 +314,28 @@ func GetMainClasses(manifest io.Reader) ([]string, error) {
 	scanner := bufio.NewScanner(manifest)
 
 	var classes []string
+	var lines []string
+
+	// Read all lines into memory for easier processing.
 	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
+		lines = append(lines, scanner.Text())
+	}
+
+	for i := 0; i < len(lines); i++ {
+		line := strings.TrimSpace(lines[i])
 		for _, marker := range markers {
 			if strings.HasPrefix(line, marker) {
 				class := strings.TrimSpace(strings.TrimPrefix(line, marker))
+				// Handle wrapped lines. Class names exceeding line length limits
+				// may be split across multiple lines, starting with a space.
+				for index := i + 1; index < len(lines); index++ {
+					nextLine := lines[index]
+					if strings.HasPrefix(nextLine, " ") {
+						class += strings.TrimSpace(nextLine)
+					} else {
+						break
+					}
+				}
 				classes = append(classes, strings.ReplaceAll(class, ".", "/"))
 			}
 		}

--- a/experimental/javareach/javaclass.go
+++ b/experimental/javareach/javaclass.go
@@ -24,7 +24,6 @@ var (
 	}
 
 	StandardLibraryPrefixes = []string{
-		"com/",
 		"java/",
 		"javax/",
 		"jdk/",


### PR DESCRIPTION
Fixes a bunch of Java readability issues:
- remove `com/` from stdlib prefixes
- exit program with errors if running against a non maven JAR
- handle wrapped class names in the manifest file
- replace some non-fatel error messages with debug messages to reduce noise