### PR TITLE
fix: add spacing in logged serve url

### DIFF
--- a/cmd/osv-scanner/internal/helper/helper.go
+++ b/cmd/osv-scanner/internal/helper/helper.go
@@ -172,7 +172,7 @@ func GetScanGlobalFlags() []cli.Flag {
 // until the user manually terminates it (e.g. using Ctrl+C).
 func ServeHTML(outputPath string) {
 	localhostURL := fmt.Sprintf("http://localhost:%s/", servePort)
-	slog.Info("Serving HTML report at " + localhostURL)
+	slog.Info("Serving HTML report at: " + localhostURL)
 	slog.Info("If you are accessing remotely, use the following SSH command:")
 	slog.Info(fmt.Sprintf("`ssh -L local_port:destination_server_ip:%s ssh_server_hostname`", servePort))
 	server := &http.Server{


### PR DESCRIPTION
## Summary

Add a space between the logged text and the logger URL when serving a report locally. Currently, the logged output looks like
```
Serving HTML report athttp://localhost:8000/
If you are accessing remotely, use the following SSH command:
`ssh -L local_port:destination_server_ip:8000 ssh_server_hostname`
```
with no space between the message and the URL. Many terminal programs will not detect the URL to make it easy to select and copy or click.

### Proposed fix

With this change, the output will look like
```
Serving HTML report at: http://localhost:8000/
If you are accessing remotely, use the following SSH command:
`ssh -L local_port:destination_server_ip:8000 ssh_server_hostname`
```

### Additional format options

I could drop the `:` or move the URL down to a new line as well, if desired.
```
Serving HTML report at http://localhost:8000/
If you are accessing remotely, use the following SSH command:
`ssh -L local_port:destination_server_ip:8000 ssh_server_hostname`
```

```
Serving HTML report at:
http://localhost:8000/
If you are accessing remotely, use the following SSH command:
`ssh -L local_port:destination_server_ip:8000 ssh_server_hostname`
```