### PR TITLE
fix: remove OpenHTML()

### DIFF
--- a/cmd/osv-scanner/internal/helper/helper.go
+++ b/cmd/osv-scanner/internal/helper/helper.go
@@ -6,8 +6,6 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
-	"os/exec"
-	"runtime"
 	"slices"
 	"strings"
 	"time"
@@ -166,28 +164,6 @@ func GetScanGlobalFlags() []cli.Flag {
 				allowList: "",
 			},
 		},
-	}
-}
-
-// OpenHTML will attempt to open the outputted HTML file in the default browser
-func OpenHTML(outputPath string) {
-	// Open the outputted HTML file in the default browser.
-	slog.Info(fmt.Sprintf("Opening %s...", outputPath))
-	var err error
-	switch runtime.GOOS {
-	case "linux":
-		err = exec.Command("xdg-open", outputPath).Start()
-	case "windows":
-		err = exec.Command("start", "", outputPath).Start()
-	case "darwin": // macOS
-		err = exec.Command("open", outputPath).Start()
-	default:
-		slog.Info("Unsupported OS.")
-	}
-
-	if err != nil {
-		slog.Error(fmt.Sprintf("Failed to open: %s", err))
-		slog.Error("Please manually open the outputted HTML file: " + outputPath)
 	}
 }
 

--- a/cmd/osv-scanner/scan/image/main.go
+++ b/cmd/osv-scanner/scan/image/main.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 
@@ -86,7 +87,7 @@ func action(context *cli.Context, stdout, stderr io.Writer) error {
 		if serve {
 			helper.ServeHTML(outputPath)
 		} else if format == "html" {
-			helper.OpenHTML(outputPath)
+			slog.Info("HTML output available at: " + outputPath)
 		}
 	}
 

--- a/cmd/osv-scanner/scan/source/main.go
+++ b/cmd/osv-scanner/scan/source/main.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 
@@ -149,7 +150,7 @@ func action(context *cli.Context, stdout, stderr io.Writer) error {
 		if serve {
 			helper.ServeHTML(outputPath)
 		} else if format == "html" {
-			helper.OpenHTML(outputPath)
+			slog.Info("HTML output available at: " + outputPath)
 		}
 	}
 


### PR DESCRIPTION
Removes automatic HTML opening, avoids extra command execution. Resolves https://github.com/google/osv-scanner/issues/1721