### PR TITLE
fix: osv-reporter should be print a warning instead of an error for these messages

### DIFF
--- a/cmd/osv-reporter/main.go
+++ b/cmd/osv-reporter/main.go
@@ -103,7 +103,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 			if oldPath != "" {
 				oldVulns, err = ci.LoadVulnResults(oldPath)
 				if err != nil {
-					slog.Error(fmt.Sprintf("failed to open old results at %s: %v - likely because target branch has no lockfiles.", oldPath, err))
+					slog.Warn(fmt.Sprintf("failed to open old results at %s: %v - likely because target branch has no lockfiles.", oldPath, err))
 					// Do not return, assume there is no oldVulns (which will display all new vulns).
 					oldVulns = models.VulnerabilityResults{}
 				}
@@ -111,7 +111,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 
 			newVulns, err := ci.LoadVulnResults(newPath)
 			if err != nil {
-				slog.Error(fmt.Sprintf("failed to open new results at %s: %v - likely because previous step failed.", newPath, err))
+				slog.Warn(fmt.Sprintf("failed to open new results at %s: %v - likely because previous step failed.", newPath, err))
 				newVulns = models.VulnerabilityResults{}
 				// Do not return a non zero error code.
 			}


### PR DESCRIPTION
Printing an error results in a 127 return code, when we want to return 0 when these warnings happen. This fixes a unintented behaviour change made as part of the slog refactor.

Fixes https://github.com/google/osv-scanner-action/issues/65