### PR TITLE
chore: update snapshot script for `goreleaser` v2

### DIFF
--- a/scripts/build_snapshot.sh
+++ b/scripts/build_snapshot.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-goreleaser build --rm-dist --single-target --snapshot
+goreleaser build --clean --single-target --snapshot


### PR DESCRIPTION
This was changed in v2: https://goreleaser.com/deprecations/#-rm-dist