### PR TITLE
test: remove redundant `os.Exit` calls

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -96,8 +96,10 @@ linters-settings:
         disabled: false
       - name: redefines-builtin-id
         disabled: false
-      - name: redundant-test-main-exit
-        disabled: false
+      # todo: enable once we've upgraded to v2, as the validation schema
+      #    used by the github v1 action does not have this rule yet
+      # - name: redundant-test-main-exit
+      #   disabled: false
       - name: superfluous-else
         disabled: false
       - name: time-naming

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -96,6 +96,8 @@ linters-settings:
         disabled: false
       - name: redefines-builtin-id
         disabled: false
+      - name: redundant-test-main-exit
+        disabled: false
       - name: superfluous-else
         disabled: false
       - name: time-naming

--- a/cmd/osv-scanner/fix/testmain_test.go
+++ b/cmd/osv-scanner/fix/testmain_test.go
@@ -1,16 +1,13 @@
 package fix
 
 import (
-	"os"
 	"testing"
 
 	"github.com/google/osv-scanner/v2/internal/testutility"
 )
 
 func TestMain(m *testing.M) {
-	code := m.Run()
+	m.Run()
 
 	testutility.CleanSnapshots(m)
-
-	os.Exit(code)
 }

--- a/cmd/osv-scanner/internal/cmd/testmain_test.go
+++ b/cmd/osv-scanner/internal/cmd/testmain_test.go
@@ -1,16 +1,13 @@
 package cmd
 
 import (
-	"os"
 	"testing"
 
 	"github.com/google/osv-scanner/v2/internal/testutility"
 )
 
 func TestMain(m *testing.M) {
-	code := m.Run()
+	m.Run()
 
 	testutility.CleanSnapshots(m)
-
-	os.Exit(code)
 }

--- a/cmd/osv-scanner/scan/image/testmain_test.go
+++ b/cmd/osv-scanner/scan/image/testmain_test.go
@@ -1,16 +1,13 @@
 package image_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/google/osv-scanner/v2/internal/testutility"
 )
 
 func TestMain(m *testing.M) {
-	code := m.Run()
+	m.Run()
 
 	testutility.CleanSnapshots(m)
-
-	os.Exit(code)
 }

--- a/cmd/osv-scanner/scan/testmain_test.go
+++ b/cmd/osv-scanner/scan/testmain_test.go
@@ -1,16 +1,13 @@
 package scan_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/google/osv-scanner/v2/internal/testutility"
 )
 
 func TestMain(m *testing.M) {
-	code := m.Run()
+	m.Run()
 
 	testutility.CleanSnapshots(m)
-
-	os.Exit(code)
 }

--- a/cmd/osv-scanner/testmain_test.go
+++ b/cmd/osv-scanner/testmain_test.go
@@ -18,10 +18,9 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		panic(err)
 	}
-	code := m.Run()
+	m.Run()
 
 	testutility.CleanSnapshots(m)
 
 	os.RemoveAll("./fixtures/.git")
-	os.Exit(code)
 }

--- a/cmd/osv-scanner/update/testmain_test.go
+++ b/cmd/osv-scanner/update/testmain_test.go
@@ -1,16 +1,13 @@
 package update_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/google/osv-scanner/v2/internal/testutility"
 )
 
 func TestMain(m *testing.M) {
-	code := m.Run()
+	m.Run()
 
 	testutility.CleanSnapshots(m)
-
-	os.Exit(code)
 }

--- a/internal/ci/testmain_test.go
+++ b/internal/ci/testmain_test.go
@@ -1,16 +1,13 @@
 package ci_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/google/osv-scanner/v2/internal/testutility"
 )
 
 func TestMain(m *testing.M) {
-	code := m.Run()
+	m.Run()
 
 	testutility.CleanSnapshots(m)
-
-	os.Exit(code)
 }

--- a/internal/datasource/testmain_test.go
+++ b/internal/datasource/testmain_test.go
@@ -1,16 +1,13 @@
 package datasource_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/google/osv-scanner/v2/internal/testutility"
 )
 
 func TestMain(m *testing.M) {
-	code := m.Run()
+	m.Run()
 
 	testutility.CleanSnapshots(m)
-
-	os.Exit(code)
 }

--- a/internal/output/testmain_test.go
+++ b/internal/output/testmain_test.go
@@ -1,16 +1,13 @@
 package output_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/google/osv-scanner/v2/internal/testutility"
 )
 
 func TestMain(m *testing.M) {
-	code := m.Run()
+	m.Run()
 
 	testutility.CleanSnapshots(m)
-
-	os.Exit(code)
 }

--- a/internal/remediation/testmain_test.go
+++ b/internal/remediation/testmain_test.go
@@ -1,16 +1,13 @@
 package remediation_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/google/osv-scanner/v2/internal/testutility"
 )
 
 func TestMain(m *testing.M) {
-	code := m.Run()
+	m.Run()
 
 	testutility.CleanSnapshots(m)
-
-	os.Exit(code)
 }

--- a/internal/resolution/lockfile/testmain_test.go
+++ b/internal/resolution/lockfile/testmain_test.go
@@ -1,16 +1,13 @@
 package lockfile_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/google/osv-scanner/v2/internal/testutility"
 )
 
 func TestMain(m *testing.M) {
-	code := m.Run()
+	m.Run()
 
 	testutility.CleanSnapshots(m)
-
-	os.Exit(code)
 }

--- a/internal/resolution/manifest/testmain_test.go
+++ b/internal/resolution/manifest/testmain_test.go
@@ -1,16 +1,13 @@
 package manifest_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/google/osv-scanner/v2/internal/testutility"
 )
 
 func TestMain(m *testing.M) {
-	code := m.Run()
+	m.Run()
 
 	testutility.CleanSnapshots(m)
-
-	os.Exit(code)
 }

--- a/internal/resolution/testmain_test.go
+++ b/internal/resolution/testmain_test.go
@@ -1,16 +1,13 @@
 package resolution_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/google/osv-scanner/v2/internal/testutility"
 )
 
 func TestMain(m *testing.M) {
-	code := m.Run()
+	m.Run()
 
 	testutility.CleanSnapshots(m)
-
-	os.Exit(code)
 }

--- a/internal/sourceanalysis/testmain_test.go
+++ b/internal/sourceanalysis/testmain_test.go
@@ -1,16 +1,13 @@
 package sourceanalysis_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/google/osv-scanner/v2/internal/testutility"
 )
 
 func TestMain(m *testing.M) {
-	code := m.Run()
+	m.Run()
 
 	testutility.CleanSnapshots(m)
-
-	os.Exit(code)
 }

--- a/pkg/models/testmain_test.go
+++ b/pkg/models/testmain_test.go
@@ -1,16 +1,13 @@
 package models_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/google/osv-scanner/v2/internal/testutility"
 )
 
 func TestMain(m *testing.M) {
-	code := m.Run()
+	m.Run()
 
 	testutility.CleanSnapshots(m)
-
-	os.Exit(code)
 }

--- a/pkg/osvscanner/testmain_test.go
+++ b/pkg/osvscanner/testmain_test.go
@@ -1,16 +1,13 @@
 package osvscanner_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/google/osv-scanner/v2/internal/testutility"
 )
 
 func TestMain(m *testing.M) {
-	code := m.Run()
+	m.Run()
 
 	testutility.CleanSnapshots(m)
-
-	os.Exit(code)
 }


### PR DESCRIPTION
Apparently since Go v1.15 `os.Exit` will be called automatically by the runner with the result of `m.Run` if a call to exit has not been made when `TestMain` finishes, so we can omit doing it ourselves