### PR TITLE
feat: Add support for more .NET extrators

### DIFF
--- a/cmd/osv-scanner/__snapshots__/main_test.snap
+++ b/cmd/osv-scanner/__snapshots__/main_test.snap
@@ -1133,7 +1133,10 @@ Scanned <rootdir>/fixtures/locks-requirements/the_requirements_for_test.txt file
 | https://osv.dev/GHSA-xc3p-ff3m-f46v |      |           |            |         |                                                   |
 | https://osv.dev/PYSEC-2024-71       | 8.7  | PyPI      | flask-cors | 1.0.0   | fixtures/locks-requirements/requirements.txt      |
 | https://osv.dev/GHSA-hxwh-jpp2-84pm |      |           |            |         |                                                   |
+| https://osv.dev/GHSA-43qf-4rqw-9q2g | 5.3  | PyPI      | flask-cors | 1.0.0   | fixtures/locks-requirements/requirements.txt      |
+| https://osv.dev/GHSA-7rxf-gvfg-47g4 | 4.3  | PyPI      | flask-cors | 1.0.0   | fixtures/locks-requirements/requirements.txt      |
 | https://osv.dev/GHSA-84pr-m4jr-85g5 | 5.3  | PyPI      | flask-cors | 1.0.0   | fixtures/locks-requirements/requirements.txt      |
+| https://osv.dev/GHSA-8vgw-p6qm-5gr7 | 5.3  | PyPI      | flask-cors | 1.0.0   | fixtures/locks-requirements/requirements.txt      |
 | https://osv.dev/PYSEC-2020-73       |      | PyPI      | pandas     | 0.23.4  | fixtures/locks-requirements/requirements.txt      |
 +-------------------------------------+------+-----------+------------+---------+---------------------------------------------------+
 
@@ -3106,6 +3109,26 @@ Scanned <rootdir>/fixtures/locks-scalibr/depsjson file as a deps.json and found 
 ---
 
 [Test_run_MoreLockfiles/depsjson - 2]
+
+---
+
+[Test_run_MoreLockfiles/packages.config - 1]
+Scanned <rootdir>/fixtures/locks-scalibr/packages.config file and found 2 packages
+No issues found
+
+---
+
+[Test_run_MoreLockfiles/packages.config - 2]
+
+---
+
+[Test_run_MoreLockfiles/packages.lock.json - 1]
+Scanned <rootdir>/fixtures/locks-scalibr/packages.lock.json file and found 1 package
+No issues found
+
+---
+
+[Test_run_MoreLockfiles/packages.lock.json - 2]
 
 ---
 

--- a/cmd/osv-scanner/fixtures/locks-scalibr/packages.config
+++ b/cmd/osv-scanner/fixtures/locks-scalibr/packages.config
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.Net.Compilers" version="1.0.0" targetFramework="net46" developmentDependency="true" />
+</packages>

--- a/cmd/osv-scanner/fixtures/locks-scalibr/packages.lock.json
+++ b/cmd/osv-scanner/fixtures/locks-scalibr/packages.lock.json
@@ -1,0 +1,13 @@
+{
+    "version": 1,
+    "dependencies": {
+      "net8.0": {
+        "Newtonsoft.Json": {
+          "type": "Direct",
+          "requested": "[13.0.3, )",
+          "resolved": "13.0.3",
+          "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+        }
+      }
+    }
+  }

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -1035,6 +1035,16 @@ func Test_run_MoreLockfiles(t *testing.T) {
 			args: []string{"", "-L", "./fixtures/locks-scalibr/stack.yaml.lock"},
 			exit: 0,
 		},
+		{
+			name: "packages.config",
+			args: []string{"", "-L", "./fixtures/locks-scalibr/packages.config"},
+			exit: 0,
+		},
+		{
+			name: "packages.lock.json",
+			args: []string{"", "-L", "./fixtures/locks-scalibr/packages.lock.json"},
+			exit: 0,
+		},
 		/*
 			{
 				name: "Package.resolved",

--- a/docs/supported_languages_and_lockfiles.md
+++ b/docs/supported_languages_and_lockfiles.md
@@ -53,7 +53,7 @@ When scanning source code (`osv-scanner scan source ...`), OSV-Scanner automatic
 | Haskell    | `cabal.project.freeze`<br> `stack.yaml.lock`                                                                                               |
 | Java       | `buildscript-gradle.lockfile`<br>`gradle.lockfile`<br>`gradle/verification-metadata.xml`<br>`pom.xml`[\*](#transitive-dependency-scanning) |
 | Javascript | `package-lock.json`<br>`pnpm-lock.yaml`<br>`yarn.lock`                                                                                     |
-| .NET       | `deps.json`                                                                                                                                |
+| .NET       | `deps.json`<br>`packages.config`<br>`packages.lock.json`                                                                                   |
 | PHP        | `composer.lock`                                                                                                                            |
 | Python     | `Pipfile.lock`<br>`poetry.lock`<br>`requirements.txt`[\*](https://github.com/google/osv-scanner/issues/34)<br>`pdm.lock`<br>`uv.lock`      |
 | R          | `renv.lock`                                                                                                                                |

--- a/pkg/osvscanner/internal/scanners/extractorbuilder.go
+++ b/pkg/osvscanner/internal/scanners/extractorbuilder.go
@@ -7,6 +7,8 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/language/cpp/conanlock"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/dart/pubspec"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/dotnet/depsjson"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/dotnet/packagesconfig"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/dotnet/packageslockjson"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/erlang/mixlock"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/golang/gobinary"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/golang/gomod"
@@ -91,6 +93,8 @@ var lockfileExtractors = []filesystem.Extractor{
 
 	// NuGet
 	depsjson.Extractor{},
+	packagesconfig.Extractor{},
+	packageslockjson.Extractor{},
 
 	// Haskell
 	cabal.Extractor{},

--- a/pkg/osvscanner/internal/scanners/lockfile.go
+++ b/pkg/osvscanner/internal/scanners/lockfile.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/language/cpp/conanlock"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/dart/pubspec"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/dotnet/depsjson"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/dotnet/packagesconfig"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/dotnet/packageslockjson"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/erlang/mixlock"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/golang/gomod"
@@ -61,6 +62,7 @@ var lockfileExtractorMapping = map[string][]string{
 	"mix.lock":                    {mixlock.Name},
 	"renv.lock":                   {renvlock.Name},
 	"deps.json":                   {depsjson.Name},
+	"packages.config":             {packagesconfig.Name},
 	"packages.lock.json":          {packageslockjson.Name},
 	"conan.lock":                  {conanlock.Name},
 	"go.mod":                      {gomod.Name},


### PR DESCRIPTION
This PR adds more lockfile extractors supported in OSV-Scalibr for .NET:
 - `packages.config`
 - `packages.lock.json`