### PR TITLE
ci: cache test images for reuse across runs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -91,22 +91,29 @@ jobs:
       contents: read # to fetch code (actions/checkout)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
-        continue-on-error: true
-        with:
-          pattern: image-fixtures-*
-          path: internal/image/fixtures/
-          merge-multiple: true
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
+      - uses: actions/cache/restore@v4
+        id: cache-image-fixtures-restore
+        with:
+          path: tmp/cache
+          key: cache-image-fixtures-${{ github.ref }}-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            cache-image-fixtures-${{ github.ref }}-${{ github.sha }}-
+            cache-image-fixtures-${{ github.ref }}-
+            cache-image-fixtures-
       - run: scripts/build_test_images.sh
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: image-fixtures-${{ github.run_number }}-${{ github.run_attempt }}
           path: internal/image/fixtures/*.tar
           retention-days: 1
+      - uses: actions/cache/save@v4
+        with:
+          path: internal/image/fixtures/*.tar
+          key: ${{ steps.cache-image-fixtures-restore.outputs.cache-primary-key }}
   tests:
     permissions:
       contents: read # to fetch code (actions/checkout)

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -98,7 +98,7 @@ jobs:
       - uses: actions/cache/restore@v4
         id: cache-image-fixtures-restore
         with:
-          path: tmp/cache
+          path: internal/image/fixtures/
           key: cache-image-fixtures-${{ github.ref }}-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
             cache-image-fixtures-${{ github.ref }}-${{ github.sha }}-

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -91,6 +91,10 @@ jobs:
       contents: read # to fetch code (actions/checkout)
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+        with:
+          name: image-fixtures-*
+          path: internal/image/fixtures/
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -92,6 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+        continue-on-error: true
         with:
           name: image-fixtures-*
           path: internal/image/fixtures/

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -94,8 +94,9 @@ jobs:
       - uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         continue-on-error: true
         with:
-          name: image-fixtures-*
+          pattern: image-fixtures-*
           path: internal/image/fixtures/
+          merge-multiple: true
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 [![SLSA 3](https://slsa.dev/images/gh-badge-level3.svg)](https://slsa.dev)
 [![GitHub Release](https://img.shields.io/github/v/release/google/osv-scanner)](https://github.com/google/osv-scanner/releases)
 
+This is a change!
+
 Use OSV-Scanner to find existing vulnerabilities affecting your project's dependencies.
 OSV-Scanner provides an officially supported frontend to the [OSV database](https://osv.dev/) and CLI interface to [OSV-Scalibr](https://github.com/google/osv-scalibr) that connects a project’s list of dependencies with the vulnerabilities that affect them.
 


### PR DESCRIPTION
While it only tends to take 2-3 minutes, they completely block our three test jobs and in theory it should be very straightforward to cache our test images as (again, in theory) they should be very stable.

Right now I'm just redownloading the tars and skipping the build entirely, though we could also possibly try re-importing them so that we always do a build but they're available as cached layers, which _might_ be a better middleground