### PR TITLE
feat: make `vertical` output the default

### DIFF
--- a/cmd/osv-scanner/__snapshots__/main_test.snap
+++ b/cmd/osv-scanner/__snapshots__/main_test.snap
@@ -180,27 +180,33 @@ Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
 [Test_run/Go_project_with_an_overridden_go_version - 1]
 Scanning dir ./fixtures/go-project
 Scanned <rootdir>/fixtures/go-project/go.mod file and found 1 package
-+------------------------------+------+-----------+---------+---------+----------------------------+
-| OSV URL                      | CVSS | ECOSYSTEM | PACKAGE | VERSION | SOURCE                     |
-+------------------------------+------+-----------+---------+---------+----------------------------+
-| Uncalled vulnerabilities     |      |           |         |         |                            |
-+------------------------------+------+-----------+---------+---------+----------------------------+
-| https://osv.dev/GO-2024-2598 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod |
-| https://osv.dev/GO-2024-2599 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod |
-| https://osv.dev/GO-2024-2600 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod |
-| https://osv.dev/GO-2024-2609 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod |
-| https://osv.dev/GO-2024-2610 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod |
-| https://osv.dev/GO-2024-2687 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod |
-| https://osv.dev/GO-2024-2887 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod |
-| https://osv.dev/GO-2024-2888 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod |
-| https://osv.dev/GO-2024-2963 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod |
-| https://osv.dev/GO-2024-3105 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod |
-| https://osv.dev/GO-2024-3106 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod |
-| https://osv.dev/GO-2024-3107 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod |
-| https://osv.dev/GO-2025-3373 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod |
-| https://osv.dev/GO-2025-3420 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod |
-| https://osv.dev/GO-2025-3447 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod |
-+------------------------------+------+-----------+---------+---------+----------------------------+
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+Go
+
+lockfile:<rootdir>/fixtures/go-project/go.mod: found 0 packages with issues
+
+  stdlib@1.21.7 has the following uncalled vulnerabilities:
+    GO-2024-2598: Verify panics on certificates with an unknown public key algorithm in... (https://osv.dev/GO-2024-2598)
+    GO-2024-2599: Memory exhaustion in multipart form parsing in net/textproto and net/http (https://osv.dev/GO-2024-2599)
+    GO-2024-2600: Incorrect forwarding of sensitive headers and cookies on HTTP redirect in... (https://osv.dev/GO-2024-2600)
+    GO-2024-2609: Comments in display names are incorrectly handled in net/mail (https://osv.dev/GO-2024-2609)
+    GO-2024-2610: Errors returned from JSON marshaling may break template escaping in... (https://osv.dev/GO-2024-2610)
+    GO-2024-2687: HTTP/2 CONTINUATION flood in net/http (https://osv.dev/GO-2024-2687)
+    GO-2024-2887: Unexpected behavior from Is methods for IPv4-mapped IPv6 addresses in net/netip (https://osv.dev/GO-2024-2887)
+    GO-2024-2888: Mishandling of corrupt central directory record in archive/zip (https://osv.dev/GO-2024-2888)
+    GO-2024-2963: Denial of service due to improper 100-continue handling in net/http (https://osv.dev/GO-2024-2963)
+    GO-2024-3105: Stack exhaustion in all Parse functions in go/parser (https://osv.dev/GO-2024-3105)
+    GO-2024-3106: Stack exhaustion in Decoder.Decode in encoding/gob (https://osv.dev/GO-2024-3106)
+    GO-2024-3107: Stack exhaustion in Parse in go/build/constraint (https://osv.dev/GO-2024-3107)
+    GO-2025-3373: Usage of IPv6 zone IDs can bypass URI name constraints in crypto/x509 (https://osv.dev/GO-2025-3373)
+    GO-2025-3420: Sensitive headers incorrectly sent after cross-domain redirect in net/http (https://osv.dev/GO-2025-3420)
+    GO-2025-3447: Timing sidechannel for P-256 on ppc64le in crypto/internal/nistec (https://osv.dev/GO-2025-3447)
+
+  15 uncalled/unimportant vulnerabilities found in lockfile:<rootdir>/fixtures/go-project/go.mod (filtered out)
+
 
 ---
 
@@ -212,42 +218,54 @@ Scanned <rootdir>/fixtures/go-project/go.mod file and found 1 package
 Scanning dir ./fixtures/go-project
 Scanned <rootdir>/fixtures/go-project/go.mod file and found 1 package
 Scanned <rootdir>/fixtures/go-project/nested/go.mod file and found 1 package
-+------------------------------+------+-----------+---------+---------+-----------------------------------+
-| OSV URL                      | CVSS | ECOSYSTEM | PACKAGE | VERSION | SOURCE                            |
-+------------------------------+------+-----------+---------+---------+-----------------------------------+
-| Uncalled vulnerabilities     |      |           |         |         |                                   |
-+------------------------------+------+-----------+---------+---------+-----------------------------------+
-| https://osv.dev/GO-2024-2598 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod        |
-| https://osv.dev/GO-2024-2599 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod        |
-| https://osv.dev/GO-2024-2600 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod        |
-| https://osv.dev/GO-2024-2609 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod        |
-| https://osv.dev/GO-2024-2610 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod        |
-| https://osv.dev/GO-2024-2687 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod        |
-| https://osv.dev/GO-2024-2887 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod        |
-| https://osv.dev/GO-2024-2888 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod        |
-| https://osv.dev/GO-2024-2963 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod        |
-| https://osv.dev/GO-2024-3105 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod        |
-| https://osv.dev/GO-2024-3106 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod        |
-| https://osv.dev/GO-2024-3107 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod        |
-| https://osv.dev/GO-2025-3373 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod        |
-| https://osv.dev/GO-2025-3420 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod        |
-| https://osv.dev/GO-2025-3447 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/go.mod        |
-| https://osv.dev/GO-2024-2598 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/nested/go.mod |
-| https://osv.dev/GO-2024-2599 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/nested/go.mod |
-| https://osv.dev/GO-2024-2600 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/nested/go.mod |
-| https://osv.dev/GO-2024-2609 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/nested/go.mod |
-| https://osv.dev/GO-2024-2610 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/nested/go.mod |
-| https://osv.dev/GO-2024-2687 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/nested/go.mod |
-| https://osv.dev/GO-2024-2887 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/nested/go.mod |
-| https://osv.dev/GO-2024-2888 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/nested/go.mod |
-| https://osv.dev/GO-2024-2963 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/nested/go.mod |
-| https://osv.dev/GO-2024-3105 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/nested/go.mod |
-| https://osv.dev/GO-2024-3106 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/nested/go.mod |
-| https://osv.dev/GO-2024-3107 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/nested/go.mod |
-| https://osv.dev/GO-2025-3373 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/nested/go.mod |
-| https://osv.dev/GO-2025-3420 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/nested/go.mod |
-| https://osv.dev/GO-2025-3447 |      | Go        | stdlib  | 1.21.7  | fixtures/go-project/nested/go.mod |
-+------------------------------+------+-----------+---------+---------+-----------------------------------+
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+Go
+
+lockfile:<rootdir>/fixtures/go-project/go.mod: found 0 packages with issues
+
+  stdlib@1.21.7 has the following uncalled vulnerabilities:
+    GO-2024-2598: Verify panics on certificates with an unknown public key algorithm in... (https://osv.dev/GO-2024-2598)
+    GO-2024-2599: Memory exhaustion in multipart form parsing in net/textproto and net/http (https://osv.dev/GO-2024-2599)
+    GO-2024-2600: Incorrect forwarding of sensitive headers and cookies on HTTP redirect in... (https://osv.dev/GO-2024-2600)
+    GO-2024-2609: Comments in display names are incorrectly handled in net/mail (https://osv.dev/GO-2024-2609)
+    GO-2024-2610: Errors returned from JSON marshaling may break template escaping in... (https://osv.dev/GO-2024-2610)
+    GO-2024-2687: HTTP/2 CONTINUATION flood in net/http (https://osv.dev/GO-2024-2687)
+    GO-2024-2887: Unexpected behavior from Is methods for IPv4-mapped IPv6 addresses in net/netip (https://osv.dev/GO-2024-2887)
+    GO-2024-2888: Mishandling of corrupt central directory record in archive/zip (https://osv.dev/GO-2024-2888)
+    GO-2024-2963: Denial of service due to improper 100-continue handling in net/http (https://osv.dev/GO-2024-2963)
+    GO-2024-3105: Stack exhaustion in all Parse functions in go/parser (https://osv.dev/GO-2024-3105)
+    GO-2024-3106: Stack exhaustion in Decoder.Decode in encoding/gob (https://osv.dev/GO-2024-3106)
+    GO-2024-3107: Stack exhaustion in Parse in go/build/constraint (https://osv.dev/GO-2024-3107)
+    GO-2025-3373: Usage of IPv6 zone IDs can bypass URI name constraints in crypto/x509 (https://osv.dev/GO-2025-3373)
+    GO-2025-3420: Sensitive headers incorrectly sent after cross-domain redirect in net/http (https://osv.dev/GO-2025-3420)
+    GO-2025-3447: Timing sidechannel for P-256 on ppc64le in crypto/internal/nistec (https://osv.dev/GO-2025-3447)
+
+  15 uncalled/unimportant vulnerabilities found in lockfile:<rootdir>/fixtures/go-project/go.mod (filtered out)
+
+lockfile:<rootdir>/fixtures/go-project/nested/go.mod: found 0 packages with issues
+
+  stdlib@1.21.7 has the following uncalled vulnerabilities:
+    GO-2024-2598: Verify panics on certificates with an unknown public key algorithm in... (https://osv.dev/GO-2024-2598)
+    GO-2024-2599: Memory exhaustion in multipart form parsing in net/textproto and net/http (https://osv.dev/GO-2024-2599)
+    GO-2024-2600: Incorrect forwarding of sensitive headers and cookies on HTTP redirect in... (https://osv.dev/GO-2024-2600)
+    GO-2024-2609: Comments in display names are incorrectly handled in net/mail (https://osv.dev/GO-2024-2609)
+    GO-2024-2610: Errors returned from JSON marshaling may break template escaping in... (https://osv.dev/GO-2024-2610)
+    GO-2024-2687: HTTP/2 CONTINUATION flood in net/http (https://osv.dev/GO-2024-2687)
+    GO-2024-2887: Unexpected behavior from Is methods for IPv4-mapped IPv6 addresses in net/netip (https://osv.dev/GO-2024-2887)
+    GO-2024-2888: Mishandling of corrupt central directory record in archive/zip (https://osv.dev/GO-2024-2888)
+    GO-2024-2963: Denial of service due to improper 100-continue handling in net/http (https://osv.dev/GO-2024-2963)
+    GO-2024-3105: Stack exhaustion in all Parse functions in go/parser (https://osv.dev/GO-2024-3105)
+    GO-2024-3106: Stack exhaustion in Decoder.Decode in encoding/gob (https://osv.dev/GO-2024-3106)
+    GO-2024-3107: Stack exhaustion in Parse in go/build/constraint (https://osv.dev/GO-2024-3107)
+    GO-2025-3373: Usage of IPv6 zone IDs can bypass URI name constraints in crypto/x509 (https://osv.dev/GO-2025-3373)
+    GO-2025-3420: Sensitive headers incorrectly sent after cross-domain redirect in net/http (https://osv.dev/GO-2025-3420)
+    GO-2025-3447: Timing sidechannel for P-256 on ppc64le in crypto/internal/nistec (https://osv.dev/GO-2025-3447)
+
+  15 uncalled/unimportant vulnerabilities found in lockfile:<rootdir>/fixtures/go-project/nested/go.mod (filtered out)
+
 
 ---
 
@@ -397,6 +415,11 @@ Scanning dir ./fixtures/locks-many-with-invalid
 Scanned <rootdir>/fixtures/locks-many-with-invalid/Gemfile.lock file and found 1 package
 Scanned <rootdir>/fixtures/locks-many-with-invalid/yarn.lock file and found 1 package
 
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 0 ecosystems.
+0 vulnerabilities can be fixed.
+
+
+
 ---
 
 [Test_run/all_supported_lockfiles_in_the_directory_should_be_checked - 2]
@@ -442,27 +465,67 @@ overriding license for package Alpine/ssl_client/1.36.1-r27 with MIT
 overriding license for package Alpine/zlib/1.2.13-r0 with MIT
 overriding license for package Packagist/sentry/sdk/2.0.4 with 0BSD
 overriding license for package Packagist/league/flysystem/1.0.8 with 0BSD
-+-------------------------------------+------+-----------+------------------+----------+---------------------------------------+
-| OSV URL                             | CVSS | ECOSYSTEM | PACKAGE          | VERSION  | SOURCE                                |
-+-------------------------------------+------+-----------+------------------+----------+---------------------------------------+
-| https://osv.dev/GHSA-9f46-5r25-5wfm | 9.8  | Packagist | league/flysystem | 1.0.8    | fixtures/locks-insecure/composer.lock |
-| https://osv.dev/CVE-2025-26519      |      | Alpine    | musl             | 1.2.3-r4 | fixtures/locks-many/alpine.cdx.xml    |
-+-------------------------------------+------+-----------+------------------+----------+---------------------------------------+
-+---------+-------------------------+
-| LICENSE | NO. OF PACKAGE VERSIONS |
-+---------+-------------------------+
-| UNKNOWN |                      20 |
-+---------+-------------------------+
-+-------------------+-----------+------------------------------------------------+---------+-------------------------------------------------------+
-| LICENSE VIOLATION | ECOSYSTEM | PACKAGE                                        | VERSION | SOURCE                                                |
-+-------------------+-----------+------------------------------------------------+---------+-------------------------------------------------------+
-| 0BSD              | Packagist | league/flysystem                               | 1.0.8   | fixtures/locks-insecure/composer.lock                 |
-| UNKNOWN           |           | https://chromium.googlesource.com/chromium/src |         | fixtures/locks-insecure/osv-scanner-flutter-deps.json |
-| UNKNOWN           |           | https://github.com/brendan-duncan/archive.git  |         | fixtures/locks-insecure/osv-scanner-flutter-deps.json |
-| UNKNOWN           |           | https://github.com/flutter/buildroot.git       |         | fixtures/locks-insecure/osv-scanner-flutter-deps.json |
-| UNKNOWN           | RubyGems  | ast                                            | 2.4.2   | fixtures/locks-many/Gemfile.lock                      |
-| 0BSD              | Packagist | sentry/sdk                                     | 2.0.4   | fixtures/locks-many/composer.lock                     |
-+-------------------+-----------+------------------------------------------------+---------+-------------------------------------------------------+
+
+Total 2 packages affected by 2 known vulnerabilities (1 Critical, 0 High, 0 Medium, 0 Low, 1 Unknown) from 4 ecosystems.
+1 vulnerability can be fixed.
+
+License summary:
+  UNKNOWN: 20
+
+
+
+lockfile:<rootdir>/fixtures/locks-insecure/osv-scanner-flutter-deps.json: found 0 packages with issues
+  no known vulnerabilities found
+
+  license violations found:
+    https://chromium.googlesource.com/chromium/src@ (UNKNOWN)
+    https://github.com/brendan-duncan/archive.git@ (UNKNOWN)
+    https://github.com/flutter/buildroot.git@ (UNKNOWN)
+
+  3 license violations found in lockfile:<rootdir>/fixtures/locks-insecure/osv-scanner-flutter-deps.json
+
+Packagist
+
+lockfile:<rootdir>/fixtures/locks-insecure/composer.lock: found 1 package with issues
+
+  league/flysystem@1.0.8 has the following known vulnerabilities:
+    GHSA-9f46-5r25-5wfm: Time-of-check Time-of-use (TOCTOU) Race Condition in league/flysystem (https://osv.dev/GHSA-9f46-5r25-5wfm)
+
+  1 known vulnerability found in lockfile:<rootdir>/fixtures/locks-insecure/composer.lock
+
+  license violations found:
+    league/flysystem@1.0.8 (0BSD)
+
+  1 license violation found in lockfile:<rootdir>/fixtures/locks-insecure/composer.lock
+
+lockfile:<rootdir>/fixtures/locks-many/composer.lock: found 0 packages with issues
+  no known vulnerabilities found
+
+  license violations found:
+    sentry/sdk@2.0.4 (0BSD)
+
+  1 license violation found in lockfile:<rootdir>/fixtures/locks-many/composer.lock
+
+RubyGems
+
+lockfile:<rootdir>/fixtures/locks-many/Gemfile.lock: found 0 packages with issues
+  no known vulnerabilities found
+
+  license violations found:
+    ast@2.4.2 (UNKNOWN)
+
+  1 license violation found in lockfile:<rootdir>/fixtures/locks-many/Gemfile.lock
+
+Alpine
+
+sbom:<rootdir>/fixtures/locks-many/alpine.cdx.xml: found 1 package with issues
+
+  musl@1.2.3-r4 has the following known vulnerabilities:
+    CVE-2025-26519: musl libc 0.9.13 through 1.2.5 before 1.2.6 has an out-of-bounds write... (https://osv.dev/CVE-2025-26519)
+
+  1 known vulnerability found in sbom:<rootdir>/fixtures/locks-many/alpine.cdx.xml
+  no license violations found
+
 
 ---
 
@@ -473,6 +536,11 @@ overriding license for package Packagist/league/flysystem/1.0.8 with 0BSD
 [Test_run/config_file_is_invalid - 1]
 Scanning dir ./fixtures/config-invalid
 Scanned <rootdir>/fixtures/config-invalid/composer.lock file and found 1 package
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 0 ecosystems.
+0 vulnerabilities can be fixed.
+
+
 
 ---
 
@@ -678,215 +746,273 @@ Scanned <rootdir>/fixtures/sbom-insecure/bad-purls.cdx.xml file and found 15 pac
 Scanned <rootdir>/fixtures/sbom-insecure/postgres-stretch.cdx.xml file and found 136 packages
 Scanned <rootdir>/fixtures/sbom-insecure/with-duplicates.cdx.xml file and found 15 packages
 Filtered 9 local/unscannable package/s from the scan.
-+-------------------------------------+------+-----------+--------------------------------+------------------------------------+-------------------------------------------------+
-| OSV URL                             | CVSS | ECOSYSTEM | PACKAGE                        | VERSION                            | SOURCE                                          |
-+-------------------------------------+------+-----------+--------------------------------+------------------------------------+-------------------------------------------------+
-| https://osv.dev/CVE-2025-26519      |      | Alpine    | musl                           | 1.2.3-r4                           | fixtures/sbom-insecure/alpine.cdx.xml           |
-| https://osv.dev/CVE-2018-25032      | 7.5  | Alpine    | zlib                           | 1.2.10-r0                          | fixtures/sbom-insecure/alpine.cdx.xml           |
-| https://osv.dev/CVE-2022-37434      | 9.8  | Alpine    | zlib                           | 1.2.10-r0                          | fixtures/sbom-insecure/alpine.cdx.xml           |
-| https://osv.dev/DSA-4685-1          | 5.5  | Debian    | apt                            | 1.4.11                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-4808-1          | 5.7  | Debian    | apt                            | 1.4.11                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-0501       | 5.9  | Debian    | apt                            | 1.4.11                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2019-3462       | 8.1  | Debian    | apt                            | 1.4.11                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-3715       | 7.8  | Debian    | bash                           | 4.4-5                              | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2016-2781       | 6.5  | Debian    | coreutils                      | 8.26-3                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2024-0684       | 5.5  | Debian    | coreutils                      | 8.26-3                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3482-1          |      | Debian    | debian-archive-keyring         | 2017.5+deb9u2                      | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5147-1          | 9.8  | Debian    | dpkg                           | 1.18.25                            | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3022-1          |      | Debian    | dpkg                           | 1.18.25                            | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-4535-1          | 6.7  | Debian    | e2fsprogs                      | 1.43.4-2+deb9u2                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2019-5188       | 6.7  | Debian    | e2fsprogs                      | 1.43.4-2+deb9u2                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-1304       | 7.8  | Debian    | e2fsprogs                      | 1.43.4-2+deb9u2                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3910-1          |      | Debian    | e2fsprogs                      | 1.43.4-2+deb9u2                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/GO-2022-0274        | 6.0  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/GHSA-v95c-p5hm-xq8f |      |           |                                |                                    |                                                 |
-| https://osv.dev/GO-2022-0452        | 5.9  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/GHSA-f3fp-gc8g-vw66 |      |           |                                |                                    |                                                 |
-| https://osv.dev/GO-2023-1627        | 7.0  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/GHSA-vpvm-3wq2-2wvm |      |           |                                |                                    |                                                 |
-| https://osv.dev/GO-2023-1682        | 2.5  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/GHSA-m8cg-xc2p-r3fc |      |           |                                |                                    |                                                 |
-| https://osv.dev/GO-2023-1683        | 6.1  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/GHSA-g2j6-57v7-gm8c |      |           |                                |                                    |                                                 |
-| https://osv.dev/GO-2024-2491        | 8.6  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/GHSA-xr7r-f8xq-vfvv |      |           |                                |                                    |                                                 |
-| https://osv.dev/GO-2024-3110        | 4.8  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/GHSA-jfvp-7x6p-h2pv |      |           |                                |                                    |                                                 |
-| https://osv.dev/GO-2022-0493        | 5.3  | Go        | golang.org/x/sys               | v0.0.0-20210817142637-7d9622a276b7 | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/GHSA-p782-xgp4-8hr8 |      |           |                                |                                    |                                                 |
-| https://osv.dev/DSA-5122-1          | 8.8  | Debian    | gzip                           | 1.6-5+deb9u1                       | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-0379       | 7.5  | Debian    | libgcrypt20                    | 1.7.6-2+deb9u4                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-7526       | 6.8  | Debian    | libgcrypt20                    | 1.7.6-2+deb9u4                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-0495       | 4.7  | Debian    | libgcrypt20                    | 1.7.6-2+deb9u4                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2019-13627      | 6.3  | Debian    | libgcrypt20                    | 1.7.6-2+deb9u4                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2021-33560      | 7.5  | Debian    | libgcrypt20                    | 1.7.6-2+deb9u4                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2021-40528      | 5.9  | Debian    | libgcrypt20                    | 1.7.6-2+deb9u4                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2024-2236       |      | Debian    | libgcrypt20                    | 1.7.6-2+deb9u4                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5863-1          |      | Debian    | libtasn1-6                     | 4.10-1.1+deb9u1                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-10790      | 7.5  | Debian    | libtasn1-6                     | 4.10-1.1+deb9u1                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-6003       | 7.5  | Debian    | libtasn1-6                     | 4.10-1.1+deb9u1                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2021-46848      | 9.1  | Debian    | libtasn1-6                     | 4.10-1.1+deb9u1                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3263-1          |      | Debian    | libtasn1-6                     | 4.10-1.1+deb9u1                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-4061-1          |      | Debian    | libtasn1-6                     | 4.10-1.1+deb9u1                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5142-1          | 6.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5271-1          | 7.8  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5391-1          | 6.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2016-3709       | 6.1  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2016-9318       | 5.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-0663       | 7.8  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-15412      | 8.8  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-16931      | 9.8  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-16932      | 7.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-18258      | 6.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-5130       | 8.8  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-7375       | 9.8  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-7376       | 9.8  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-8872       | 9.1  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-9047       | 7.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-9048       | 7.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-9049       | 7.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-9050       | 7.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-14404      | 7.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-14567      | 6.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2019-19956      | 7.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2019-20388      | 7.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2020-7595       | 7.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2021-3516       | 7.8  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2021-3517       | 8.6  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2021-3518       | 8.8  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2021-3537       | 5.9  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2021-3541       | 6.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-2309       | 7.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-23308      | 7.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-49043      |      | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2024-25062      | 7.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2024-56171      |      | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2025-24928      |      | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2025-27113      | 7.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3012-1          |      | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3172-1          |      | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3405-1          |      | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3878-1          |      | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-4064-1          |      | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-4539-1          | 4.7  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-4539-3          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-4661-1          | 7.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-4807-1          | 5.9  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-4855-1          | 7.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-4875-1          | 5.9  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-4963-1          | 9.8  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5103-1          | 7.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5139-1          | 9.8  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5169-1          | 9.8  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5343-1          | 7.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5417-1          | 7.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5532-1          | 7.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5764-1          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-0732       | 7.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-0734       | 5.9  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-0735       | 5.9  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-5407       | 4.7  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2019-1543       | 7.4  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2019-1549       | 5.3  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2021-3450       | 7.4  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-2274       | 9.8  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-3358       | 7.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-3602       | 7.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-3786       | 7.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-3996       | 7.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-4203       | 4.9  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2023-0216       | 7.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2023-0217       | 7.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2023-0401       | 7.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2023-1255       | 5.9  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2023-2975       | 5.3  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2023-3446       | 5.3  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2023-3817       | 5.3  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2023-5678       | 5.3  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2023-6129       | 6.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2023-6237       |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2024-0727       | 5.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2024-12797      |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2024-13176      |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2024-2511       |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2024-4603       |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2024-4741       |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2024-5535       |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2024-9143       |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3008-1          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3325-1          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3449-1          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3530-1          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3942-1          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3942-2          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-12837      | 7.5  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-12883      | 9.1  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-12015      | 7.5  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-18311      | 9.8  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-18312      | 9.8  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-18313      | 9.1  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-18314      | 9.8  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-6797       | 9.8  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-6798       | 7.5  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-6913       | 9.8  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2020-10543      | 8.2  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2020-10878      | 8.6  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2020-12723      | 7.5  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2020-16156      | 7.8  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2021-36770      | 7.8  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2023-31484      | 8.1  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2023-47038      | 7.8  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3926-1          |      | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5135-1          |      | Debian    | postgresql-11                  | 11.15-1.pgdg90+1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3072-1          |      | Debian    | postgresql-11                  | 11.15-1.pgdg90+1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3189-1          |      | Debian    | postgresql-11                  | 11.15-1.pgdg90+1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3316-1          |      | Debian    | postgresql-11                  | 11.15-1.pgdg90+1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3422-1          |      | Debian    | postgresql-11                  | 11.15-1.pgdg90+1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3600-1          |      | Debian    | postgresql-11                  | 11.15-1.pgdg90+1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3651-1          |      | Debian    | postgresql-11                  | 11.15-1.pgdg90+1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3764-1          |      | Debian    | postgresql-11                  | 11.15-1.pgdg90+1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-17512      | 8.8  | Debian    | sensible-utils                 | 0.0.9+deb9u1                       | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-20482      | 4.7  | Debian    | tar                            | 1.29b-1.1+deb9u1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2023-39804      |      | Debian    | tar                            | 1.29b-1.1+deb9u1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3755-1          |      | Debian    | tar                            | 1.29b-1.1+deb9u1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3051-1          |      | Debian    | tzdata                         | 2021a-0+deb9u3                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3134-1          |      | Debian    | tzdata                         | 2021a-0+deb9u3                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3161-1          |      | Debian    | tzdata                         | 2021a-0+deb9u3                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3366-1          |      | Debian    | tzdata                         | 2021a-0+deb9u3                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3412-1          |      | Debian    | tzdata                         | 2021a-0+deb9u3                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3684-1          |      | Debian    | tzdata                         | 2021a-0+deb9u3                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3788-1          |      | Debian    | tzdata                         | 2021a-0+deb9u3                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3972-1          |      | Debian    | tzdata                         | 2021a-0+deb9u3                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-4016-1          |      | Debian    | ucf                            | 3.0036                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5055-1          | 5.5  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5650-1          |      | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2016-2779       | 7.8  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3782-1          |      | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5123-1          | 8.8  | Debian    | xz-utils                       | 5.2.2-1.2+deb9u1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2024-3094       | 10.0 | Debian    | xz-utils                       | 5.2.2-1.2+deb9u1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2025-26519      |      | Alpine    | musl                           | 1.2.3-r4                           | fixtures/sbom-insecure/with-duplicates.cdx.xml  |
-| https://osv.dev/CVE-2018-25032      | 7.5  | Alpine    | zlib                           | 1.2.10-r0                          | fixtures/sbom-insecure/with-duplicates.cdx.xml  |
-| https://osv.dev/CVE-2022-37434      | 9.8  | Alpine    | zlib                           | 1.2.10-r0                          | fixtures/sbom-insecure/with-duplicates.cdx.xml  |
-+-------------------------------------+------+-----------+--------------------------------+------------------------------------+-------------------------------------------------+
-| Unimportant vulnerabilities         |      |           |                                |                                    |                                                 |
-+-------------------------------------+------+-----------+--------------------------------+------------------------------------+-------------------------------------------------+
-| https://osv.dev/CVE-2011-3374       | 3.7  | Debian    | apt                            | 1.4.11                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2019-18276      | 7.8  | Debian    | bash                           | 4.4-5                              | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-18018      | 4.7  | Debian    | coreutils                      | 8.26-3                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-6829       | 7.5  | Debian    | libgcrypt20                    | 1.7.6-2+deb9u4                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-1000654    | 5.5  | Debian    | libtasn1-6                     | 4.10-1.1+deb9u1                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2020-24977      | 6.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2024-34459      |      | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2011-4116       | 7.5  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-48522      | 9.8  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2023-31486      | 8.1  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2005-2541       |      | Debian    | tar                            | 1.29b-1.1+deb9u1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2019-9923       | 7.5  | Debian    | tar                            | 1.29b-1.1+deb9u1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2021-20193      | 3.3  | Debian    | tar                            | 1.29b-1.1+deb9u1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-48303      | 5.5  | Debian    | tar                            | 1.29b-1.1+deb9u1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-7738       | 7.8  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-0563       | 5.5  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-+-------------------------------------+------+-----------+--------------------------------+------------------------------------+-------------------------------------------------+
+
+Total 25 packages affected by 178 known vulnerabilities (20 Critical, 61 High, 41 Medium, 1 Low, 55 Unknown) from 3 ecosystems.
+8 vulnerabilities can be fixed.
+
+Go
+
+sbom:<rootdir>/fixtures/sbom-insecure/postgres-stretch.cdx.xml: found 2 packages with issues
+
+  github.com/opencontainers/runc@v1.0.1 has the following known vulnerabilities:
+    GO-2022-0274: Namespace restriction bypass in github.com/opencontainers/runc (https://osv.dev/GO-2022-0274)
+    GO-2022-0452: Default inheritable capabilities for linux container should be empty in... (https://osv.dev/GO-2022-0452)
+    GO-2023-1627: Opencontainers runc Incorrect Authorization vulnerability in... (https://osv.dev/GO-2023-1627)
+    GO-2023-1682: rootless: `/sys/fs/cgroup` is writable when cgroupns isn't unshared in runc in... (https://osv.dev/GO-2023-1682)
+    GO-2023-1683: runc AppArmor bypass with symlinked /proc in github.com/opencontainers/runc (https://osv.dev/GO-2023-1683)
+    GO-2024-2491: Container breakout through process.cwd trickery and leaked fds in... (https://osv.dev/GO-2024-2491)
+    GO-2024-3110: runc can be confused to create empty files/directories on the host in... (https://osv.dev/GO-2024-3110)
+  golang.org/x/sys@v0.0.0-20210817142637-7d9622a276b7 has the following known vulnerabilities:
+    GO-2022-0493: Incorrect privilege reporting in syscall and golang.org/x/sys/unix (https://osv.dev/GO-2022-0493)
+
+  8 known vulnerabilities found in sbom:<rootdir>/fixtures/sbom-insecure/postgres-stretch.cdx.xml
+
+Alpine
+
+sbom:<rootdir>/fixtures/sbom-insecure/alpine.cdx.xml: found 2 packages with issues
+
+  musl@1.2.3-r4 has the following known vulnerabilities:
+    CVE-2025-26519: musl libc 0.9.13 through 1.2.5 before 1.2.6 has an out-of-bounds write... (https://osv.dev/CVE-2025-26519)
+  zlib@1.2.10-r0 has the following known vulnerabilities:
+    CVE-2018-25032: zlib before 1.2.12 allows memory corruption when deflating (i.e., when... (https://osv.dev/CVE-2018-25032)
+    CVE-2022-37434: zlib through 1.2.12 has a heap-based buffer over-read or buffer overflow in... (https://osv.dev/CVE-2022-37434)
+
+  3 known vulnerabilities found in sbom:<rootdir>/fixtures/sbom-insecure/alpine.cdx.xml
+
+sbom:<rootdir>/fixtures/sbom-insecure/with-duplicates.cdx.xml: found 2 packages with issues
+
+  musl@1.2.3-r4 has the following known vulnerabilities:
+    CVE-2025-26519: musl libc 0.9.13 through 1.2.5 before 1.2.6 has an out-of-bounds write... (https://osv.dev/CVE-2025-26519)
+  zlib@1.2.10-r0 has the following known vulnerabilities:
+    CVE-2018-25032: zlib before 1.2.12 allows memory corruption when deflating (i.e., when... (https://osv.dev/CVE-2018-25032)
+    CVE-2022-37434: zlib through 1.2.12 has a heap-based buffer over-read or buffer overflow in... (https://osv.dev/CVE-2022-37434)
+
+  3 known vulnerabilities found in sbom:<rootdir>/fixtures/sbom-insecure/with-duplicates.cdx.xml
+
+Debian
+
+sbom:<rootdir>/fixtures/sbom-insecure/postgres-stretch.cdx.xml: found 19 packages with issues
+
+  apt@1.4.11 has the following known vulnerabilities:
+    DSA-4685-1: apt - security update (https://osv.dev/DSA-4685-1)
+    DSA-4808-1: apt - security update (https://osv.dev/DSA-4808-1)
+    CVE-2018-0501: The mirror:// method implementation in Advanced Package Tool (APT) 1.6.x before... (https://osv.dev/CVE-2018-0501)
+    CVE-2019-3462: Incorrect sanitation of the 302 redirect field in HTTP transport method of apt... (https://osv.dev/CVE-2019-3462)
+  bash@4.4-5 has the following known vulnerabilities:
+    CVE-2022-3715: A flaw was found in the bash package, where a heap-buffer overflow can occur in... (https://osv.dev/CVE-2022-3715)
+  coreutils@8.26-3 has the following known vulnerabilities:
+    CVE-2016-2781: chroot in GNU coreutils, when used with --userspec, allows local users to... (https://osv.dev/CVE-2016-2781)
+    CVE-2024-0684: A flaw was found in the GNU coreutils "split" program. A heap overflow with... (https://osv.dev/CVE-2024-0684)
+  debian-archive-keyring@2017.5+deb9u2 has the following known vulnerabilities:
+    DLA-3482-1: debian-archive-keyring - security update (https://osv.dev/DLA-3482-1)
+  dpkg@1.18.25 has the following known vulnerabilities:
+    DSA-5147-1: dpkg - security update (https://osv.dev/DSA-5147-1)
+    DLA-3022-1: dpkg - security update (https://osv.dev/DLA-3022-1)
+  e2fsprogs@1.43.4-2+deb9u2 has the following known vulnerabilities:
+    DSA-4535-1: e2fsprogs - security update (https://osv.dev/DSA-4535-1)
+    CVE-2019-5188: A code execution vulnerability exists in the directory rehashing functionality... (https://osv.dev/CVE-2019-5188)
+    CVE-2022-1304: An out-of-bounds read/write vulnerability was found in e2fsprogs 1.46.5. This... (https://osv.dev/CVE-2022-1304)
+    DLA-3910-1: e2fsprogs - security update (https://osv.dev/DLA-3910-1)
+  gzip@1.6-5+deb9u1 has the following known vulnerabilities:
+    DSA-5122-1: gzip - security update (https://osv.dev/DSA-5122-1)
+  libgcrypt20@1.7.6-2+deb9u4 has the following known vulnerabilities:
+    CVE-2017-0379: Libgcrypt before 1.8.1 does not properly consider Curve25519 side-channel... (https://osv.dev/CVE-2017-0379)
+    CVE-2017-7526: libgcrypt before version 1.7.8 is vulnerable to a cache side-channel attack... (https://osv.dev/CVE-2017-7526)
+    CVE-2018-0495: Libgcrypt before 1.7.10 and 1.8.x before 1.8.3 allows a memory-cache... (https://osv.dev/CVE-2018-0495)
+    CVE-2019-13627: It was discovered that there was a ECDSA timing attack in the libgcrypt20... (https://osv.dev/CVE-2019-13627)
+    CVE-2021-33560: Libgcrypt before 1.8.8 and 1.9.x before 1.9.3 mishandles ElGamal encryption... (https://osv.dev/CVE-2021-33560)
+    CVE-2021-40528: The ElGamal implementation in Libgcrypt before 1.9.4 allows plaintext recovery... (https://osv.dev/CVE-2021-40528)
+    CVE-2024-2236: A timing-based side-channel flaw was found in libgcrypt's RSA implementation.... (https://osv.dev/CVE-2024-2236)
+  libtasn1-6@4.10-1.1+deb9u1 has the following known vulnerabilities:
+    DSA-5863-1: libtasn1-6 - security update (https://osv.dev/DSA-5863-1)
+    CVE-2017-10790: The _asn1_check_identifier function in GNU Libtasn1 through 4.12 causes a NULL... (https://osv.dev/CVE-2017-10790)
+    CVE-2018-6003: An issue was discovered in the _asn1_decode_simple_ber function in decoding.c... (https://osv.dev/CVE-2018-6003)
+    CVE-2021-46848: GNU Libtasn1 before 4.19.0 has an ETYPE_OK off-by-one array size check that... (https://osv.dev/CVE-2021-46848)
+    DLA-3263-1: libtasn1-6 - security update (https://osv.dev/DLA-3263-1)
+    DLA-4061-1: libtasn1-6 - security update (https://osv.dev/DLA-4061-1)
+  libxml2@2.9.4+dfsg1-2.2+deb9u6 has the following known vulnerabilities:
+    DSA-5142-1: libxml2 - security update (https://osv.dev/DSA-5142-1)
+    DSA-5271-1: libxml2 - security update (https://osv.dev/DSA-5271-1)
+    DSA-5391-1: libxml2 - security update (https://osv.dev/DSA-5391-1)
+    CVE-2016-3709: Possible cross-site scripting vulnerability in libxml after commit 960f0e2. (https://osv.dev/CVE-2016-3709)
+    CVE-2016-9318: libxml2 2.9.4 and earlier, as used in XMLSec 1.2.23 and earlier and other... (https://osv.dev/CVE-2016-9318)
+    CVE-2017-0663: A remote code execution vulnerability in libxml2 could enable an attacker using... (https://osv.dev/CVE-2017-0663)
+    CVE-2017-15412: Use after free in libxml2 before 2.9.5, as used in Google Chrome prior to... (https://osv.dev/CVE-2017-15412)
+    CVE-2017-16931: parser.c in libxml2 before 2.9.5 mishandles parameter-entity references because... (https://osv.dev/CVE-2017-16931)
+    CVE-2017-16932: parser.c in libxml2 before 2.9.5 does not prevent infinite recursion in... (https://osv.dev/CVE-2017-16932)
+    CVE-2017-18258: The xz_head function in xzlib.c in libxml2 before 2.9.6 allows remote attackers... (https://osv.dev/CVE-2017-18258)
+    CVE-2017-5130: An integer overflow in xmlmemory.c in libxml2 before 2.9.5, as used in Google... (https://osv.dev/CVE-2017-5130)
+    CVE-2017-7375: A flaw in libxml2 allows remote XML entity inclusion with default parser flags... (https://osv.dev/CVE-2017-7375)
+    CVE-2017-7376: Buffer overflow in libxml2 allows remote attackers to execute arbitrary code by... (https://osv.dev/CVE-2017-7376)
+    CVE-2017-8872: The htmlParseTryOrFinish function in HTMLparser.c in libxml2 2.9.4 allows... (https://osv.dev/CVE-2017-8872)
+    CVE-2017-9047: A buffer overflow was discovered in libxml2 20904-GITv2.9.4-16-g0741801. The... (https://osv.dev/CVE-2017-9047)
+    CVE-2017-9048: libxml2 20904-GITv2.9.4-16-g0741801 is vulnerable to a stack-based buffer... (https://osv.dev/CVE-2017-9048)
+    CVE-2017-9049: libxml2 20904-GITv2.9.4-16-g0741801 is vulnerable to a heap-based buffer... (https://osv.dev/CVE-2017-9049)
+    CVE-2017-9050: libxml2 20904-GITv2.9.4-16-g0741801 is vulnerable to a heap-based buffer... (https://osv.dev/CVE-2017-9050)
+    CVE-2018-14404: A NULL pointer dereference vulnerability exists in the... (https://osv.dev/CVE-2018-14404)
+    CVE-2018-14567: libxml2 2.9.8, if --with-lzma is used, allows remote attackers to cause a... (https://osv.dev/CVE-2018-14567)
+    CVE-2019-19956: xmlParseBalancedChunkMemoryRecover in parser.c in libxml2 before 2.9.10 has a... (https://osv.dev/CVE-2019-19956)
+    CVE-2019-20388: xmlSchemaPreRun in xmlschemas.c in libxml2 2.9.10 allows an... (https://osv.dev/CVE-2019-20388)
+    CVE-2020-7595: xmlStringLenDecodeEntities in parser.c in libxml2 2.9.10 has an infinite loop... (https://osv.dev/CVE-2020-7595)
+    CVE-2021-3516: There's a flaw in libxml2's xmllint in versions before 2.9.11. An attacker who... (https://osv.dev/CVE-2021-3516)
+    CVE-2021-3517: There is a flaw in the xml entity encoding functionality of libxml2 in versions... (https://osv.dev/CVE-2021-3517)
+    CVE-2021-3518: There's a flaw in libxml2 in versions before 2.9.11. An attacker who is able to... (https://osv.dev/CVE-2021-3518)
+    CVE-2021-3537: A vulnerability found in libxml2 in versions before 2.9.11 shows that it did... (https://osv.dev/CVE-2021-3537)
+    CVE-2021-3541: A flaw was found in libxml2. Exponential entity expansion attack its possible... (https://osv.dev/CVE-2021-3541)
+    CVE-2022-2309: NULL Pointer Dereference allows attackers to cause a denial of service (or... (https://osv.dev/CVE-2022-2309)
+    CVE-2022-23308: valid.c in libxml2 before 2.9.13 has a use-after-free of ID and IDREF... (https://osv.dev/CVE-2022-23308)
+    CVE-2022-49043: xmlXIncludeAddNode in xinclude.c in libxml2 before 2.11.0 has a use-after-free. (https://osv.dev/CVE-2022-49043)
+    CVE-2024-25062: An issue was discovered in libxml2 before 2.11.7 and 2.12.x before 2.12.5. When... (https://osv.dev/CVE-2024-25062)
+    CVE-2024-56171: libxml2 before 2.12.10 and 2.13.x before 2.13.6 has a use-after-free in... (https://osv.dev/CVE-2024-56171)
+    CVE-2025-24928: libxml2 before 2.12.10 and 2.13.x before 2.13.6 has a stack-based buffer... (https://osv.dev/CVE-2025-24928)
+    CVE-2025-27113: libxml2 before 2.12.10 and 2.13.x before 2.13.6 has a NULL pointer dereference... (https://osv.dev/CVE-2025-27113)
+    DLA-3012-1: libxml2 - security update (https://osv.dev/DLA-3012-1)
+    DLA-3172-1: libxml2 - security update (https://osv.dev/DLA-3172-1)
+    DLA-3405-1: libxml2 - security update (https://osv.dev/DLA-3405-1)
+    DLA-3878-1: libxml2 - security update (https://osv.dev/DLA-3878-1)
+    DLA-4064-1: libxml2 - security update (https://osv.dev/DLA-4064-1)
+  openssl@1.1.0l-1~deb9u5 has the following known vulnerabilities:
+    DSA-4539-1: openssl - security update (https://osv.dev/DSA-4539-1)
+    DSA-4539-3: openssl - regression update (https://osv.dev/DSA-4539-3)
+    DSA-4661-1: openssl - security update (https://osv.dev/DSA-4661-1)
+    DSA-4807-1: openssl - security update (https://osv.dev/DSA-4807-1)
+    DSA-4855-1: openssl - security update (https://osv.dev/DSA-4855-1)
+    DSA-4875-1: openssl - security update (https://osv.dev/DSA-4875-1)
+    DSA-4963-1: openssl - security update (https://osv.dev/DSA-4963-1)
+    DSA-5103-1: openssl - security update (https://osv.dev/DSA-5103-1)
+    DSA-5139-1: openssl - security update (https://osv.dev/DSA-5139-1)
+    DSA-5169-1: openssl - security update (https://osv.dev/DSA-5169-1)
+    DSA-5343-1: openssl - security update (https://osv.dev/DSA-5343-1)
+    DSA-5417-1: openssl - security update (https://osv.dev/DSA-5417-1)
+    DSA-5532-1: openssl - security update (https://osv.dev/DSA-5532-1)
+    DSA-5764-1: openssl - security update (https://osv.dev/DSA-5764-1)
+    CVE-2018-0732: During key agreement in a TLS handshake using a DH(E) based ciphersuite a... (https://osv.dev/CVE-2018-0732)
+    CVE-2018-0734: The OpenSSL DSA signature algorithm has been shown to be vulnerable to a timing... (https://osv.dev/CVE-2018-0734)
+    CVE-2018-0735: The OpenSSL ECDSA signature algorithm has been shown to be vulnerable to a... (https://osv.dev/CVE-2018-0735)
+    CVE-2018-5407: Simultaneous Multi-threading (SMT) in processors can enable local users to... (https://osv.dev/CVE-2018-5407)
+    CVE-2019-1543: ChaCha20-Poly1305 is an AEAD cipher, and requires a unique nonce input for... (https://osv.dev/CVE-2019-1543)
+    CVE-2019-1549: OpenSSL 1.1.1 introduced a rewritten random number generator (RNG). This was... (https://osv.dev/CVE-2019-1549)
+    CVE-2021-3450: The X509_V_FLAG_X509_STRICT flag enables additional security checks of the... (https://osv.dev/CVE-2021-3450)
+    CVE-2022-2274: The OpenSSL 3.0.4 release introduced a serious bug in the RSA implementation... (https://osv.dev/CVE-2022-2274)
+    CVE-2022-3358: OpenSSL supports creating a custom cipher via the legacy EVP_CIPHER_meth_new()... (https://osv.dev/CVE-2022-3358)
+    CVE-2022-3602: A buffer overrun can be triggered in X.509 certificate verification,... (https://osv.dev/CVE-2022-3602)
+    CVE-2022-3786: A buffer overrun can be triggered in X.509 certificate verification,... (https://osv.dev/CVE-2022-3786)
+    CVE-2022-3996: If an X.509 certificate contains a malformed policy constraint and
+policy... (https://osv.dev/CVE-2022-3996)
+    CVE-2022-4203: A read buffer overrun can be triggered in X.509 certificate verification,... (https://osv.dev/CVE-2022-4203)
+    CVE-2023-0216: An invalid pointer dereference on read can be triggered when an
+application... (https://osv.dev/CVE-2023-0216)
+    CVE-2023-0217: An invalid pointer dereference on read can be triggered when an
+application... (https://osv.dev/CVE-2023-0217)
+    CVE-2023-0401: A NULL pointer can be dereferenced when signatures are being
+verified on PKCS7... (https://osv.dev/CVE-2023-0401)
+    CVE-2023-1255: Issue summary: The AES-XTS cipher decryption implementation for 64 bit ARM... (https://osv.dev/CVE-2023-1255)
+    CVE-2023-2975: Issue summary: The AES-SIV cipher implementation contains a bug that causes
+it... (https://osv.dev/CVE-2023-2975)
+    CVE-2023-3446: Issue summary: Checking excessively long DH keys or parameters may be very... (https://osv.dev/CVE-2023-3446)
+    CVE-2023-3817: Issue summary: Checking excessively long DH keys or parameters may be very... (https://osv.dev/CVE-2023-3817)
+    CVE-2023-5678: Issue summary: Generating excessively long X9.42 DH keys or checking... (https://osv.dev/CVE-2023-5678)
+    CVE-2023-6129: Issue summary: The POLY1305 MAC (message authentication code) implementation... (https://osv.dev/CVE-2023-6129)
+    CVE-2023-6237: Issue summary: Checking excessively long invalid RSA public keys may take
+a... (https://osv.dev/CVE-2023-6237)
+    CVE-2024-0727: Issue summary: Processing a maliciously formatted PKCS12 file may lead OpenSSL... (https://osv.dev/CVE-2024-0727)
+    CVE-2024-12797: Issue summary: Clients using RFC7250 Raw Public Keys (RPKs) to authenticate a... (https://osv.dev/CVE-2024-12797)
+    CVE-2024-13176: Issue summary: A timing side-channel which could potentially allow recovering... (https://osv.dev/CVE-2024-13176)
+    CVE-2024-2511: Issue summary: Some non-default TLS server configurations can cause unbounded... (https://osv.dev/CVE-2024-2511)
+    CVE-2024-4603: Issue summary: Checking excessively long DSA keys or parameters may be very... (https://osv.dev/CVE-2024-4603)
+    CVE-2024-4741: Issue summary: Calling the OpenSSL API function SSL_free_buffers may cause... (https://osv.dev/CVE-2024-4741)
+    CVE-2024-5535: Issue summary: Calling the OpenSSL API function SSL_select_next_proto with an... (https://osv.dev/CVE-2024-5535)
+    CVE-2024-9143: Issue summary: Use of the low-level GF(2^m) elliptic curve APIs with untrusted... (https://osv.dev/CVE-2024-9143)
+    DLA-3008-1: openssl - security update (https://osv.dev/DLA-3008-1)
+    DLA-3325-1: openssl - security update (https://osv.dev/DLA-3325-1)
+    DLA-3449-1: openssl - security update (https://osv.dev/DLA-3449-1)
+    DLA-3530-1: openssl - security update (https://osv.dev/DLA-3530-1)
+    DLA-3942-1: openssl - security update (https://osv.dev/DLA-3942-1)
+    DLA-3942-2: openssl - regression update (https://osv.dev/DLA-3942-2)
+  perl@5.24.1-3+deb9u7 has the following known vulnerabilities:
+    CVE-2017-12837: Heap-based buffer overflow in the S_regatom function in regcomp.c in Perl 5... (https://osv.dev/CVE-2017-12837)
+    CVE-2017-12883: Buffer overflow in the S_grok_bslash_N function in regcomp.c in Perl 5 before... (https://osv.dev/CVE-2017-12883)
+    CVE-2018-12015: In Perl through 5.26.2, the Archive::Tar module allows remote attackers to... (https://osv.dev/CVE-2018-12015)
+    CVE-2018-18311: Perl before 5.26.3 and 5.28.x before 5.28.1 has a buffer overflow via a crafted... (https://osv.dev/CVE-2018-18311)
+    CVE-2018-18312: Perl before 5.26.3 and 5.28.0 before 5.28.1 has a buffer overflow via a crafted... (https://osv.dev/CVE-2018-18312)
+    CVE-2018-18313: Perl before 5.26.3 has a buffer over-read via a crafted regular expression that... (https://osv.dev/CVE-2018-18313)
+    CVE-2018-18314: Perl before 5.26.3 has a buffer overflow via a crafted regular expression that... (https://osv.dev/CVE-2018-18314)
+    CVE-2018-6797: An issue was discovered in Perl 5.18 through 5.26. A crafted regular expression... (https://osv.dev/CVE-2018-6797)
+    CVE-2018-6798: An issue was discovered in Perl 5.22 through 5.26. Matching a crafted locale... (https://osv.dev/CVE-2018-6798)
+    CVE-2018-6913: Heap-based buffer overflow in the pack function in Perl before 5.26.2 allows... (https://osv.dev/CVE-2018-6913)
+    CVE-2020-10543: Perl before 5.30.3 on 32-bit platforms allows a heap-based buffer overflow... (https://osv.dev/CVE-2020-10543)
+    CVE-2020-10878: Perl before 5.30.3 has an integer overflow related to mishandling of a... (https://osv.dev/CVE-2020-10878)
+    CVE-2020-12723: regcomp.c in Perl before 5.30.3 allows a buffer overflow via a crafted regular... (https://osv.dev/CVE-2020-12723)
+    CVE-2020-16156: CPAN 2.28 allows Signature Verification Bypass. (https://osv.dev/CVE-2020-16156)
+    CVE-2021-36770: Encode.pm, as distributed in Perl through 5.34.0, allows local users to gain... (https://osv.dev/CVE-2021-36770)
+    CVE-2023-31484: CPAN.pm before 2.35 does not verify TLS certificates when downloading... (https://osv.dev/CVE-2023-31484)
+    CVE-2023-47038: A vulnerability was found in perl 5.30.0 through 5.38.0. This issue occurs when... (https://osv.dev/CVE-2023-47038)
+    DLA-3926-1: perl - security update (https://osv.dev/DLA-3926-1)
+  postgresql-11@11.15-1.pgdg90+1 has the following known vulnerabilities:
+    DSA-5135-1: postgresql-11 - security update (https://osv.dev/DSA-5135-1)
+    DLA-3072-1: postgresql-11 - security update (https://osv.dev/DLA-3072-1)
+    DLA-3189-1: postgresql-11 - bugfix update (https://osv.dev/DLA-3189-1)
+    DLA-3316-1: postgresql-11 - security update (https://osv.dev/DLA-3316-1)
+    DLA-3422-1: postgresql-11 - security update (https://osv.dev/DLA-3422-1)
+    DLA-3600-1: postgresql-11 - security update (https://osv.dev/DLA-3600-1)
+    DLA-3651-1: postgresql-11 - security update (https://osv.dev/DLA-3651-1)
+    DLA-3764-1: postgresql-11 - security update (https://osv.dev/DLA-3764-1)
+  sensible-utils@0.0.9+deb9u1 has the following known vulnerabilities:
+    CVE-2017-17512: sensible-browser in sensible-utils before 0.0.11 does not validate strings... (https://osv.dev/CVE-2017-17512)
+  tar@1.29b-1.1+deb9u1 has the following known vulnerabilities:
+    CVE-2018-20482: GNU Tar through 1.30, when --sparse is used, mishandles file shrinkage during... (https://osv.dev/CVE-2018-20482)
+    CVE-2023-39804: In GNU tar before 1.35, mishandled extension attributes in a PAX archive can... (https://osv.dev/CVE-2023-39804)
+    DLA-3755-1: tar - security update (https://osv.dev/DLA-3755-1)
+  tzdata@2021a-0+deb9u3 has the following known vulnerabilities:
+    DLA-3051-1: tzdata - new timezone database (https://osv.dev/DLA-3051-1)
+    DLA-3134-1: tzdata - new timezone database (https://osv.dev/DLA-3134-1)
+    DLA-3161-1: tzdata - new timezone database (https://osv.dev/DLA-3161-1)
+    DLA-3366-1: tzdata - new timezone database (https://osv.dev/DLA-3366-1)
+    DLA-3412-1: tzdata - new timezone database (https://osv.dev/DLA-3412-1)
+    DLA-3684-1: tzdata - new timezone database (https://osv.dev/DLA-3684-1)
+    DLA-3788-1: tzdata - new timezone database (https://osv.dev/DLA-3788-1)
+    DLA-3972-1: tzdata - new timezone database (https://osv.dev/DLA-3972-1)
+  ucf@3.0036 has the following known vulnerabilities:
+    DLA-4016-1: ucf - security update (https://osv.dev/DLA-4016-1)
+  util-linux@2.29.2-1+deb9u1 has the following known vulnerabilities:
+    DSA-5055-1: util-linux - security update (https://osv.dev/DSA-5055-1)
+    DSA-5650-1: util-linux - security update (https://osv.dev/DSA-5650-1)
+    CVE-2016-2779: runuser in util-linux allows local users to escape to the parent session via a... (https://osv.dev/CVE-2016-2779)
+    DLA-3782-1: util-linux - security update (https://osv.dev/DLA-3782-1)
+  xz-utils@5.2.2-1.2+deb9u1 has the following known vulnerabilities:
+    DSA-5123-1: xz-utils - security update (https://osv.dev/DSA-5123-1)
+    CVE-2024-3094: Malicious code was discovered in the upstream tarballs of xz, starting with... (https://osv.dev/CVE-2024-3094)
+
+  164 known vulnerabilities found in sbom:<rootdir>/fixtures/sbom-insecure/postgres-stretch.cdx.xml
+
+  apt@1.4.11 has the following unimportant vulnerabilities:
+    CVE-2011-3374: It was found that apt-key in apt, all versions, do not correctly validate gpg... (https://osv.dev/CVE-2011-3374)
+  bash@4.4-5 has the following unimportant vulnerabilities:
+    CVE-2019-18276: An issue was discovered in disable_priv_mode in shell.c in GNU Bash through 5.0... (https://osv.dev/CVE-2019-18276)
+  coreutils@8.26-3 has the following unimportant vulnerabilities:
+    CVE-2017-18018: In GNU Coreutils through 8.29, chown-core.c in chown and chgrp does not prevent... (https://osv.dev/CVE-2017-18018)
+  libgcrypt20@1.7.6-2+deb9u4 has the following unimportant vulnerabilities:
+    CVE-2018-6829: cipher/elgamal.c in Libgcrypt through 1.8.2, when used to encrypt messages... (https://osv.dev/CVE-2018-6829)
+  libtasn1-6@4.10-1.1+deb9u1 has the following unimportant vulnerabilities:
+    CVE-2018-1000654: GNU Libtasn1-4.13 libtasn1-4.13 version libtasn1-4.13, libtasn1-4.12 contains a... (https://osv.dev/CVE-2018-1000654)
+  libxml2@2.9.4+dfsg1-2.2+deb9u6 has the following unimportant vulnerabilities:
+    CVE-2020-24977: GNOME project libxml2 v2.9.10 has a global buffer over-read vulnerability in... (https://osv.dev/CVE-2020-24977)
+    CVE-2024-34459: An issue was discovered in xmllint (from libxml2) before 2.11.8 and 2.12.x... (https://osv.dev/CVE-2024-34459)
+  perl@5.24.1-3+deb9u7 has the following unimportant vulnerabilities:
+    CVE-2011-4116: _is_safe in the File::Temp module for Perl does not properly handle symlinks. (https://osv.dev/CVE-2011-4116)
+    CVE-2022-48522: In Perl 5.34.0, function S_find_uninit_var in sv.c has a stack-based crash that... (https://osv.dev/CVE-2022-48522)
+    CVE-2023-31486: HTTP::Tiny before 0.083, a Perl core module since 5.13.9 and available... (https://osv.dev/CVE-2023-31486)
+  tar@1.29b-1.1+deb9u1 has the following unimportant vulnerabilities:
+    CVE-2005-2541: Tar 1.15.1 does not properly warn the user when extracting setuid or setgid... (https://osv.dev/CVE-2005-2541)
+    CVE-2019-9923: pax_decode_header in sparse.c in GNU Tar before 1.32 had a NULL pointer... (https://osv.dev/CVE-2019-9923)
+    CVE-2021-20193: A flaw was found in the src/list.c of tar 1.33 and earlier. This flaw allows an... (https://osv.dev/CVE-2021-20193)
+    CVE-2022-48303: GNU Tar through 1.34 has a one-byte out-of-bounds read that results in use of... (https://osv.dev/CVE-2022-48303)
+  util-linux@2.29.2-1+deb9u1 has the following unimportant vulnerabilities:
+    CVE-2018-7738: In util-linux before 2.32-rc1, bash-completion/umount allows local users to... (https://osv.dev/CVE-2018-7738)
+    CVE-2022-0563: A flaw was found in the util-linux chfn and chsh utilities when compiled with... (https://osv.dev/CVE-2022-0563)
+
+  16 uncalled/unimportant vulnerabilities found in sbom:<rootdir>/fixtures/sbom-insecure/postgres-stretch.cdx.xml (filtered out)
+
 
 ---
 
@@ -1009,13 +1135,22 @@ No issues found
 [Test_run/one_specific_supported_sbom_with_duplicate_PURLs - 1]
 Scanned <rootdir>/fixtures/sbom-insecure/with-duplicates.cdx.xml file and found 15 packages
 Filtered 1 local/unscannable package/s from the scan.
-+--------------------------------+------+-----------+---------+-----------+------------------------------------------------+
-| OSV URL                        | CVSS | ECOSYSTEM | PACKAGE | VERSION   | SOURCE                                         |
-+--------------------------------+------+-----------+---------+-----------+------------------------------------------------+
-| https://osv.dev/CVE-2025-26519 |      | Alpine    | musl    | 1.2.3-r4  | fixtures/sbom-insecure/with-duplicates.cdx.xml |
-| https://osv.dev/CVE-2018-25032 | 7.5  | Alpine    | zlib    | 1.2.10-r0 | fixtures/sbom-insecure/with-duplicates.cdx.xml |
-| https://osv.dev/CVE-2022-37434 | 9.8  | Alpine    | zlib    | 1.2.10-r0 | fixtures/sbom-insecure/with-duplicates.cdx.xml |
-+--------------------------------+------+-----------+---------+-----------+------------------------------------------------+
+
+Total 2 packages affected by 3 known vulnerabilities (1 Critical, 1 High, 0 Medium, 0 Low, 1 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+Alpine
+
+sbom:<rootdir>/fixtures/sbom-insecure/with-duplicates.cdx.xml: found 2 packages with issues
+
+  musl@1.2.3-r4 has the following known vulnerabilities:
+    CVE-2025-26519: musl libc 0.9.13 through 1.2.5 before 1.2.6 has an out-of-bounds write... (https://osv.dev/CVE-2025-26519)
+  zlib@1.2.10-r0 has the following known vulnerabilities:
+    CVE-2018-25032: zlib before 1.2.12 allows memory corruption when deflating (i.e., when... (https://osv.dev/CVE-2018-25032)
+    CVE-2022-37434: zlib through 1.2.12 has a heap-based buffer over-read or buffer overflow in... (https://osv.dev/CVE-2022-37434)
+
+  3 known vulnerabilities found in sbom:<rootdir>/fixtures/sbom-insecure/with-duplicates.cdx.xml
+
 
 ---
 
@@ -1037,13 +1172,22 @@ No issues found
 [Test_run/one_specific_supported_sbom_with_vulns - 1]
 Scanned <rootdir>/fixtures/sbom-insecure/alpine.cdx.xml file and found 15 packages
 Filtered 1 local/unscannable package/s from the scan.
-+--------------------------------+------+-----------+---------+-----------+---------------------------------------+
-| OSV URL                        | CVSS | ECOSYSTEM | PACKAGE | VERSION   | SOURCE                                |
-+--------------------------------+------+-----------+---------+-----------+---------------------------------------+
-| https://osv.dev/CVE-2025-26519 |      | Alpine    | musl    | 1.2.3-r4  | fixtures/sbom-insecure/alpine.cdx.xml |
-| https://osv.dev/CVE-2018-25032 | 7.5  | Alpine    | zlib    | 1.2.10-r0 | fixtures/sbom-insecure/alpine.cdx.xml |
-| https://osv.dev/CVE-2022-37434 | 9.8  | Alpine    | zlib    | 1.2.10-r0 | fixtures/sbom-insecure/alpine.cdx.xml |
-+--------------------------------+------+-----------+---------+-----------+---------------------------------------+
+
+Total 2 packages affected by 3 known vulnerabilities (1 Critical, 1 High, 0 Medium, 0 Low, 1 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+Alpine
+
+sbom:<rootdir>/fixtures/sbom-insecure/alpine.cdx.xml: found 2 packages with issues
+
+  musl@1.2.3-r4 has the following known vulnerabilities:
+    CVE-2025-26519: musl libc 0.9.13 through 1.2.5 before 1.2.6 has an out-of-bounds write... (https://osv.dev/CVE-2025-26519)
+  zlib@1.2.10-r0 has the following known vulnerabilities:
+    CVE-2018-25032: zlib before 1.2.12 allows memory corruption when deflating (i.e., when... (https://osv.dev/CVE-2018-25032)
+    CVE-2022-37434: zlib through 1.2.12 has a heap-based buffer over-read or buffer overflow in... (https://osv.dev/CVE-2022-37434)
+
+  3 known vulnerabilities found in sbom:<rootdir>/fixtures/sbom-insecure/alpine.cdx.xml
+
 
 ---
 
@@ -1101,40 +1245,55 @@ Scanned <rootdir>/fixtures/locks-requirements/requirements-dev.txt file and foun
 Scanned <rootdir>/fixtures/locks-requirements/requirements.prod.txt file and found 1 package
 Scanned <rootdir>/fixtures/locks-requirements/requirements.txt file and found 3 packages
 Scanned <rootdir>/fixtures/locks-requirements/the_requirements_for_test.txt file and found 1 package
-+-------------------------------------+------+-----------+------------+---------+---------------------------------------------------+
-| OSV URL                             | CVSS | ECOSYSTEM | PACKAGE    | VERSION | SOURCE                                            |
-+-------------------------------------+------+-----------+------------+---------+---------------------------------------------------+
-| https://osv.dev/PYSEC-2023-62       | 8.7  | PyPI      | flask      | 1.0.0   | fixtures/locks-requirements/my-requirements.txt   |
-| https://osv.dev/GHSA-m2qf-hxjv-5gpq |      |           |            |         |                                                   |
-| https://osv.dev/PYSEC-2024-48       | 5.3  | PyPI      | black      | 1.0.0   | fixtures/locks-requirements/requirements-dev.txt  |
-| https://osv.dev/GHSA-fj7x-q9j7-g6q6 |      |           |            |         |                                                   |
-| https://osv.dev/PYSEC-2021-439      | 7.3  | PyPI      | django     | 2.2.24  | fixtures/locks-requirements/requirements.prod.txt |
-| https://osv.dev/GHSA-v6rh-hp5x-86rv |      |           |            |         |                                                   |
-| https://osv.dev/PYSEC-2022-1        | 8.7  | PyPI      | django     | 2.2.24  | fixtures/locks-requirements/requirements.prod.txt |
-| https://osv.dev/GHSA-53qw-q765-4fww |      |           |            |         |                                                   |
-| https://osv.dev/PYSEC-2022-19       | 6.1  | PyPI      | django     | 2.2.24  | fixtures/locks-requirements/requirements.prod.txt |
-| https://osv.dev/GHSA-95rw-fx8r-36v6 |      |           |            |         |                                                   |
-| https://osv.dev/PYSEC-2022-190      | 9.8  | PyPI      | django     | 2.2.24  | fixtures/locks-requirements/requirements.prod.txt |
-| https://osv.dev/GHSA-2gwj-7jmv-h26r |      |           |            |         |                                                   |
-| https://osv.dev/PYSEC-2022-191      | 9.8  | PyPI      | django     | 2.2.24  | fixtures/locks-requirements/requirements.prod.txt |
-| https://osv.dev/GHSA-w24h-v9qh-8gxj |      |           |            |         |                                                   |
-| https://osv.dev/PYSEC-2022-2        | 8.7  | PyPI      | django     | 2.2.24  | fixtures/locks-requirements/requirements.prod.txt |
-| https://osv.dev/GHSA-8c5j-9r9f-c6w8 |      |           |            |         |                                                   |
-| https://osv.dev/PYSEC-2022-20       | 8.7  | PyPI      | django     | 2.2.24  | fixtures/locks-requirements/requirements.prod.txt |
-| https://osv.dev/GHSA-6cw3-g6wv-c2xv |      |           |            |         |                                                   |
-| https://osv.dev/PYSEC-2022-3        | 6.9  | PyPI      | django     | 2.2.24  | fixtures/locks-requirements/requirements.prod.txt |
-| https://osv.dev/GHSA-jrh2-hc4r-7jwx |      |           |            |         |                                                   |
-| https://osv.dev/GHSA-8x94-hmjh-97hq | 8.8  | PyPI      | django     | 2.2.24  | fixtures/locks-requirements/requirements.prod.txt |
-| https://osv.dev/GHSA-rrqc-c2jx-6jgv | 6.3  | PyPI      | django     | 2.2.24  | fixtures/locks-requirements/requirements.prod.txt |
-| https://osv.dev/PYSEC-2023-62       | 8.7  | PyPI      | flask      | 1.0.0   | fixtures/locks-requirements/requirements.txt      |
-| https://osv.dev/GHSA-m2qf-hxjv-5gpq |      |           |            |         |                                                   |
-| https://osv.dev/PYSEC-2020-43       | 8.7  | PyPI      | flask-cors | 1.0.0   | fixtures/locks-requirements/requirements.txt      |
-| https://osv.dev/GHSA-xc3p-ff3m-f46v |      |           |            |         |                                                   |
-| https://osv.dev/PYSEC-2024-71       | 8.7  | PyPI      | flask-cors | 1.0.0   | fixtures/locks-requirements/requirements.txt      |
-| https://osv.dev/GHSA-hxwh-jpp2-84pm |      |           |            |         |                                                   |
-| https://osv.dev/GHSA-84pr-m4jr-85g5 | 5.3  | PyPI      | flask-cors | 1.0.0   | fixtures/locks-requirements/requirements.txt      |
-| https://osv.dev/PYSEC-2020-73       |      | PyPI      | pandas     | 0.23.4  | fixtures/locks-requirements/requirements.txt      |
-+-------------------------------------+------+-----------+------------+---------+---------------------------------------------------+
+
+Total 6 packages affected by 17 known vulnerabilities (2 Critical, 9 High, 5 Medium, 0 Low, 1 Unknown) from 1 ecosystem.
+17 vulnerabilities can be fixed.
+
+PyPI
+
+lockfile:<rootdir>/fixtures/locks-requirements/my-requirements.txt: found 1 package with issues
+
+  flask@1.0.0 has the following known vulnerabilities:
+    PYSEC-2023-62: Flask is a lightweight WSGI web application framework. When all of the... (https://osv.dev/PYSEC-2023-62)
+
+  1 known vulnerability found in lockfile:<rootdir>/fixtures/locks-requirements/my-requirements.txt
+
+lockfile:<rootdir>/fixtures/locks-requirements/requirements-dev.txt: found 1 package with issues
+
+  black@1.0.0 has the following known vulnerabilities:
+    PYSEC-2024-48: Versions of the package black before 24.3.0 are vulnerable to Regular... (https://osv.dev/PYSEC-2024-48)
+
+  1 known vulnerability found in lockfile:<rootdir>/fixtures/locks-requirements/requirements-dev.txt
+
+lockfile:<rootdir>/fixtures/locks-requirements/requirements.prod.txt: found 1 package with issues
+
+  django@2.2.24 has the following known vulnerabilities:
+    PYSEC-2021-439: In Django 2.2 before 2.2.25, 3.1 before 3.1.14, and 3.2 before 3.2.10, HTTP... (https://osv.dev/PYSEC-2021-439)
+    PYSEC-2022-1: An issue was discovered in Django 2.2 before 2.2.26, 3.2 before 3.2.11, and 4.0... (https://osv.dev/PYSEC-2022-1)
+    PYSEC-2022-19: The {% debug %} template tag in Django 2.2 before 2.2.27, 3.2 before 3.2.12,... (https://osv.dev/PYSEC-2022-19)
+    PYSEC-2022-190: An issue was discovered in Django 2.2 before 2.2.28, 3.2 before 3.2.13, and 4.0... (https://osv.dev/PYSEC-2022-190)
+    PYSEC-2022-191: A SQL injection issue was discovered in QuerySet.explain() in Django 2.2 before... (https://osv.dev/PYSEC-2022-191)
+    PYSEC-2022-2: An issue was discovered in Django 2.2 before 2.2.26, 3.2 before 3.2.11, and 4.0... (https://osv.dev/PYSEC-2022-2)
+    PYSEC-2022-20: An issue was discovered in MultiPartParser in Django 2.2 before 2.2.27, 3.2... (https://osv.dev/PYSEC-2022-20)
+    PYSEC-2022-3: Storage.save in Django 2.2 before 2.2.26, 3.2 before 3.2.11, and 4.0 before... (https://osv.dev/PYSEC-2022-3)
+    GHSA-8x94-hmjh-97hq: Django vulnerable to Reflected File Download attack (https://osv.dev/GHSA-8x94-hmjh-97hq)
+    GHSA-rrqc-c2jx-6jgv: Django allows enumeration of user e-mail addresses (https://osv.dev/GHSA-rrqc-c2jx-6jgv)
+
+  10 known vulnerabilities found in lockfile:<rootdir>/fixtures/locks-requirements/requirements.prod.txt
+
+lockfile:<rootdir>/fixtures/locks-requirements/requirements.txt: found 3 packages with issues
+
+  flask@1.0.0 has the following known vulnerabilities:
+    PYSEC-2023-62: Flask is a lightweight WSGI web application framework. When all of the... (https://osv.dev/PYSEC-2023-62)
+  flask-cors@1.0.0 has the following known vulnerabilities:
+    PYSEC-2020-43: An issue was discovered in Flask-CORS (aka CORS Middleware for Flask) before... (https://osv.dev/PYSEC-2020-43)
+    PYSEC-2024-71: A vulnerability in corydolphin/flask-cors up to version 4.0.1 allows the... (https://osv.dev/PYSEC-2024-71)
+    GHSA-84pr-m4jr-85g5: flask-cors vulnerable to log injection when the log level is set to debug (https://osv.dev/GHSA-84pr-m4jr-85g5)
+  pandas@0.23.4 has the following known vulnerabilities:
+    PYSEC-2020-73: ** DISPUTED ** pandas through 1.0.3 can unserialize and execute commands from... (https://osv.dev/PYSEC-2020-73)
+
+  5 known vulnerabilities found in lockfile:<rootdir>/fixtures/locks-requirements/requirements.txt
+
 
 ---
 
@@ -1179,46 +1338,52 @@ Scanning dir ./fixtures/call-analysis-go-project
 Scanned <rootdir>/fixtures/call-analysis-go-project/go.mod file and found 4 packages
 GO-2025-3447 and 2 aliases have been filtered out because: This is called in Go v1.23, but not in v1.24
 Filtered 1 vulnerability from output
-+-------------------------------------+------+-----------+-----------------------------+---------+------------------------------------------+
-| OSV URL                             | CVSS | ECOSYSTEM | PACKAGE                     | VERSION | SOURCE                                   |
-+-------------------------------------+------+-----------+-----------------------------+---------+------------------------------------------+
-| https://osv.dev/GO-2023-1558        | 5.9  | Go        | github.com/ipfs/go-bitfield | 1.0.0   | fixtures/call-analysis-go-project/go.mod |
-| https://osv.dev/GHSA-2h6c-j3gf-xp9r |      |           |                             |         |                                          |
-| https://osv.dev/GO-2023-2102        |      | Go        | stdlib                      | 1.19.99 | fixtures/call-analysis-go-project/go.mod |
-| https://osv.dev/GO-2023-2185        |      | Go        | stdlib                      | 1.19.99 | fixtures/call-analysis-go-project/go.mod |
-| https://osv.dev/GO-2023-2375        |      | Go        | stdlib                      | 1.19.99 | fixtures/call-analysis-go-project/go.mod |
-| https://osv.dev/GO-2023-2382        |      | Go        | stdlib                      | 1.19.99 | fixtures/call-analysis-go-project/go.mod |
-| https://osv.dev/GO-2024-2598        |      | Go        | stdlib                      | 1.19.99 | fixtures/call-analysis-go-project/go.mod |
-| https://osv.dev/GO-2024-2599        |      | Go        | stdlib                      | 1.19.99 | fixtures/call-analysis-go-project/go.mod |
-| https://osv.dev/GO-2024-2687        |      | Go        | stdlib                      | 1.19.99 | fixtures/call-analysis-go-project/go.mod |
-| https://osv.dev/GO-2024-2887        |      | Go        | stdlib                      | 1.19.99 | fixtures/call-analysis-go-project/go.mod |
-| https://osv.dev/GO-2025-3373        |      | Go        | stdlib                      | 1.19.99 | fixtures/call-analysis-go-project/go.mod |
-+-------------------------------------+------+-----------+-----------------------------+---------+------------------------------------------+
-| Uncalled vulnerabilities            |      |           |                             |         |                                          |
-+-------------------------------------+------+-----------+-----------------------------+---------+------------------------------------------+
-| https://osv.dev/GO-2021-0053        | 8.6  | Go        | github.com/gogo/protobuf    | 1.3.1   | fixtures/call-analysis-go-project/go.mod |
-| https://osv.dev/GHSA-c3h9-896r-86jm |      |           |                             |         |                                          |
-| https://osv.dev/GO-2023-1572        | 5.5  | Go        | golang.org/x/image          | 0.4.0   | fixtures/call-analysis-go-project/go.mod |
-| https://osv.dev/GHSA-qgc7-mgm3-q253 |      |           |                             |         |                                          |
-| https://osv.dev/GO-2023-1989        | 6.5  | Go        | golang.org/x/image          | 0.4.0   | fixtures/call-analysis-go-project/go.mod |
-| https://osv.dev/GHSA-x92r-3vfx-4cv3 |      |           |                             |         |                                          |
-| https://osv.dev/GO-2023-1990        | 6.5  | Go        | golang.org/x/image          | 0.4.0   | fixtures/call-analysis-go-project/go.mod |
-| https://osv.dev/GHSA-j3p8-6mrq-6g7h |      |           |                             |         |                                          |
-| https://osv.dev/GO-2024-2937        | 8.7  | Go        | golang.org/x/image          | 0.4.0   | fixtures/call-analysis-go-project/go.mod |
-| https://osv.dev/GHSA-9phm-fm57-rhg8 |      |           |                             |         |                                          |
-| https://osv.dev/GO-2023-2041        |      | Go        | stdlib                      | 1.19.99 | fixtures/call-analysis-go-project/go.mod |
-| https://osv.dev/GO-2023-2043        |      | Go        | stdlib                      | 1.19.99 | fixtures/call-analysis-go-project/go.mod |
-| https://osv.dev/GO-2023-2186        |      | Go        | stdlib                      | 1.19.99 | fixtures/call-analysis-go-project/go.mod |
-| https://osv.dev/GO-2024-2600        |      | Go        | stdlib                      | 1.19.99 | fixtures/call-analysis-go-project/go.mod |
-| https://osv.dev/GO-2024-2609        |      | Go        | stdlib                      | 1.19.99 | fixtures/call-analysis-go-project/go.mod |
-| https://osv.dev/GO-2024-2610        |      | Go        | stdlib                      | 1.19.99 | fixtures/call-analysis-go-project/go.mod |
-| https://osv.dev/GO-2024-2888        |      | Go        | stdlib                      | 1.19.99 | fixtures/call-analysis-go-project/go.mod |
-| https://osv.dev/GO-2024-2963        |      | Go        | stdlib                      | 1.19.99 | fixtures/call-analysis-go-project/go.mod |
-| https://osv.dev/GO-2024-3105        |      | Go        | stdlib                      | 1.19.99 | fixtures/call-analysis-go-project/go.mod |
-| https://osv.dev/GO-2024-3106        |      | Go        | stdlib                      | 1.19.99 | fixtures/call-analysis-go-project/go.mod |
-| https://osv.dev/GO-2024-3107        |      | Go        | stdlib                      | 1.19.99 | fixtures/call-analysis-go-project/go.mod |
-| https://osv.dev/GO-2025-3420        |      | Go        | stdlib                      | 1.19.99 | fixtures/call-analysis-go-project/go.mod |
-+-------------------------------------+------+-----------+-----------------------------+---------+------------------------------------------+
+
+Total 2 packages affected by 10 known vulnerabilities (0 Critical, 0 High, 1 Medium, 0 Low, 9 Unknown) from 1 ecosystem.
+10 vulnerabilities can be fixed.
+
+Go
+
+lockfile:<rootdir>/fixtures/call-analysis-go-project/go.mod: found 2 packages with issues
+
+  github.com/ipfs/go-bitfield@1.0.0 has the following known vulnerabilities:
+    GO-2023-1558: Denial of service via malformed size parameters in github.com/ipfs/go-bitfield (https://osv.dev/GO-2023-1558)
+  stdlib@1.19.99 has the following known vulnerabilities:
+    GO-2023-2102: HTTP/2 rapid reset can cause excessive work in net/http (https://osv.dev/GO-2023-2102)
+    GO-2023-2185: Insecure parsing of Windows paths with a /??/ prefix in path/filepath (https://osv.dev/GO-2023-2185)
+    GO-2023-2375: Before Go 1.20, the RSA based key exchange methods in crypto/tls may exhibit a... (https://osv.dev/GO-2023-2375)
+    GO-2023-2382: Denial of service via chunk extensions in net/http (https://osv.dev/GO-2023-2382)
+    GO-2024-2598: Verify panics on certificates with an unknown public key algorithm in... (https://osv.dev/GO-2024-2598)
+    GO-2024-2599: Memory exhaustion in multipart form parsing in net/textproto and net/http (https://osv.dev/GO-2024-2599)
+    GO-2024-2687: HTTP/2 CONTINUATION flood in net/http (https://osv.dev/GO-2024-2687)
+    GO-2024-2887: Unexpected behavior from Is methods for IPv4-mapped IPv6 addresses in net/netip (https://osv.dev/GO-2024-2887)
+    GO-2025-3373: Usage of IPv6 zone IDs can bypass URI name constraints in crypto/x509 (https://osv.dev/GO-2025-3373)
+
+  10 known vulnerabilities found in lockfile:<rootdir>/fixtures/call-analysis-go-project/go.mod
+
+  github.com/gogo/protobuf@1.3.1 has the following uncalled vulnerabilities:
+    GO-2021-0053: Panic due to improper input validation in github.com/gogo/protobuf (https://osv.dev/GO-2021-0053)
+  golang.org/x/image@0.4.0 has the following uncalled vulnerabilities:
+    GO-2023-1572: Denial of service via crafted TIFF image in golang.org/x/image/tiff (https://osv.dev/GO-2023-1572)
+    GO-2023-1989: Excessive resource consumption in golang.org/x/image/tiff (https://osv.dev/GO-2023-1989)
+    GO-2023-1990: Excessive CPU consumption when decoding 0-height images in... (https://osv.dev/GO-2023-1990)
+    GO-2024-2937: Panic when parsing invalid palette-color images in golang.org/x/image (https://osv.dev/GO-2024-2937)
+  stdlib@1.19.99 has the following uncalled vulnerabilities:
+    GO-2023-2041: Improper handling of HTML-like comments in script contexts in html/template (https://osv.dev/GO-2023-2041)
+    GO-2023-2043: Improper handling of special tags within script contexts in html/template (https://osv.dev/GO-2023-2043)
+    GO-2023-2186: Incorrect detection of reserved device names on Windows in path/filepath (https://osv.dev/GO-2023-2186)
+    GO-2024-2600: Incorrect forwarding of sensitive headers and cookies on HTTP redirect in... (https://osv.dev/GO-2024-2600)
+    GO-2024-2609: Comments in display names are incorrectly handled in net/mail (https://osv.dev/GO-2024-2609)
+    GO-2024-2610: Errors returned from JSON marshaling may break template escaping in... (https://osv.dev/GO-2024-2610)
+    GO-2024-2888: Mishandling of corrupt central directory record in archive/zip (https://osv.dev/GO-2024-2888)
+    GO-2024-2963: Denial of service due to improper 100-continue handling in net/http (https://osv.dev/GO-2024-2963)
+    GO-2024-3105: Stack exhaustion in all Parse functions in go/parser (https://osv.dev/GO-2024-3105)
+    GO-2024-3106: Stack exhaustion in Decoder.Decode in encoding/gob (https://osv.dev/GO-2024-3106)
+    GO-2024-3107: Stack exhaustion in Parse in go/build/constraint (https://osv.dev/GO-2024-3107)
+    GO-2025-3420: Sensitive headers incorrectly sent after cross-domain redirect in net/http (https://osv.dev/GO-2025-3420)
+
+  17 uncalled/unimportant vulnerabilities found in lockfile:<rootdir>/fixtures/call-analysis-go-project/go.mod (filtered out)
+
 
 ---
 
@@ -1259,23 +1424,30 @@ Checking if docker image ("alpine:3.18.9") exists locally...
 Saving docker image ("alpine:3.18.9") to temporary file...
 Scanning image "alpine:3.18.9"
 
-Container Scanning Result (Alpine Linux v3.18):
 Total 2 packages affected by 3 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 3 Unknown) from 1 ecosystem.
 3 vulnerabilities can be fixed.
 
+Container image information:
+  OS version: Alpine Linux v3.18
+  Base Image 1 (alpine):
+    Layer 0 ADD alpine-minirootfs-3.18.9-x86_64.tar.gz / # buildkit (3 vulns)
+    Layer 1 CMD ["/bin/sh"]
+  Your Image:
 
 Alpine:v3.18
-+---------------------------------------------------------------------------------------------+
-| Source:os:lib/apk/db/installed                                                              |
-+---------+-------------------+---------------+------------+------------------+---------------+
-| PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
-+---------+-------------------+---------------+------------+------------------+---------------+
-| musl    | 1.2.4-r2          | Fix Available |          1 | # 0 Layer        | alpine        |
-| openssl | 3.1.7-r0          | Fix Available |          2 | # 0 Layer        | alpine        |
-+---------+-------------------+---------------+------------+------------------+---------------+
 
-For the most comprehensive scan results, we recommend using the HTML output: `osv-scanner scan image --serve <image_name>`.
-You can also view the full vulnerability list in your terminal with: `osv-scanner scan image --format vertical <image_name>`.
+os:lib/apk/db/installed: found 2 packages with issues
+
+  musl@1.2.4-r2 has the following known vulnerabilities:
+    introduced in # 0 Layer (alpine)
+    CVE-2025-26519: musl libc 0.9.13 through 1.2.5 before 1.2.6 has an out-of-bounds write... (https://osv.dev/CVE-2025-26519)
+  openssl@3.1.7-r0 has the following known vulnerabilities:
+    introduced in # 0 Layer (alpine)
+    CVE-2024-13176: Issue summary: A timing side-channel which could potentially allow recovering... (https://osv.dev/CVE-2024-13176)
+    CVE-2024-9143: Issue summary: Use of the low-level GF(2^m) elliptic curve APIs with untrusted... (https://osv.dev/CVE-2024-9143)
+
+  3 known vulnerabilities found in os:lib/apk/db/installed
+
 
 ---
 
@@ -1312,12 +1484,20 @@ No package sources found, --help for usage information.
 
 [Test_run_GithubActions/scanning_osv-scanner_custom_format - 1]
 Scanned <rootdir>/fixtures/locks-insecure/osv-scanner-flutter-deps.json file as a osv-scanner and found 3 packages
-+--------------------------------+------+-----------+----------------------------+-----------------------------+-------------------------------------------------------+
-| OSV URL                        | CVSS | ECOSYSTEM | PACKAGE                    | VERSION                     | SOURCE                                                |
-+--------------------------------+------+-----------+----------------------------+-----------------------------+-------------------------------------------------------+
-| https://osv.dev/CVE-2023-39137 | 7.8  | GIT       |  https://github.com/brendan-duncan/archive.git@9de7a054  | fixtures/locks-insecure/osv-scanner-flutter-deps.json |
-| https://osv.dev/CVE-2023-39139 | 7.8  | GIT       |  https://github.com/brendan-duncan/archive.git@9de7a054  | fixtures/locks-insecure/osv-scanner-flutter-deps.json |
-+--------------------------------+------+-----------+----------------------------------------------------------+-------------------------------------------------------+
+
+Total 1 package affected by 2 known vulnerabilities (0 Critical, 2 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+
+
+lockfile:<rootdir>/fixtures/locks-insecure/osv-scanner-flutter-deps.json: found 1 package with issues
+
+  https://github.com/brendan-duncan/archive.git@ has the following known vulnerabilities:
+    CVE-2023-39137: An issue in Archive v3.3.7 allows attackers to spoof zip filenames which can... (https://osv.dev/CVE-2023-39137)
+    CVE-2023-39139: An issue in Archive v3.3.7 allows attackers to execute a path traversal via... (https://osv.dev/CVE-2023-39139)
+
+  2 known vulnerabilities found in lockfile:<rootdir>/fixtures/locks-insecure/osv-scanner-flutter-deps.json
+
 
 ---
 
@@ -1478,18 +1658,25 @@ Scanned <rootdir>/fixtures/locks-licenses/package-lock.json file and found 4 pac
 overriding license for package npm/babel/6.23.0 with MIT AND (LGPL-2.1-or-later OR BSD-3-Clause)
 overriding license for package npm/human-signals/5.0.0 with LGPL-2.1-only OR MIT OR BSD-3-Clause
 overriding license for package npm/ms/2.1.3 with MIT WITH Bison-exception-2.2
-+----------------+-------------------------+
-| LICENSE        | NO. OF PACKAGE VERSIONS |
-+----------------+-------------------------+
-| MIT            |                       2 |
-| Apache-2.0     |                       1 |
-| CC0-1.0 OR MIT |                       1 |
-+----------------+-------------------------+
-+------------------------------+-----------+---------+---------+-------------------------------------------+
-| LICENSE VIOLATION            | ECOSYSTEM | PACKAGE | VERSION | SOURCE                                    |
-+------------------------------+-----------+---------+---------+-------------------------------------------+
-| MIT WITH Bison-exception-2.2 | npm       | ms      | 2.1.3   | fixtures/locks-licenses/package-lock.json |
-+------------------------------+-----------+---------+---------+-------------------------------------------+
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+License summary:
+  MIT: 2
+  Apache-2.0: 1
+  CC0-1.0 OR MIT: 1
+
+npm
+
+lockfile:<rootdir>/fixtures/locks-licenses/package-lock.json: found 0 packages with issues
+  no known vulnerabilities found
+
+  license violations found:
+    ms@2.1.3 (MIT WITH Bison-exception-2.2)
+
+  1 license violation found in lockfile:<rootdir>/fixtures/locks-licenses/package-lock.json
+
 
 ---
 
@@ -1503,19 +1690,26 @@ Scanned <rootdir>/fixtures/locks-licenses/package-lock.json file and found 4 pac
 overriding license for package npm/babel/6.23.0 with MIT AND (LGPL-2.1-or-later OR BSD-3-Clause))
 overriding license for package npm/human-signals/5.0.0 with LGPL-2.1-only OR OR BSD-3-Clause
 overriding license for package npm/ms/2.1.3 with MIT WITH (Bison-exception-2.2 AND somethingelse)
-+----------------+-------------------------+
-| LICENSE        | NO. OF PACKAGE VERSIONS |
-+----------------+-------------------------+
-| MIT            |                       2 |
-| Apache-2.0     |                       1 |
-| CC0-1.0 OR MIT |                       1 |
-+----------------+-------------------------+
-+--------------------------------------------------+-----------+---------------+---------+-------------------------------------------+
-| LICENSE VIOLATION                                | ECOSYSTEM | PACKAGE       | VERSION | SOURCE                                    |
-+--------------------------------------------------+-----------+---------------+---------+-------------------------------------------+
-| LGPL-2.1-only OR OR BSD-3-Clause                 | npm       | human-signals | 5.0.0   | fixtures/locks-licenses/package-lock.json |
-| MIT WITH (Bison-exception-2.2 AND somethingelse) | npm       | ms            | 2.1.3   | fixtures/locks-licenses/package-lock.json |
-+--------------------------------------------------+-----------+---------------+---------+-------------------------------------------+
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+License summary:
+  MIT: 2
+  Apache-2.0: 1
+  CC0-1.0 OR MIT: 1
+
+npm
+
+lockfile:<rootdir>/fixtures/locks-licenses/package-lock.json: found 0 packages with issues
+  no known vulnerabilities found
+
+  license violations found:
+    human-signals@5.0.0 (LGPL-2.1-only OR OR BSD-3-Clause)
+    ms@2.1.3 (MIT WITH (Bison-exception-2.2 AND somethingelse))
+
+  2 license violations found in lockfile:<rootdir>/fixtures/locks-licenses/package-lock.json
+
 
 ---
 
@@ -1622,13 +1816,16 @@ Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
 CVE-2025-26519 has been filtered out because: Test manifest file (alpine.cdx.xml)
 GHSA-whgm-jr23-g3j9 and 1 alias have been filtered out because: Test manifest file
 Filtered 2 vulnerabilities from output
-+------------+-------------------------+
-| LICENSE    | NO. OF PACKAGE VERSIONS |
-+------------+-------------------------+
-| Apache-2.0 |                       1 |
-| MIT        |                       1 |
-| UNKNOWN    |                      16 |
-+------------+-------------------------+
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 0 ecosystems.
+0 vulnerabilities can be fixed.
+
+License summary:
+  Apache-2.0: 1
+  MIT: 1
+  UNKNOWN: 16
+
+
 
 ---
 
@@ -1774,25 +1971,59 @@ ignoring license for package Alpine/ssl_client/1.36.1-r27
 ignoring license for package Alpine/zlib/1.2.13-r0
 overriding license for package Packagist/sentry/sdk/2.0.4 with 0BSD
 overriding license for package Packagist/league/flysystem/1.0.8 with 0BSD
-+-------------------------------------+------+-----------+------------------+----------+---------------------------------------+
-| OSV URL                             | CVSS | ECOSYSTEM | PACKAGE          | VERSION  | SOURCE                                |
-+-------------------------------------+------+-----------+------------------+----------+---------------------------------------+
-| https://osv.dev/GHSA-9f46-5r25-5wfm | 9.8  | Packagist | league/flysystem | 1.0.8    | fixtures/locks-insecure/composer.lock |
-| https://osv.dev/CVE-2025-26519      |      | Alpine    | musl             | 1.2.3-r4 | fixtures/locks-many/alpine.cdx.xml    |
-+-------------------------------------+------+-----------+------------------+----------+---------------------------------------+
-+---------+-------------------------+
-| LICENSE | NO. OF PACKAGE VERSIONS |
-+---------+-------------------------+
-| UNKNOWN |                      17 |
-+---------+-------------------------+
-+-------------------+-----------+------------------+----------+---------------------------------------+
-| LICENSE VIOLATION | ECOSYSTEM | PACKAGE          | VERSION  | SOURCE                                |
-+-------------------+-----------+------------------+----------+---------------------------------------+
-| 0BSD              | Packagist | league/flysystem | 1.0.8    | fixtures/locks-insecure/composer.lock |
-| UNKNOWN           | RubyGems  | ast              | 2.4.2    | fixtures/locks-many/Gemfile.lock      |
-| UNKNOWN           | Alpine    | musl             | 1.2.3-r4 | fixtures/locks-many/alpine.cdx.xml    |
-| 0BSD              | Packagist | sentry/sdk       | 2.0.4    | fixtures/locks-many/composer.lock     |
-+-------------------+-----------+------------------+----------+---------------------------------------+
+
+Total 2 packages affected by 2 known vulnerabilities (1 Critical, 0 High, 0 Medium, 0 Low, 1 Unknown) from 3 ecosystems.
+1 vulnerability can be fixed.
+
+License summary:
+  UNKNOWN: 17
+
+Packagist
+
+lockfile:<rootdir>/fixtures/locks-insecure/composer.lock: found 1 package with issues
+
+  league/flysystem@1.0.8 has the following known vulnerabilities:
+    GHSA-9f46-5r25-5wfm: Time-of-check Time-of-use (TOCTOU) Race Condition in league/flysystem (https://osv.dev/GHSA-9f46-5r25-5wfm)
+
+  1 known vulnerability found in lockfile:<rootdir>/fixtures/locks-insecure/composer.lock
+
+  license violations found:
+    league/flysystem@1.0.8 (0BSD)
+
+  1 license violation found in lockfile:<rootdir>/fixtures/locks-insecure/composer.lock
+
+lockfile:<rootdir>/fixtures/locks-many/composer.lock: found 0 packages with issues
+  no known vulnerabilities found
+
+  license violations found:
+    sentry/sdk@2.0.4 (0BSD)
+
+  1 license violation found in lockfile:<rootdir>/fixtures/locks-many/composer.lock
+
+RubyGems
+
+lockfile:<rootdir>/fixtures/locks-many/Gemfile.lock: found 0 packages with issues
+  no known vulnerabilities found
+
+  license violations found:
+    ast@2.4.2 (UNKNOWN)
+
+  1 license violation found in lockfile:<rootdir>/fixtures/locks-many/Gemfile.lock
+
+Alpine
+
+sbom:<rootdir>/fixtures/locks-many/alpine.cdx.xml: found 1 package with issues
+
+  musl@1.2.3-r4 has the following known vulnerabilities:
+    CVE-2025-26519: musl libc 0.9.13 through 1.2.5 before 1.2.6 has an out-of-bounds write... (https://osv.dev/CVE-2025-26519)
+
+  1 known vulnerability found in sbom:<rootdir>/fixtures/locks-many/alpine.cdx.xml
+
+  license violations found:
+    musl@1.2.3-r4 (UNKNOWN)
+
+  1 license violation found in sbom:<rootdir>/fixtures/locks-many/alpine.cdx.xml
+
 
 ---
 
@@ -1947,16 +2178,23 @@ Scanned <rootdir>/fixtures/locks-licenses/package-lock.json file and found 4 pac
 [Test_run_Licenses/Vulnerabilities_and_all_license_violations_allowlisted - 1]
 Scanning dir ./fixtures/locks-many/package-lock.json
 Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
-+-------------------------------------+------+-----------+-----------+---------+---------------------------------------+
-| OSV URL                             | CVSS | ECOSYSTEM | PACKAGE   | VERSION | SOURCE                                |
-+-------------------------------------+------+-----------+-----------+---------+---------------------------------------+
-| https://osv.dev/GHSA-whgm-jr23-g3j9 | 7.5  | npm       | ansi-html | 0.0.1   | fixtures/locks-many/package-lock.json |
-+-------------------------------------+------+-----------+-----------+---------+---------------------------------------+
-+------------+-------------------------+
-| LICENSE    | NO. OF PACKAGE VERSIONS |
-+------------+-------------------------+
-| Apache-2.0 |                       1 |
-+------------+-------------------------+
+
+Total 1 package affected by 1 known vulnerability (0 Critical, 1 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+1 vulnerability can be fixed.
+
+License summary:
+  Apache-2.0: 1
+
+npm
+
+lockfile:<rootdir>/fixtures/locks-many/package-lock.json: found 1 package with issues
+
+  ansi-html@0.0.1 has the following known vulnerabilities:
+    GHSA-whgm-jr23-g3j9: Uncontrolled Resource Consumption in ansi-html (https://osv.dev/GHSA-whgm-jr23-g3j9)
+
+  1 known vulnerability found in lockfile:<rootdir>/fixtures/locks-many/package-lock.json
+  no license violations found
+
 
 ---
 
@@ -1967,16 +2205,22 @@ Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
 [Test_run_Licenses/Vulnerabilities_and_license_summary - 1]
 Scanning dir ./fixtures/locks-many/package-lock.json
 Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
-+-------------------------------------+------+-----------+-----------+---------+---------------------------------------+
-| OSV URL                             | CVSS | ECOSYSTEM | PACKAGE   | VERSION | SOURCE                                |
-+-------------------------------------+------+-----------+-----------+---------+---------------------------------------+
-| https://osv.dev/GHSA-whgm-jr23-g3j9 | 7.5  | npm       | ansi-html | 0.0.1   | fixtures/locks-many/package-lock.json |
-+-------------------------------------+------+-----------+-----------+---------+---------------------------------------+
-+------------+-------------------------+
-| LICENSE    | NO. OF PACKAGE VERSIONS |
-+------------+-------------------------+
-| Apache-2.0 |                       1 |
-+------------+-------------------------+
+
+Total 1 package affected by 1 known vulnerability (0 Critical, 1 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+1 vulnerability can be fixed.
+
+License summary:
+  Apache-2.0: 1
+
+npm
+
+lockfile:<rootdir>/fixtures/locks-many/package-lock.json: found 1 package with issues
+
+  ansi-html@0.0.1 has the following known vulnerabilities:
+    GHSA-whgm-jr23-g3j9: Uncontrolled Resource Consumption in ansi-html (https://osv.dev/GHSA-whgm-jr23-g3j9)
+
+  1 known vulnerability found in lockfile:<rootdir>/fixtures/locks-many/package-lock.json
+
 
 ---
 
@@ -1987,21 +2231,27 @@ Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
 [Test_run_Licenses/Vulnerabilities_and_license_violations_with_allowlist - 1]
 Scanning dir ./fixtures/locks-many/package-lock.json
 Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
-+-------------------------------------+------+-----------+-----------+---------+---------------------------------------+
-| OSV URL                             | CVSS | ECOSYSTEM | PACKAGE   | VERSION | SOURCE                                |
-+-------------------------------------+------+-----------+-----------+---------+---------------------------------------+
-| https://osv.dev/GHSA-whgm-jr23-g3j9 | 7.5  | npm       | ansi-html | 0.0.1   | fixtures/locks-many/package-lock.json |
-+-------------------------------------+------+-----------+-----------+---------+---------------------------------------+
-+------------+-------------------------+
-| LICENSE    | NO. OF PACKAGE VERSIONS |
-+------------+-------------------------+
-| Apache-2.0 |                       1 |
-+------------+-------------------------+
-+-------------------+-----------+-----------+---------+---------------------------------------+
-| LICENSE VIOLATION | ECOSYSTEM | PACKAGE   | VERSION | SOURCE                                |
-+-------------------+-----------+-----------+---------+---------------------------------------+
-| Apache-2.0        | npm       | ansi-html | 0.0.1   | fixtures/locks-many/package-lock.json |
-+-------------------+-----------+-----------+---------+---------------------------------------+
+
+Total 1 package affected by 1 known vulnerability (0 Critical, 1 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+1 vulnerability can be fixed.
+
+License summary:
+  Apache-2.0: 1
+
+npm
+
+lockfile:<rootdir>/fixtures/locks-many/package-lock.json: found 1 package with issues
+
+  ansi-html@0.0.1 has the following known vulnerabilities:
+    GHSA-whgm-jr23-g3j9: Uncontrolled Resource Consumption in ansi-html (https://osv.dev/GHSA-whgm-jr23-g3j9)
+
+  1 known vulnerability found in lockfile:<rootdir>/fixtures/locks-many/package-lock.json
+
+  license violations found:
+    ansi-html@0.0.1 (Apache-2.0)
+
+  1 license violation found in lockfile:<rootdir>/fixtures/locks-many/package-lock.json
+
 
 ---
 
@@ -2092,6 +2342,11 @@ Scanned <rootdir>/fixtures/locks-many-with-invalid/yarn.lock file and found 1 pa
 Loaded RubyGems local db from <tempdir>/osv-scanner/RubyGems/all.zip
 Loaded npm local db from <tempdir>/osv-scanner/npm/all.zip
 
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 0 ecosystems.
+0 vulnerabilities can be fixed.
+
+
+
 ---
 
 [Test_run_LocalDatabases/all_supported_lockfiles_in_the_directory_should_be_checked#01 - 2]
@@ -2105,6 +2360,11 @@ Scanned <rootdir>/fixtures/locks-many-with-invalid/Gemfile.lock file and found 1
 Scanned <rootdir>/fixtures/locks-many-with-invalid/yarn.lock file and found 1 package
 Loaded RubyGems local db from <tempdir>/osv-scanner/RubyGems/all.zip
 Loaded npm local db from <tempdir>/osv-scanner/npm/all.zip
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 0 ecosystems.
+0 vulnerabilities can be fixed.
+
+
 
 ---
 
@@ -2233,209 +2493,251 @@ Scanned <rootdir>/fixtures/sbom-insecure/postgres-stretch.cdx.xml file and found
 Loaded Debian local db from <tempdir>/osv-scanner/Debian/all.zip
 Loaded Go local db from <tempdir>/osv-scanner/Go/all.zip
 Loaded OSS-Fuzz local db from <tempdir>/osv-scanner/OSS-Fuzz/all.zip
-+-------------------------------------+------+-----------+--------------------------------+------------------------------------+-------------------------------------------------+
-| OSV URL                             | CVSS | ECOSYSTEM | PACKAGE                        | VERSION                            | SOURCE                                          |
-+-------------------------------------+------+-----------+--------------------------------+------------------------------------+-------------------------------------------------+
-| https://osv.dev/DSA-4685-1          | 5.5  | Debian    | apt                            | 1.4.11                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-4808-1          | 5.7  | Debian    | apt                            | 1.4.11                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-0501       | 5.9  | Debian    | apt                            | 1.4.11                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2019-3462       | 8.1  | Debian    | apt                            | 1.4.11                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-3715       | 7.8  | Debian    | bash                           | 4.4-5                              | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2016-2781       | 6.5  | Debian    | coreutils                      | 8.26-3                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2024-0684       | 5.5  | Debian    | coreutils                      | 8.26-3                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3482-1          |      | Debian    | debian-archive-keyring         | 2017.5+deb9u2                      | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5147-1          | 9.8  | Debian    | dpkg                           | 1.18.25                            | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3022-1          |      | Debian    | dpkg                           | 1.18.25                            | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-4535-1          | 6.7  | Debian    | e2fsprogs                      | 1.43.4-2+deb9u2                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2019-5188       | 6.7  | Debian    | e2fsprogs                      | 1.43.4-2+deb9u2                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-1304       | 7.8  | Debian    | e2fsprogs                      | 1.43.4-2+deb9u2                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3910-1          |      | Debian    | e2fsprogs                      | 1.43.4-2+deb9u2                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/GO-2022-0274        | 6.0  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/GHSA-v95c-p5hm-xq8f |      |           |                                |                                    |                                                 |
-| https://osv.dev/GO-2022-0452        | 5.9  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/GHSA-f3fp-gc8g-vw66 |      |           |                                |                                    |                                                 |
-| https://osv.dev/GO-2023-1627        | 7.0  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/GHSA-vpvm-3wq2-2wvm |      |           |                                |                                    |                                                 |
-| https://osv.dev/GO-2023-1682        | 2.5  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/GHSA-m8cg-xc2p-r3fc |      |           |                                |                                    |                                                 |
-| https://osv.dev/GO-2023-1683        | 6.1  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/GHSA-g2j6-57v7-gm8c |      |           |                                |                                    |                                                 |
-| https://osv.dev/GO-2024-2491        | 8.6  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/GHSA-xr7r-f8xq-vfvv |      |           |                                |                                    |                                                 |
-| https://osv.dev/GO-2024-3110        | 4.8  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/GHSA-jfvp-7x6p-h2pv |      |           |                                |                                    |                                                 |
-| https://osv.dev/GO-2022-0493        | 5.3  | Go        | golang.org/x/sys               | v0.0.0-20210817142637-7d9622a276b7 | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/GHSA-p782-xgp4-8hr8 |      |           |                                |                                    |                                                 |
-| https://osv.dev/DSA-5122-1          | 8.8  | Debian    | gzip                           | 1.6-5+deb9u1                       | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-0379       | 7.5  | Debian    | libgcrypt20                    | 1.7.6-2+deb9u4                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-7526       | 6.8  | Debian    | libgcrypt20                    | 1.7.6-2+deb9u4                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-0495       | 4.7  | Debian    | libgcrypt20                    | 1.7.6-2+deb9u4                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2019-13627      | 6.3  | Debian    | libgcrypt20                    | 1.7.6-2+deb9u4                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2021-33560      | 7.5  | Debian    | libgcrypt20                    | 1.7.6-2+deb9u4                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2021-40528      | 5.9  | Debian    | libgcrypt20                    | 1.7.6-2+deb9u4                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2024-2236       |      | Debian    | libgcrypt20                    | 1.7.6-2+deb9u4                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5863-1          |      | Debian    | libtasn1-6                     | 4.10-1.1+deb9u1                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-10790      | 7.5  | Debian    | libtasn1-6                     | 4.10-1.1+deb9u1                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-6003       | 7.5  | Debian    | libtasn1-6                     | 4.10-1.1+deb9u1                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2021-46848      | 9.1  | Debian    | libtasn1-6                     | 4.10-1.1+deb9u1                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3263-1          |      | Debian    | libtasn1-6                     | 4.10-1.1+deb9u1                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-4061-1          |      | Debian    | libtasn1-6                     | 4.10-1.1+deb9u1                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5142-1          | 6.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5271-1          | 7.8  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5391-1          | 6.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2016-3709       | 6.1  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2016-9318       | 5.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-0663       | 7.8  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-15412      | 8.8  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-16931      | 9.8  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-16932      | 7.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-18258      | 6.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-5130       | 8.8  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-7375       | 9.8  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-7376       | 9.8  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-8872       | 9.1  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-9047       | 7.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-9048       | 7.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-9049       | 7.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-9050       | 7.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-14404      | 7.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-14567      | 6.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2019-19956      | 7.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2019-20388      | 7.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2020-7595       | 7.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2021-3516       | 7.8  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2021-3517       | 8.6  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2021-3518       | 8.8  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2021-3537       | 5.9  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2021-3541       | 6.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-2309       | 7.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-23308      | 7.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-49043      |      | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2024-25062      | 7.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2024-56171      |      | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2025-24928      |      | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2025-27113      | 7.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3012-1          |      | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3172-1          |      | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3405-1          |      | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3878-1          |      | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-4064-1          |      | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-4539-1          | 4.7  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-4539-3          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-4661-1          | 7.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-4807-1          | 5.9  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-4855-1          | 7.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-4875-1          | 5.9  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-4963-1          | 9.8  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5103-1          | 7.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5139-1          | 9.8  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5169-1          | 9.8  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5343-1          | 7.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5417-1          | 7.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5532-1          | 7.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5764-1          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-0732       | 7.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-0734       | 5.9  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-0735       | 5.9  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-5407       | 4.7  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2019-1543       | 7.4  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2019-1549       | 5.3  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2021-3450       | 7.4  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-2274       | 9.8  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-3358       | 7.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-3602       | 7.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-3786       | 7.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-3996       | 7.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-4203       | 4.9  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2023-0216       | 7.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2023-0217       | 7.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2023-0401       | 7.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2023-1255       | 5.9  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2023-2975       | 5.3  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2023-3446       | 5.3  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2023-3817       | 5.3  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2023-5678       | 5.3  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2023-6129       | 6.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2023-6237       |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2024-0727       | 5.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2024-12797      |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2024-13176      |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2024-2511       |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2024-4603       |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2024-4741       |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2024-5535       |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2024-9143       |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3008-1          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3325-1          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3449-1          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3530-1          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3942-1          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3942-2          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-12837      | 7.5  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-12883      | 9.1  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-12015      | 7.5  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-18311      | 9.8  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-18312      | 9.8  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-18313      | 9.1  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-18314      | 9.8  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-6797       | 9.8  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-6798       | 7.5  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-6913       | 9.8  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2020-10543      | 8.2  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2020-10878      | 8.6  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2020-12723      | 7.5  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2020-16156      | 7.8  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2021-36770      | 7.8  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2023-31484      | 8.1  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2023-47038      | 7.8  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3926-1          |      | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5135-1          |      | Debian    | postgresql-11                  | 11.15-1.pgdg90+1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3072-1          |      | Debian    | postgresql-11                  | 11.15-1.pgdg90+1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3189-1          |      | Debian    | postgresql-11                  | 11.15-1.pgdg90+1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3316-1          |      | Debian    | postgresql-11                  | 11.15-1.pgdg90+1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3422-1          |      | Debian    | postgresql-11                  | 11.15-1.pgdg90+1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3600-1          |      | Debian    | postgresql-11                  | 11.15-1.pgdg90+1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3651-1          |      | Debian    | postgresql-11                  | 11.15-1.pgdg90+1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3764-1          |      | Debian    | postgresql-11                  | 11.15-1.pgdg90+1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-17512      | 8.8  | Debian    | sensible-utils                 | 0.0.9+deb9u1                       | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-20482      | 4.7  | Debian    | tar                            | 1.29b-1.1+deb9u1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2023-39804      |      | Debian    | tar                            | 1.29b-1.1+deb9u1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3755-1          |      | Debian    | tar                            | 1.29b-1.1+deb9u1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3051-1          |      | Debian    | tzdata                         | 2021a-0+deb9u3                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3134-1          |      | Debian    | tzdata                         | 2021a-0+deb9u3                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3161-1          |      | Debian    | tzdata                         | 2021a-0+deb9u3                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3366-1          |      | Debian    | tzdata                         | 2021a-0+deb9u3                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3412-1          |      | Debian    | tzdata                         | 2021a-0+deb9u3                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3684-1          |      | Debian    | tzdata                         | 2021a-0+deb9u3                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3788-1          |      | Debian    | tzdata                         | 2021a-0+deb9u3                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3972-1          |      | Debian    | tzdata                         | 2021a-0+deb9u3                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-4016-1          |      | Debian    | ucf                            | 3.0036                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5055-1          | 5.5  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5650-1          |      | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2016-2779       | 7.8  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3782-1          |      | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5123-1          | 8.8  | Debian    | xz-utils                       | 5.2.2-1.2+deb9u1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2024-3094       | 10.0 | Debian    | xz-utils                       | 5.2.2-1.2+deb9u1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-+-------------------------------------+------+-----------+--------------------------------+------------------------------------+-------------------------------------------------+
-| Unimportant vulnerabilities         |      |           |                                |                                    |                                                 |
-+-------------------------------------+------+-----------+--------------------------------+------------------------------------+-------------------------------------------------+
-| https://osv.dev/CVE-2011-3374       | 3.7  | Debian    | apt                            | 1.4.11                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2019-18276      | 7.8  | Debian    | bash                           | 4.4-5                              | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-18018      | 4.7  | Debian    | coreutils                      | 8.26-3                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-6829       | 7.5  | Debian    | libgcrypt20                    | 1.7.6-2+deb9u4                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-1000654    | 5.5  | Debian    | libtasn1-6                     | 4.10-1.1+deb9u1                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2020-24977      | 6.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2024-34459      |      | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2011-4116       | 7.5  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-48522      | 9.8  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2023-31486      | 8.1  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2005-2541       |      | Debian    | tar                            | 1.29b-1.1+deb9u1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2019-9923       | 7.5  | Debian    | tar                            | 1.29b-1.1+deb9u1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2021-20193      | 3.3  | Debian    | tar                            | 1.29b-1.1+deb9u1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-48303      | 5.5  | Debian    | tar                            | 1.29b-1.1+deb9u1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-7738       | 7.8  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-0563       | 5.5  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-+-------------------------------------+------+-----------+--------------------------------+------------------------------------+-------------------------------------------------+
+
+Total 21 packages affected by 172 known vulnerabilities (18 Critical, 59 High, 41 Medium, 1 Low, 53 Unknown) from 2 ecosystems.
+8 vulnerabilities can be fixed.
+
+Go
+
+sbom:<rootdir>/fixtures/sbom-insecure/postgres-stretch.cdx.xml: found 2 packages with issues
+
+  github.com/opencontainers/runc@v1.0.1 has the following known vulnerabilities:
+    GO-2022-0274: Namespace restriction bypass in github.com/opencontainers/runc (https://osv.dev/GO-2022-0274)
+    GO-2022-0452: Default inheritable capabilities for linux container should be empty in... (https://osv.dev/GO-2022-0452)
+    GO-2023-1627: Opencontainers runc Incorrect Authorization vulnerability in... (https://osv.dev/GO-2023-1627)
+    GO-2023-1682: rootless: `/sys/fs/cgroup` is writable when cgroupns isn't unshared in runc in... (https://osv.dev/GO-2023-1682)
+    GO-2023-1683: runc AppArmor bypass with symlinked /proc in github.com/opencontainers/runc (https://osv.dev/GO-2023-1683)
+    GO-2024-2491: Container breakout through process.cwd trickery and leaked fds in... (https://osv.dev/GO-2024-2491)
+    GO-2024-3110: runc can be confused to create empty files/directories on the host in... (https://osv.dev/GO-2024-3110)
+  golang.org/x/sys@v0.0.0-20210817142637-7d9622a276b7 has the following known vulnerabilities:
+    GO-2022-0493: Incorrect privilege reporting in syscall and golang.org/x/sys/unix (https://osv.dev/GO-2022-0493)
+
+  8 known vulnerabilities found in sbom:<rootdir>/fixtures/sbom-insecure/postgres-stretch.cdx.xml
+
+Debian
+
+sbom:<rootdir>/fixtures/sbom-insecure/postgres-stretch.cdx.xml: found 19 packages with issues
+
+  apt@1.4.11 has the following known vulnerabilities:
+    DSA-4685-1: apt - security update (https://osv.dev/DSA-4685-1)
+    DSA-4808-1: apt - security update (https://osv.dev/DSA-4808-1)
+    CVE-2018-0501: The mirror:// method implementation in Advanced Package Tool (APT) 1.6.x before... (https://osv.dev/CVE-2018-0501)
+    CVE-2019-3462: Incorrect sanitation of the 302 redirect field in HTTP transport method of apt... (https://osv.dev/CVE-2019-3462)
+  bash@4.4-5 has the following known vulnerabilities:
+    CVE-2022-3715: A flaw was found in the bash package, where a heap-buffer overflow can occur in... (https://osv.dev/CVE-2022-3715)
+  coreutils@8.26-3 has the following known vulnerabilities:
+    CVE-2016-2781: chroot in GNU coreutils, when used with --userspec, allows local users to... (https://osv.dev/CVE-2016-2781)
+    CVE-2024-0684: A flaw was found in the GNU coreutils "split" program. A heap overflow with... (https://osv.dev/CVE-2024-0684)
+  debian-archive-keyring@2017.5+deb9u2 has the following known vulnerabilities:
+    DLA-3482-1: debian-archive-keyring - security update (https://osv.dev/DLA-3482-1)
+  dpkg@1.18.25 has the following known vulnerabilities:
+    DSA-5147-1: dpkg - security update (https://osv.dev/DSA-5147-1)
+    DLA-3022-1: dpkg - security update (https://osv.dev/DLA-3022-1)
+  e2fsprogs@1.43.4-2+deb9u2 has the following known vulnerabilities:
+    DSA-4535-1: e2fsprogs - security update (https://osv.dev/DSA-4535-1)
+    CVE-2019-5188: A code execution vulnerability exists in the directory rehashing functionality... (https://osv.dev/CVE-2019-5188)
+    CVE-2022-1304: An out-of-bounds read/write vulnerability was found in e2fsprogs 1.46.5. This... (https://osv.dev/CVE-2022-1304)
+    DLA-3910-1: e2fsprogs - security update (https://osv.dev/DLA-3910-1)
+  gzip@1.6-5+deb9u1 has the following known vulnerabilities:
+    DSA-5122-1: gzip - security update (https://osv.dev/DSA-5122-1)
+  libgcrypt20@1.7.6-2+deb9u4 has the following known vulnerabilities:
+    CVE-2017-0379: Libgcrypt before 1.8.1 does not properly consider Curve25519 side-channel... (https://osv.dev/CVE-2017-0379)
+    CVE-2017-7526: libgcrypt before version 1.7.8 is vulnerable to a cache side-channel attack... (https://osv.dev/CVE-2017-7526)
+    CVE-2018-0495: Libgcrypt before 1.7.10 and 1.8.x before 1.8.3 allows a memory-cache... (https://osv.dev/CVE-2018-0495)
+    CVE-2019-13627: It was discovered that there was a ECDSA timing attack in the libgcrypt20... (https://osv.dev/CVE-2019-13627)
+    CVE-2021-33560: Libgcrypt before 1.8.8 and 1.9.x before 1.9.3 mishandles ElGamal encryption... (https://osv.dev/CVE-2021-33560)
+    CVE-2021-40528: The ElGamal implementation in Libgcrypt before 1.9.4 allows plaintext recovery... (https://osv.dev/CVE-2021-40528)
+    CVE-2024-2236: A timing-based side-channel flaw was found in libgcrypt's RSA implementation.... (https://osv.dev/CVE-2024-2236)
+  libtasn1-6@4.10-1.1+deb9u1 has the following known vulnerabilities:
+    DSA-5863-1: libtasn1-6 - security update (https://osv.dev/DSA-5863-1)
+    CVE-2017-10790: The _asn1_check_identifier function in GNU Libtasn1 through 4.12 causes a NULL... (https://osv.dev/CVE-2017-10790)
+    CVE-2018-6003: An issue was discovered in the _asn1_decode_simple_ber function in decoding.c... (https://osv.dev/CVE-2018-6003)
+    CVE-2021-46848: GNU Libtasn1 before 4.19.0 has an ETYPE_OK off-by-one array size check that... (https://osv.dev/CVE-2021-46848)
+    DLA-3263-1: libtasn1-6 - security update (https://osv.dev/DLA-3263-1)
+    DLA-4061-1: libtasn1-6 - security update (https://osv.dev/DLA-4061-1)
+  libxml2@2.9.4+dfsg1-2.2+deb9u6 has the following known vulnerabilities:
+    DSA-5142-1: libxml2 - security update (https://osv.dev/DSA-5142-1)
+    DSA-5271-1: libxml2 - security update (https://osv.dev/DSA-5271-1)
+    DSA-5391-1: libxml2 - security update (https://osv.dev/DSA-5391-1)
+    CVE-2016-3709: Possible cross-site scripting vulnerability in libxml after commit 960f0e2. (https://osv.dev/CVE-2016-3709)
+    CVE-2016-9318: libxml2 2.9.4 and earlier, as used in XMLSec 1.2.23 and earlier and other... (https://osv.dev/CVE-2016-9318)
+    CVE-2017-0663: A remote code execution vulnerability in libxml2 could enable an attacker using... (https://osv.dev/CVE-2017-0663)
+    CVE-2017-15412: Use after free in libxml2 before 2.9.5, as used in Google Chrome prior to... (https://osv.dev/CVE-2017-15412)
+    CVE-2017-16931: parser.c in libxml2 before 2.9.5 mishandles parameter-entity references because... (https://osv.dev/CVE-2017-16931)
+    CVE-2017-16932: parser.c in libxml2 before 2.9.5 does not prevent infinite recursion in... (https://osv.dev/CVE-2017-16932)
+    CVE-2017-18258: The xz_head function in xzlib.c in libxml2 before 2.9.6 allows remote attackers... (https://osv.dev/CVE-2017-18258)
+    CVE-2017-5130: An integer overflow in xmlmemory.c in libxml2 before 2.9.5, as used in Google... (https://osv.dev/CVE-2017-5130)
+    CVE-2017-7375: A flaw in libxml2 allows remote XML entity inclusion with default parser flags... (https://osv.dev/CVE-2017-7375)
+    CVE-2017-7376: Buffer overflow in libxml2 allows remote attackers to execute arbitrary code by... (https://osv.dev/CVE-2017-7376)
+    CVE-2017-8872: The htmlParseTryOrFinish function in HTMLparser.c in libxml2 2.9.4 allows... (https://osv.dev/CVE-2017-8872)
+    CVE-2017-9047: A buffer overflow was discovered in libxml2 20904-GITv2.9.4-16-g0741801. The... (https://osv.dev/CVE-2017-9047)
+    CVE-2017-9048: libxml2 20904-GITv2.9.4-16-g0741801 is vulnerable to a stack-based buffer... (https://osv.dev/CVE-2017-9048)
+    CVE-2017-9049: libxml2 20904-GITv2.9.4-16-g0741801 is vulnerable to a heap-based buffer... (https://osv.dev/CVE-2017-9049)
+    CVE-2017-9050: libxml2 20904-GITv2.9.4-16-g0741801 is vulnerable to a heap-based buffer... (https://osv.dev/CVE-2017-9050)
+    CVE-2018-14404: A NULL pointer dereference vulnerability exists in the... (https://osv.dev/CVE-2018-14404)
+    CVE-2018-14567: libxml2 2.9.8, if --with-lzma is used, allows remote attackers to cause a... (https://osv.dev/CVE-2018-14567)
+    CVE-2019-19956: xmlParseBalancedChunkMemoryRecover in parser.c in libxml2 before 2.9.10 has a... (https://osv.dev/CVE-2019-19956)
+    CVE-2019-20388: xmlSchemaPreRun in xmlschemas.c in libxml2 2.9.10 allows an... (https://osv.dev/CVE-2019-20388)
+    CVE-2020-7595: xmlStringLenDecodeEntities in parser.c in libxml2 2.9.10 has an infinite loop... (https://osv.dev/CVE-2020-7595)
+    CVE-2021-3516: There's a flaw in libxml2's xmllint in versions before 2.9.11. An attacker who... (https://osv.dev/CVE-2021-3516)
+    CVE-2021-3517: There is a flaw in the xml entity encoding functionality of libxml2 in versions... (https://osv.dev/CVE-2021-3517)
+    CVE-2021-3518: There's a flaw in libxml2 in versions before 2.9.11. An attacker who is able to... (https://osv.dev/CVE-2021-3518)
+    CVE-2021-3537: A vulnerability found in libxml2 in versions before 2.9.11 shows that it did... (https://osv.dev/CVE-2021-3537)
+    CVE-2021-3541: A flaw was found in libxml2. Exponential entity expansion attack its possible... (https://osv.dev/CVE-2021-3541)
+    CVE-2022-2309: NULL Pointer Dereference allows attackers to cause a denial of service (or... (https://osv.dev/CVE-2022-2309)
+    CVE-2022-23308: valid.c in libxml2 before 2.9.13 has a use-after-free of ID and IDREF... (https://osv.dev/CVE-2022-23308)
+    CVE-2022-49043: xmlXIncludeAddNode in xinclude.c in libxml2 before 2.11.0 has a use-after-free. (https://osv.dev/CVE-2022-49043)
+    CVE-2024-25062: An issue was discovered in libxml2 before 2.11.7 and 2.12.x before 2.12.5. When... (https://osv.dev/CVE-2024-25062)
+    CVE-2024-56171: libxml2 before 2.12.10 and 2.13.x before 2.13.6 has a use-after-free in... (https://osv.dev/CVE-2024-56171)
+    CVE-2025-24928: libxml2 before 2.12.10 and 2.13.x before 2.13.6 has a stack-based buffer... (https://osv.dev/CVE-2025-24928)
+    CVE-2025-27113: libxml2 before 2.12.10 and 2.13.x before 2.13.6 has a NULL pointer dereference... (https://osv.dev/CVE-2025-27113)
+    DLA-3012-1: libxml2 - security update (https://osv.dev/DLA-3012-1)
+    DLA-3172-1: libxml2 - security update (https://osv.dev/DLA-3172-1)
+    DLA-3405-1: libxml2 - security update (https://osv.dev/DLA-3405-1)
+    DLA-3878-1: libxml2 - security update (https://osv.dev/DLA-3878-1)
+    DLA-4064-1: libxml2 - security update (https://osv.dev/DLA-4064-1)
+  openssl@1.1.0l-1~deb9u5 has the following known vulnerabilities:
+    DSA-4539-1: openssl - security update (https://osv.dev/DSA-4539-1)
+    DSA-4539-3: openssl - regression update (https://osv.dev/DSA-4539-3)
+    DSA-4661-1: openssl - security update (https://osv.dev/DSA-4661-1)
+    DSA-4807-1: openssl - security update (https://osv.dev/DSA-4807-1)
+    DSA-4855-1: openssl - security update (https://osv.dev/DSA-4855-1)
+    DSA-4875-1: openssl - security update (https://osv.dev/DSA-4875-1)
+    DSA-4963-1: openssl - security update (https://osv.dev/DSA-4963-1)
+    DSA-5103-1: openssl - security update (https://osv.dev/DSA-5103-1)
+    DSA-5139-1: openssl - security update (https://osv.dev/DSA-5139-1)
+    DSA-5169-1: openssl - security update (https://osv.dev/DSA-5169-1)
+    DSA-5343-1: openssl - security update (https://osv.dev/DSA-5343-1)
+    DSA-5417-1: openssl - security update (https://osv.dev/DSA-5417-1)
+    DSA-5532-1: openssl - security update (https://osv.dev/DSA-5532-1)
+    DSA-5764-1: openssl - security update (https://osv.dev/DSA-5764-1)
+    CVE-2018-0732: During key agreement in a TLS handshake using a DH(E) based ciphersuite a... (https://osv.dev/CVE-2018-0732)
+    CVE-2018-0734: The OpenSSL DSA signature algorithm has been shown to be vulnerable to a timing... (https://osv.dev/CVE-2018-0734)
+    CVE-2018-0735: The OpenSSL ECDSA signature algorithm has been shown to be vulnerable to a... (https://osv.dev/CVE-2018-0735)
+    CVE-2018-5407: Simultaneous Multi-threading (SMT) in processors can enable local users to... (https://osv.dev/CVE-2018-5407)
+    CVE-2019-1543: ChaCha20-Poly1305 is an AEAD cipher, and requires a unique nonce input for... (https://osv.dev/CVE-2019-1543)
+    CVE-2019-1549: OpenSSL 1.1.1 introduced a rewritten random number generator (RNG). This was... (https://osv.dev/CVE-2019-1549)
+    CVE-2021-3450: The X509_V_FLAG_X509_STRICT flag enables additional security checks of the... (https://osv.dev/CVE-2021-3450)
+    CVE-2022-2274: The OpenSSL 3.0.4 release introduced a serious bug in the RSA implementation... (https://osv.dev/CVE-2022-2274)
+    CVE-2022-3358: OpenSSL supports creating a custom cipher via the legacy EVP_CIPHER_meth_new()... (https://osv.dev/CVE-2022-3358)
+    CVE-2022-3602: A buffer overrun can be triggered in X.509 certificate verification,... (https://osv.dev/CVE-2022-3602)
+    CVE-2022-3786: A buffer overrun can be triggered in X.509 certificate verification,... (https://osv.dev/CVE-2022-3786)
+    CVE-2022-3996: If an X.509 certificate contains a malformed policy constraint and
+policy... (https://osv.dev/CVE-2022-3996)
+    CVE-2022-4203: A read buffer overrun can be triggered in X.509 certificate verification,... (https://osv.dev/CVE-2022-4203)
+    CVE-2023-0216: An invalid pointer dereference on read can be triggered when an
+application... (https://osv.dev/CVE-2023-0216)
+    CVE-2023-0217: An invalid pointer dereference on read can be triggered when an
+application... (https://osv.dev/CVE-2023-0217)
+    CVE-2023-0401: A NULL pointer can be dereferenced when signatures are being
+verified on PKCS7... (https://osv.dev/CVE-2023-0401)
+    CVE-2023-1255: Issue summary: The AES-XTS cipher decryption implementation for 64 bit ARM... (https://osv.dev/CVE-2023-1255)
+    CVE-2023-2975: Issue summary: The AES-SIV cipher implementation contains a bug that causes
+it... (https://osv.dev/CVE-2023-2975)
+    CVE-2023-3446: Issue summary: Checking excessively long DH keys or parameters may be very... (https://osv.dev/CVE-2023-3446)
+    CVE-2023-3817: Issue summary: Checking excessively long DH keys or parameters may be very... (https://osv.dev/CVE-2023-3817)
+    CVE-2023-5678: Issue summary: Generating excessively long X9.42 DH keys or checking... (https://osv.dev/CVE-2023-5678)
+    CVE-2023-6129: Issue summary: The POLY1305 MAC (message authentication code) implementation... (https://osv.dev/CVE-2023-6129)
+    CVE-2023-6237: Issue summary: Checking excessively long invalid RSA public keys may take
+a... (https://osv.dev/CVE-2023-6237)
+    CVE-2024-0727: Issue summary: Processing a maliciously formatted PKCS12 file may lead OpenSSL... (https://osv.dev/CVE-2024-0727)
+    CVE-2024-12797: Issue summary: Clients using RFC7250 Raw Public Keys (RPKs) to authenticate a... (https://osv.dev/CVE-2024-12797)
+    CVE-2024-13176: Issue summary: A timing side-channel which could potentially allow recovering... (https://osv.dev/CVE-2024-13176)
+    CVE-2024-2511: Issue summary: Some non-default TLS server configurations can cause unbounded... (https://osv.dev/CVE-2024-2511)
+    CVE-2024-4603: Issue summary: Checking excessively long DSA keys or parameters may be very... (https://osv.dev/CVE-2024-4603)
+    CVE-2024-4741: Issue summary: Calling the OpenSSL API function SSL_free_buffers may cause... (https://osv.dev/CVE-2024-4741)
+    CVE-2024-5535: Issue summary: Calling the OpenSSL API function SSL_select_next_proto with an... (https://osv.dev/CVE-2024-5535)
+    CVE-2024-9143: Issue summary: Use of the low-level GF(2^m) elliptic curve APIs with untrusted... (https://osv.dev/CVE-2024-9143)
+    DLA-3008-1: openssl - security update (https://osv.dev/DLA-3008-1)
+    DLA-3325-1: openssl - security update (https://osv.dev/DLA-3325-1)
+    DLA-3449-1: openssl - security update (https://osv.dev/DLA-3449-1)
+    DLA-3530-1: openssl - security update (https://osv.dev/DLA-3530-1)
+    DLA-3942-1: openssl - security update (https://osv.dev/DLA-3942-1)
+    DLA-3942-2: openssl - regression update (https://osv.dev/DLA-3942-2)
+  perl@5.24.1-3+deb9u7 has the following known vulnerabilities:
+    CVE-2017-12837: Heap-based buffer overflow in the S_regatom function in regcomp.c in Perl 5... (https://osv.dev/CVE-2017-12837)
+    CVE-2017-12883: Buffer overflow in the S_grok_bslash_N function in regcomp.c in Perl 5 before... (https://osv.dev/CVE-2017-12883)
+    CVE-2018-12015: In Perl through 5.26.2, the Archive::Tar module allows remote attackers to... (https://osv.dev/CVE-2018-12015)
+    CVE-2018-18311: Perl before 5.26.3 and 5.28.x before 5.28.1 has a buffer overflow via a crafted... (https://osv.dev/CVE-2018-18311)
+    CVE-2018-18312: Perl before 5.26.3 and 5.28.0 before 5.28.1 has a buffer overflow via a crafted... (https://osv.dev/CVE-2018-18312)
+    CVE-2018-18313: Perl before 5.26.3 has a buffer over-read via a crafted regular expression that... (https://osv.dev/CVE-2018-18313)
+    CVE-2018-18314: Perl before 5.26.3 has a buffer overflow via a crafted regular expression that... (https://osv.dev/CVE-2018-18314)
+    CVE-2018-6797: An issue was discovered in Perl 5.18 through 5.26. A crafted regular expression... (https://osv.dev/CVE-2018-6797)
+    CVE-2018-6798: An issue was discovered in Perl 5.22 through 5.26. Matching a crafted locale... (https://osv.dev/CVE-2018-6798)
+    CVE-2018-6913: Heap-based buffer overflow in the pack function in Perl before 5.26.2 allows... (https://osv.dev/CVE-2018-6913)
+    CVE-2020-10543: Perl before 5.30.3 on 32-bit platforms allows a heap-based buffer overflow... (https://osv.dev/CVE-2020-10543)
+    CVE-2020-10878: Perl before 5.30.3 has an integer overflow related to mishandling of a... (https://osv.dev/CVE-2020-10878)
+    CVE-2020-12723: regcomp.c in Perl before 5.30.3 allows a buffer overflow via a crafted regular... (https://osv.dev/CVE-2020-12723)
+    CVE-2020-16156: CPAN 2.28 allows Signature Verification Bypass. (https://osv.dev/CVE-2020-16156)
+    CVE-2021-36770: Encode.pm, as distributed in Perl through 5.34.0, allows local users to gain... (https://osv.dev/CVE-2021-36770)
+    CVE-2023-31484: CPAN.pm before 2.35 does not verify TLS certificates when downloading... (https://osv.dev/CVE-2023-31484)
+    CVE-2023-47038: A vulnerability was found in perl 5.30.0 through 5.38.0. This issue occurs when... (https://osv.dev/CVE-2023-47038)
+    DLA-3926-1: perl - security update (https://osv.dev/DLA-3926-1)
+  postgresql-11@11.15-1.pgdg90+1 has the following known vulnerabilities:
+    DSA-5135-1: postgresql-11 - security update (https://osv.dev/DSA-5135-1)
+    DLA-3072-1: postgresql-11 - security update (https://osv.dev/DLA-3072-1)
+    DLA-3189-1: postgresql-11 - bugfix update (https://osv.dev/DLA-3189-1)
+    DLA-3316-1: postgresql-11 - security update (https://osv.dev/DLA-3316-1)
+    DLA-3422-1: postgresql-11 - security update (https://osv.dev/DLA-3422-1)
+    DLA-3600-1: postgresql-11 - security update (https://osv.dev/DLA-3600-1)
+    DLA-3651-1: postgresql-11 - security update (https://osv.dev/DLA-3651-1)
+    DLA-3764-1: postgresql-11 - security update (https://osv.dev/DLA-3764-1)
+  sensible-utils@0.0.9+deb9u1 has the following known vulnerabilities:
+    CVE-2017-17512: sensible-browser in sensible-utils before 0.0.11 does not validate strings... (https://osv.dev/CVE-2017-17512)
+  tar@1.29b-1.1+deb9u1 has the following known vulnerabilities:
+    CVE-2018-20482: GNU Tar through 1.30, when --sparse is used, mishandles file shrinkage during... (https://osv.dev/CVE-2018-20482)
+    CVE-2023-39804: In GNU tar before 1.35, mishandled extension attributes in a PAX archive can... (https://osv.dev/CVE-2023-39804)
+    DLA-3755-1: tar - security update (https://osv.dev/DLA-3755-1)
+  tzdata@2021a-0+deb9u3 has the following known vulnerabilities:
+    DLA-3051-1: tzdata - new timezone database (https://osv.dev/DLA-3051-1)
+    DLA-3134-1: tzdata - new timezone database (https://osv.dev/DLA-3134-1)
+    DLA-3161-1: tzdata - new timezone database (https://osv.dev/DLA-3161-1)
+    DLA-3366-1: tzdata - new timezone database (https://osv.dev/DLA-3366-1)
+    DLA-3412-1: tzdata - new timezone database (https://osv.dev/DLA-3412-1)
+    DLA-3684-1: tzdata - new timezone database (https://osv.dev/DLA-3684-1)
+    DLA-3788-1: tzdata - new timezone database (https://osv.dev/DLA-3788-1)
+    DLA-3972-1: tzdata - new timezone database (https://osv.dev/DLA-3972-1)
+  ucf@3.0036 has the following known vulnerabilities:
+    DLA-4016-1: ucf - security update (https://osv.dev/DLA-4016-1)
+  util-linux@2.29.2-1+deb9u1 has the following known vulnerabilities:
+    DSA-5055-1: util-linux - security update (https://osv.dev/DSA-5055-1)
+    DSA-5650-1: util-linux - security update (https://osv.dev/DSA-5650-1)
+    CVE-2016-2779: runuser in util-linux allows local users to escape to the parent session via a... (https://osv.dev/CVE-2016-2779)
+    DLA-3782-1: util-linux - security update (https://osv.dev/DLA-3782-1)
+  xz-utils@5.2.2-1.2+deb9u1 has the following known vulnerabilities:
+    DSA-5123-1: xz-utils - security update (https://osv.dev/DSA-5123-1)
+    CVE-2024-3094: Malicious code was discovered in the upstream tarballs of xz, starting with... (https://osv.dev/CVE-2024-3094)
+
+  164 known vulnerabilities found in sbom:<rootdir>/fixtures/sbom-insecure/postgres-stretch.cdx.xml
+
+  apt@1.4.11 has the following unimportant vulnerabilities:
+    CVE-2011-3374: It was found that apt-key in apt, all versions, do not correctly validate gpg... (https://osv.dev/CVE-2011-3374)
+  bash@4.4-5 has the following unimportant vulnerabilities:
+    CVE-2019-18276: An issue was discovered in disable_priv_mode in shell.c in GNU Bash through 5.0... (https://osv.dev/CVE-2019-18276)
+  coreutils@8.26-3 has the following unimportant vulnerabilities:
+    CVE-2017-18018: In GNU Coreutils through 8.29, chown-core.c in chown and chgrp does not prevent... (https://osv.dev/CVE-2017-18018)
+  libgcrypt20@1.7.6-2+deb9u4 has the following unimportant vulnerabilities:
+    CVE-2018-6829: cipher/elgamal.c in Libgcrypt through 1.8.2, when used to encrypt messages... (https://osv.dev/CVE-2018-6829)
+  libtasn1-6@4.10-1.1+deb9u1 has the following unimportant vulnerabilities:
+    CVE-2018-1000654: GNU Libtasn1-4.13 libtasn1-4.13 version libtasn1-4.13, libtasn1-4.12 contains a... (https://osv.dev/CVE-2018-1000654)
+  libxml2@2.9.4+dfsg1-2.2+deb9u6 has the following unimportant vulnerabilities:
+    CVE-2020-24977: GNOME project libxml2 v2.9.10 has a global buffer over-read vulnerability in... (https://osv.dev/CVE-2020-24977)
+    CVE-2024-34459: An issue was discovered in xmllint (from libxml2) before 2.11.8 and 2.12.x... (https://osv.dev/CVE-2024-34459)
+  perl@5.24.1-3+deb9u7 has the following unimportant vulnerabilities:
+    CVE-2011-4116: _is_safe in the File::Temp module for Perl does not properly handle symlinks. (https://osv.dev/CVE-2011-4116)
+    CVE-2022-48522: In Perl 5.34.0, function S_find_uninit_var in sv.c has a stack-based crash that... (https://osv.dev/CVE-2022-48522)
+    CVE-2023-31486: HTTP::Tiny before 0.083, a Perl core module since 5.13.9 and available... (https://osv.dev/CVE-2023-31486)
+  tar@1.29b-1.1+deb9u1 has the following unimportant vulnerabilities:
+    CVE-2005-2541: Tar 1.15.1 does not properly warn the user when extracting setuid or setgid... (https://osv.dev/CVE-2005-2541)
+    CVE-2019-9923: pax_decode_header in sparse.c in GNU Tar before 1.32 had a NULL pointer... (https://osv.dev/CVE-2019-9923)
+    CVE-2021-20193: A flaw was found in the src/list.c of tar 1.33 and earlier. This flaw allows an... (https://osv.dev/CVE-2021-20193)
+    CVE-2022-48303: GNU Tar through 1.34 has a one-byte out-of-bounds read that results in use of... (https://osv.dev/CVE-2022-48303)
+  util-linux@2.29.2-1+deb9u1 has the following unimportant vulnerabilities:
+    CVE-2018-7738: In util-linux before 2.32-rc1, bash-completion/umount allows local users to... (https://osv.dev/CVE-2018-7738)
+    CVE-2022-0563: A flaw was found in the util-linux chfn and chsh utilities when compiled with... (https://osv.dev/CVE-2022-0563)
+
+  16 uncalled/unimportant vulnerabilities found in sbom:<rootdir>/fixtures/sbom-insecure/postgres-stretch.cdx.xml (filtered out)
+
 
 ---
 
@@ -2449,209 +2751,251 @@ Scanned <rootdir>/fixtures/sbom-insecure/postgres-stretch.cdx.xml file and found
 Loaded Debian local db from <tempdir>/osv-scanner/Debian/all.zip
 Loaded Go local db from <tempdir>/osv-scanner/Go/all.zip
 Loaded OSS-Fuzz local db from <tempdir>/osv-scanner/OSS-Fuzz/all.zip
-+-------------------------------------+------+-----------+--------------------------------+------------------------------------+-------------------------------------------------+
-| OSV URL                             | CVSS | ECOSYSTEM | PACKAGE                        | VERSION                            | SOURCE                                          |
-+-------------------------------------+------+-----------+--------------------------------+------------------------------------+-------------------------------------------------+
-| https://osv.dev/DSA-4685-1          | 5.5  | Debian    | apt                            | 1.4.11                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-4808-1          | 5.7  | Debian    | apt                            | 1.4.11                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-0501       | 5.9  | Debian    | apt                            | 1.4.11                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2019-3462       | 8.1  | Debian    | apt                            | 1.4.11                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-3715       | 7.8  | Debian    | bash                           | 4.4-5                              | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2016-2781       | 6.5  | Debian    | coreutils                      | 8.26-3                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2024-0684       | 5.5  | Debian    | coreutils                      | 8.26-3                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3482-1          |      | Debian    | debian-archive-keyring         | 2017.5+deb9u2                      | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5147-1          | 9.8  | Debian    | dpkg                           | 1.18.25                            | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3022-1          |      | Debian    | dpkg                           | 1.18.25                            | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-4535-1          | 6.7  | Debian    | e2fsprogs                      | 1.43.4-2+deb9u2                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2019-5188       | 6.7  | Debian    | e2fsprogs                      | 1.43.4-2+deb9u2                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-1304       | 7.8  | Debian    | e2fsprogs                      | 1.43.4-2+deb9u2                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3910-1          |      | Debian    | e2fsprogs                      | 1.43.4-2+deb9u2                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/GO-2022-0274        | 6.0  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/GHSA-v95c-p5hm-xq8f |      |           |                                |                                    |                                                 |
-| https://osv.dev/GO-2022-0452        | 5.9  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/GHSA-f3fp-gc8g-vw66 |      |           |                                |                                    |                                                 |
-| https://osv.dev/GO-2023-1627        | 7.0  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/GHSA-vpvm-3wq2-2wvm |      |           |                                |                                    |                                                 |
-| https://osv.dev/GO-2023-1682        | 2.5  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/GHSA-m8cg-xc2p-r3fc |      |           |                                |                                    |                                                 |
-| https://osv.dev/GO-2023-1683        | 6.1  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/GHSA-g2j6-57v7-gm8c |      |           |                                |                                    |                                                 |
-| https://osv.dev/GO-2024-2491        | 8.6  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/GHSA-xr7r-f8xq-vfvv |      |           |                                |                                    |                                                 |
-| https://osv.dev/GO-2024-3110        | 4.8  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/GHSA-jfvp-7x6p-h2pv |      |           |                                |                                    |                                                 |
-| https://osv.dev/GO-2022-0493        | 5.3  | Go        | golang.org/x/sys               | v0.0.0-20210817142637-7d9622a276b7 | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/GHSA-p782-xgp4-8hr8 |      |           |                                |                                    |                                                 |
-| https://osv.dev/DSA-5122-1          | 8.8  | Debian    | gzip                           | 1.6-5+deb9u1                       | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-0379       | 7.5  | Debian    | libgcrypt20                    | 1.7.6-2+deb9u4                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-7526       | 6.8  | Debian    | libgcrypt20                    | 1.7.6-2+deb9u4                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-0495       | 4.7  | Debian    | libgcrypt20                    | 1.7.6-2+deb9u4                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2019-13627      | 6.3  | Debian    | libgcrypt20                    | 1.7.6-2+deb9u4                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2021-33560      | 7.5  | Debian    | libgcrypt20                    | 1.7.6-2+deb9u4                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2021-40528      | 5.9  | Debian    | libgcrypt20                    | 1.7.6-2+deb9u4                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2024-2236       |      | Debian    | libgcrypt20                    | 1.7.6-2+deb9u4                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5863-1          |      | Debian    | libtasn1-6                     | 4.10-1.1+deb9u1                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-10790      | 7.5  | Debian    | libtasn1-6                     | 4.10-1.1+deb9u1                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-6003       | 7.5  | Debian    | libtasn1-6                     | 4.10-1.1+deb9u1                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2021-46848      | 9.1  | Debian    | libtasn1-6                     | 4.10-1.1+deb9u1                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3263-1          |      | Debian    | libtasn1-6                     | 4.10-1.1+deb9u1                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-4061-1          |      | Debian    | libtasn1-6                     | 4.10-1.1+deb9u1                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5142-1          | 6.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5271-1          | 7.8  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5391-1          | 6.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2016-3709       | 6.1  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2016-9318       | 5.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-0663       | 7.8  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-15412      | 8.8  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-16931      | 9.8  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-16932      | 7.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-18258      | 6.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-5130       | 8.8  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-7375       | 9.8  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-7376       | 9.8  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-8872       | 9.1  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-9047       | 7.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-9048       | 7.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-9049       | 7.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-9050       | 7.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-14404      | 7.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-14567      | 6.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2019-19956      | 7.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2019-20388      | 7.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2020-7595       | 7.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2021-3516       | 7.8  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2021-3517       | 8.6  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2021-3518       | 8.8  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2021-3537       | 5.9  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2021-3541       | 6.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-2309       | 7.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-23308      | 7.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-49043      |      | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2024-25062      | 7.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2024-56171      |      | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2025-24928      |      | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2025-27113      | 7.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3012-1          |      | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3172-1          |      | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3405-1          |      | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3878-1          |      | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-4064-1          |      | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-4539-1          | 4.7  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-4539-3          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-4661-1          | 7.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-4807-1          | 5.9  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-4855-1          | 7.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-4875-1          | 5.9  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-4963-1          | 9.8  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5103-1          | 7.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5139-1          | 9.8  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5169-1          | 9.8  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5343-1          | 7.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5417-1          | 7.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5532-1          | 7.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5764-1          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-0732       | 7.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-0734       | 5.9  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-0735       | 5.9  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-5407       | 4.7  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2019-1543       | 7.4  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2019-1549       | 5.3  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2021-3450       | 7.4  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-2274       | 9.8  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-3358       | 7.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-3602       | 7.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-3786       | 7.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-3996       | 7.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-4203       | 4.9  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2023-0216       | 7.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2023-0217       | 7.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2023-0401       | 7.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2023-1255       | 5.9  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2023-2975       | 5.3  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2023-3446       | 5.3  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2023-3817       | 5.3  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2023-5678       | 5.3  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2023-6129       | 6.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2023-6237       |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2024-0727       | 5.5  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2024-12797      |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2024-13176      |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2024-2511       |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2024-4603       |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2024-4741       |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2024-5535       |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2024-9143       |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3008-1          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3325-1          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3449-1          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3530-1          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3942-1          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3942-2          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-12837      | 7.5  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-12883      | 9.1  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-12015      | 7.5  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-18311      | 9.8  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-18312      | 9.8  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-18313      | 9.1  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-18314      | 9.8  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-6797       | 9.8  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-6798       | 7.5  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-6913       | 9.8  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2020-10543      | 8.2  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2020-10878      | 8.6  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2020-12723      | 7.5  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2020-16156      | 7.8  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2021-36770      | 7.8  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2023-31484      | 8.1  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2023-47038      | 7.8  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3926-1          |      | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5135-1          |      | Debian    | postgresql-11                  | 11.15-1.pgdg90+1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3072-1          |      | Debian    | postgresql-11                  | 11.15-1.pgdg90+1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3189-1          |      | Debian    | postgresql-11                  | 11.15-1.pgdg90+1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3316-1          |      | Debian    | postgresql-11                  | 11.15-1.pgdg90+1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3422-1          |      | Debian    | postgresql-11                  | 11.15-1.pgdg90+1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3600-1          |      | Debian    | postgresql-11                  | 11.15-1.pgdg90+1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3651-1          |      | Debian    | postgresql-11                  | 11.15-1.pgdg90+1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3764-1          |      | Debian    | postgresql-11                  | 11.15-1.pgdg90+1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-17512      | 8.8  | Debian    | sensible-utils                 | 0.0.9+deb9u1                       | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-20482      | 4.7  | Debian    | tar                            | 1.29b-1.1+deb9u1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2023-39804      |      | Debian    | tar                            | 1.29b-1.1+deb9u1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3755-1          |      | Debian    | tar                            | 1.29b-1.1+deb9u1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3051-1          |      | Debian    | tzdata                         | 2021a-0+deb9u3                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3134-1          |      | Debian    | tzdata                         | 2021a-0+deb9u3                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3161-1          |      | Debian    | tzdata                         | 2021a-0+deb9u3                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3366-1          |      | Debian    | tzdata                         | 2021a-0+deb9u3                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3412-1          |      | Debian    | tzdata                         | 2021a-0+deb9u3                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3684-1          |      | Debian    | tzdata                         | 2021a-0+deb9u3                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3788-1          |      | Debian    | tzdata                         | 2021a-0+deb9u3                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3972-1          |      | Debian    | tzdata                         | 2021a-0+deb9u3                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-4016-1          |      | Debian    | ucf                            | 3.0036                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5055-1          | 5.5  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5650-1          |      | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2016-2779       | 7.8  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DLA-3782-1          |      | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5123-1          | 8.8  | Debian    | xz-utils                       | 5.2.2-1.2+deb9u1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2024-3094       | 10.0 | Debian    | xz-utils                       | 5.2.2-1.2+deb9u1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-+-------------------------------------+------+-----------+--------------------------------+------------------------------------+-------------------------------------------------+
-| Unimportant vulnerabilities         |      |           |                                |                                    |                                                 |
-+-------------------------------------+------+-----------+--------------------------------+------------------------------------+-------------------------------------------------+
-| https://osv.dev/CVE-2011-3374       | 3.7  | Debian    | apt                            | 1.4.11                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2019-18276      | 7.8  | Debian    | bash                           | 4.4-5                              | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-18018      | 4.7  | Debian    | coreutils                      | 8.26-3                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-6829       | 7.5  | Debian    | libgcrypt20                    | 1.7.6-2+deb9u4                     | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-1000654    | 5.5  | Debian    | libtasn1-6                     | 4.10-1.1+deb9u1                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2020-24977      | 6.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2024-34459      |      | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2011-4116       | 7.5  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-48522      | 9.8  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2023-31486      | 8.1  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2005-2541       |      | Debian    | tar                            | 1.29b-1.1+deb9u1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2019-9923       | 7.5  | Debian    | tar                            | 1.29b-1.1+deb9u1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2021-20193      | 3.3  | Debian    | tar                            | 1.29b-1.1+deb9u1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-48303      | 5.5  | Debian    | tar                            | 1.29b-1.1+deb9u1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-7738       | 7.8  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-0563       | 5.5  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-+-------------------------------------+------+-----------+--------------------------------+------------------------------------+-------------------------------------------------+
+
+Total 21 packages affected by 172 known vulnerabilities (18 Critical, 59 High, 41 Medium, 1 Low, 53 Unknown) from 2 ecosystems.
+8 vulnerabilities can be fixed.
+
+Go
+
+sbom:<rootdir>/fixtures/sbom-insecure/postgres-stretch.cdx.xml: found 2 packages with issues
+
+  github.com/opencontainers/runc@v1.0.1 has the following known vulnerabilities:
+    GO-2022-0274: Namespace restriction bypass in github.com/opencontainers/runc (https://osv.dev/GO-2022-0274)
+    GO-2022-0452: Default inheritable capabilities for linux container should be empty in... (https://osv.dev/GO-2022-0452)
+    GO-2023-1627: Opencontainers runc Incorrect Authorization vulnerability in... (https://osv.dev/GO-2023-1627)
+    GO-2023-1682: rootless: `/sys/fs/cgroup` is writable when cgroupns isn't unshared in runc in... (https://osv.dev/GO-2023-1682)
+    GO-2023-1683: runc AppArmor bypass with symlinked /proc in github.com/opencontainers/runc (https://osv.dev/GO-2023-1683)
+    GO-2024-2491: Container breakout through process.cwd trickery and leaked fds in... (https://osv.dev/GO-2024-2491)
+    GO-2024-3110: runc can be confused to create empty files/directories on the host in... (https://osv.dev/GO-2024-3110)
+  golang.org/x/sys@v0.0.0-20210817142637-7d9622a276b7 has the following known vulnerabilities:
+    GO-2022-0493: Incorrect privilege reporting in syscall and golang.org/x/sys/unix (https://osv.dev/GO-2022-0493)
+
+  8 known vulnerabilities found in sbom:<rootdir>/fixtures/sbom-insecure/postgres-stretch.cdx.xml
+
+Debian
+
+sbom:<rootdir>/fixtures/sbom-insecure/postgres-stretch.cdx.xml: found 19 packages with issues
+
+  apt@1.4.11 has the following known vulnerabilities:
+    DSA-4685-1: apt - security update (https://osv.dev/DSA-4685-1)
+    DSA-4808-1: apt - security update (https://osv.dev/DSA-4808-1)
+    CVE-2018-0501: The mirror:// method implementation in Advanced Package Tool (APT) 1.6.x before... (https://osv.dev/CVE-2018-0501)
+    CVE-2019-3462: Incorrect sanitation of the 302 redirect field in HTTP transport method of apt... (https://osv.dev/CVE-2019-3462)
+  bash@4.4-5 has the following known vulnerabilities:
+    CVE-2022-3715: A flaw was found in the bash package, where a heap-buffer overflow can occur in... (https://osv.dev/CVE-2022-3715)
+  coreutils@8.26-3 has the following known vulnerabilities:
+    CVE-2016-2781: chroot in GNU coreutils, when used with --userspec, allows local users to... (https://osv.dev/CVE-2016-2781)
+    CVE-2024-0684: A flaw was found in the GNU coreutils "split" program. A heap overflow with... (https://osv.dev/CVE-2024-0684)
+  debian-archive-keyring@2017.5+deb9u2 has the following known vulnerabilities:
+    DLA-3482-1: debian-archive-keyring - security update (https://osv.dev/DLA-3482-1)
+  dpkg@1.18.25 has the following known vulnerabilities:
+    DSA-5147-1: dpkg - security update (https://osv.dev/DSA-5147-1)
+    DLA-3022-1: dpkg - security update (https://osv.dev/DLA-3022-1)
+  e2fsprogs@1.43.4-2+deb9u2 has the following known vulnerabilities:
+    DSA-4535-1: e2fsprogs - security update (https://osv.dev/DSA-4535-1)
+    CVE-2019-5188: A code execution vulnerability exists in the directory rehashing functionality... (https://osv.dev/CVE-2019-5188)
+    CVE-2022-1304: An out-of-bounds read/write vulnerability was found in e2fsprogs 1.46.5. This... (https://osv.dev/CVE-2022-1304)
+    DLA-3910-1: e2fsprogs - security update (https://osv.dev/DLA-3910-1)
+  gzip@1.6-5+deb9u1 has the following known vulnerabilities:
+    DSA-5122-1: gzip - security update (https://osv.dev/DSA-5122-1)
+  libgcrypt20@1.7.6-2+deb9u4 has the following known vulnerabilities:
+    CVE-2017-0379: Libgcrypt before 1.8.1 does not properly consider Curve25519 side-channel... (https://osv.dev/CVE-2017-0379)
+    CVE-2017-7526: libgcrypt before version 1.7.8 is vulnerable to a cache side-channel attack... (https://osv.dev/CVE-2017-7526)
+    CVE-2018-0495: Libgcrypt before 1.7.10 and 1.8.x before 1.8.3 allows a memory-cache... (https://osv.dev/CVE-2018-0495)
+    CVE-2019-13627: It was discovered that there was a ECDSA timing attack in the libgcrypt20... (https://osv.dev/CVE-2019-13627)
+    CVE-2021-33560: Libgcrypt before 1.8.8 and 1.9.x before 1.9.3 mishandles ElGamal encryption... (https://osv.dev/CVE-2021-33560)
+    CVE-2021-40528: The ElGamal implementation in Libgcrypt before 1.9.4 allows plaintext recovery... (https://osv.dev/CVE-2021-40528)
+    CVE-2024-2236: A timing-based side-channel flaw was found in libgcrypt's RSA implementation.... (https://osv.dev/CVE-2024-2236)
+  libtasn1-6@4.10-1.1+deb9u1 has the following known vulnerabilities:
+    DSA-5863-1: libtasn1-6 - security update (https://osv.dev/DSA-5863-1)
+    CVE-2017-10790: The _asn1_check_identifier function in GNU Libtasn1 through 4.12 causes a NULL... (https://osv.dev/CVE-2017-10790)
+    CVE-2018-6003: An issue was discovered in the _asn1_decode_simple_ber function in decoding.c... (https://osv.dev/CVE-2018-6003)
+    CVE-2021-46848: GNU Libtasn1 before 4.19.0 has an ETYPE_OK off-by-one array size check that... (https://osv.dev/CVE-2021-46848)
+    DLA-3263-1: libtasn1-6 - security update (https://osv.dev/DLA-3263-1)
+    DLA-4061-1: libtasn1-6 - security update (https://osv.dev/DLA-4061-1)
+  libxml2@2.9.4+dfsg1-2.2+deb9u6 has the following known vulnerabilities:
+    DSA-5142-1: libxml2 - security update (https://osv.dev/DSA-5142-1)
+    DSA-5271-1: libxml2 - security update (https://osv.dev/DSA-5271-1)
+    DSA-5391-1: libxml2 - security update (https://osv.dev/DSA-5391-1)
+    CVE-2016-3709: Possible cross-site scripting vulnerability in libxml after commit 960f0e2. (https://osv.dev/CVE-2016-3709)
+    CVE-2016-9318: libxml2 2.9.4 and earlier, as used in XMLSec 1.2.23 and earlier and other... (https://osv.dev/CVE-2016-9318)
+    CVE-2017-0663: A remote code execution vulnerability in libxml2 could enable an attacker using... (https://osv.dev/CVE-2017-0663)
+    CVE-2017-15412: Use after free in libxml2 before 2.9.5, as used in Google Chrome prior to... (https://osv.dev/CVE-2017-15412)
+    CVE-2017-16931: parser.c in libxml2 before 2.9.5 mishandles parameter-entity references because... (https://osv.dev/CVE-2017-16931)
+    CVE-2017-16932: parser.c in libxml2 before 2.9.5 does not prevent infinite recursion in... (https://osv.dev/CVE-2017-16932)
+    CVE-2017-18258: The xz_head function in xzlib.c in libxml2 before 2.9.6 allows remote attackers... (https://osv.dev/CVE-2017-18258)
+    CVE-2017-5130: An integer overflow in xmlmemory.c in libxml2 before 2.9.5, as used in Google... (https://osv.dev/CVE-2017-5130)
+    CVE-2017-7375: A flaw in libxml2 allows remote XML entity inclusion with default parser flags... (https://osv.dev/CVE-2017-7375)
+    CVE-2017-7376: Buffer overflow in libxml2 allows remote attackers to execute arbitrary code by... (https://osv.dev/CVE-2017-7376)
+    CVE-2017-8872: The htmlParseTryOrFinish function in HTMLparser.c in libxml2 2.9.4 allows... (https://osv.dev/CVE-2017-8872)
+    CVE-2017-9047: A buffer overflow was discovered in libxml2 20904-GITv2.9.4-16-g0741801. The... (https://osv.dev/CVE-2017-9047)
+    CVE-2017-9048: libxml2 20904-GITv2.9.4-16-g0741801 is vulnerable to a stack-based buffer... (https://osv.dev/CVE-2017-9048)
+    CVE-2017-9049: libxml2 20904-GITv2.9.4-16-g0741801 is vulnerable to a heap-based buffer... (https://osv.dev/CVE-2017-9049)
+    CVE-2017-9050: libxml2 20904-GITv2.9.4-16-g0741801 is vulnerable to a heap-based buffer... (https://osv.dev/CVE-2017-9050)
+    CVE-2018-14404: A NULL pointer dereference vulnerability exists in the... (https://osv.dev/CVE-2018-14404)
+    CVE-2018-14567: libxml2 2.9.8, if --with-lzma is used, allows remote attackers to cause a... (https://osv.dev/CVE-2018-14567)
+    CVE-2019-19956: xmlParseBalancedChunkMemoryRecover in parser.c in libxml2 before 2.9.10 has a... (https://osv.dev/CVE-2019-19956)
+    CVE-2019-20388: xmlSchemaPreRun in xmlschemas.c in libxml2 2.9.10 allows an... (https://osv.dev/CVE-2019-20388)
+    CVE-2020-7595: xmlStringLenDecodeEntities in parser.c in libxml2 2.9.10 has an infinite loop... (https://osv.dev/CVE-2020-7595)
+    CVE-2021-3516: There's a flaw in libxml2's xmllint in versions before 2.9.11. An attacker who... (https://osv.dev/CVE-2021-3516)
+    CVE-2021-3517: There is a flaw in the xml entity encoding functionality of libxml2 in versions... (https://osv.dev/CVE-2021-3517)
+    CVE-2021-3518: There's a flaw in libxml2 in versions before 2.9.11. An attacker who is able to... (https://osv.dev/CVE-2021-3518)
+    CVE-2021-3537: A vulnerability found in libxml2 in versions before 2.9.11 shows that it did... (https://osv.dev/CVE-2021-3537)
+    CVE-2021-3541: A flaw was found in libxml2. Exponential entity expansion attack its possible... (https://osv.dev/CVE-2021-3541)
+    CVE-2022-2309: NULL Pointer Dereference allows attackers to cause a denial of service (or... (https://osv.dev/CVE-2022-2309)
+    CVE-2022-23308: valid.c in libxml2 before 2.9.13 has a use-after-free of ID and IDREF... (https://osv.dev/CVE-2022-23308)
+    CVE-2022-49043: xmlXIncludeAddNode in xinclude.c in libxml2 before 2.11.0 has a use-after-free. (https://osv.dev/CVE-2022-49043)
+    CVE-2024-25062: An issue was discovered in libxml2 before 2.11.7 and 2.12.x before 2.12.5. When... (https://osv.dev/CVE-2024-25062)
+    CVE-2024-56171: libxml2 before 2.12.10 and 2.13.x before 2.13.6 has a use-after-free in... (https://osv.dev/CVE-2024-56171)
+    CVE-2025-24928: libxml2 before 2.12.10 and 2.13.x before 2.13.6 has a stack-based buffer... (https://osv.dev/CVE-2025-24928)
+    CVE-2025-27113: libxml2 before 2.12.10 and 2.13.x before 2.13.6 has a NULL pointer dereference... (https://osv.dev/CVE-2025-27113)
+    DLA-3012-1: libxml2 - security update (https://osv.dev/DLA-3012-1)
+    DLA-3172-1: libxml2 - security update (https://osv.dev/DLA-3172-1)
+    DLA-3405-1: libxml2 - security update (https://osv.dev/DLA-3405-1)
+    DLA-3878-1: libxml2 - security update (https://osv.dev/DLA-3878-1)
+    DLA-4064-1: libxml2 - security update (https://osv.dev/DLA-4064-1)
+  openssl@1.1.0l-1~deb9u5 has the following known vulnerabilities:
+    DSA-4539-1: openssl - security update (https://osv.dev/DSA-4539-1)
+    DSA-4539-3: openssl - regression update (https://osv.dev/DSA-4539-3)
+    DSA-4661-1: openssl - security update (https://osv.dev/DSA-4661-1)
+    DSA-4807-1: openssl - security update (https://osv.dev/DSA-4807-1)
+    DSA-4855-1: openssl - security update (https://osv.dev/DSA-4855-1)
+    DSA-4875-1: openssl - security update (https://osv.dev/DSA-4875-1)
+    DSA-4963-1: openssl - security update (https://osv.dev/DSA-4963-1)
+    DSA-5103-1: openssl - security update (https://osv.dev/DSA-5103-1)
+    DSA-5139-1: openssl - security update (https://osv.dev/DSA-5139-1)
+    DSA-5169-1: openssl - security update (https://osv.dev/DSA-5169-1)
+    DSA-5343-1: openssl - security update (https://osv.dev/DSA-5343-1)
+    DSA-5417-1: openssl - security update (https://osv.dev/DSA-5417-1)
+    DSA-5532-1: openssl - security update (https://osv.dev/DSA-5532-1)
+    DSA-5764-1: openssl - security update (https://osv.dev/DSA-5764-1)
+    CVE-2018-0732: During key agreement in a TLS handshake using a DH(E) based ciphersuite a... (https://osv.dev/CVE-2018-0732)
+    CVE-2018-0734: The OpenSSL DSA signature algorithm has been shown to be vulnerable to a timing... (https://osv.dev/CVE-2018-0734)
+    CVE-2018-0735: The OpenSSL ECDSA signature algorithm has been shown to be vulnerable to a... (https://osv.dev/CVE-2018-0735)
+    CVE-2018-5407: Simultaneous Multi-threading (SMT) in processors can enable local users to... (https://osv.dev/CVE-2018-5407)
+    CVE-2019-1543: ChaCha20-Poly1305 is an AEAD cipher, and requires a unique nonce input for... (https://osv.dev/CVE-2019-1543)
+    CVE-2019-1549: OpenSSL 1.1.1 introduced a rewritten random number generator (RNG). This was... (https://osv.dev/CVE-2019-1549)
+    CVE-2021-3450: The X509_V_FLAG_X509_STRICT flag enables additional security checks of the... (https://osv.dev/CVE-2021-3450)
+    CVE-2022-2274: The OpenSSL 3.0.4 release introduced a serious bug in the RSA implementation... (https://osv.dev/CVE-2022-2274)
+    CVE-2022-3358: OpenSSL supports creating a custom cipher via the legacy EVP_CIPHER_meth_new()... (https://osv.dev/CVE-2022-3358)
+    CVE-2022-3602: A buffer overrun can be triggered in X.509 certificate verification,... (https://osv.dev/CVE-2022-3602)
+    CVE-2022-3786: A buffer overrun can be triggered in X.509 certificate verification,... (https://osv.dev/CVE-2022-3786)
+    CVE-2022-3996: If an X.509 certificate contains a malformed policy constraint and
+policy... (https://osv.dev/CVE-2022-3996)
+    CVE-2022-4203: A read buffer overrun can be triggered in X.509 certificate verification,... (https://osv.dev/CVE-2022-4203)
+    CVE-2023-0216: An invalid pointer dereference on read can be triggered when an
+application... (https://osv.dev/CVE-2023-0216)
+    CVE-2023-0217: An invalid pointer dereference on read can be triggered when an
+application... (https://osv.dev/CVE-2023-0217)
+    CVE-2023-0401: A NULL pointer can be dereferenced when signatures are being
+verified on PKCS7... (https://osv.dev/CVE-2023-0401)
+    CVE-2023-1255: Issue summary: The AES-XTS cipher decryption implementation for 64 bit ARM... (https://osv.dev/CVE-2023-1255)
+    CVE-2023-2975: Issue summary: The AES-SIV cipher implementation contains a bug that causes
+it... (https://osv.dev/CVE-2023-2975)
+    CVE-2023-3446: Issue summary: Checking excessively long DH keys or parameters may be very... (https://osv.dev/CVE-2023-3446)
+    CVE-2023-3817: Issue summary: Checking excessively long DH keys or parameters may be very... (https://osv.dev/CVE-2023-3817)
+    CVE-2023-5678: Issue summary: Generating excessively long X9.42 DH keys or checking... (https://osv.dev/CVE-2023-5678)
+    CVE-2023-6129: Issue summary: The POLY1305 MAC (message authentication code) implementation... (https://osv.dev/CVE-2023-6129)
+    CVE-2023-6237: Issue summary: Checking excessively long invalid RSA public keys may take
+a... (https://osv.dev/CVE-2023-6237)
+    CVE-2024-0727: Issue summary: Processing a maliciously formatted PKCS12 file may lead OpenSSL... (https://osv.dev/CVE-2024-0727)
+    CVE-2024-12797: Issue summary: Clients using RFC7250 Raw Public Keys (RPKs) to authenticate a... (https://osv.dev/CVE-2024-12797)
+    CVE-2024-13176: Issue summary: A timing side-channel which could potentially allow recovering... (https://osv.dev/CVE-2024-13176)
+    CVE-2024-2511: Issue summary: Some non-default TLS server configurations can cause unbounded... (https://osv.dev/CVE-2024-2511)
+    CVE-2024-4603: Issue summary: Checking excessively long DSA keys or parameters may be very... (https://osv.dev/CVE-2024-4603)
+    CVE-2024-4741: Issue summary: Calling the OpenSSL API function SSL_free_buffers may cause... (https://osv.dev/CVE-2024-4741)
+    CVE-2024-5535: Issue summary: Calling the OpenSSL API function SSL_select_next_proto with an... (https://osv.dev/CVE-2024-5535)
+    CVE-2024-9143: Issue summary: Use of the low-level GF(2^m) elliptic curve APIs with untrusted... (https://osv.dev/CVE-2024-9143)
+    DLA-3008-1: openssl - security update (https://osv.dev/DLA-3008-1)
+    DLA-3325-1: openssl - security update (https://osv.dev/DLA-3325-1)
+    DLA-3449-1: openssl - security update (https://osv.dev/DLA-3449-1)
+    DLA-3530-1: openssl - security update (https://osv.dev/DLA-3530-1)
+    DLA-3942-1: openssl - security update (https://osv.dev/DLA-3942-1)
+    DLA-3942-2: openssl - regression update (https://osv.dev/DLA-3942-2)
+  perl@5.24.1-3+deb9u7 has the following known vulnerabilities:
+    CVE-2017-12837: Heap-based buffer overflow in the S_regatom function in regcomp.c in Perl 5... (https://osv.dev/CVE-2017-12837)
+    CVE-2017-12883: Buffer overflow in the S_grok_bslash_N function in regcomp.c in Perl 5 before... (https://osv.dev/CVE-2017-12883)
+    CVE-2018-12015: In Perl through 5.26.2, the Archive::Tar module allows remote attackers to... (https://osv.dev/CVE-2018-12015)
+    CVE-2018-18311: Perl before 5.26.3 and 5.28.x before 5.28.1 has a buffer overflow via a crafted... (https://osv.dev/CVE-2018-18311)
+    CVE-2018-18312: Perl before 5.26.3 and 5.28.0 before 5.28.1 has a buffer overflow via a crafted... (https://osv.dev/CVE-2018-18312)
+    CVE-2018-18313: Perl before 5.26.3 has a buffer over-read via a crafted regular expression that... (https://osv.dev/CVE-2018-18313)
+    CVE-2018-18314: Perl before 5.26.3 has a buffer overflow via a crafted regular expression that... (https://osv.dev/CVE-2018-18314)
+    CVE-2018-6797: An issue was discovered in Perl 5.18 through 5.26. A crafted regular expression... (https://osv.dev/CVE-2018-6797)
+    CVE-2018-6798: An issue was discovered in Perl 5.22 through 5.26. Matching a crafted locale... (https://osv.dev/CVE-2018-6798)
+    CVE-2018-6913: Heap-based buffer overflow in the pack function in Perl before 5.26.2 allows... (https://osv.dev/CVE-2018-6913)
+    CVE-2020-10543: Perl before 5.30.3 on 32-bit platforms allows a heap-based buffer overflow... (https://osv.dev/CVE-2020-10543)
+    CVE-2020-10878: Perl before 5.30.3 has an integer overflow related to mishandling of a... (https://osv.dev/CVE-2020-10878)
+    CVE-2020-12723: regcomp.c in Perl before 5.30.3 allows a buffer overflow via a crafted regular... (https://osv.dev/CVE-2020-12723)
+    CVE-2020-16156: CPAN 2.28 allows Signature Verification Bypass. (https://osv.dev/CVE-2020-16156)
+    CVE-2021-36770: Encode.pm, as distributed in Perl through 5.34.0, allows local users to gain... (https://osv.dev/CVE-2021-36770)
+    CVE-2023-31484: CPAN.pm before 2.35 does not verify TLS certificates when downloading... (https://osv.dev/CVE-2023-31484)
+    CVE-2023-47038: A vulnerability was found in perl 5.30.0 through 5.38.0. This issue occurs when... (https://osv.dev/CVE-2023-47038)
+    DLA-3926-1: perl - security update (https://osv.dev/DLA-3926-1)
+  postgresql-11@11.15-1.pgdg90+1 has the following known vulnerabilities:
+    DSA-5135-1: postgresql-11 - security update (https://osv.dev/DSA-5135-1)
+    DLA-3072-1: postgresql-11 - security update (https://osv.dev/DLA-3072-1)
+    DLA-3189-1: postgresql-11 - bugfix update (https://osv.dev/DLA-3189-1)
+    DLA-3316-1: postgresql-11 - security update (https://osv.dev/DLA-3316-1)
+    DLA-3422-1: postgresql-11 - security update (https://osv.dev/DLA-3422-1)
+    DLA-3600-1: postgresql-11 - security update (https://osv.dev/DLA-3600-1)
+    DLA-3651-1: postgresql-11 - security update (https://osv.dev/DLA-3651-1)
+    DLA-3764-1: postgresql-11 - security update (https://osv.dev/DLA-3764-1)
+  sensible-utils@0.0.9+deb9u1 has the following known vulnerabilities:
+    CVE-2017-17512: sensible-browser in sensible-utils before 0.0.11 does not validate strings... (https://osv.dev/CVE-2017-17512)
+  tar@1.29b-1.1+deb9u1 has the following known vulnerabilities:
+    CVE-2018-20482: GNU Tar through 1.30, when --sparse is used, mishandles file shrinkage during... (https://osv.dev/CVE-2018-20482)
+    CVE-2023-39804: In GNU tar before 1.35, mishandled extension attributes in a PAX archive can... (https://osv.dev/CVE-2023-39804)
+    DLA-3755-1: tar - security update (https://osv.dev/DLA-3755-1)
+  tzdata@2021a-0+deb9u3 has the following known vulnerabilities:
+    DLA-3051-1: tzdata - new timezone database (https://osv.dev/DLA-3051-1)
+    DLA-3134-1: tzdata - new timezone database (https://osv.dev/DLA-3134-1)
+    DLA-3161-1: tzdata - new timezone database (https://osv.dev/DLA-3161-1)
+    DLA-3366-1: tzdata - new timezone database (https://osv.dev/DLA-3366-1)
+    DLA-3412-1: tzdata - new timezone database (https://osv.dev/DLA-3412-1)
+    DLA-3684-1: tzdata - new timezone database (https://osv.dev/DLA-3684-1)
+    DLA-3788-1: tzdata - new timezone database (https://osv.dev/DLA-3788-1)
+    DLA-3972-1: tzdata - new timezone database (https://osv.dev/DLA-3972-1)
+  ucf@3.0036 has the following known vulnerabilities:
+    DLA-4016-1: ucf - security update (https://osv.dev/DLA-4016-1)
+  util-linux@2.29.2-1+deb9u1 has the following known vulnerabilities:
+    DSA-5055-1: util-linux - security update (https://osv.dev/DSA-5055-1)
+    DSA-5650-1: util-linux - security update (https://osv.dev/DSA-5650-1)
+    CVE-2016-2779: runuser in util-linux allows local users to escape to the parent session via a... (https://osv.dev/CVE-2016-2779)
+    DLA-3782-1: util-linux - security update (https://osv.dev/DLA-3782-1)
+  xz-utils@5.2.2-1.2+deb9u1 has the following known vulnerabilities:
+    DSA-5123-1: xz-utils - security update (https://osv.dev/DSA-5123-1)
+    CVE-2024-3094: Malicious code was discovered in the upstream tarballs of xz, starting with... (https://osv.dev/CVE-2024-3094)
+
+  164 known vulnerabilities found in sbom:<rootdir>/fixtures/sbom-insecure/postgres-stretch.cdx.xml
+
+  apt@1.4.11 has the following unimportant vulnerabilities:
+    CVE-2011-3374: It was found that apt-key in apt, all versions, do not correctly validate gpg... (https://osv.dev/CVE-2011-3374)
+  bash@4.4-5 has the following unimportant vulnerabilities:
+    CVE-2019-18276: An issue was discovered in disable_priv_mode in shell.c in GNU Bash through 5.0... (https://osv.dev/CVE-2019-18276)
+  coreutils@8.26-3 has the following unimportant vulnerabilities:
+    CVE-2017-18018: In GNU Coreutils through 8.29, chown-core.c in chown and chgrp does not prevent... (https://osv.dev/CVE-2017-18018)
+  libgcrypt20@1.7.6-2+deb9u4 has the following unimportant vulnerabilities:
+    CVE-2018-6829: cipher/elgamal.c in Libgcrypt through 1.8.2, when used to encrypt messages... (https://osv.dev/CVE-2018-6829)
+  libtasn1-6@4.10-1.1+deb9u1 has the following unimportant vulnerabilities:
+    CVE-2018-1000654: GNU Libtasn1-4.13 libtasn1-4.13 version libtasn1-4.13, libtasn1-4.12 contains a... (https://osv.dev/CVE-2018-1000654)
+  libxml2@2.9.4+dfsg1-2.2+deb9u6 has the following unimportant vulnerabilities:
+    CVE-2020-24977: GNOME project libxml2 v2.9.10 has a global buffer over-read vulnerability in... (https://osv.dev/CVE-2020-24977)
+    CVE-2024-34459: An issue was discovered in xmllint (from libxml2) before 2.11.8 and 2.12.x... (https://osv.dev/CVE-2024-34459)
+  perl@5.24.1-3+deb9u7 has the following unimportant vulnerabilities:
+    CVE-2011-4116: _is_safe in the File::Temp module for Perl does not properly handle symlinks. (https://osv.dev/CVE-2011-4116)
+    CVE-2022-48522: In Perl 5.34.0, function S_find_uninit_var in sv.c has a stack-based crash that... (https://osv.dev/CVE-2022-48522)
+    CVE-2023-31486: HTTP::Tiny before 0.083, a Perl core module since 5.13.9 and available... (https://osv.dev/CVE-2023-31486)
+  tar@1.29b-1.1+deb9u1 has the following unimportant vulnerabilities:
+    CVE-2005-2541: Tar 1.15.1 does not properly warn the user when extracting setuid or setgid... (https://osv.dev/CVE-2005-2541)
+    CVE-2019-9923: pax_decode_header in sparse.c in GNU Tar before 1.32 had a NULL pointer... (https://osv.dev/CVE-2019-9923)
+    CVE-2021-20193: A flaw was found in the src/list.c of tar 1.33 and earlier. This flaw allows an... (https://osv.dev/CVE-2021-20193)
+    CVE-2022-48303: GNU Tar through 1.34 has a one-byte out-of-bounds read that results in use of... (https://osv.dev/CVE-2022-48303)
+  util-linux@2.29.2-1+deb9u1 has the following unimportant vulnerabilities:
+    CVE-2018-7738: In util-linux before 2.32-rc1, bash-completion/umount allows local users to... (https://osv.dev/CVE-2018-7738)
+    CVE-2022-0563: A flaw was found in the util-linux chfn and chsh utilities when compiled with... (https://osv.dev/CVE-2022-0563)
+
+  16 uncalled/unimportant vulnerabilities found in sbom:<rootdir>/fixtures/sbom-insecure/postgres-stretch.cdx.xml (filtered out)
+
 
 ---
 
@@ -2786,6 +3130,11 @@ Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
 Scanned <rootdir>/fixtures/locks-many/yarn.lock file and found 1 package
 Filtered 1 local/unscannable package/s from the scan.
 
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 0 ecosystems.
+0 vulnerabilities can be fixed.
+
+
+
 ---
 
 [Test_run_LocalDatabases_AlwaysOffline/a_bunch_of_different_lockfiles_and_ecosystem - 2]
@@ -2811,6 +3160,11 @@ Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
 Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
 Scanned <rootdir>/fixtures/locks-many/yarn.lock file and found 1 package
 Filtered 1 local/unscannable package/s from the scan.
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 0 ecosystems.
+0 vulnerabilities can be fixed.
+
+
 
 ---
 
@@ -2889,13 +3243,35 @@ Scanned <rootdir>/fixtures/locks-insecure/my-yarn.lock file as a yarn.lock and f
 Scanning dir ./fixtures/locks-insecure
 Scanned <rootdir>/fixtures/locks-insecure/bun.lock file and found 2 packages
 Scanned <rootdir>/fixtures/locks-insecure/composer.lock file and found 1 package
-+-------------------------------------+------+-----------+------------------+---------+----------------------------------------------+
-| OSV URL                             | CVSS | ECOSYSTEM | PACKAGE          | VERSION | SOURCE                                       |
-+-------------------------------------+------+-----------+------------------+---------+----------------------------------------------+
-| https://osv.dev/GHSA-9f46-5r25-5wfm | 9.8  | Packagist | league/flysystem | 1.0.8   | fixtures/locks-insecure/composer.lock        |
-| https://osv.dev/GHSA-whgm-jr23-g3j9 | 7.5  | npm       | ansi-html        | 0.0.1   | fixtures/locks-insecure/my-package-lock.json |
-| https://osv.dev/GHSA-whgm-jr23-g3j9 | 7.5  | npm       | ansi-html        | 0.0.1   | fixtures/locks-insecure/my-yarn.lock         |
-+-------------------------------------+------+-----------+------------------+---------+----------------------------------------------+
+
+Total 3 packages affected by 3 known vulnerabilities (1 Critical, 2 High, 0 Medium, 0 Low, 0 Unknown) from 2 ecosystems.
+3 vulnerabilities can be fixed.
+
+Packagist
+
+lockfile:<rootdir>/fixtures/locks-insecure/composer.lock: found 1 package with issues
+
+  league/flysystem@1.0.8 has the following known vulnerabilities:
+    GHSA-9f46-5r25-5wfm: Time-of-check Time-of-use (TOCTOU) Race Condition in league/flysystem (https://osv.dev/GHSA-9f46-5r25-5wfm)
+
+  1 known vulnerability found in lockfile:<rootdir>/fixtures/locks-insecure/composer.lock
+
+npm
+
+lockfile:<rootdir>/fixtures/locks-insecure/my-package-lock.json: found 1 package with issues
+
+  ansi-html@0.0.1 has the following known vulnerabilities:
+    GHSA-whgm-jr23-g3j9: Uncontrolled Resource Consumption in ansi-html (https://osv.dev/GHSA-whgm-jr23-g3j9)
+
+  1 known vulnerability found in lockfile:<rootdir>/fixtures/locks-insecure/my-package-lock.json
+
+lockfile:<rootdir>/fixtures/locks-insecure/my-yarn.lock: found 1 package with issues
+
+  ansi-html@0.0.1 has the following known vulnerabilities:
+    GHSA-whgm-jr23-g3j9: Uncontrolled Resource Consumption in ansi-html (https://osv.dev/GHSA-whgm-jr23-g3j9)
+
+  1 known vulnerability found in lockfile:<rootdir>/fixtures/locks-insecure/my-yarn.lock
+
 
 ---
 
@@ -2909,13 +3285,35 @@ Scanned <rootdir>/fixtures/locks-insecure/my-package-lock.json file as a package
 Scanning dir ./fixtures/locks-insecure
 Scanned <rootdir>/fixtures/locks-insecure/bun.lock file and found 2 packages
 Scanned <rootdir>/fixtures/locks-insecure/composer.lock file and found 1 package
-+-------------------------------------+------+-----------+------------------+---------+----------------------------------------------+
-| OSV URL                             | CVSS | ECOSYSTEM | PACKAGE          | VERSION | SOURCE                                       |
-+-------------------------------------+------+-----------+------------------+---------+----------------------------------------------+
-| https://osv.dev/GHSA-9f46-5r25-5wfm | 9.8  | Packagist | league/flysystem | 1.0.8   | fixtures/locks-insecure/composer.lock        |
-| https://osv.dev/GHSA-whgm-jr23-g3j9 | 7.5  | npm       | ansi-html        | 0.0.1   | fixtures/locks-insecure/my-package-lock.json |
-| https://osv.dev/GHSA-whgm-jr23-g3j9 | 7.5  | npm       | ansi-html        | 0.0.1   | fixtures/locks-insecure/my-yarn.lock         |
-+-------------------------------------+------+-----------+------------------+---------+----------------------------------------------+
+
+Total 3 packages affected by 3 known vulnerabilities (1 Critical, 2 High, 0 Medium, 0 Low, 0 Unknown) from 2 ecosystems.
+3 vulnerabilities can be fixed.
+
+Packagist
+
+lockfile:<rootdir>/fixtures/locks-insecure/composer.lock: found 1 package with issues
+
+  league/flysystem@1.0.8 has the following known vulnerabilities:
+    GHSA-9f46-5r25-5wfm: Time-of-check Time-of-use (TOCTOU) Race Condition in league/flysystem (https://osv.dev/GHSA-9f46-5r25-5wfm)
+
+  1 known vulnerability found in lockfile:<rootdir>/fixtures/locks-insecure/composer.lock
+
+npm
+
+lockfile:<rootdir>/fixtures/locks-insecure/my-package-lock.json: found 1 package with issues
+
+  ansi-html@0.0.1 has the following known vulnerabilities:
+    GHSA-whgm-jr23-g3j9: Uncontrolled Resource Consumption in ansi-html (https://osv.dev/GHSA-whgm-jr23-g3j9)
+
+  1 known vulnerability found in lockfile:<rootdir>/fixtures/locks-insecure/my-package-lock.json
+
+lockfile:<rootdir>/fixtures/locks-insecure/my-yarn.lock: found 1 package with issues
+
+  ansi-html@0.0.1 has the following known vulnerabilities:
+    GHSA-whgm-jr23-g3j9: Uncontrolled Resource Consumption in ansi-html (https://osv.dev/GHSA-whgm-jr23-g3j9)
+
+  1 known vulnerability found in lockfile:<rootdir>/fixtures/locks-insecure/my-yarn.lock
+
 
 ---
 
@@ -2957,12 +3355,28 @@ Scanned <rootdir>/fixtures/locks-insecure/my-package-lock.json file as a package
 Scanning dir ./fixtures/locks-insecure
 Scanned <rootdir>/fixtures/locks-insecure/bun.lock file and found 2 packages
 Scanned <rootdir>/fixtures/locks-insecure/composer.lock file and found 1 package
-+-------------------------------------+------+-----------+------------------+---------+----------------------------------------------+
-| OSV URL                             | CVSS | ECOSYSTEM | PACKAGE          | VERSION | SOURCE                                       |
-+-------------------------------------+------+-----------+------------------+---------+----------------------------------------------+
-| https://osv.dev/GHSA-9f46-5r25-5wfm | 9.8  | Packagist | league/flysystem | 1.0.8   | fixtures/locks-insecure/composer.lock        |
-| https://osv.dev/GHSA-whgm-jr23-g3j9 | 7.5  | npm       | ansi-html        | 0.0.1   | fixtures/locks-insecure/my-package-lock.json |
-+-------------------------------------+------+-----------+------------------+---------+----------------------------------------------+
+
+Total 2 packages affected by 2 known vulnerabilities (1 Critical, 1 High, 0 Medium, 0 Low, 0 Unknown) from 2 ecosystems.
+2 vulnerabilities can be fixed.
+
+Packagist
+
+lockfile:<rootdir>/fixtures/locks-insecure/composer.lock: found 1 package with issues
+
+  league/flysystem@1.0.8 has the following known vulnerabilities:
+    GHSA-9f46-5r25-5wfm: Time-of-check Time-of-use (TOCTOU) Race Condition in league/flysystem (https://osv.dev/GHSA-9f46-5r25-5wfm)
+
+  1 known vulnerability found in lockfile:<rootdir>/fixtures/locks-insecure/composer.lock
+
+npm
+
+lockfile:<rootdir>/fixtures/locks-insecure/my-package-lock.json: found 1 package with issues
+
+  ansi-html@0.0.1 has the following known vulnerabilities:
+    GHSA-whgm-jr23-g3j9: Uncontrolled Resource Consumption in ansi-html (https://osv.dev/GHSA-whgm-jr23-g3j9)
+
+  1 known vulnerability found in lockfile:<rootdir>/fixtures/locks-insecure/my-package-lock.json
+
 
 ---
 
@@ -2995,15 +3409,24 @@ No issues found
 
 [Test_run_MavenTransitive/resolve_transitive_dependencies_with_native_data_source - 1]
 Scanned <rootdir>/fixtures/maven-transitive/registry.xml file as a pom.xml and found 59 packages
-+-------------------------------------+------+-----------+-----------------------------------------------+---------+----------------------------------------+
-| OSV URL                             | CVSS | ECOSYSTEM | PACKAGE                                       | VERSION | SOURCE                                 |
-+-------------------------------------+------+-----------+-----------------------------------------------+---------+----------------------------------------+
-| https://osv.dev/GHSA-cm6r-892j-jv2g | 6.1  | Maven     | com.google.android.gms:play-services-basement | 10.0.0  | fixtures/maven-transitive/registry.xml |
-| https://osv.dev/GHSA-7rjr-3q55-vv33 | 9.0  | Maven     | org.apache.logging.log4j:log4j-core           | 2.14.1  | fixtures/maven-transitive/registry.xml |
-| https://osv.dev/GHSA-8489-44mv-ggj8 | 6.6  | Maven     | org.apache.logging.log4j:log4j-core           | 2.14.1  | fixtures/maven-transitive/registry.xml |
-| https://osv.dev/GHSA-jfh8-c2jp-5v3q | 10.0 | Maven     | org.apache.logging.log4j:log4j-core           | 2.14.1  | fixtures/maven-transitive/registry.xml |
-| https://osv.dev/GHSA-p6xc-xr62-6r2g | 8.6  | Maven     | org.apache.logging.log4j:log4j-core           | 2.14.1  | fixtures/maven-transitive/registry.xml |
-+-------------------------------------+------+-----------+-----------------------------------------------+---------+----------------------------------------+
+
+Total 2 packages affected by 5 known vulnerabilities (2 Critical, 1 High, 2 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+5 vulnerabilities can be fixed.
+
+Maven
+
+lockfile:<rootdir>/fixtures/maven-transitive/registry.xml: found 2 packages with issues
+
+  com.google.android.gms:play-services-basement@10.0.0 has the following known vulnerabilities:
+    GHSA-cm6r-892j-jv2g: Google Play Services SDK leads to apps having incorrectly set mutability flag (https://osv.dev/GHSA-cm6r-892j-jv2g)
+  org.apache.logging.log4j:log4j-core@2.14.1 has the following known vulnerabilities:
+    GHSA-7rjr-3q55-vv33: Incomplete fix for Apache Log4j vulnerability (https://osv.dev/GHSA-7rjr-3q55-vv33)
+    GHSA-8489-44mv-ggj8: Improper Input Validation and Injection in Apache Log4j2 (https://osv.dev/GHSA-8489-44mv-ggj8)
+    GHSA-jfh8-c2jp-5v3q: Remote code injection in Log4j (https://osv.dev/GHSA-jfh8-c2jp-5v3q)
+    GHSA-p6xc-xr62-6r2g: Apache Log4j2 vulnerable to Improper Input Validation and Uncontrolled... (https://osv.dev/GHSA-p6xc-xr62-6r2g)
+
+  5 known vulnerabilities found in lockfile:<rootdir>/fixtures/maven-transitive/registry.xml
+
 
 ---
 
@@ -3013,15 +3436,24 @@ Scanned <rootdir>/fixtures/maven-transitive/registry.xml file as a pom.xml and f
 
 [Test_run_MavenTransitive/scans_dependencies_from_multiple_registries - 1]
 Scanned <rootdir>/fixtures/maven-transitive/registry.xml file as a pom.xml and found 59 packages
-+-------------------------------------+------+-----------+-----------------------------------------------+---------+----------------------------------------+
-| OSV URL                             | CVSS | ECOSYSTEM | PACKAGE                                       | VERSION | SOURCE                                 |
-+-------------------------------------+------+-----------+-----------------------------------------------+---------+----------------------------------------+
-| https://osv.dev/GHSA-cm6r-892j-jv2g | 6.1  | Maven     | com.google.android.gms:play-services-basement | 10.0.0  | fixtures/maven-transitive/registry.xml |
-| https://osv.dev/GHSA-7rjr-3q55-vv33 | 9.0  | Maven     | org.apache.logging.log4j:log4j-core           | 2.14.1  | fixtures/maven-transitive/registry.xml |
-| https://osv.dev/GHSA-8489-44mv-ggj8 | 6.6  | Maven     | org.apache.logging.log4j:log4j-core           | 2.14.1  | fixtures/maven-transitive/registry.xml |
-| https://osv.dev/GHSA-jfh8-c2jp-5v3q | 10.0 | Maven     | org.apache.logging.log4j:log4j-core           | 2.14.1  | fixtures/maven-transitive/registry.xml |
-| https://osv.dev/GHSA-p6xc-xr62-6r2g | 8.6  | Maven     | org.apache.logging.log4j:log4j-core           | 2.14.1  | fixtures/maven-transitive/registry.xml |
-+-------------------------------------+------+-----------+-----------------------------------------------+---------+----------------------------------------+
+
+Total 2 packages affected by 5 known vulnerabilities (2 Critical, 1 High, 2 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+5 vulnerabilities can be fixed.
+
+Maven
+
+lockfile:<rootdir>/fixtures/maven-transitive/registry.xml: found 2 packages with issues
+
+  com.google.android.gms:play-services-basement@10.0.0 has the following known vulnerabilities:
+    GHSA-cm6r-892j-jv2g: Google Play Services SDK leads to apps having incorrectly set mutability flag (https://osv.dev/GHSA-cm6r-892j-jv2g)
+  org.apache.logging.log4j:log4j-core@2.14.1 has the following known vulnerabilities:
+    GHSA-7rjr-3q55-vv33: Incomplete fix for Apache Log4j vulnerability (https://osv.dev/GHSA-7rjr-3q55-vv33)
+    GHSA-8489-44mv-ggj8: Improper Input Validation and Injection in Apache Log4j2 (https://osv.dev/GHSA-8489-44mv-ggj8)
+    GHSA-jfh8-c2jp-5v3q: Remote code injection in Log4j (https://osv.dev/GHSA-jfh8-c2jp-5v3q)
+    GHSA-p6xc-xr62-6r2g: Apache Log4j2 vulnerable to Improper Input Validation and Uncontrolled... (https://osv.dev/GHSA-p6xc-xr62-6r2g)
+
+  5 known vulnerabilities found in lockfile:<rootdir>/fixtures/maven-transitive/registry.xml
+
 
 ---
 
@@ -3031,11 +3463,19 @@ Scanned <rootdir>/fixtures/maven-transitive/registry.xml file as a pom.xml and f
 
 [Test_run_MavenTransitive/scans_pom.xml_with_non_UTF-8_encoding - 1]
 Scanned <rootdir>/fixtures/maven-transitive/encoding.xml file as a pom.xml and found 2 packages
-+-------------------------------------+------+-----------+-------------+---------+----------------------------------------+
-| OSV URL                             | CVSS | ECOSYSTEM | PACKAGE     | VERSION | SOURCE                                 |
-+-------------------------------------+------+-----------+-------------+---------+----------------------------------------+
-| https://osv.dev/GHSA-269g-pwp5-87pp | 4.4  | Maven     | junit:junit | 4.12    | fixtures/maven-transitive/encoding.xml |
-+-------------------------------------+------+-----------+-------------+---------+----------------------------------------+
+
+Total 1 package affected by 1 known vulnerability (0 Critical, 0 High, 1 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+1 vulnerability can be fixed.
+
+Maven
+
+lockfile:<rootdir>/fixtures/maven-transitive/encoding.xml: found 1 package with issues
+
+  junit:junit@4.12 has the following known vulnerabilities:
+    GHSA-269g-pwp5-87pp: TemporaryFolder on unix-like systems does not limit access to created files (https://osv.dev/GHSA-269g-pwp5-87pp)
+
+  1 known vulnerability found in lockfile:<rootdir>/fixtures/maven-transitive/encoding.xml
+
 
 ---
 
@@ -3045,14 +3485,22 @@ Scanned <rootdir>/fixtures/maven-transitive/encoding.xml file as a pom.xml and f
 
 [Test_run_MavenTransitive/scans_transitive_dependencies_by_specifying_pom.xml - 1]
 Scanned <rootdir>/fixtures/maven-transitive/abc.xml file as a pom.xml and found 3 packages
-+-------------------------------------+------+-----------+-------------------------------------+---------+-----------------------------------+
-| OSV URL                             | CVSS | ECOSYSTEM | PACKAGE                             | VERSION | SOURCE                            |
-+-------------------------------------+------+-----------+-------------------------------------+---------+-----------------------------------+
-| https://osv.dev/GHSA-7rjr-3q55-vv33 | 9.0  | Maven     | org.apache.logging.log4j:log4j-core | 2.14.1  | fixtures/maven-transitive/abc.xml |
-| https://osv.dev/GHSA-8489-44mv-ggj8 | 6.6  | Maven     | org.apache.logging.log4j:log4j-core | 2.14.1  | fixtures/maven-transitive/abc.xml |
-| https://osv.dev/GHSA-jfh8-c2jp-5v3q | 10.0 | Maven     | org.apache.logging.log4j:log4j-core | 2.14.1  | fixtures/maven-transitive/abc.xml |
-| https://osv.dev/GHSA-p6xc-xr62-6r2g | 8.6  | Maven     | org.apache.logging.log4j:log4j-core | 2.14.1  | fixtures/maven-transitive/abc.xml |
-+-------------------------------------+------+-----------+-------------------------------------+---------+-----------------------------------+
+
+Total 1 package affected by 4 known vulnerabilities (2 Critical, 1 High, 1 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+4 vulnerabilities can be fixed.
+
+Maven
+
+lockfile:<rootdir>/fixtures/maven-transitive/abc.xml: found 1 package with issues
+
+  org.apache.logging.log4j:log4j-core@2.14.1 has the following known vulnerabilities:
+    GHSA-7rjr-3q55-vv33: Incomplete fix for Apache Log4j vulnerability (https://osv.dev/GHSA-7rjr-3q55-vv33)
+    GHSA-8489-44mv-ggj8: Improper Input Validation and Injection in Apache Log4j2 (https://osv.dev/GHSA-8489-44mv-ggj8)
+    GHSA-jfh8-c2jp-5v3q: Remote code injection in Log4j (https://osv.dev/GHSA-jfh8-c2jp-5v3q)
+    GHSA-p6xc-xr62-6r2g: Apache Log4j2 vulnerable to Improper Input Validation and Uncontrolled... (https://osv.dev/GHSA-p6xc-xr62-6r2g)
+
+  4 known vulnerabilities found in lockfile:<rootdir>/fixtures/maven-transitive/abc.xml
+
 
 ---
 
@@ -3063,14 +3511,22 @@ Scanned <rootdir>/fixtures/maven-transitive/abc.xml file as a pom.xml and found 
 [Test_run_MavenTransitive/scans_transitive_dependencies_for_pom.xml_by_default - 1]
 Scanning dir ./fixtures/maven-transitive/pom.xml
 Scanned <rootdir>/fixtures/maven-transitive/pom.xml file and found 3 packages
-+-------------------------------------+------+-----------+-------------------------------------+---------+-----------------------------------+
-| OSV URL                             | CVSS | ECOSYSTEM | PACKAGE                             | VERSION | SOURCE                            |
-+-------------------------------------+------+-----------+-------------------------------------+---------+-----------------------------------+
-| https://osv.dev/GHSA-7rjr-3q55-vv33 | 9.0  | Maven     | org.apache.logging.log4j:log4j-core | 2.14.1  | fixtures/maven-transitive/pom.xml |
-| https://osv.dev/GHSA-8489-44mv-ggj8 | 6.6  | Maven     | org.apache.logging.log4j:log4j-core | 2.14.1  | fixtures/maven-transitive/pom.xml |
-| https://osv.dev/GHSA-jfh8-c2jp-5v3q | 10.0 | Maven     | org.apache.logging.log4j:log4j-core | 2.14.1  | fixtures/maven-transitive/pom.xml |
-| https://osv.dev/GHSA-p6xc-xr62-6r2g | 8.6  | Maven     | org.apache.logging.log4j:log4j-core | 2.14.1  | fixtures/maven-transitive/pom.xml |
-+-------------------------------------+------+-----------+-------------------------------------+---------+-----------------------------------+
+
+Total 1 package affected by 4 known vulnerabilities (2 Critical, 1 High, 1 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+4 vulnerabilities can be fixed.
+
+Maven
+
+lockfile:<rootdir>/fixtures/maven-transitive/pom.xml: found 1 package with issues
+
+  org.apache.logging.log4j:log4j-core@2.14.1 has the following known vulnerabilities:
+    GHSA-7rjr-3q55-vv33: Incomplete fix for Apache Log4j vulnerability (https://osv.dev/GHSA-7rjr-3q55-vv33)
+    GHSA-8489-44mv-ggj8: Improper Input Validation and Injection in Apache Log4j2 (https://osv.dev/GHSA-8489-44mv-ggj8)
+    GHSA-jfh8-c2jp-5v3q: Remote code injection in Log4j (https://osv.dev/GHSA-jfh8-c2jp-5v3q)
+    GHSA-p6xc-xr62-6r2g: Apache Log4j2 vulnerable to Improper Input Validation and Uncontrolled... (https://osv.dev/GHSA-p6xc-xr62-6r2g)
+
+  4 known vulnerabilities found in lockfile:<rootdir>/fixtures/maven-transitive/pom.xml
+
 
 ---
 
@@ -3080,11 +3536,19 @@ Scanned <rootdir>/fixtures/maven-transitive/pom.xml file and found 3 packages
 
 [Test_run_MoreLockfiles/cabal.project.freeze - 1]
 Scanned <rootdir>/fixtures/locks-scalibr/cabal.project.freeze file and found 6 packages
-+--------------------------------+------+-----------+-----------------+---------+---------------------------------------------+
-| OSV URL                        | CVSS | ECOSYSTEM | PACKAGE         | VERSION | SOURCE                                      |
-+--------------------------------+------+-----------+-----------------+---------+---------------------------------------------+
-| https://osv.dev/HSEC-2024-0009 |      | Hackage   | biscuit-haskell | 0.3.0.0 | fixtures/locks-scalibr/cabal.project.freeze |
-+--------------------------------+------+-----------+-----------------+---------+---------------------------------------------+
+
+Total 1 package affected by 1 known vulnerability (0 Critical, 0 High, 0 Medium, 0 Low, 1 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+Hackage
+
+lockfile:<rootdir>/fixtures/locks-scalibr/cabal.project.freeze: found 1 package with issues
+
+  biscuit-haskell@0.3.0.0 has the following known vulnerabilities:
+    HSEC-2024-0009: Public key confusion in third-party blocks (https://osv.dev/HSEC-2024-0009)
+
+  1 known vulnerability found in lockfile:<rootdir>/fixtures/locks-scalibr/cabal.project.freeze
+
 
 ---
 
@@ -3094,11 +3558,19 @@ Scanned <rootdir>/fixtures/locks-scalibr/cabal.project.freeze file and found 6 p
 
 [Test_run_MoreLockfiles/depsjson - 1]
 Scanned <rootdir>/fixtures/locks-scalibr/depsjson file as a deps.json and found 4 packages
-+-------------------------------------+------+-----------+--------------------------+---------+---------------------------------+
-| OSV URL                             | CVSS | ECOSYSTEM | PACKAGE                  | VERSION | SOURCE                          |
-+-------------------------------------+------+-----------+--------------------------+---------+---------------------------------+
-| https://osv.dev/GHSA-4cv2-4hjh-77rx |      | NuGet     | System.Linq.Dynamic.Core | 1.3.7   | fixtures/locks-scalibr/depsjson |
-+-------------------------------------+------+-----------+--------------------------+---------+---------------------------------+
+
+Total 1 package affected by 1 known vulnerability (0 Critical, 0 High, 0 Medium, 0 Low, 1 Unknown) from 1 ecosystem.
+1 vulnerability can be fixed.
+
+NuGet
+
+lockfile:<rootdir>/fixtures/locks-scalibr/depsjson: found 1 package with issues
+
+  System.Linq.Dynamic.Core@1.3.7 has the following known vulnerabilities:
+    GHSA-4cv2-4hjh-77rx: Property reflection in System.Linq.Dynamic.Core (https://osv.dev/GHSA-4cv2-4hjh-77rx)
+
+  1 known vulnerability found in lockfile:<rootdir>/fixtures/locks-scalibr/depsjson
+
 
 ---
 
@@ -3129,23 +3601,78 @@ No issues found
 [Test_run_OCIImage/Alpine_3.10_image_tar_with_3.18_version_file - 1]
 Scanning local image tarball "../../internal/image/fixtures/test-alpine.tar"
 
-Container Scanning Result (Alpine Linux v3.18):
 Total 2 packages affected by 41 known vulnerabilities (2 Critical, 17 High, 14 Medium, 0 Low, 8 Unknown) from 1 ecosystem.
 41 vulnerabilities can be fixed.
 
+Container image information:
+  OS version: Alpine Linux v3.18
+  Base Image 1 (alpine):
+    Layer 0 /bin/sh -c #(nop) ADD file:UNKNOWN in /
+    Layer 1 /bin/sh -c #(nop) CMD ["/bin/sh"]
+  Your Image:
+    Layer 2 COPY alpine-3.18-alpine-release /etc/alpine-release # buildkit
+    Layer 3 COPY alpine-3.18-os-release /etc/os-release # buildkit (41 vulns)
 
 Alpine:v3.18
-+---------------------------------------------------------------------------------------------+
-| Source:os:lib/apk/db/installed                                                              |
-+---------+-------------------+---------------+------------+------------------+---------------+
-| PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
-+---------+-------------------+---------------+------------+------------------+---------------+
-| openssl | 1.1.1k-r0         | Fix Available |         39 | # 3 Layer        | --            |
-| zlib    | 1.2.11-r1         | Fix Available |          2 | # 3 Layer        | --            |
-+---------+-------------------+---------------+------------+------------------+---------------+
 
-For the most comprehensive scan results, we recommend using the HTML output: `osv-scanner scan image --serve <image_name>`.
-You can also view the full vulnerability list in your terminal with: `osv-scanner scan image --format vertical <image_name>`.
+os:lib/apk/db/installed: found 2 packages with issues
+
+  openssl@1.1.1k-r0 has the following known vulnerabilities:
+    introduced in # 3 Layer
+    CVE-2021-3711: In order to decrypt SM2 encrypted data an application is expected to call the... (https://osv.dev/CVE-2021-3711)
+    CVE-2021-3712: ASN.1 strings are represented internally within OpenSSL as an ASN1_STRING... (https://osv.dev/CVE-2021-3712)
+    CVE-2021-4044: Internally libssl in OpenSSL calls X509_verify_cert() on the client side to... (https://osv.dev/CVE-2021-4044)
+    CVE-2022-0778: The BN_mod_sqrt() function, which computes a modular square root, contains a... (https://osv.dev/CVE-2022-0778)
+    CVE-2022-1343: The function `OCSP_basic_verify` verifies the signer certificate on an OCSP... (https://osv.dev/CVE-2022-1343)
+    CVE-2022-1434: The OpenSSL 3.0 implementation of the RC4-MD5 ciphersuite incorrectly uses the... (https://osv.dev/CVE-2022-1434)
+    CVE-2022-1473: The OPENSSL_LH_flush() function, which empties a hash table, contains a bug... (https://osv.dev/CVE-2022-1473)
+    CVE-2022-2097: AES OCB mode for 32-bit x86 platforms using the AES-NI assembly optimised... (https://osv.dev/CVE-2022-2097)
+    CVE-2022-3358: OpenSSL supports creating a custom cipher via the legacy EVP_CIPHER_meth_new()... (https://osv.dev/CVE-2022-3358)
+    CVE-2022-3602: A buffer overrun can be triggered in X.509 certificate verification,... (https://osv.dev/CVE-2022-3602)
+    CVE-2022-3786: A buffer overrun can be triggered in X.509 certificate verification,... (https://osv.dev/CVE-2022-3786)
+    CVE-2022-3996: If an X.509 certificate contains a malformed policy constraint and
+policy... (https://osv.dev/CVE-2022-3996)
+    CVE-2022-4203: A read buffer overrun can be triggered in X.509 certificate verification,... (https://osv.dev/CVE-2022-4203)
+    CVE-2022-4304: A timing based side channel exists in the OpenSSL RSA Decryption implementation... (https://osv.dev/CVE-2022-4304)
+    CVE-2022-4450: The function PEM_read_bio_ex() reads a PEM file from a BIO and parses and... (https://osv.dev/CVE-2022-4450)
+    CVE-2023-0215: The public API function BIO_new_NDEF is a helper function used for streaming... (https://osv.dev/CVE-2023-0215)
+    CVE-2023-0216: An invalid pointer dereference on read can be triggered when an
+application... (https://osv.dev/CVE-2023-0216)
+    CVE-2023-0217: An invalid pointer dereference on read can be triggered when an
+application... (https://osv.dev/CVE-2023-0217)
+    CVE-2023-0286: There is a type confusion vulnerability relating to X.400 address processing... (https://osv.dev/CVE-2023-0286)
+    CVE-2023-0401: A NULL pointer can be dereferenced when signatures are being
+verified on PKCS7... (https://osv.dev/CVE-2023-0401)
+    CVE-2023-0464: A security vulnerability has been identified in all supported versions
+
+of... (https://osv.dev/CVE-2023-0464)
+    CVE-2023-0465: Applications that use a non-default option when verifying certificates may be... (https://osv.dev/CVE-2023-0465)
+    CVE-2023-1255: Issue summary: The AES-XTS cipher decryption implementation for 64 bit ARM... (https://osv.dev/CVE-2023-1255)
+    CVE-2023-2650: Issue summary: Processing some specially crafted ASN.1 object identifiers or... (https://osv.dev/CVE-2023-2650)
+    CVE-2023-2975: Issue summary: The AES-SIV cipher implementation contains a bug that causes
+it... (https://osv.dev/CVE-2023-2975)
+    CVE-2023-3446: Issue summary: Checking excessively long DH keys or parameters may be very... (https://osv.dev/CVE-2023-3446)
+    CVE-2023-3817: Issue summary: Checking excessively long DH keys or parameters may be very... (https://osv.dev/CVE-2023-3817)
+    CVE-2023-5363: Issue summary: A bug has been identified in the processing of key and... (https://osv.dev/CVE-2023-5363)
+    CVE-2023-5678: Issue summary: Generating excessively long X9.42 DH keys or checking... (https://osv.dev/CVE-2023-5678)
+    CVE-2023-6129: Issue summary: The POLY1305 MAC (message authentication code) implementation... (https://osv.dev/CVE-2023-6129)
+    CVE-2023-6237: Issue summary: Checking excessively long invalid RSA public keys may take
+a... (https://osv.dev/CVE-2023-6237)
+    CVE-2024-0727: Issue summary: Processing a maliciously formatted PKCS12 file may lead OpenSSL... (https://osv.dev/CVE-2024-0727)
+    CVE-2024-13176: Issue summary: A timing side-channel which could potentially allow recovering... (https://osv.dev/CVE-2024-13176)
+    CVE-2024-2511: Issue summary: Some non-default TLS server configurations can cause unbounded... (https://osv.dev/CVE-2024-2511)
+    CVE-2024-4603: Issue summary: Checking excessively long DSA keys or parameters may be very... (https://osv.dev/CVE-2024-4603)
+    CVE-2024-4741: Issue summary: Calling the OpenSSL API function SSL_free_buffers may cause... (https://osv.dev/CVE-2024-4741)
+    CVE-2024-5535: Issue summary: Calling the OpenSSL API function SSL_select_next_proto with an... (https://osv.dev/CVE-2024-5535)
+    CVE-2024-6119: Issue summary: Applications performing certificate name checks (e.g., TLS... (https://osv.dev/CVE-2024-6119)
+    CVE-2024-9143: Issue summary: Use of the low-level GF(2^m) elliptic curve APIs with untrusted... (https://osv.dev/CVE-2024-9143)
+  zlib@1.2.11-r1 has the following known vulnerabilities:
+    introduced in # 3 Layer
+    CVE-2018-25032: zlib before 1.2.12 allows memory corruption when deflating (i.e., when... (https://osv.dev/CVE-2018-25032)
+    CVE-2022-37434: zlib through 1.2.12 has a heap-based buffer over-read or buffer overflow in... (https://osv.dev/CVE-2022-37434)
+
+  41 known vulnerabilities found in os:lib/apk/db/installed
+
 
 ---
 
@@ -3168,41 +3695,90 @@ failed to load image from tarball with path "./fixtures/oci-image/no-file-here.t
 [Test_run_OCIImage/Scanning_java_image_with_some_packages - 1]
 Scanning local image tarball "../../internal/image/fixtures/test-java-full.tar"
 
-Container Scanning Result (Alpine Linux v3.21):
 Total 13 packages affected by 18 known vulnerabilities (1 Critical, 5 High, 8 Medium, 0 Low, 4 Unknown) from 2 ecosystems.
 18 vulnerabilities can be fixed.
 
+Container image information:
+  OS version: Alpine Linux v3.21
+  Base Image 5 (alpine):
+    Layer 0  ADD alpine-minirootfs-3.21.2-x86_64.tar.gz / # buildkit (3 vulns)
+  Base Image 4 (alpine):
+    Layer 1  CMD ["/bin/sh"]
+  Base Image 3 (amitnimbus2004/alpine-amsobit-git):
+    Layer 2  ENV JAVA_HOME=/opt/java/openjdk
+  Base Image 2 (kabomo7586/test):
+    Layer 3  ENV PATH=/opt/java/openjdk/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+  Base Image 1 (eclipse-temurin):
+    Layer 4  ENV LANG=en_US.UTF-8 LANGUAGE=en_US:en LC_ALL=en_US.UTF-8
+    Layer 5  RUN /bin/sh -c set -eux; apk add --no-cache fontconfig ttf-dejavu gnupg ca-certificates... (1 vulns)
+    Layer 6  ENV JAVA_VERSION=jdk-21.0.6+7
+    Layer 7  RUN /bin/sh -c set -eux; ARCH="$(apk --print-arch)"; case "${ARCH}" in aarch64)...
+    Layer 8  RUN /bin/sh -c set -eux; echo "Verifying install ..."; echo "java --version"; java --version; echo...
+    Layer 9  COPY --chmod=755 entrypoint.sh /__cacert_entrypoint.sh # buildkit
+    Layer 10 ENTRYPOINT ["/__cacert_entrypoint.sh"]
+  Your Image:
+    Layer 11 WORKDIR /app
+    Layer 12 COPY /app/target/my-app-1.0-SNAPSHOT-jar-with-dependencies.jar target.jar # buildkit (14 vulns)
+    Layer 13 ENTRYPOINT ["java" "-jar" "target.jar"]
 
 Maven
-+-------------------------------------------------------------------------------------------------------------------------------+
-| Source:artifact:app/target.jar                                                                                                |
-+-------------------------------------------+-------------------+---------------+------------+------------------+---------------+
-| PACKAGE                                   | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
-+-------------------------------------------+-------------------+---------------+------------+------------------+---------------+
-| com.google.protobuf:protobuf-java         | 3.21.12           | Fix Available |          1 | # 12 Layer       | --            |
-| com.nimbusds:nimbus-jose-jwt              | 9.31              | Fix Available |          1 | # 12 Layer       | --            |
-| dnsjava:dnsjava                           | 3.4.0             | Fix Available |          1 | # 12 Layer       | --            |
-| io.netty:netty-codec-http                 | 4.1.100.Final     | Fix Available |          1 | # 12 Layer       | --            |
-| io.netty:netty-common                     | 4.1.100.Final     | Fix Available |          2 | # 12 Layer       | --            |
-| io.netty:netty-handler                    | 4.1.100.Final     | Fix Available |          1 | # 12 Layer       | --            |
-| org.apache.avro:avro                      | 1.9.2             | Fix Available |          2 | # 12 Layer       | --            |
-| org.apache.commons:commons-compress       | 1.21              | Fix Available |          2 | # 12 Layer       | --            |
-| org.apache.commons:commons-configuration2 | 2.8.0             | Fix Available |          2 | # 12 Layer       | --            |
-| org.eclipse.jetty:jetty-http              | 9.4.53.v20231009  | Fix Available |          1 | # 12 Layer       | --            |
-+-------------------------------------------+-------------------+---------------+------------+------------------+---------------+
-Alpine:v3.21
-+------------------------------------------------------------------------------------------------+
-| Source:os:lib/apk/db/installed                                                                 |
-+----------+-------------------+---------------+------------+------------------+-----------------+
-| PACKAGE  | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE   |
-+----------+-------------------+---------------+------------+------------------+-----------------+
-| libtasn1 | 4.19.0-r2         | Fix Available |          1 | # 5 Layer        | eclipse-temurin |
-| musl     | 1.2.5-r8          | Fix Available |          1 | # 0 Layer        | alpine          |
-| openssl  | 3.3.2-r4          | Fix Available |          2 | # 0 Layer        | alpine          |
-+----------+-------------------+---------------+------------+------------------+-----------------+
 
-For the most comprehensive scan results, we recommend using the HTML output: `osv-scanner scan image --serve <image_name>`.
-You can also view the full vulnerability list in your terminal with: `osv-scanner scan image --format vertical <image_name>`.
+artifact:app/target.jar: found 10 packages with issues
+
+  com.google.protobuf:protobuf-java@3.21.12 has the following known vulnerabilities:
+    introduced in # 12 Layer
+    GHSA-735f-pc8j-v9w8: protobuf-java has potential Denial of Service issue (https://osv.dev/GHSA-735f-pc8j-v9w8)
+  com.nimbusds:nimbus-jose-jwt@9.31 has the following known vulnerabilities:
+    introduced in # 12 Layer
+    GHSA-gvpg-vgmx-xg6w: Denial of Service in Connect2id Nimbus JOSE+JWT (https://osv.dev/GHSA-gvpg-vgmx-xg6w)
+  dnsjava:dnsjava@3.4.0 has the following known vulnerabilities:
+    introduced in # 12 Layer
+    GHSA-cfxw-4h78-h7fw: DNSJava DNSSEC Bypass (https://osv.dev/GHSA-cfxw-4h78-h7fw)
+  io.netty:netty-codec-http@4.1.100.Final has the following known vulnerabilities:
+    introduced in # 12 Layer
+    GHSA-5jpm-x58v-624v: Netty's HttpPostRequestDecoder can OOM (https://osv.dev/GHSA-5jpm-x58v-624v)
+  io.netty:netty-common@4.1.100.Final has the following known vulnerabilities:
+    introduced in # 12 Layer
+    GHSA-389x-839f-4rhx: Denial of Service attack on windows app using Netty (https://osv.dev/GHSA-389x-839f-4rhx)
+    GHSA-xq3w-v528-46rv: Denial of Service attack on windows app using netty (https://osv.dev/GHSA-xq3w-v528-46rv)
+  io.netty:netty-handler@4.1.100.Final has the following known vulnerabilities:
+    introduced in # 12 Layer
+    GHSA-4g8c-wm8x-jfhw: SslHandler doesn't correctly validate packets which can lead to native crash... (https://osv.dev/GHSA-4g8c-wm8x-jfhw)
+  org.apache.avro:avro@1.9.2 has the following known vulnerabilities:
+    introduced in # 12 Layer
+    GHSA-r7pg-v2c8-mfg3: Apache Avro Java SDK: Arbitrary Code Execution when reading Avro Data (Java... (https://osv.dev/GHSA-r7pg-v2c8-mfg3)
+    GHSA-rhrv-645h-fjfh: Apache Avro Java SDK vulnerable to Improper Input Validation (https://osv.dev/GHSA-rhrv-645h-fjfh)
+  org.apache.commons:commons-compress@1.21 has the following known vulnerabilities:
+    introduced in # 12 Layer
+    GHSA-4265-ccf5-phj5: Apache Commons Compress: OutOfMemoryError unpacking broken Pack200 file (https://osv.dev/GHSA-4265-ccf5-phj5)
+    GHSA-4g9r-vxhx-9pgx: Apache Commons Compress: Denial of service caused by an infinite loop for a... (https://osv.dev/GHSA-4g9r-vxhx-9pgx)
+  org.apache.commons:commons-configuration2@2.8.0 has the following known vulnerabilities:
+    introduced in # 12 Layer
+    GHSA-9w38-p64v-xpmv: Apache Commons Configuration: StackOverflowError calling... (https://osv.dev/GHSA-9w38-p64v-xpmv)
+    GHSA-xjp4-hw94-mvp5: Apache Commons Configuration: StackOverflowError adding property in... (https://osv.dev/GHSA-xjp4-hw94-mvp5)
+  org.eclipse.jetty:jetty-http@9.4.53.v20231009 has the following known vulnerabilities:
+    introduced in # 12 Layer
+    GHSA-qh8g-58pp-2wxh: Eclipse Jetty URI parsing of invalid authority (https://osv.dev/GHSA-qh8g-58pp-2wxh)
+
+  14 known vulnerabilities found in artifact:app/target.jar
+
+Alpine:v3.21
+
+os:lib/apk/db/installed: found 3 packages with issues
+
+  libtasn1@4.19.0-r2 has the following known vulnerabilities:
+    introduced in # 5 Layer (eclipse-temurin)
+    CVE-2024-12133: A flaw in libtasn1 causes inefficient handling of specific certificate data.... (https://osv.dev/CVE-2024-12133)
+  musl@1.2.5-r8 has the following known vulnerabilities:
+    introduced in # 0 Layer (alpine)
+    CVE-2025-26519: musl libc 0.9.13 through 1.2.5 before 1.2.6 has an out-of-bounds write... (https://osv.dev/CVE-2025-26519)
+  openssl@3.3.2-r4 has the following known vulnerabilities:
+    introduced in # 0 Layer (alpine)
+    CVE-2024-12797: Issue summary: Clients using RFC7250 Raw Public Keys (RPKs) to authenticate a... (https://osv.dev/CVE-2024-12797)
+    CVE-2024-13176: Issue summary: A timing side-channel which could potentially allow recovering... (https://osv.dev/CVE-2024-13176)
+
+  4 known vulnerabilities found in os:lib/apk/db/installed
+
 
 ---
 
@@ -3214,46 +3790,93 @@ Warning: `scan` exists as both a subcommand of OSV-Scanner and as a file on the 
 [Test_run_OCIImage/Scanning_python_image_with_no_packages - 1]
 Scanning local image tarball "../../internal/image/fixtures/test-python-empty.tar"
 
-Container Scanning Result (Debian GNU/Linux 10 (buster)):
 Total 12 packages affected by 17 known vulnerabilities (0 Critical, 2 High, 1 Medium, 0 Low, 14 Unknown) from 2 ecosystems.
 17 vulnerabilities can be fixed.
 
+Container image information:
+  OS version: Debian GNU/Linux 10 (buster)
+  Base Image 1 (python):
+    Layer 0  /bin/sh -c #(nop) ADD file:UNKNOWN in / (12 vulns)
+    Layer 1  /bin/sh -c #(nop) CMD ["bash"]
+    Layer 2  ENV PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    Layer 3  ENV LANG=C.UTF-8
+    Layer 4  RUN /bin/sh -c set -eux; apt-get update; apt-get install -y --no-install-recommends ca-certificates... (1 vulns)
+    Layer 5  ENV GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
+    Layer 6  ENV PYTHON_VERSION=3.9.17
+    Layer 7  RUN /bin/sh -c set -eux; savedAptMark="$(apt-mark showmanual)"; apt-get update; apt-get install -y... (1 vulns)
+    Layer 8  RUN /bin/sh -c set -eux; for src in idle3 pydoc3 python3 python3-config; do dst="$(echo "$src" | tr...
+    Layer 9  ENV PYTHON_PIP_VERSION=23.0.1
+    Layer 10 ENV PYTHON_SETUPTOOLS_VERSION=58.1.0
+    Layer 11 ENV...
+    Layer 12 ENV PYTHON_GET_PIP_SHA256=96461deced5c2a487ddc65207ec5a9cffeca0d34e7af7ea1afc470ff0d746207
+    Layer 13 RUN /bin/sh -c set -eux; savedAptMark="$(apt-mark showmanual)"; apt-get update; apt-get install -y... (3 vulns)
+    Layer 14 CMD ["python3"]
+  Your Image:
+    Layer 15 WORKDIR /app
+    Layer 16 COPY python-fixture/main.py main.py # buildkit
+    Layer 17 CMD ["python" "main.py"]
 
 PyPI
-+---------------------------------------------------------------------------------------------+
-| Source:artifact:usr/local/lib/python3.9/site-packages/pip-23.0.1.dist-info/METADATA         |
-+---------+-------------------+---------------+------------+------------------+---------------+
-| PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
-+---------+-------------------+---------------+------------+------------------+---------------+
-| pip     | 23.0.1            | Fix Available |          1 | # 13 Layer       | python        |
-+---------+-------------------+---------------+------------+------------------+---------------+
-+------------------------------------------------------------------------------------------------+
-| Source:artifact:usr/local/lib/python3.9/site-packages/setuptools-58.1.0.dist-info/METADATA     |
-+------------+-------------------+---------------+------------+------------------+---------------+
-| PACKAGE    | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
-+------------+-------------------+---------------+------------+------------------+---------------+
-| setuptools | 58.1.0            | Fix Available |          2 | # 13 Layer       | python        |
-+------------+-------------------+---------------+------------+------------------+---------------+
-Debian:10
-+-----------------------------------------------------------------------------------------------------------------+
-| Source:os:var/lib/dpkg/status                                                                                   |
-+------------------------+------------------------+---------------+------------+------------------+---------------+
-| PACKAGE                | INSTALLED VERSION      | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
-+------------------------+------------------------+---------------+------------+------------------+---------------+
-| debian-archive-keyring | 2019.1+deb10u1         | Fix Available |          1 | # 0 Layer        | python        |
-| expat                  | 2.2.6-2+deb10u6        | Fix Available |          1 | # 7 Layer        | python        |
-| glibc                  | 2.28-10+deb10u2        | Fix Available |          2 | # 0 Layer        | python        |
-| gnutls28               | 3.6.7-4+deb10u10       | Fix Available |          2 | # 0 Layer        | python        |
-| ncurses                | 6.1+20181013-2+deb10u3 | Fix Available |          2 | # 0 Layer        | python        |
-| openssl                | 1.1.1n-0+deb10u5       | Fix Available |          1 | # 4 Layer        | python        |
-| systemd                | 241-7~deb10u9          | Fix Available |          1 | # 0 Layer        | python        |
-| tar                    | 1.30+dfsg-6            | Fix Available |          1 | # 0 Layer        | python        |
-| tzdata                 | 2021a-0+deb10u11       | Fix Available |          2 | # 0 Layer        | python        |
-| util-linux             | 2.33.1-0.1             | Fix Available |          1 | # 0 Layer        | python        |
-+------------------------+------------------------+---------------+------------+------------------+---------------+
 
-For the most comprehensive scan results, we recommend using the HTML output: `osv-scanner scan image --serve <image_name>`.
-You can also view the full vulnerability list in your terminal with: `osv-scanner scan image --format vertical <image_name>`.
+artifact:usr/local/lib/python3.9/site-packages/pip-23.0.1.dist-info/METADATA: found 1 package with issues
+
+  pip@23.0.1 has the following known vulnerabilities:
+    introduced in # 13 Layer (python)
+    PYSEC-2023-228: When installing a package from a Mercurial VCS URL  (ie "pip install 
+hg+...")... (https://osv.dev/PYSEC-2023-228)
+
+  1 known vulnerability found in artifact:usr/local/lib/python3.9/site-packages/pip-23.0.1.dist-info/METADATA
+
+artifact:usr/local/lib/python3.9/site-packages/setuptools-58.1.0.dist-info/METADATA: found 1 package with issues
+
+  setuptools@58.1.0 has the following known vulnerabilities:
+    introduced in # 13 Layer (python)
+    PYSEC-2022-43012: Python Packaging Authority (PyPA) setuptools before 65.5.1 allows remote... (https://osv.dev/PYSEC-2022-43012)
+    GHSA-cx63-2mw6-8hw5: setuptools vulnerable to Command Injection via package URL (https://osv.dev/GHSA-cx63-2mw6-8hw5)
+
+  2 known vulnerabilities found in artifact:usr/local/lib/python3.9/site-packages/setuptools-58.1.0.dist-info/METADATA
+
+Debian:10
+
+os:var/lib/dpkg/status: found 10 packages with issues
+
+  debian-archive-keyring@2019.1+deb10u1 has the following known vulnerabilities:
+    introduced in # 0 Layer (python)
+    DLA-3482-1: debian-archive-keyring - security update (https://osv.dev/DLA-3482-1)
+  expat@2.2.6-2+deb10u6 has the following known vulnerabilities:
+    introduced in # 7 Layer (python)
+    DLA-3783-1: expat - security update (https://osv.dev/DLA-3783-1)
+  glibc@2.28-10+deb10u2 has the following known vulnerabilities:
+    introduced in # 0 Layer (python)
+    DLA-3807-1: glibc - security update (https://osv.dev/DLA-3807-1)
+    DLA-3850-1: glibc - security update (https://osv.dev/DLA-3850-1)
+  gnutls28@3.6.7-4+deb10u10 has the following known vulnerabilities:
+    introduced in # 0 Layer (python)
+    DLA-3660-1: gnutls28 - security update (https://osv.dev/DLA-3660-1)
+    DLA-3740-1: gnutls28 - security update (https://osv.dev/DLA-3740-1)
+  ncurses@6.1+20181013-2+deb10u3 has the following known vulnerabilities:
+    introduced in # 0 Layer (python)
+    DLA-3586-1: ncurses - security update (https://osv.dev/DLA-3586-1)
+    DLA-3682-1: ncurses - security update (https://osv.dev/DLA-3682-1)
+  openssl@1.1.1n-0+deb10u5 has the following known vulnerabilities:
+    introduced in # 4 Layer (python)
+    DLA-3530-1: openssl - security update (https://osv.dev/DLA-3530-1)
+  systemd@241-7~deb10u9 has the following known vulnerabilities:
+    introduced in # 0 Layer (python)
+    DLA-3474-1: systemd - security update (https://osv.dev/DLA-3474-1)
+  tar@1.30+dfsg-6 has the following known vulnerabilities:
+    introduced in # 0 Layer (python)
+    DLA-3755-1: tar - security update (https://osv.dev/DLA-3755-1)
+  tzdata@2021a-0+deb10u11 has the following known vulnerabilities:
+    introduced in # 0 Layer (python)
+    DLA-3684-1: tzdata - new timezone database (https://osv.dev/DLA-3684-1)
+    DLA-3788-1: tzdata - new timezone database (https://osv.dev/DLA-3788-1)
+  util-linux@2.33.1-0.1 has the following known vulnerabilities:
+    introduced in # 0 Layer (python)
+    DLA-3782-1: util-linux - security update (https://osv.dev/DLA-3782-1)
+
+  14 known vulnerabilities found in os:var/lib/dpkg/status
+
 
 ---
 
@@ -3265,81 +3888,152 @@ Warning: `scan` exists as both a subcommand of OSV-Scanner and as a file on the 
 [Test_run_OCIImage/Scanning_python_image_with_some_packages - 1]
 Scanning local image tarball "../../internal/image/fixtures/test-python-full.tar"
 
-Container Scanning Result (Debian GNU/Linux 10 (buster)):
-Total 17 packages affected by 31 known vulnerabilities (0 Critical, 8 High, 8 Medium, 0 Low, 15 Unknown) from 2 ecosystems.
-31 vulnerabilities can be fixed.
+Total 18 packages affected by 32 known vulnerabilities (0 Critical, 8 High, 9 Medium, 0 Low, 15 Unknown) from 2 ecosystems.
+32 vulnerabilities can be fixed.
 
+Container image information:
+  OS version: Debian GNU/Linux 10 (buster)
+  Base Image 1 (python):
+    Layer 0  /bin/sh -c #(nop) ADD file:UNKNOWN in / (12 vulns)
+    Layer 1  /bin/sh -c #(nop) CMD ["bash"]
+    Layer 2  ENV PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    Layer 3  ENV LANG=C.UTF-8
+    Layer 4  RUN /bin/sh -c set -eux; apt-get update; apt-get install -y --no-install-recommends ca-certificates... (1 vulns)
+    Layer 5  ENV GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
+    Layer 6  ENV PYTHON_VERSION=3.9.17
+    Layer 7  RUN /bin/sh -c set -eux; savedAptMark="$(apt-mark showmanual)"; apt-get update; apt-get install -y... (1 vulns)
+    Layer 8  RUN /bin/sh -c set -eux; for src in idle3 pydoc3 python3 python3-config; do dst="$(echo "$src" | tr...
+    Layer 9  ENV PYTHON_PIP_VERSION=23.0.1
+    Layer 10 ENV PYTHON_SETUPTOOLS_VERSION=58.1.0
+    Layer 11 ENV...
+    Layer 12 ENV PYTHON_GET_PIP_SHA256=96461deced5c2a487ddc65207ec5a9cffeca0d34e7af7ea1afc470ff0d746207
+    Layer 13 RUN /bin/sh -c set -eux; savedAptMark="$(apt-mark showmanual)"; apt-get update; apt-get install -y... (3 vulns)
+    Layer 14 CMD ["python3"]
+  Your Image:
+    Layer 15 WORKDIR /app
+    Layer 16 COPY ./python-fixture/requirements.txt . # buildkit
+    Layer 17 RUN /bin/sh -c pip install --no-cache-dir -r requirements.txt # buildkit (15 vulns)
+    Layer 18 COPY python-fixture/main.py main.py # buildkit
+    Layer 19 CMD ["python" "main.py"]
 
 PyPI
-+---------------------------------------------------------------------------------------------+
-| Source:artifact:usr/local/lib/python3.9/site-packages/Django-1.11.29.dist-info/METADATA     |
-+---------+-------------------+---------------+------------+------------------+---------------+
-| PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
-+---------+-------------------+---------------+------------+------------------+---------------+
-| django  | 1.11.29           | Fix Available |          3 | # 17 Layer       | --            |
-+---------+-------------------+---------------+------------+------------------+---------------+
-+---------------------------------------------------------------------------------------------+
-| Source:artifact:usr/local/lib/python3.9/site-packages/Flask-0.12.2.dist-info/METADATA       |
-+---------+-------------------+---------------+------------+------------------+---------------+
-| PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
-+---------+-------------------+---------------+------------+------------------+---------------+
-| flask   | 0.12.2            | Fix Available |          3 | # 17 Layer       | --            |
-+---------+-------------------+---------------+------------+------------------+---------------+
-+---------------------------------------------------------------------------------------------+
-| Source:artifact:usr/local/lib/python3.9/site-packages/idna-2.7.dist-info/METADATA           |
-+---------+-------------------+---------------+------------+------------------+---------------+
-| PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
-+---------+-------------------+---------------+------------+------------------+---------------+
-| idna    | 2.7               | Fix Available |          1 | # 17 Layer       | --            |
-+---------+-------------------+---------------+------------+------------------+---------------+
-+---------------------------------------------------------------------------------------------+
-| Source:artifact:usr/local/lib/python3.9/site-packages/pip-23.0.1.dist-info/METADATA         |
-+---------+-------------------+---------------+------------+------------------+---------------+
-| PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
-+---------+-------------------+---------------+------------+------------------+---------------+
-| pip     | 23.0.1            | Fix Available |          1 | # 13 Layer       | python        |
-+---------+-------------------+---------------+------------+------------------+---------------+
-+----------------------------------------------------------------------------------------------+
-| Source:artifact:usr/local/lib/python3.9/site-packages/requests-2.20.0.dist-info/METADATA     |
-+----------+-------------------+---------------+------------+------------------+---------------+
-| PACKAGE  | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
-+----------+-------------------+---------------+------------+------------------+---------------+
-| requests | 2.20.0            | Fix Available |          2 | # 17 Layer       | --            |
-+----------+-------------------+---------------+------------+------------------+---------------+
-+------------------------------------------------------------------------------------------------+
-| Source:artifact:usr/local/lib/python3.9/site-packages/setuptools-58.1.0.dist-info/METADATA     |
-+------------+-------------------+---------------+------------+------------------+---------------+
-| PACKAGE    | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
-+------------+-------------------+---------------+------------+------------------+---------------+
-| setuptools | 58.1.0            | Fix Available |          2 | # 13 Layer       | python        |
-+------------+-------------------+---------------+------------+------------------+---------------+
-+---------------------------------------------------------------------------------------------+
-| Source:artifact:usr/local/lib/python3.9/site-packages/urllib3-1.24.3.dist-info/METADATA     |
-+---------+-------------------+---------------+------------+------------------+---------------+
-| PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
-+---------+-------------------+---------------+------------+------------------+---------------+
-| urllib3 | 1.24.3            | Fix Available |          5 | # 17 Layer       | --            |
-+---------+-------------------+---------------+------------+------------------+---------------+
-Debian:10
-+-----------------------------------------------------------------------------------------------------------------+
-| Source:os:var/lib/dpkg/status                                                                                   |
-+------------------------+------------------------+---------------+------------+------------------+---------------+
-| PACKAGE                | INSTALLED VERSION      | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
-+------------------------+------------------------+---------------+------------+------------------+---------------+
-| debian-archive-keyring | 2019.1+deb10u1         | Fix Available |          1 | # 0 Layer        | python        |
-| expat                  | 2.2.6-2+deb10u6        | Fix Available |          1 | # 7 Layer        | python        |
-| glibc                  | 2.28-10+deb10u2        | Fix Available |          2 | # 0 Layer        | python        |
-| gnutls28               | 3.6.7-4+deb10u10       | Fix Available |          2 | # 0 Layer        | python        |
-| ncurses                | 6.1+20181013-2+deb10u3 | Fix Available |          2 | # 0 Layer        | python        |
-| openssl                | 1.1.1n-0+deb10u5       | Fix Available |          1 | # 4 Layer        | python        |
-| systemd                | 241-7~deb10u9          | Fix Available |          1 | # 0 Layer        | python        |
-| tar                    | 1.30+dfsg-6            | Fix Available |          1 | # 0 Layer        | python        |
-| tzdata                 | 2021a-0+deb10u11       | Fix Available |          2 | # 0 Layer        | python        |
-| util-linux             | 2.33.1-0.1             | Fix Available |          1 | # 0 Layer        | python        |
-+------------------------+------------------------+---------------+------------+------------------+---------------+
 
-For the most comprehensive scan results, we recommend using the HTML output: `osv-scanner scan image --serve <image_name>`.
-You can also view the full vulnerability list in your terminal with: `osv-scanner scan image --format vertical <image_name>`.
+artifact:usr/local/lib/python3.9/site-packages/Django-1.11.29.dist-info/METADATA: found 1 package with issues
+
+  django@1.11.29 has the following known vulnerabilities:
+    introduced in # 17 Layer
+    PYSEC-2021-98: Django before 2.2.24, 3.x before 3.1.12, and 3.2.x before 3.2.4 has a potential... (https://osv.dev/PYSEC-2021-98)
+    GHSA-8x94-hmjh-97hq: Django vulnerable to Reflected File Download attack (https://osv.dev/GHSA-8x94-hmjh-97hq)
+    GHSA-rrqc-c2jx-6jgv: Django allows enumeration of user e-mail addresses (https://osv.dev/GHSA-rrqc-c2jx-6jgv)
+
+  3 known vulnerabilities found in artifact:usr/local/lib/python3.9/site-packages/Django-1.11.29.dist-info/METADATA
+
+artifact:usr/local/lib/python3.9/site-packages/Flask-0.12.2.dist-info/METADATA: found 1 package with issues
+
+  flask@0.12.2 has the following known vulnerabilities:
+    introduced in # 17 Layer
+    PYSEC-2018-66: The Pallets Project flask version Before 0.12.3 contains a CWE-20: Improper... (https://osv.dev/PYSEC-2018-66)
+    PYSEC-2019-179: The Pallets Project Flask before 1.0 is affected by: unexpected memory usage.... (https://osv.dev/PYSEC-2019-179)
+    PYSEC-2023-62: Flask is a lightweight WSGI web application framework. When all of the... (https://osv.dev/PYSEC-2023-62)
+
+  3 known vulnerabilities found in artifact:usr/local/lib/python3.9/site-packages/Flask-0.12.2.dist-info/METADATA
+
+artifact:usr/local/lib/python3.9/site-packages/idna-2.7.dist-info/METADATA: found 1 package with issues
+
+  idna@2.7 has the following known vulnerabilities:
+    introduced in # 17 Layer
+    PYSEC-2024-60: A vulnerability was identified in the kjd/idna library, specifically within the... (https://osv.dev/PYSEC-2024-60)
+
+  1 known vulnerability found in artifact:usr/local/lib/python3.9/site-packages/idna-2.7.dist-info/METADATA
+
+artifact:usr/local/lib/python3.9/site-packages/jinja2-3.1.5.dist-info/METADATA: found 1 package with issues
+
+  jinja2@3.1.5 has the following known vulnerabilities:
+    introduced in # 17 Layer
+    GHSA-cpwx-vrp4-4pq7: Jinja2 vulnerable to sandbox breakout through attr filter selecting format... (https://osv.dev/GHSA-cpwx-vrp4-4pq7)
+
+  1 known vulnerability found in artifact:usr/local/lib/python3.9/site-packages/jinja2-3.1.5.dist-info/METADATA
+
+artifact:usr/local/lib/python3.9/site-packages/pip-23.0.1.dist-info/METADATA: found 1 package with issues
+
+  pip@23.0.1 has the following known vulnerabilities:
+    introduced in # 13 Layer (python)
+    PYSEC-2023-228: When installing a package from a Mercurial VCS URL  (ie "pip install 
+hg+...")... (https://osv.dev/PYSEC-2023-228)
+
+  1 known vulnerability found in artifact:usr/local/lib/python3.9/site-packages/pip-23.0.1.dist-info/METADATA
+
+artifact:usr/local/lib/python3.9/site-packages/requests-2.20.0.dist-info/METADATA: found 1 package with issues
+
+  requests@2.20.0 has the following known vulnerabilities:
+    introduced in # 17 Layer
+    PYSEC-2023-74: Requests is a HTTP library. Since Requests 2.3.0, Requests has been leaking... (https://osv.dev/PYSEC-2023-74)
+    GHSA-9wx4-h78v-vm56: Requests `Session` object does not verify requests after making first request... (https://osv.dev/GHSA-9wx4-h78v-vm56)
+
+  2 known vulnerabilities found in artifact:usr/local/lib/python3.9/site-packages/requests-2.20.0.dist-info/METADATA
+
+artifact:usr/local/lib/python3.9/site-packages/setuptools-58.1.0.dist-info/METADATA: found 1 package with issues
+
+  setuptools@58.1.0 has the following known vulnerabilities:
+    introduced in # 13 Layer (python)
+    PYSEC-2022-43012: Python Packaging Authority (PyPA) setuptools before 65.5.1 allows remote... (https://osv.dev/PYSEC-2022-43012)
+    GHSA-cx63-2mw6-8hw5: setuptools vulnerable to Command Injection via package URL (https://osv.dev/GHSA-cx63-2mw6-8hw5)
+
+  2 known vulnerabilities found in artifact:usr/local/lib/python3.9/site-packages/setuptools-58.1.0.dist-info/METADATA
+
+artifact:usr/local/lib/python3.9/site-packages/urllib3-1.24.3.dist-info/METADATA: found 1 package with issues
+
+  urllib3@1.24.3 has the following known vulnerabilities:
+    introduced in # 17 Layer
+    PYSEC-2020-148: urllib3 before 1.25.9 allows CRLF injection if the attacker controls the HTTP... (https://osv.dev/PYSEC-2020-148)
+    PYSEC-2021-108: An issue was discovered in urllib3 before 1.26.5. When provided with a URL... (https://osv.dev/PYSEC-2021-108)
+    PYSEC-2023-192: urllib3 is a user-friendly HTTP client library for Python. urllib3 doesn't... (https://osv.dev/PYSEC-2023-192)
+    PYSEC-2023-212: urllib3 is a user-friendly HTTP client library for Python. urllib3 previously... (https://osv.dev/PYSEC-2023-212)
+    GHSA-34jh-p97f-mpxf: urllib3's Proxy-Authorization request header isn't stripped during cross-origin... (https://osv.dev/GHSA-34jh-p97f-mpxf)
+
+  5 known vulnerabilities found in artifact:usr/local/lib/python3.9/site-packages/urllib3-1.24.3.dist-info/METADATA
+
+Debian:10
+
+os:var/lib/dpkg/status: found 10 packages with issues
+
+  debian-archive-keyring@2019.1+deb10u1 has the following known vulnerabilities:
+    introduced in # 0 Layer (python)
+    DLA-3482-1: debian-archive-keyring - security update (https://osv.dev/DLA-3482-1)
+  expat@2.2.6-2+deb10u6 has the following known vulnerabilities:
+    introduced in # 7 Layer (python)
+    DLA-3783-1: expat - security update (https://osv.dev/DLA-3783-1)
+  glibc@2.28-10+deb10u2 has the following known vulnerabilities:
+    introduced in # 0 Layer (python)
+    DLA-3807-1: glibc - security update (https://osv.dev/DLA-3807-1)
+    DLA-3850-1: glibc - security update (https://osv.dev/DLA-3850-1)
+  gnutls28@3.6.7-4+deb10u10 has the following known vulnerabilities:
+    introduced in # 0 Layer (python)
+    DLA-3660-1: gnutls28 - security update (https://osv.dev/DLA-3660-1)
+    DLA-3740-1: gnutls28 - security update (https://osv.dev/DLA-3740-1)
+  ncurses@6.1+20181013-2+deb10u3 has the following known vulnerabilities:
+    introduced in # 0 Layer (python)
+    DLA-3586-1: ncurses - security update (https://osv.dev/DLA-3586-1)
+    DLA-3682-1: ncurses - security update (https://osv.dev/DLA-3682-1)
+  openssl@1.1.1n-0+deb10u5 has the following known vulnerabilities:
+    introduced in # 4 Layer (python)
+    DLA-3530-1: openssl - security update (https://osv.dev/DLA-3530-1)
+  systemd@241-7~deb10u9 has the following known vulnerabilities:
+    introduced in # 0 Layer (python)
+    DLA-3474-1: systemd - security update (https://osv.dev/DLA-3474-1)
+  tar@1.30+dfsg-6 has the following known vulnerabilities:
+    introduced in # 0 Layer (python)
+    DLA-3755-1: tar - security update (https://osv.dev/DLA-3755-1)
+  tzdata@2021a-0+deb10u11 has the following known vulnerabilities:
+    introduced in # 0 Layer (python)
+    DLA-3684-1: tzdata - new timezone database (https://osv.dev/DLA-3684-1)
+    DLA-3788-1: tzdata - new timezone database (https://osv.dev/DLA-3788-1)
+  util-linux@2.33.1-0.1 has the following known vulnerabilities:
+    introduced in # 0 Layer (python)
+    DLA-3782-1: util-linux - security update (https://osv.dev/DLA-3782-1)
+
+  14 known vulnerabilities found in os:var/lib/dpkg/status
+
 
 ---
 
@@ -3351,66 +4045,129 @@ Warning: `scan` exists as both a subcommand of OSV-Scanner and as a file on the 
 [Test_run_OCIImage/scanning_image_with_go_binary - 1]
 Scanning local image tarball "../../internal/image/fixtures/test-package-tracing.tar"
 
-Container Scanning Result (Alpine Linux v3.20):
 Total 8 packages affected by 48 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 48 Unknown) from 2 ecosystems.
 48 vulnerabilities can be fixed.
 
+Container image information:
+  OS version: Alpine Linux v3.20
+  Base Image 2 (alpine):
+    Layer 0  /bin/sh -c #(nop) ADD file:UNKNOWN in / (6 vulns)
+  Base Image 1 (alpine):
+    Layer 1  /bin/sh -c #(nop) CMD ["/bin/sh"]
+  Your Image:
+    Layer 2  COPY /work/ptf-1.2.0 /work/ptf-1.3.0 /work/ptf-1.4.0 /go/bin/ # buildkit (14 vulns)
+    Layer 3  RUN /bin/sh -c mv /go/bin/ptf-1.3.0 /go/bin/ptf-1.3.0-moved # buildkit (7 vulns)
+    Layer 4  RUN /bin/sh -c cp /go/bin/ptf-1.3.0-moved /go/bin/ptf-1.3.0 # buildkit (7 vulns)
+    Layer 5  RUN /bin/sh -c cp /go/bin/ptf-1.3.0 /go/bin/ptf-1.3.0-copy # buildkit
+    Layer 6  RUN /bin/sh -c rm /go/bin/ptf-1.3.0-copy # buildkit
+    Layer 7  RUN /bin/sh -c cp /go/bin/ptf-1.3.0 /go/bin/ptf-vulnerable # buildkit (7 vulns)
+    Layer 8  RUN /bin/sh -c cp /go/bin/ptf-1.4.0 /go/bin/ptf-vulnerable # buildkit
+    Layer 9  RUN /bin/sh -c cp /go/bin/ptf-1.4.0 /go/bin/more-vuln-overwrite-less-vuln # buildkit (7 vulns)
+    Layer 10 RUN /bin/sh -c cp /go/bin/ptf-1.2.0 /go/bin/more-vuln-overwrite-less-vuln # buildkit
 
 Go
-+---------------------------------------------------------------------------------------------+
-| Source:artifact:go/bin/more-vuln-overwrite-less-vuln                                        |
-+---------+-------------------+---------------+------------+------------------+---------------+
-| PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
-+---------+-------------------+---------------+------------+------------------+---------------+
-| stdlib  | 1.22.4            | Fix Available |          7 | # 9 Layer        | --            |
-+---------+-------------------+---------------+------------+------------------+---------------+
-+---------------------------------------------------------------------------------------------+
-| Source:artifact:go/bin/ptf-1.2.0                                                            |
-+---------+-------------------+---------------+------------+------------------+---------------+
-| PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
-+---------+-------------------+---------------+------------+------------------+---------------+
-| stdlib  | 1.22.4            | Fix Available |          7 | # 2 Layer        | --            |
-+---------+-------------------+---------------+------------+------------------+---------------+
-+---------------------------------------------------------------------------------------------+
-| Source:artifact:go/bin/ptf-1.3.0                                                            |
-+---------+-------------------+---------------+------------+------------------+---------------+
-| PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
-+---------+-------------------+---------------+------------+------------------+---------------+
-| stdlib  | 1.22.4            | Fix Available |          7 | # 4 Layer        | --            |
-+---------+-------------------+---------------+------------+------------------+---------------+
-+---------------------------------------------------------------------------------------------+
-| Source:artifact:go/bin/ptf-1.3.0-moved                                                      |
-+---------+-------------------+---------------+------------+------------------+---------------+
-| PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
-+---------+-------------------+---------------+------------+------------------+---------------+
-| stdlib  | 1.22.4            | Fix Available |          7 | # 3 Layer        | --            |
-+---------+-------------------+---------------+------------+------------------+---------------+
-+---------------------------------------------------------------------------------------------+
-| Source:artifact:go/bin/ptf-1.4.0                                                            |
-+---------+-------------------+---------------+------------+------------------+---------------+
-| PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
-+---------+-------------------+---------------+------------+------------------+---------------+
-| stdlib  | 1.22.4            | Fix Available |          7 | # 2 Layer        | --            |
-+---------+-------------------+---------------+------------+------------------+---------------+
-+---------------------------------------------------------------------------------------------+
-| Source:artifact:go/bin/ptf-vulnerable                                                       |
-+---------+-------------------+---------------+------------+------------------+---------------+
-| PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
-+---------+-------------------+---------------+------------+------------------+---------------+
-| stdlib  | 1.22.4            | Fix Available |          7 | # 7 Layer        | --            |
-+---------+-------------------+---------------+------------+------------------+---------------+
-Alpine:v3.20
-+---------------------------------------------------------------------------------------------+
-| Source:os:lib/apk/db/installed                                                              |
-+---------+-------------------+---------------+------------+------------------+---------------+
-| PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
-+---------+-------------------+---------------+------------+------------------+---------------+
-| musl    | 1.2.5-r0          | Fix Available |          1 | # 0 Layer        | alpine        |
-| openssl | 3.3.1-r0          | Fix Available |          5 | # 0 Layer        | alpine        |
-+---------+-------------------+---------------+------------+------------------+---------------+
 
-For the most comprehensive scan results, we recommend using the HTML output: `osv-scanner scan image --serve <image_name>`.
-You can also view the full vulnerability list in your terminal with: `osv-scanner scan image --format vertical <image_name>`.
+artifact:go/bin/more-vuln-overwrite-less-vuln: found 1 package with issues
+
+  stdlib@1.22.4 has the following known vulnerabilities:
+    introduced in # 9 Layer
+    GO-2024-2963: Denial of service due to improper 100-continue handling in net/http (https://osv.dev/GO-2024-2963)
+    GO-2024-3105: Stack exhaustion in all Parse functions in go/parser (https://osv.dev/GO-2024-3105)
+    GO-2024-3106: Stack exhaustion in Decoder.Decode in encoding/gob (https://osv.dev/GO-2024-3106)
+    GO-2024-3107: Stack exhaustion in Parse in go/build/constraint (https://osv.dev/GO-2024-3107)
+    GO-2025-3373: Usage of IPv6 zone IDs can bypass URI name constraints in crypto/x509 (https://osv.dev/GO-2025-3373)
+    GO-2025-3420: Sensitive headers incorrectly sent after cross-domain redirect in net/http (https://osv.dev/GO-2025-3420)
+    GO-2025-3447: Timing sidechannel for P-256 on ppc64le in crypto/internal/nistec (https://osv.dev/GO-2025-3447)
+
+  7 known vulnerabilities found in artifact:go/bin/more-vuln-overwrite-less-vuln
+
+artifact:go/bin/ptf-1.2.0: found 1 package with issues
+
+  stdlib@1.22.4 has the following known vulnerabilities:
+    introduced in # 2 Layer
+    GO-2024-2963: Denial of service due to improper 100-continue handling in net/http (https://osv.dev/GO-2024-2963)
+    GO-2024-3105: Stack exhaustion in all Parse functions in go/parser (https://osv.dev/GO-2024-3105)
+    GO-2024-3106: Stack exhaustion in Decoder.Decode in encoding/gob (https://osv.dev/GO-2024-3106)
+    GO-2024-3107: Stack exhaustion in Parse in go/build/constraint (https://osv.dev/GO-2024-3107)
+    GO-2025-3373: Usage of IPv6 zone IDs can bypass URI name constraints in crypto/x509 (https://osv.dev/GO-2025-3373)
+    GO-2025-3420: Sensitive headers incorrectly sent after cross-domain redirect in net/http (https://osv.dev/GO-2025-3420)
+    GO-2025-3447: Timing sidechannel for P-256 on ppc64le in crypto/internal/nistec (https://osv.dev/GO-2025-3447)
+
+  7 known vulnerabilities found in artifact:go/bin/ptf-1.2.0
+
+artifact:go/bin/ptf-1.3.0: found 1 package with issues
+
+  stdlib@1.22.4 has the following known vulnerabilities:
+    introduced in # 4 Layer
+    GO-2024-2963: Denial of service due to improper 100-continue handling in net/http (https://osv.dev/GO-2024-2963)
+    GO-2024-3105: Stack exhaustion in all Parse functions in go/parser (https://osv.dev/GO-2024-3105)
+    GO-2024-3106: Stack exhaustion in Decoder.Decode in encoding/gob (https://osv.dev/GO-2024-3106)
+    GO-2024-3107: Stack exhaustion in Parse in go/build/constraint (https://osv.dev/GO-2024-3107)
+    GO-2025-3373: Usage of IPv6 zone IDs can bypass URI name constraints in crypto/x509 (https://osv.dev/GO-2025-3373)
+    GO-2025-3420: Sensitive headers incorrectly sent after cross-domain redirect in net/http (https://osv.dev/GO-2025-3420)
+    GO-2025-3447: Timing sidechannel for P-256 on ppc64le in crypto/internal/nistec (https://osv.dev/GO-2025-3447)
+
+  7 known vulnerabilities found in artifact:go/bin/ptf-1.3.0
+
+artifact:go/bin/ptf-1.3.0-moved: found 1 package with issues
+
+  stdlib@1.22.4 has the following known vulnerabilities:
+    introduced in # 3 Layer
+    GO-2024-2963: Denial of service due to improper 100-continue handling in net/http (https://osv.dev/GO-2024-2963)
+    GO-2024-3105: Stack exhaustion in all Parse functions in go/parser (https://osv.dev/GO-2024-3105)
+    GO-2024-3106: Stack exhaustion in Decoder.Decode in encoding/gob (https://osv.dev/GO-2024-3106)
+    GO-2024-3107: Stack exhaustion in Parse in go/build/constraint (https://osv.dev/GO-2024-3107)
+    GO-2025-3373: Usage of IPv6 zone IDs can bypass URI name constraints in crypto/x509 (https://osv.dev/GO-2025-3373)
+    GO-2025-3420: Sensitive headers incorrectly sent after cross-domain redirect in net/http (https://osv.dev/GO-2025-3420)
+    GO-2025-3447: Timing sidechannel for P-256 on ppc64le in crypto/internal/nistec (https://osv.dev/GO-2025-3447)
+
+  7 known vulnerabilities found in artifact:go/bin/ptf-1.3.0-moved
+
+artifact:go/bin/ptf-1.4.0: found 1 package with issues
+
+  stdlib@1.22.4 has the following known vulnerabilities:
+    introduced in # 2 Layer
+    GO-2024-2963: Denial of service due to improper 100-continue handling in net/http (https://osv.dev/GO-2024-2963)
+    GO-2024-3105: Stack exhaustion in all Parse functions in go/parser (https://osv.dev/GO-2024-3105)
+    GO-2024-3106: Stack exhaustion in Decoder.Decode in encoding/gob (https://osv.dev/GO-2024-3106)
+    GO-2024-3107: Stack exhaustion in Parse in go/build/constraint (https://osv.dev/GO-2024-3107)
+    GO-2025-3373: Usage of IPv6 zone IDs can bypass URI name constraints in crypto/x509 (https://osv.dev/GO-2025-3373)
+    GO-2025-3420: Sensitive headers incorrectly sent after cross-domain redirect in net/http (https://osv.dev/GO-2025-3420)
+    GO-2025-3447: Timing sidechannel for P-256 on ppc64le in crypto/internal/nistec (https://osv.dev/GO-2025-3447)
+
+  7 known vulnerabilities found in artifact:go/bin/ptf-1.4.0
+
+artifact:go/bin/ptf-vulnerable: found 1 package with issues
+
+  stdlib@1.22.4 has the following known vulnerabilities:
+    introduced in # 7 Layer
+    GO-2024-2963: Denial of service due to improper 100-continue handling in net/http (https://osv.dev/GO-2024-2963)
+    GO-2024-3105: Stack exhaustion in all Parse functions in go/parser (https://osv.dev/GO-2024-3105)
+    GO-2024-3106: Stack exhaustion in Decoder.Decode in encoding/gob (https://osv.dev/GO-2024-3106)
+    GO-2024-3107: Stack exhaustion in Parse in go/build/constraint (https://osv.dev/GO-2024-3107)
+    GO-2025-3373: Usage of IPv6 zone IDs can bypass URI name constraints in crypto/x509 (https://osv.dev/GO-2025-3373)
+    GO-2025-3420: Sensitive headers incorrectly sent after cross-domain redirect in net/http (https://osv.dev/GO-2025-3420)
+    GO-2025-3447: Timing sidechannel for P-256 on ppc64le in crypto/internal/nistec (https://osv.dev/GO-2025-3447)
+
+  7 known vulnerabilities found in artifact:go/bin/ptf-vulnerable
+
+Alpine:v3.20
+
+os:lib/apk/db/installed: found 2 packages with issues
+
+  musl@1.2.5-r0 has the following known vulnerabilities:
+    introduced in # 0 Layer (alpine)
+    CVE-2025-26519: musl libc 0.9.13 through 1.2.5 before 1.2.6 has an out-of-bounds write... (https://osv.dev/CVE-2025-26519)
+  openssl@3.3.1-r0 has the following known vulnerabilities:
+    introduced in # 0 Layer (alpine)
+    CVE-2024-12797: Issue summary: Clients using RFC7250 Raw Public Keys (RPKs) to authenticate a... (https://osv.dev/CVE-2024-12797)
+    CVE-2024-13176: Issue summary: A timing side-channel which could potentially allow recovering... (https://osv.dev/CVE-2024-13176)
+    CVE-2024-5535: Issue summary: Calling the OpenSSL API function SSL_select_next_proto with an... (https://osv.dev/CVE-2024-5535)
+    CVE-2024-6119: Issue summary: Applications performing certificate name checks (e.g., TLS... (https://osv.dev/CVE-2024-6119)
+    CVE-2024-9143: Issue summary: Use of the low-level GF(2^m) elliptic curve APIs with untrusted... (https://osv.dev/CVE-2024-9143)
+
+  6 known vulnerabilities found in os:lib/apk/db/installed
+
 
 ---
 
@@ -3422,23 +4179,53 @@ Warning: `scan` exists as both a subcommand of OSV-Scanner and as a file on the 
 [Test_run_OCIImage/scanning_node_modules_using_npm_with_no_packages - 1]
 Scanning local image tarball "../../internal/image/fixtures/test-node_modules-npm-empty.tar"
 
-Container Scanning Result (Alpine Linux v3.19):
 Total 2 packages affected by 11 known vulnerabilities (0 Critical, 0 High, 4 Medium, 0 Low, 7 Unknown) from 1 ecosystem.
 11 vulnerabilities can be fixed.
 
+Container image information:
+  OS version: Alpine Linux v3.19
+  Base Image 4 (alpine):
+    Layer 0  /bin/sh -c #(nop) ADD file:UNKNOWN in / (11 vulns)
+  Base Image 3 (alpine):
+    Layer 1  /bin/sh -c #(nop) CMD ["/bin/sh"]
+  Base Image 2 (ayan4m1/maven-node):
+    Layer 2  /bin/sh -c #(nop) ENV NODE_VERSION=20.11.1
+  Base Image 1 (library/node):
+    Layer 3  /bin/sh -c addgroup -g 1000 node && adduser -u 1000 -G node -s /bin/sh -D node && apk add...
+    Layer 4  /bin/sh -c #(nop) ENV YARN_VERSION=1.22.19
+    Layer 5  /bin/sh -c apk add --no-cache --virtual .build-deps-yarn curl gnupg tar && export...
+    Layer 6  /bin/sh -c #(nop) COPY file:UNKNOWN in /usr/local/bin/
+    Layer 7  /bin/sh -c #(nop) ENTRYPOINT ["docker-entrypoint.sh"]
+    Layer 8  /bin/sh -c #(nop) CMD ["node"]
+  Your Image:
+    Layer 9  ARG MANAGER_VERSION=10.2.4
+    Layer 10 WORKDIR /prod/app
+    Layer 11 RUN |1 MANAGER_VERSION=10.2.4 /bin/sh -c npm i -g "npm@$MANAGER_VERSION" # buildkit
+    Layer 12 RUN |1 MANAGER_VERSION=10.2.4 /bin/sh -c npm init -y # buildkit
+    Layer 13 RUN |1 MANAGER_VERSION=10.2.4 /bin/sh -c npm install # buildkit
 
 Alpine:v3.19
-+---------------------------------------------------------------------------------------------+
-| Source:os:lib/apk/db/installed                                                              |
-+---------+-------------------+---------------+------------+------------------+---------------+
-| PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
-+---------+-------------------+---------------+------------+------------------+---------------+
-| busybox | 1.36.1-r15        | Fix Available |          4 | # 0 Layer        | alpine        |
-| openssl | 3.1.4-r5          | Fix Available |          7 | # 0 Layer        | alpine        |
-+---------+-------------------+---------------+------------+------------------+---------------+
 
-For the most comprehensive scan results, we recommend using the HTML output: `osv-scanner scan image --serve <image_name>`.
-You can also view the full vulnerability list in your terminal with: `osv-scanner scan image --format vertical <image_name>`.
+os:lib/apk/db/installed: found 2 packages with issues
+
+  busybox@1.36.1-r15 has the following known vulnerabilities:
+    introduced in # 0 Layer (alpine)
+    CVE-2023-42363: A use-after-free vulnerability was discovered in xasprintf function in... (https://osv.dev/CVE-2023-42363)
+    CVE-2023-42364: A use-after-free vulnerability in BusyBox v.1.36.1 allows attackers to cause a... (https://osv.dev/CVE-2023-42364)
+    CVE-2023-42365: A use-after-free vulnerability was discovered in BusyBox v.1.36.1 via a crafted... (https://osv.dev/CVE-2023-42365)
+    CVE-2023-42366: A heap-buffer-overflow was discovered in BusyBox v.1.36.1 in the next_token... (https://osv.dev/CVE-2023-42366)
+  openssl@3.1.4-r5 has the following known vulnerabilities:
+    introduced in # 0 Layer (alpine)
+    CVE-2024-13176: Issue summary: A timing side-channel which could potentially allow recovering... (https://osv.dev/CVE-2024-13176)
+    CVE-2024-2511: Issue summary: Some non-default TLS server configurations can cause unbounded... (https://osv.dev/CVE-2024-2511)
+    CVE-2024-4603: Issue summary: Checking excessively long DSA keys or parameters may be very... (https://osv.dev/CVE-2024-4603)
+    CVE-2024-4741: Issue summary: Calling the OpenSSL API function SSL_free_buffers may cause... (https://osv.dev/CVE-2024-4741)
+    CVE-2024-5535: Issue summary: Calling the OpenSSL API function SSL_select_next_proto with an... (https://osv.dev/CVE-2024-5535)
+    CVE-2024-6119: Issue summary: Applications performing certificate name checks (e.g., TLS... (https://osv.dev/CVE-2024-6119)
+    CVE-2024-9143: Issue summary: Use of the low-level GF(2^m) elliptic curve APIs with untrusted... (https://osv.dev/CVE-2024-9143)
+
+  11 known vulnerabilities found in os:lib/apk/db/installed
+
 
 ---
 
@@ -3450,32 +4237,69 @@ Warning: `scan` exists as both a subcommand of OSV-Scanner and as a file on the 
 [Test_run_OCIImage/scanning_node_modules_using_npm_with_some_packages - 1]
 Scanning local image tarball "../../internal/image/fixtures/test-node_modules-npm-full.tar"
 
-Container Scanning Result (Alpine Linux v3.19):
 Total 4 packages affected by 14 known vulnerabilities (2 Critical, 0 High, 5 Medium, 0 Low, 7 Unknown) from 2 ecosystems.
 13 vulnerabilities can be fixed.
 
+Container image information:
+  OS version: Alpine Linux v3.19
+  Base Image 4 (alpine):
+    Layer 0  /bin/sh -c #(nop) ADD file:UNKNOWN in / (11 vulns)
+  Base Image 3 (alpine):
+    Layer 1  /bin/sh -c #(nop) CMD ["/bin/sh"]
+  Base Image 2 (ayan4m1/maven-node):
+    Layer 2  /bin/sh -c #(nop) ENV NODE_VERSION=20.11.1
+  Base Image 1 (library/node):
+    Layer 3  /bin/sh -c addgroup -g 1000 node && adduser -u 1000 -G node -s /bin/sh -D node && apk add...
+    Layer 4  /bin/sh -c #(nop) ENV YARN_VERSION=1.22.19
+    Layer 5  /bin/sh -c apk add --no-cache --virtual .build-deps-yarn curl gnupg tar && export...
+    Layer 6  /bin/sh -c #(nop) COPY file:UNKNOWN in /usr/local/bin/
+    Layer 7  /bin/sh -c #(nop) ENTRYPOINT ["docker-entrypoint.sh"]
+    Layer 8  /bin/sh -c #(nop) CMD ["node"]
+  Your Image:
+    Layer 9  ARG MANAGER_VERSION=10.2.4
+    Layer 10 WORKDIR /prod/app
+    Layer 11 RUN |1 MANAGER_VERSION=10.2.4 /bin/sh -c npm i -g "npm@$MANAGER_VERSION" # buildkit
+    Layer 12 RUN |1 MANAGER_VERSION=10.2.4 /bin/sh -c npm init -y # buildkit
+    Layer 13 RUN |1 MANAGER_VERSION=10.2.4 /bin/sh -c npm i mkdirp@0.5.0 # buildkit (2 vulns)
+    Layer 14 RUN |1 MANAGER_VERSION=10.2.4 /bin/sh -c npm i -d cryo@0.0.6 # buildkit (1 vulns)
+    Layer 15 RUN |1 MANAGER_VERSION=10.2.4 /bin/sh -c npm install # buildkit
 
 npm
-+-------------------------------------------------------------------------------------------------+
-| Source:artifact:prod/app/node_modules/.package-lock.json                                        |
-+----------+-------------------+------------------+------------+------------------+---------------+
-| PACKAGE  | INSTALLED VERSION | FIX AVAILABLE    | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
-+----------+-------------------+------------------+------------+------------------+---------------+
-| cryo     | 0.0.6             | No fix available |          1 | # 14 Layer       | --            |
-| minimist | 0.0.8             | Fix Available    |          2 | # 13 Layer       | --            |
-+----------+-------------------+------------------+------------+------------------+---------------+
-Alpine:v3.19
-+---------------------------------------------------------------------------------------------+
-| Source:os:lib/apk/db/installed                                                              |
-+---------+-------------------+---------------+------------+------------------+---------------+
-| PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
-+---------+-------------------+---------------+------------+------------------+---------------+
-| busybox | 1.36.1-r15        | Fix Available |          4 | # 0 Layer        | alpine        |
-| openssl | 3.1.4-r5          | Fix Available |          7 | # 0 Layer        | alpine        |
-+---------+-------------------+---------------+------------+------------------+---------------+
 
-For the most comprehensive scan results, we recommend using the HTML output: `osv-scanner scan image --serve <image_name>`.
-You can also view the full vulnerability list in your terminal with: `osv-scanner scan image --format vertical <image_name>`.
+artifact:prod/app/node_modules/.package-lock.json: found 2 packages with issues
+
+  cryo@0.0.6 has the following known vulnerabilities:
+    introduced in # 14 Layer
+    GHSA-38f5-ghc2-fcmv: Code Injection in cryo (https://osv.dev/GHSA-38f5-ghc2-fcmv)
+  minimist@0.0.8 has the following known vulnerabilities:
+    introduced in # 13 Layer
+    GHSA-vh95-rmgr-6w4m: Prototype Pollution in minimist (https://osv.dev/GHSA-vh95-rmgr-6w4m)
+    GHSA-xvch-5gv4-984h: Prototype Pollution in minimist (https://osv.dev/GHSA-xvch-5gv4-984h)
+
+  3 known vulnerabilities found in artifact:prod/app/node_modules/.package-lock.json
+
+Alpine:v3.19
+
+os:lib/apk/db/installed: found 2 packages with issues
+
+  busybox@1.36.1-r15 has the following known vulnerabilities:
+    introduced in # 0 Layer (alpine)
+    CVE-2023-42363: A use-after-free vulnerability was discovered in xasprintf function in... (https://osv.dev/CVE-2023-42363)
+    CVE-2023-42364: A use-after-free vulnerability in BusyBox v.1.36.1 allows attackers to cause a... (https://osv.dev/CVE-2023-42364)
+    CVE-2023-42365: A use-after-free vulnerability was discovered in BusyBox v.1.36.1 via a crafted... (https://osv.dev/CVE-2023-42365)
+    CVE-2023-42366: A heap-buffer-overflow was discovered in BusyBox v.1.36.1 in the next_token... (https://osv.dev/CVE-2023-42366)
+  openssl@3.1.4-r5 has the following known vulnerabilities:
+    introduced in # 0 Layer (alpine)
+    CVE-2024-13176: Issue summary: A timing side-channel which could potentially allow recovering... (https://osv.dev/CVE-2024-13176)
+    CVE-2024-2511: Issue summary: Some non-default TLS server configurations can cause unbounded... (https://osv.dev/CVE-2024-2511)
+    CVE-2024-4603: Issue summary: Checking excessively long DSA keys or parameters may be very... (https://osv.dev/CVE-2024-4603)
+    CVE-2024-4741: Issue summary: Calling the OpenSSL API function SSL_free_buffers may cause... (https://osv.dev/CVE-2024-4741)
+    CVE-2024-5535: Issue summary: Calling the OpenSSL API function SSL_select_next_proto with an... (https://osv.dev/CVE-2024-5535)
+    CVE-2024-6119: Issue summary: Applications performing certificate name checks (e.g., TLS... (https://osv.dev/CVE-2024-6119)
+    CVE-2024-9143: Issue summary: Use of the low-level GF(2^m) elliptic curve APIs with untrusted... (https://osv.dev/CVE-2024-9143)
+
+  11 known vulnerabilities found in os:lib/apk/db/installed
+
 
 ---
 
@@ -3487,23 +4311,53 @@ Warning: `scan` exists as both a subcommand of OSV-Scanner and as a file on the 
 [Test_run_OCIImage/scanning_node_modules_using_pnpm_with_no_packages - 1]
 Scanning local image tarball "../../internal/image/fixtures/test-node_modules-pnpm-empty.tar"
 
-Container Scanning Result (Alpine Linux v3.19):
 Total 2 packages affected by 11 known vulnerabilities (0 Critical, 0 High, 4 Medium, 0 Low, 7 Unknown) from 1 ecosystem.
 11 vulnerabilities can be fixed.
 
+Container image information:
+  OS version: Alpine Linux v3.19
+  Base Image 4 (alpine):
+    Layer 0  /bin/sh -c #(nop) ADD file:UNKNOWN in / (11 vulns)
+  Base Image 3 (alpine):
+    Layer 1  /bin/sh -c #(nop) CMD ["/bin/sh"]
+  Base Image 2 (ayan4m1/maven-node):
+    Layer 2  /bin/sh -c #(nop) ENV NODE_VERSION=20.11.1
+  Base Image 1 (library/node):
+    Layer 3  /bin/sh -c addgroup -g 1000 node && adduser -u 1000 -G node -s /bin/sh -D node && apk add...
+    Layer 4  /bin/sh -c #(nop) ENV YARN_VERSION=1.22.19
+    Layer 5  /bin/sh -c apk add --no-cache --virtual .build-deps-yarn curl gnupg tar && export...
+    Layer 6  /bin/sh -c #(nop) COPY file:UNKNOWN in /usr/local/bin/
+    Layer 7  /bin/sh -c #(nop) ENTRYPOINT ["docker-entrypoint.sh"]
+    Layer 8  /bin/sh -c #(nop) CMD ["node"]
+  Your Image:
+    Layer 9  ARG MANAGER_VERSION=8.15.4
+    Layer 10 WORKDIR /prod/app
+    Layer 11 RUN |1 MANAGER_VERSION=8.15.4 /bin/sh -c npm i -g "pnpm@$MANAGER_VERSION" # buildkit
+    Layer 12 RUN |1 MANAGER_VERSION=8.15.4 /bin/sh -c pnpm init # buildkit
+    Layer 13 RUN |1 MANAGER_VERSION=8.15.4 /bin/sh -c pnpm install # buildkit
 
 Alpine:v3.19
-+---------------------------------------------------------------------------------------------+
-| Source:os:lib/apk/db/installed                                                              |
-+---------+-------------------+---------------+------------+------------------+---------------+
-| PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
-+---------+-------------------+---------------+------------+------------------+---------------+
-| busybox | 1.36.1-r15        | Fix Available |          4 | # 0 Layer        | alpine        |
-| openssl | 3.1.4-r5          | Fix Available |          7 | # 0 Layer        | alpine        |
-+---------+-------------------+---------------+------------+------------------+---------------+
 
-For the most comprehensive scan results, we recommend using the HTML output: `osv-scanner scan image --serve <image_name>`.
-You can also view the full vulnerability list in your terminal with: `osv-scanner scan image --format vertical <image_name>`.
+os:lib/apk/db/installed: found 2 packages with issues
+
+  busybox@1.36.1-r15 has the following known vulnerabilities:
+    introduced in # 0 Layer (alpine)
+    CVE-2023-42363: A use-after-free vulnerability was discovered in xasprintf function in... (https://osv.dev/CVE-2023-42363)
+    CVE-2023-42364: A use-after-free vulnerability in BusyBox v.1.36.1 allows attackers to cause a... (https://osv.dev/CVE-2023-42364)
+    CVE-2023-42365: A use-after-free vulnerability was discovered in BusyBox v.1.36.1 via a crafted... (https://osv.dev/CVE-2023-42365)
+    CVE-2023-42366: A heap-buffer-overflow was discovered in BusyBox v.1.36.1 in the next_token... (https://osv.dev/CVE-2023-42366)
+  openssl@3.1.4-r5 has the following known vulnerabilities:
+    introduced in # 0 Layer (alpine)
+    CVE-2024-13176: Issue summary: A timing side-channel which could potentially allow recovering... (https://osv.dev/CVE-2024-13176)
+    CVE-2024-2511: Issue summary: Some non-default TLS server configurations can cause unbounded... (https://osv.dev/CVE-2024-2511)
+    CVE-2024-4603: Issue summary: Checking excessively long DSA keys or parameters may be very... (https://osv.dev/CVE-2024-4603)
+    CVE-2024-4741: Issue summary: Calling the OpenSSL API function SSL_free_buffers may cause... (https://osv.dev/CVE-2024-4741)
+    CVE-2024-5535: Issue summary: Calling the OpenSSL API function SSL_select_next_proto with an... (https://osv.dev/CVE-2024-5535)
+    CVE-2024-6119: Issue summary: Applications performing certificate name checks (e.g., TLS... (https://osv.dev/CVE-2024-6119)
+    CVE-2024-9143: Issue summary: Use of the low-level GF(2^m) elliptic curve APIs with untrusted... (https://osv.dev/CVE-2024-9143)
+
+  11 known vulnerabilities found in os:lib/apk/db/installed
+
 
 ---
 
@@ -3515,23 +4369,55 @@ Warning: `scan` exists as both a subcommand of OSV-Scanner and as a file on the 
 [Test_run_OCIImage/scanning_node_modules_using_pnpm_with_some_packages - 1]
 Scanning local image tarball "../../internal/image/fixtures/test-node_modules-pnpm-full.tar"
 
-Container Scanning Result (Alpine Linux v3.19):
 Total 2 packages affected by 11 known vulnerabilities (0 Critical, 0 High, 4 Medium, 0 Low, 7 Unknown) from 1 ecosystem.
 11 vulnerabilities can be fixed.
 
+Container image information:
+  OS version: Alpine Linux v3.19
+  Base Image 4 (alpine):
+    Layer 0  /bin/sh -c #(nop) ADD file:UNKNOWN in / (11 vulns)
+  Base Image 3 (alpine):
+    Layer 1  /bin/sh -c #(nop) CMD ["/bin/sh"]
+  Base Image 2 (ayan4m1/maven-node):
+    Layer 2  /bin/sh -c #(nop) ENV NODE_VERSION=20.11.1
+  Base Image 1 (library/node):
+    Layer 3  /bin/sh -c addgroup -g 1000 node && adduser -u 1000 -G node -s /bin/sh -D node && apk add...
+    Layer 4  /bin/sh -c #(nop) ENV YARN_VERSION=1.22.19
+    Layer 5  /bin/sh -c apk add --no-cache --virtual .build-deps-yarn curl gnupg tar && export...
+    Layer 6  /bin/sh -c #(nop) COPY file:UNKNOWN in /usr/local/bin/
+    Layer 7  /bin/sh -c #(nop) ENTRYPOINT ["docker-entrypoint.sh"]
+    Layer 8  /bin/sh -c #(nop) CMD ["node"]
+  Your Image:
+    Layer 9  ARG MANAGER_VERSION=8.15.4
+    Layer 10 WORKDIR /prod/app
+    Layer 11 RUN |1 MANAGER_VERSION=8.15.4 /bin/sh -c npm i -g "pnpm@$MANAGER_VERSION" # buildkit
+    Layer 12 RUN |1 MANAGER_VERSION=8.15.4 /bin/sh -c pnpm init # buildkit
+    Layer 13 RUN |1 MANAGER_VERSION=8.15.4 /bin/sh -c pnpm add mkdirp@0.5.0 # buildkit
+    Layer 14 RUN |1 MANAGER_VERSION=8.15.4 /bin/sh -c pnpm add -d cryo@0.0.6 # buildkit
+    Layer 15 RUN |1 MANAGER_VERSION=8.15.4 /bin/sh -c pnpm install # buildkit
 
 Alpine:v3.19
-+---------------------------------------------------------------------------------------------+
-| Source:os:lib/apk/db/installed                                                              |
-+---------+-------------------+---------------+------------+------------------+---------------+
-| PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
-+---------+-------------------+---------------+------------+------------------+---------------+
-| busybox | 1.36.1-r15        | Fix Available |          4 | # 0 Layer        | alpine        |
-| openssl | 3.1.4-r5          | Fix Available |          7 | # 0 Layer        | alpine        |
-+---------+-------------------+---------------+------------+------------------+---------------+
 
-For the most comprehensive scan results, we recommend using the HTML output: `osv-scanner scan image --serve <image_name>`.
-You can also view the full vulnerability list in your terminal with: `osv-scanner scan image --format vertical <image_name>`.
+os:lib/apk/db/installed: found 2 packages with issues
+
+  busybox@1.36.1-r15 has the following known vulnerabilities:
+    introduced in # 0 Layer (alpine)
+    CVE-2023-42363: A use-after-free vulnerability was discovered in xasprintf function in... (https://osv.dev/CVE-2023-42363)
+    CVE-2023-42364: A use-after-free vulnerability in BusyBox v.1.36.1 allows attackers to cause a... (https://osv.dev/CVE-2023-42364)
+    CVE-2023-42365: A use-after-free vulnerability was discovered in BusyBox v.1.36.1 via a crafted... (https://osv.dev/CVE-2023-42365)
+    CVE-2023-42366: A heap-buffer-overflow was discovered in BusyBox v.1.36.1 in the next_token... (https://osv.dev/CVE-2023-42366)
+  openssl@3.1.4-r5 has the following known vulnerabilities:
+    introduced in # 0 Layer (alpine)
+    CVE-2024-13176: Issue summary: A timing side-channel which could potentially allow recovering... (https://osv.dev/CVE-2024-13176)
+    CVE-2024-2511: Issue summary: Some non-default TLS server configurations can cause unbounded... (https://osv.dev/CVE-2024-2511)
+    CVE-2024-4603: Issue summary: Checking excessively long DSA keys or parameters may be very... (https://osv.dev/CVE-2024-4603)
+    CVE-2024-4741: Issue summary: Calling the OpenSSL API function SSL_free_buffers may cause... (https://osv.dev/CVE-2024-4741)
+    CVE-2024-5535: Issue summary: Calling the OpenSSL API function SSL_select_next_proto with an... (https://osv.dev/CVE-2024-5535)
+    CVE-2024-6119: Issue summary: Applications performing certificate name checks (e.g., TLS... (https://osv.dev/CVE-2024-6119)
+    CVE-2024-9143: Issue summary: Use of the low-level GF(2^m) elliptic curve APIs with untrusted... (https://osv.dev/CVE-2024-9143)
+
+  11 known vulnerabilities found in os:lib/apk/db/installed
+
 
 ---
 
@@ -3543,23 +4429,53 @@ Warning: `scan` exists as both a subcommand of OSV-Scanner and as a file on the 
 [Test_run_OCIImage/scanning_node_modules_using_yarn_with_no_packages - 1]
 Scanning local image tarball "../../internal/image/fixtures/test-node_modules-yarn-empty.tar"
 
-Container Scanning Result (Alpine Linux v3.19):
 Total 2 packages affected by 11 known vulnerabilities (0 Critical, 0 High, 4 Medium, 0 Low, 7 Unknown) from 1 ecosystem.
 11 vulnerabilities can be fixed.
 
+Container image information:
+  OS version: Alpine Linux v3.19
+  Base Image 4 (alpine):
+    Layer 0  /bin/sh -c #(nop) ADD file:UNKNOWN in / (11 vulns)
+  Base Image 3 (alpine):
+    Layer 1  /bin/sh -c #(nop) CMD ["/bin/sh"]
+  Base Image 2 (ayan4m1/maven-node):
+    Layer 2  /bin/sh -c #(nop) ENV NODE_VERSION=20.11.1
+  Base Image 1 (library/node):
+    Layer 3  /bin/sh -c addgroup -g 1000 node && adduser -u 1000 -G node -s /bin/sh -D node && apk add...
+    Layer 4  /bin/sh -c #(nop) ENV YARN_VERSION=1.22.19
+    Layer 5  /bin/sh -c apk add --no-cache --virtual .build-deps-yarn curl gnupg tar && export...
+    Layer 6  /bin/sh -c #(nop) COPY file:UNKNOWN in /usr/local/bin/
+    Layer 7  /bin/sh -c #(nop) ENTRYPOINT ["docker-entrypoint.sh"]
+    Layer 8  /bin/sh -c #(nop) CMD ["node"]
+  Your Image:
+    Layer 9  ARG MANAGER_VERSION=1.22.22
+    Layer 10 WORKDIR /prod/app
+    Layer 11 RUN |1 MANAGER_VERSION=1.22.22 /bin/sh -c npm i -g "yarn@$MANAGER_VERSION" --force # buildkit
+    Layer 12 RUN |1 MANAGER_VERSION=1.22.22 /bin/sh -c yarn init -y # buildkit
+    Layer 13 RUN |1 MANAGER_VERSION=1.22.22 /bin/sh -c yarn install # buildkit
 
 Alpine:v3.19
-+---------------------------------------------------------------------------------------------+
-| Source:os:lib/apk/db/installed                                                              |
-+---------+-------------------+---------------+------------+------------------+---------------+
-| PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
-+---------+-------------------+---------------+------------+------------------+---------------+
-| busybox | 1.36.1-r15        | Fix Available |          4 | # 0 Layer        | alpine        |
-| openssl | 3.1.4-r5          | Fix Available |          7 | # 0 Layer        | alpine        |
-+---------+-------------------+---------------+------------+------------------+---------------+
 
-For the most comprehensive scan results, we recommend using the HTML output: `osv-scanner scan image --serve <image_name>`.
-You can also view the full vulnerability list in your terminal with: `osv-scanner scan image --format vertical <image_name>`.
+os:lib/apk/db/installed: found 2 packages with issues
+
+  busybox@1.36.1-r15 has the following known vulnerabilities:
+    introduced in # 0 Layer (alpine)
+    CVE-2023-42363: A use-after-free vulnerability was discovered in xasprintf function in... (https://osv.dev/CVE-2023-42363)
+    CVE-2023-42364: A use-after-free vulnerability in BusyBox v.1.36.1 allows attackers to cause a... (https://osv.dev/CVE-2023-42364)
+    CVE-2023-42365: A use-after-free vulnerability was discovered in BusyBox v.1.36.1 via a crafted... (https://osv.dev/CVE-2023-42365)
+    CVE-2023-42366: A heap-buffer-overflow was discovered in BusyBox v.1.36.1 in the next_token... (https://osv.dev/CVE-2023-42366)
+  openssl@3.1.4-r5 has the following known vulnerabilities:
+    introduced in # 0 Layer (alpine)
+    CVE-2024-13176: Issue summary: A timing side-channel which could potentially allow recovering... (https://osv.dev/CVE-2024-13176)
+    CVE-2024-2511: Issue summary: Some non-default TLS server configurations can cause unbounded... (https://osv.dev/CVE-2024-2511)
+    CVE-2024-4603: Issue summary: Checking excessively long DSA keys or parameters may be very... (https://osv.dev/CVE-2024-4603)
+    CVE-2024-4741: Issue summary: Calling the OpenSSL API function SSL_free_buffers may cause... (https://osv.dev/CVE-2024-4741)
+    CVE-2024-5535: Issue summary: Calling the OpenSSL API function SSL_select_next_proto with an... (https://osv.dev/CVE-2024-5535)
+    CVE-2024-6119: Issue summary: Applications performing certificate name checks (e.g., TLS... (https://osv.dev/CVE-2024-6119)
+    CVE-2024-9143: Issue summary: Use of the low-level GF(2^m) elliptic curve APIs with untrusted... (https://osv.dev/CVE-2024-9143)
+
+  11 known vulnerabilities found in os:lib/apk/db/installed
+
 
 ---
 
@@ -3571,23 +4487,55 @@ Warning: `scan` exists as both a subcommand of OSV-Scanner and as a file on the 
 [Test_run_OCIImage/scanning_node_modules_using_yarn_with_some_packages - 1]
 Scanning local image tarball "../../internal/image/fixtures/test-node_modules-yarn-full.tar"
 
-Container Scanning Result (Alpine Linux v3.19):
 Total 2 packages affected by 11 known vulnerabilities (0 Critical, 0 High, 4 Medium, 0 Low, 7 Unknown) from 1 ecosystem.
 11 vulnerabilities can be fixed.
 
+Container image information:
+  OS version: Alpine Linux v3.19
+  Base Image 4 (alpine):
+    Layer 0  /bin/sh -c #(nop) ADD file:UNKNOWN in / (11 vulns)
+  Base Image 3 (alpine):
+    Layer 1  /bin/sh -c #(nop) CMD ["/bin/sh"]
+  Base Image 2 (ayan4m1/maven-node):
+    Layer 2  /bin/sh -c #(nop) ENV NODE_VERSION=20.11.1
+  Base Image 1 (library/node):
+    Layer 3  /bin/sh -c addgroup -g 1000 node && adduser -u 1000 -G node -s /bin/sh -D node && apk add...
+    Layer 4  /bin/sh -c #(nop) ENV YARN_VERSION=1.22.19
+    Layer 5  /bin/sh -c apk add --no-cache --virtual .build-deps-yarn curl gnupg tar && export...
+    Layer 6  /bin/sh -c #(nop) COPY file:UNKNOWN in /usr/local/bin/
+    Layer 7  /bin/sh -c #(nop) ENTRYPOINT ["docker-entrypoint.sh"]
+    Layer 8  /bin/sh -c #(nop) CMD ["node"]
+  Your Image:
+    Layer 9  ARG MANAGER_VERSION=1.22.22
+    Layer 10 WORKDIR /prod/app
+    Layer 11 RUN |1 MANAGER_VERSION=1.22.22 /bin/sh -c npm i -g "yarn@$MANAGER_VERSION" --force # buildkit
+    Layer 12 RUN |1 MANAGER_VERSION=1.22.22 /bin/sh -c yarn init -y # buildkit
+    Layer 13 RUN |1 MANAGER_VERSION=1.22.22 /bin/sh -c yarn add mkdirp@0.5.0 # buildkit
+    Layer 14 RUN |1 MANAGER_VERSION=1.22.22 /bin/sh -c yarn add --dev cryo@0.0.6 # buildkit
+    Layer 15 RUN |1 MANAGER_VERSION=1.22.22 /bin/sh -c yarn install # buildkit
 
 Alpine:v3.19
-+---------------------------------------------------------------------------------------------+
-| Source:os:lib/apk/db/installed                                                              |
-+---------+-------------------+---------------+------------+------------------+---------------+
-| PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
-+---------+-------------------+---------------+------------+------------------+---------------+
-| busybox | 1.36.1-r15        | Fix Available |          4 | # 0 Layer        | alpine        |
-| openssl | 3.1.4-r5          | Fix Available |          7 | # 0 Layer        | alpine        |
-+---------+-------------------+---------------+------------+------------------+---------------+
 
-For the most comprehensive scan results, we recommend using the HTML output: `osv-scanner scan image --serve <image_name>`.
-You can also view the full vulnerability list in your terminal with: `osv-scanner scan image --format vertical <image_name>`.
+os:lib/apk/db/installed: found 2 packages with issues
+
+  busybox@1.36.1-r15 has the following known vulnerabilities:
+    introduced in # 0 Layer (alpine)
+    CVE-2023-42363: A use-after-free vulnerability was discovered in xasprintf function in... (https://osv.dev/CVE-2023-42363)
+    CVE-2023-42364: A use-after-free vulnerability in BusyBox v.1.36.1 allows attackers to cause a... (https://osv.dev/CVE-2023-42364)
+    CVE-2023-42365: A use-after-free vulnerability was discovered in BusyBox v.1.36.1 via a crafted... (https://osv.dev/CVE-2023-42365)
+    CVE-2023-42366: A heap-buffer-overflow was discovered in BusyBox v.1.36.1 in the next_token... (https://osv.dev/CVE-2023-42366)
+  openssl@3.1.4-r5 has the following known vulnerabilities:
+    introduced in # 0 Layer (alpine)
+    CVE-2024-13176: Issue summary: A timing side-channel which could potentially allow recovering... (https://osv.dev/CVE-2024-13176)
+    CVE-2024-2511: Issue summary: Some non-default TLS server configurations can cause unbounded... (https://osv.dev/CVE-2024-2511)
+    CVE-2024-4603: Issue summary: Checking excessively long DSA keys or parameters may be very... (https://osv.dev/CVE-2024-4603)
+    CVE-2024-4741: Issue summary: Calling the OpenSSL API function SSL_free_buffers may cause... (https://osv.dev/CVE-2024-4741)
+    CVE-2024-5535: Issue summary: Calling the OpenSSL API function SSL_select_next_proto with an... (https://osv.dev/CVE-2024-5535)
+    CVE-2024-6119: Issue summary: Applications performing certificate name checks (e.g., TLS... (https://osv.dev/CVE-2024-6119)
+    CVE-2024-9143: Issue summary: Use of the low-level GF(2^m) elliptic curve APIs with untrusted... (https://osv.dev/CVE-2024-9143)
+
+  11 known vulnerabilities found in os:lib/apk/db/installed
+
 
 ---
 

--- a/cmd/osv-scanner/internal/helper/helper.go
+++ b/cmd/osv-scanner/internal/helper/helper.go
@@ -66,7 +66,7 @@ func GetScanGlobalFlags() []cli.Flag {
 			Name:    "format",
 			Aliases: []string{"f"},
 			Usage:   "sets the output format; value can be: " + strings.Join(reporter.Format(), ", "),
-			Value:   "table",
+			Value:   "vertical",
 			Action: func(_ *cli.Context, s string) error {
 				if slices.Contains(reporter.Format(), s) {
 					if s != "vertical" && s != "table" && s != "markdown" {


### PR DESCRIPTION
I can't find anywhere that we actually said explicitly "yes let's make this the default", but I'm pretty sure that was the plan and we didn't say _not_ to do it.

There was some discussion on #889 about this - I'm also pretty sure we were comfortable saying this isn't actually a breaking change, but since we've working on v2 it seems like a good time to change this all the same.