### PR TITLE
chore: explicitly allow linting errors from `package-comments`

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -121,6 +121,8 @@ linters-settings:
     block-size: 2
 
 issues:
+  include:
+    - EXC0015 # revive package-comments
   max-issues-per-linter: 0
   max-same-issues: 0
   exclude-rules:


### PR DESCRIPTION
By default `golangci-lint` ignores output from `package-comments` unless you explicitly allow it, even if you're already explicitly enabling the underlying rule, as they consider it too noisy for most codebases