### PR TITLE
feat: Add cargoaudit extractor to artifacts

### DIFF
--- a/docs/supported_languages_and_lockfiles.md
+++ b/docs/supported_languages_and_lockfiles.md
@@ -31,7 +31,7 @@ We found that when performing different forms of scanning, you are generally int
 When scanning container images (`osv-scanner scan image ...`), OSV-Scanner automatically extracts and analyzes the following artifacts:
 
 | Source                           | Example files                      |
-|----------------------------------|------------------------------------|
+| -------------------------------- | ---------------------------------- |
 | Alpine APK packages              | `/lib/apk/db/installed`            |
 | Debian/Ubuntu dpkg/apt packages  | `/var/lib/dpkg/status`             |
 |                                  |                                    |

--- a/docs/supported_languages_and_lockfiles.md
+++ b/docs/supported_languages_and_lockfiles.md
@@ -30,16 +30,16 @@ We found that when performing different forms of scanning, you are generally int
 
 When scanning container images (`osv-scanner scan image ...`), OSV-Scanner automatically extracts and analyzes the following artifacts:
 
-| Source                           | Example files                      |
-| -------------------------------- | ---------------------------------- |
-| Alpine APK packages              | `/lib/apk/db/installed`            |
-| Debian/Ubuntu dpkg/apt packages  | `/var/lib/dpkg/status`             |
-|                                  |                                    |
-| Go Binaries                      | `main-go`                          |
-| Rust Binaries (with cargo-audit) | `main-rust-built-with-audit`       |
-| Java Uber `jars`                 | `my-java-app.jar`                  |
-| Node Modules                     | `node-app/node_modules/...`        |
-| Python wheels                    | `lib/python3.11/site-packages/...` |
+| Source                               | Example files                      |
+| ------------------------------------ | ---------------------------------- |
+| Alpine APK packages                  | `/lib/apk/db/installed`            |
+| Debian/Ubuntu dpkg/apt packages      | `/var/lib/dpkg/status`             |
+|                                      |                                    |
+| Go Binaries                          | `main-go`                          |
+| Rust Binaries (with cargo-auditable) | `main-rust-built-with-auditable`   |
+| Java Uber `jars`                     | `my-java-app.jar`                  |
+| Node Modules                         | `node-app/node_modules/...`        |
+| Python wheels                        | `lib/python3.11/site-packages/...` |
 
 ## Supported lockfiles/manifests
 

--- a/docs/supported_languages_and_lockfiles.md
+++ b/docs/supported_languages_and_lockfiles.md
@@ -30,15 +30,16 @@ We found that when performing different forms of scanning, you are generally int
 
 When scanning container images (`osv-scanner scan image ...`), OSV-Scanner automatically extracts and analyzes the following artifacts:
 
-| Source                          | Example files                      |
-| ------------------------------- | ---------------------------------- |
-| Alpine APK packages             | `/lib/apk/db/installed`            |
-| Debian/Ubuntu dpkg/apt packages | `/var/lib/dpkg/status`             |
-|                                 |                                    |
-| Go Binaries                     | `main-go`                          |
-| Java Uber `jars`                | `my-java-app.jar`                  |
-| Node Modules                    | `node-app/node_modules/...`        |
-| Python wheels                   | `lib/python3.11/site-packages/...` |
+| Source                           | Example files                      |
+|----------------------------------|------------------------------------|
+| Alpine APK packages              | `/lib/apk/db/installed`            |
+| Debian/Ubuntu dpkg/apt packages  | `/var/lib/dpkg/status`             |
+|                                  |                                    |
+| Go Binaries                      | `main-go`                          |
+| Rust Binaries (With cargo-audit) | `main-rust-built-with-audit`       |
+| Java Uber `jars`                 | `my-java-app.jar`                  |
+| Node Modules                     | `node-app/node_modules/...`        |
+| Python wheels                    | `lib/python3.11/site-packages/...` |
 
 ## Supported lockfiles/manifests
 

--- a/docs/supported_languages_and_lockfiles.md
+++ b/docs/supported_languages_and_lockfiles.md
@@ -36,7 +36,7 @@ When scanning container images (`osv-scanner scan image ...`), OSV-Scanner autom
 | Debian/Ubuntu dpkg/apt packages  | `/var/lib/dpkg/status`             |
 |                                  |                                    |
 | Go Binaries                      | `main-go`                          |
-| Rust Binaries (With cargo-audit) | `main-rust-built-with-audit`       |
+| Rust Binaries (with cargo-audit) | `main-rust-built-with-audit`       |
 | Java Uber `jars`                 | `my-java-app.jar`                  |
 | Node Modules                     | `node-app/node_modules/...`        |
 | Python wheels                    | `lib/python3.11/site-packages/...` |

--- a/pkg/osvscanner/internal/scanners/extractorbuilder.go
+++ b/pkg/osvscanner/internal/scanners/extractorbuilder.go
@@ -32,6 +32,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/wheelegg"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/r/renvlock"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/ruby/gemfilelock"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/rust/cargoauditable"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/rust/cargolock"
 	"github.com/google/osv-scalibr/extractor/filesystem/os/apk"
 	"github.com/google/osv-scalibr/extractor/filesystem/os/dpkg"
@@ -177,6 +178,8 @@ func BuildArtifactExtractors() []filesystem.Extractor {
 		gobinary.New(gobinary.DefaultConfig()),
 		// Javascript
 		nodemodules.Extractor{},
+		// Rust
+		cargoauditable.NewDefault(),
 
 		// --- OS packages ---
 		// Alpine


### PR DESCRIPTION
Enable the cargoaudit extractor in container scanning 