### PR TITLE
docs: Update Maven Central and private registries support

### DIFF
--- a/docs/supported_languages_and_lockfiles.md
+++ b/docs/supported_languages_and_lockfiles.md
@@ -85,7 +85,7 @@ Vendored dependencies have been directly copied into the project folder, but do 
 
 OSV-Scanner supports transitive dependency scanning for Maven pom.xml. This feature is enabled by default when scanning, but it can be disabled using the `--no-resolve` flag. It is also disabled in the [offline mode](./offline-mode.md).
 
-OSV-Scanner uses [deps.dev’s resolver library](https://pkg.go.dev/deps.dev/util/resolve) to compute the dependency graph of a project. This graph includes all the direct and transitive dependencies. By default, [deps.dev API](https://docs.deps.dev/api/v3/index.html) is queried for package versions and requirements. The support for private registries is [coming soon](https://github.com/google/osv-scanner/issues/1045).
+OSV-Scanner uses [deps.dev’s resolver library](https://pkg.go.dev/deps.dev/util/resolve) to compute the dependency graph of a project. This graph includes all the direct and transitive dependencies. By default, [deps.dev API](https://docs.deps.dev/api/v3/index.html) is queried for package versions and requirements. Support for querying Maven Central and private registries is also available.
 
 After the dependency resolution, the OSV database is queried for the vulnerabilities associated with these dependencies as usual.
 


### PR DESCRIPTION
## Description

This PR updates the documentation on the "Supported Artifacts and Manifests" page to accurately reflect the current support status for Maven Central and private registries.

## Motivation and Context

The existing documentation stated that support for private registries was "coming soon." This information is outdated, as OSV-Scanner now supports querying these registries alongside the default deps.dev API. This change ensures users have accurate information about OSV-Scanner's capabilities.

## Changes Made

- Modified the file: `docs/supported_languages_and_lockfiles.md`
- Replaced the sentence:
    `The support for private registries is coming soon.`
  with:
    `Support for querying Maven Central and private registries is also available.`

## GitHub page

https://s-index.github.io/osv-scanner/supported-languages-and-lockfiles/
