### PR TITLE
fix: include a hint when sbom extractor cannot be found about the file name being important

### DIFF
--- a/cmd/osv-scanner/scan/__snapshots__/command_test.snap
+++ b/cmd/osv-scanner/scan/__snapshots__/command_test.snap
@@ -911,7 +911,7 @@ No issues found
 ---
 
 [TestCommand/one_file_that_does_not_match_the_supported_sbom_file_names - 1]
-Failed to parse SBOM "<rootdir>/osv-scanner/fixtures/locks-many/composer.lock" with error: could not determine extractor suitable to this file
+Failed to parse SBOM "../osv-scanner/fixtures/locks-many/composer.lock" with error: could not determine extractor suitable to this file
 If you believe this is a valid SBOM, make sure the filename follows format per your SBOMs specification.
 
 ---

--- a/cmd/osv-scanner/scan/__snapshots__/command_test.snap
+++ b/cmd/osv-scanner/scan/__snapshots__/command_test.snap
@@ -910,6 +910,17 @@ No issues found
 
 ---
 
+[TestCommand/one_file_that_does_not_match_the_supported_sbom_file_names - 1]
+Failed to parse SBOM "<rootdir>/osv-scanner/fixtures/locks-many/composer.lock" with error: could not determine extractor suitable to this file
+If you believe this is a valid SBOM, make sure the filename follows format per your SBOMs specification.
+
+---
+
+[TestCommand/one_file_that_does_not_match_the_supported_sbom_file_names - 2]
+could not determine extractor suitable to this file
+
+---
+
 [TestCommand/one_specific_supported_lockfile - 1]
 Scanning dir ../fixtures/locks-many/composer.lock
 Scanned <rootdir>/osv-scanner/fixtures/locks-many/composer.lock file and found 1 package

--- a/cmd/osv-scanner/scan/__snapshots__/command_test.snap
+++ b/cmd/osv-scanner/scan/__snapshots__/command_test.snap
@@ -911,7 +911,7 @@ No issues found
 ---
 
 [TestCommand/one_file_that_does_not_match_the_supported_sbom_file_names - 1]
-Failed to parse SBOM "../osv-scanner/fixtures/locks-many/composer.lock" with error: could not determine extractor suitable to this file
+Failed to parse SBOM "<rootdir>/osv-scanner/fixtures/locks-many/composer.lock" with error: could not determine extractor suitable to this file
 If you believe this is a valid SBOM, make sure the filename follows format per your SBOMs specification.
 
 ---

--- a/cmd/osv-scanner/scan/command_test.go
+++ b/cmd/osv-scanner/scan/command_test.go
@@ -50,6 +50,12 @@ func TestCommand(t *testing.T) {
 			Args: []string{"", "--config=../fixtures/osv-scanner-empty-config.toml", "--sbom", "../fixtures/sbom-insecure/with-duplicates.cdx.xml"},
 			Exit: 1,
 		},
