### PR TITLE
build: move off deprecated archives.format and archives.builds properties again

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -142,9 +142,9 @@ docker_manifests:
       - "ghcr.io/google/osv-scanner:{{ .Tag }}-arm64"
 
 archives:
-  - format: binary
+  - formats: binary
     name_template: "{{ .Binary }}_{{ .Os }}_{{ .Arch }}"
-    builds:
+    ids:
       - osv-scanner
 checksum:
   name_template: "{{ .ProjectName }}_SHA256SUMS"


### PR DESCRIPTION
Noticed #1742 had accidentally been reverted
```
  • setting defaults
    • DEPRECATED: archives.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
    • DEPRECATED: archives.builds should not be used anymore, check https://goreleaser.com/deprecations#archivesbuilds for more info
```