### PR TITLE
refactor: use `any` instead of `interface{}`

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -108,6 +108,8 @@ linters-settings:
         disabled: false
       - name: unused-parameter
         disabled: false
+      - name: use-any
+        disabled: false
       - name: var-declaration
         disabled: false
       - name: var-naming

--- a/internal/datasource/maven_registry.go
+++ b/internal/datasource/maven_registry.go
@@ -210,7 +210,7 @@ func (m *MavenRegistryAPIClient) getArtifactMetadata(ctx context.Context, regist
 	return metadata, nil
 }
 
-func (m *MavenRegistryAPIClient) get(ctx context.Context, auth *HTTPAuthentication, url string, dst interface{}) error {
+func (m *MavenRegistryAPIClient) get(ctx context.Context, auth *HTTPAuthentication, url string, dst any) error {
 	resp, err := m.responses.Get(url, func() (response, error) {
 		resp, err := auth.Get(ctx, http.DefaultClient, url)
 		if err != nil {

--- a/internal/datasource/npm_registry_test.go
+++ b/internal/datasource/npm_registry_test.go
@@ -156,8 +156,8 @@ func TestNpmRegistryClient(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed getting full json: %v", err)
 		}
-		wantMap := want.Value().(map[string]interface{})
-		gotMap := got.Value().(map[string]interface{})
+		wantMap := want.Value().(map[string]any)
+		gotMap := got.Value().(map[string]any)
 		if diff := cmp.Diff(wantMap, gotMap, cmpopts.SortSlices(compare.Less[string])); diff != "" {
 			t.Errorf("FullJSON(\"%s\", \"%s\") (-want +got)\n%s", pkg, ver, diff)
 		}

--- a/internal/resolution/client/client.go
+++ b/internal/resolution/client/client.go
@@ -30,7 +30,7 @@ type DependencyClient interface {
 	AddRegistries(registries []Registry) error
 }
 
-type Registry interface{}
+type Registry any
 
 // PreFetch loads cache, then makes and caches likely queries needed for resolving a package with a list of requirements
 func PreFetch(ctx context.Context, c DependencyClient, requirements []resolve.RequirementVersion, manifestPath string) {

--- a/internal/sourceanalysis/rust.go
+++ b/internal/sourceanalysis/rust.go
@@ -84,11 +84,11 @@ func rustAnalysis(pkgs []models.PackageVulns, source models.SourceInfo) {
 					//     ],
 					//     "arch": []
 					// }
-					ecosystemAffects, ok := a.EcosystemSpecific["affects"].(map[string]interface{})
+					ecosystemAffects, ok := a.EcosystemSpecific["affects"].(map[string]any)
 					if !ok {
 						continue
 					}
-					affectedFunctions, ok := ecosystemAffects["functions"].([]interface{})
+					affectedFunctions, ok := ecosystemAffects["functions"].([]any)
 					if !ok {
 						continue
 					}


### PR DESCRIPTION
This matches what I think is the general preference these days - either way, consistency is good and I don't know of a `use-interface` rule 😄 