### PR TITLE
feat(xml): do not escape double quotes

### DIFF
--- a/internal/thirdparty/xml/marshal_test.go
+++ b/internal/thirdparty/xml/marshal_test.go
@@ -2012,9 +2012,9 @@ var encodeTokenTests = []struct {
 }, {
 	desc: "char data with escaped chars",
 	toks: []Token{
-		CharData("\""),
+		CharData("&"),
 	},
-	want: "&#34;",
+	want: "&amp;",
 }, {
 	desc: "comment",
 	toks: []Token{

--- a/internal/thirdparty/xml/xml.go
+++ b/internal/thirdparty/xml/xml.go
@@ -1924,8 +1924,7 @@ func EscapeText(w io.Writer, s []byte) error {
 }
 
 // escapeText writes to w the properly escaped XML equivalent of the plain text
-// data s. If escape is true, whitespace characters and single quote will be
-// escaped.
+// data s. If escape is true, whitespace characters and quotes will be escaped.
 func escapeText(w io.Writer, s []byte, escape bool) error {
 	var esc []byte
 	last := 0
@@ -1934,6 +1933,9 @@ func escapeText(w io.Writer, s []byte, escape bool) error {
 		i += width
 		switch r {
 		case '"':
+			if !escape {
+				continue
+			}
 			esc = escQuot
 		case '\'':
 			if !escape {


### PR DESCRIPTION
Double quotes are still escaped when marshaling text fields in XML, and we don't want that behavior.