### PR TITLE
fix: override licenses in scan results

### DIFF
--- a/cmd/osv-scanner/scan/__snapshots__/command_test.snap
+++ b/cmd/osv-scanner/scan/__snapshots__/command_test.snap
@@ -389,7 +389,9 @@ overriding license for package Packagist/league/flysystem/1.0.8 with 0BSD
 +---------+-------------------------+
 | LICENSE | NO. OF PACKAGE VERSIONS |
 +---------+-------------------------+
-| UNKNOWN |                      20 |
+| MIT     |                      14 |
+| 0BSD    |                       2 |
+| UNKNOWN |                       4 |
 +---------+-------------------------+
 +-------------------+-----------+------------------------------------------------+---------+----------------------------------------------------------+
 | LICENSE VIOLATION | ECOSYSTEM | PACKAGE                                        | VERSION | SOURCE                                                   |
@@ -1346,13 +1348,14 @@ Scanned <rootdir>/osv-scanner/fixtures/locks-licenses/package-lock.json file and
 overriding license for package npm/babel/6.23.0 with MIT AND (LGPL-2.1-or-later OR BSD-3-Clause)
 overriding license for package npm/human-signals/5.0.0 with LGPL-2.1-only OR MIT OR BSD-3-Clause
 overriding license for package npm/ms/2.1.3 with MIT WITH Bison-exception-2.2
-+----------------+-------------------------+
-| LICENSE        | NO. OF PACKAGE VERSIONS |
-+----------------+-------------------------+
-| MIT            |                       2 |
-| Apache-2.0     |                       1 |
-| CC0-1.0 OR MIT |                       1 |
-+----------------+-------------------------+
++---------------------------------------------+-------------------------+
+| LICENSE                                     | NO. OF PACKAGE VERSIONS |
++---------------------------------------------+-------------------------+
+| CC0-1.0 OR MIT                              |                       1 |
+| LGPL-2.1-only OR MIT OR BSD-3-Clause        |                       1 |
+| MIT AND (LGPL-2.1-or-later OR BSD-3-Clause) |                       1 |
+| MIT WITH Bison-exception-2.2                |                       1 |
++---------------------------------------------+-------------------------+
 +------------------------------+-----------+---------+---------+----------------------------------------------+
 | LICENSE VIOLATION            | ECOSYSTEM | PACKAGE | VERSION | SOURCE                                       |
 +------------------------------+-----------+---------+---------+----------------------------------------------+
@@ -1371,13 +1374,14 @@ Scanned <rootdir>/osv-scanner/fixtures/locks-licenses/package-lock.json file and
 overriding license for package npm/babel/6.23.0 with MIT AND (LGPL-2.1-or-later OR BSD-3-Clause))
 overriding license for package npm/human-signals/5.0.0 with LGPL-2.1-only OR OR BSD-3-Clause
 overriding license for package npm/ms/2.1.3 with MIT WITH (Bison-exception-2.2 AND somethingelse)
-+----------------+-------------------------+
-| LICENSE        | NO. OF PACKAGE VERSIONS |
-+----------------+-------------------------+
-| MIT            |                       2 |
-| Apache-2.0     |                       1 |
-| CC0-1.0 OR MIT |                       1 |
-+----------------+-------------------------+
++--------------------------------------------------+-------------------------+
+| LICENSE                                          | NO. OF PACKAGE VERSIONS |
++--------------------------------------------------+-------------------------+
+| CC0-1.0 OR MIT                                   |                       1 |
+| LGPL-2.1-only OR OR BSD-3-Clause                 |                       1 |
+| MIT AND (LGPL-2.1-or-later OR BSD-3-Clause))     |                       1 |
+| MIT WITH (Bison-exception-2.2 AND somethingelse) |                       1 |
++--------------------------------------------------+-------------------------+
 +--------------------------------------------------+-----------+---------------+---------+----------------------------------------------+
 | LICENSE VIOLATION                                | ECOSYSTEM | PACKAGE       | VERSION | SOURCE                                       |
 +--------------------------------------------------+-----------+---------------+---------+----------------------------------------------+
@@ -1651,7 +1655,8 @@ overriding license for package Packagist/league/flysystem/1.0.8 with 0BSD
 +---------+-------------------------+
 | LICENSE | NO. OF PACKAGE VERSIONS |
 +---------+-------------------------+
-| UNKNOWN |                      17 |
+| 0BSD    |                       2 |
+| UNKNOWN |                       2 |
 +---------+-------------------------+
 +-------------------+-----------+------------------+----------+------------------------------------------+
 | LICENSE VIOLATION | ECOSYSTEM | PACKAGE          | VERSION  | SOURCE                                   |

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -246,8 +246,7 @@ func DoScan(actions ScannerActions) (models.VulnerabilityResults, error) {
 	results := buildVulnerabilityResults(actions, &scanResult)
 
 	if actions.ScanLicensesSummary {
-		licenseSummary := buildLicenseSummary(&scanResult)
-		results.LicenseSummary = licenseSummary
+		results.LicenseSummary = buildLicenseSummary(&scanResult)
 	}
 
 	filtered := filterResults(&results, &scanResult.ConfigManager, actions.ShowAllPackages)
@@ -372,8 +371,7 @@ func DoContainerScan(actions ScannerActions) (models.VulnerabilityResults, error
 	vulnerabilityResults := buildVulnerabilityResults(actions, &scanResult)
 
 	if actions.ScanLicensesSummary {
-		licenseSummary := buildLicenseSummary(&scanResult)
-		vulnerabilityResults.LicenseSummary = licenseSummary
+		vulnerabilityResults.LicenseSummary = buildLicenseSummary(&scanResult)
 	}
 
 	filtered := filterResults(&vulnerabilityResults, &scanResult.ConfigManager, actions.ShowAllPackages)

--- a/pkg/osvscanner/vulnerability_result.go
+++ b/pkg/osvscanner/vulnerability_result.go
@@ -37,7 +37,7 @@ func buildVulnerabilityResults(
 	}
 
 	groupedBySource := map[models.SourceInfo]*packageVulnsGroup{}
-	for _, psr := range scanResults.PackageScanResults {
+	for i, psr := range scanResults.PackageScanResults {
 		p := psr.PackageInfo
 		includePackage := actions.ShowAllPackages
 		var pkg models.PackageVulns
@@ -121,6 +121,9 @@ func buildVulnerabilityResults(
 			if actions.ScanLicensesSummary {
 				pkg.Licenses = psr.Licenses
 			}
+
+			// Make sure licenses are overriden in the scan results.
+			scanResults.PackageScanResults[i] = psr
 		}
 		if includePackage {
 			source := models.SourceInfo{

--- a/pkg/osvscanner/vulnerability_result.go
+++ b/pkg/osvscanner/vulnerability_result.go
@@ -122,7 +122,7 @@ func buildVulnerabilityResults(
 				pkg.Licenses = psr.Licenses
 			}
 
-			// Make sure licenses are overriden in the scan results.
+			// Make sure licenses are overridden in the scan results.
 			scanResults.PackageScanResults[i] = psr
 		}
 		if includePackage {


### PR DESCRIPTION
https://github.com/google/osv-scanner/issues/1794

Previously the license overrides are not reflected in the scan results so the license summary is based on the licenses before overriding. This PR fixes the issue by updating the package scan result with the license overrides.