+		// one file that does not match the supported sbom file names
+		{
+			Name: "one file that does not match the supported sbom file names",
+			Args: []string{"", "--config=../fixtures/osv-scanner-empty-config.toml", "--sbom", "../fixtures/locks-many/composer.lock"},
+			Exit: 127,
+		},
 		// one specific unsupported lockfile
 		{
 			Name: "one specific unsupported lockfile",

--- a/pkg/osvscanner/internal/scanners/lockfile.go
+++ b/pkg/osvscanner/internal/scanners/lockfile.go
@@ -75,12 +75,6 @@ var lockfileExtractorMapping = map[string][]string{
 
 // ScanSingleFile is similar to ScanSingleFileWithMapping, just without supporting the <lockfileformat>:/path/to/lockfile prefix identifier
 func ScanSingleFile(path string, extractorsToUse []filesystem.Extractor) ([]*extractor.Inventory, error) {
-	path, err := filepath.Abs(path)
-	if err != nil {
-		slog.Error(fmt.Sprintf("Failed to resolved path %q with error: %s", path, err))
-		return nil, err
-	}
-
 	invs, err := scalibrextract.ExtractWithExtractors(context.Background(), path, extractorsToUse)
 	if err != nil {
 		return nil, err

--- a/pkg/osvscanner/internal/scanners/lockfile.go
+++ b/pkg/osvscanner/internal/scanners/lockfile.go
@@ -2,6 +2,7 @@ package scanners
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"path/filepath"
@@ -85,6 +86,11 @@ func ScanSingleFile(path string, extractorsToUse []filesystem.Extractor) ([]*ext
 	invs, err := scalibrextract.ExtractWithExtractors(context.Background(), path, extractorsToUse)
 	if err != nil {
 		slog.Info(fmt.Sprintf("Failed to parse SBOM %q with error: %s", path, err))
+
+		if errors.Is(err, scalibrextract.ErrExtractorNotFound) {
+			slog.Info("If you believe this is a valid SBOM, make sure the filename follows format per your SBOMs specification.")
+		}
+
 		return nil, err
 	}
 

--- a/pkg/osvscanner/internal/scanners/lockfile.go
+++ b/pkg/osvscanner/internal/scanners/lockfile.go
@@ -2,7 +2,6 @@ package scanners
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"path/filepath"
@@ -76,7 +75,6 @@ var lockfileExtractorMapping = map[string][]string{
 
 // ScanSingleFile is similar to ScanSingleFileWithMapping, just without supporting the <lockfileformat>:/path/to/lockfile prefix identifier
 func ScanSingleFile(path string, extractorsToUse []filesystem.Extractor) ([]*extractor.Inventory, error) {
-	// TODO: Update the logging output to stop referring to SBOMs
 	path, err := filepath.Abs(path)
 	if err != nil {
 		slog.Error(fmt.Sprintf("Failed to resolved path %q with error: %s", path, err))
@@ -85,12 +83,6 @@ func ScanSingleFile(path string, extractorsToUse []filesystem.Extractor) ([]*ext
 
 	invs, err := scalibrextract.ExtractWithExtractors(context.Background(), path, extractorsToUse)
 	if err != nil {
-		slog.Info(fmt.Sprintf("Failed to parse SBOM %q with error: %s", path, err))
-
-		if errors.Is(err, scalibrextract.ErrExtractorNotFound) {
-			slog.Info("If you believe this is a valid SBOM, make sure the filename follows format per your SBOMs specification.")
-		}
-
 		return nil, err
 	}
 

--- a/pkg/osvscanner/scan.go
+++ b/pkg/osvscanner/scan.go
@@ -1,10 +1,13 @@
 package osvscanner
 
 import (
+	"errors"
+	"fmt"
 	"log/slog"
 
 	"github.com/google/osv-scalibr/extractor"
 	"github.com/google/osv-scanner/v2/internal/imodels"
+	"github.com/google/osv-scanner/v2/internal/scalibrextract"
 	"github.com/google/osv-scanner/v2/internal/scalibrextract/ecosystemmock"
 	"github.com/google/osv-scanner/v2/pkg/osvscanner/internal/scanners"
 )
@@ -30,6 +33,12 @@ func scan(accessors ExternalAccessors, actions ScannerActions) ([]imodels.Packag
 	for _, sbomPath := range actions.SBOMPaths {
 		invs, err := scanners.ScanSingleFile(sbomPath, sbomExtractors)
 		if err != nil {
+			slog.Info(fmt.Sprintf("Failed to parse SBOM %q with error: %s", sbomPath, err))
+
+			if errors.Is(err, scalibrextract.ErrExtractorNotFound) {
+				slog.Info("If you believe this is a valid SBOM, make sure the filename follows format per your SBOMs specification.")
+			}
+
 			return nil, err
 		}
 


### PR DESCRIPTION
I'm open to suggestions about the actual message - I'm a little on the fence about including a list of the file types or external links as they could change (and CycloneDX also has `bom.json` and `bom.xml` meaning it's technically not as easy as saying "it must end with these file types"), but maybe that's worth doing...

I think ideally it would be good if `osv-scalibr` could indicate the reason why the extractor can't be found, but I don't think that's compatible with the current API and also somewhat niche.

Resolves #1746
Relates to #1745