### PR TITLE
chore: add `--force` and `--no-cache` flags to script for building test images

### DIFF
--- a/scripts/build_test_images.sh
+++ b/scripts/build_test_images.sh
@@ -2,12 +2,16 @@
 
 set -e
 
+# this is inverted because docker build takes "--no-cache",
+# so "false" here means that the layer cache will be used
+no_layer_cache=false
+
 function build_docker_image_fixture {
   image_name="$1"
   output_tar="internal/image/fixtures/$image_name.tar"
 
   if [ ! -f "$output_tar" ]; then
-    docker build internal/image/fixtures/ -f "internal/image/fixtures/$image_name.Dockerfile" -t "osv-scanner/$image_name:latest"
+    docker build internal/image/fixtures/ -f "internal/image/fixtures/$image_name.Dockerfile" -t "osv-scanner/$image_name:latest" --no-cache="$no_layer_cache"
     docker image save "osv-scanner/$image_name:latest" -o "$output_tar"
 
     echo "finished building $output_tar (did not exist)"
@@ -16,8 +20,31 @@ function build_docker_image_fixture {
   fi
 }
 
+force=false
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --force)
+      force=true
+      shift
+      ;;
+    --no-cache)
+      no_layer_cache=true
+      shift
+      ;;
+    *)
+      echo "Unknown argument: $1"
+      exit 1
+      ;;
+  esac
+done
+
 for dockerfile in internal/image/fixtures/*.Dockerfile; do
   image_name=$(basename "$dockerfile" .Dockerfile)
+
+  if [ "$force" = true ]; then
+    echo "Removing existing tar file for $image_name..."
+    rm -f "internal/image/fixtures/$image_name.tar"
+  fi
 
   build_docker_image_fixture "$image_name"
 done

--- a/scripts/build_test_images.sh
+++ b/scripts/build_test_images.sh
@@ -43,7 +43,7 @@ for dockerfile in internal/image/fixtures/*.Dockerfile; do
 
   if [ "$force" = true ]; then
     echo "Removing existing tar file for $image_name..."
-    rm -f "internal/image/fixtures/$image_name.tar"
+    rm "internal/image/fixtures/$image_name.tar"
   fi
 
   build_docker_image_fixture "$image_name"


### PR DESCRIPTION
This should make it easier to ensure that you've got the same images as in CI - it'd be good if someone on macOS could test these for me, as opt-parsing has a bit patchy between OSs

Usages:

```
scripts/build_test_images.sh --force
scripts/build_test_images.sh --no-cache
scripts/build_test_images.sh --force --no-cache
```