### PR TITLE
test: ensure that all tests are run in parallel

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -132,8 +132,5 @@ issues:
     - path: _test\.go
       linters:
         - dupl
-    - path: cmd/osv-scanner/.+_test.go
-      linters:
-        - paralleltest
   exclude-dirs:
     - internal/thirdparty/

--- a/cmd/osv-scanner/fix/command_test.go
+++ b/cmd/osv-scanner/fix/command_test.go
@@ -129,6 +129,8 @@ func parseFlags(t *testing.T, flags []string, arguments []string) (*cli.Context,
 }
 
 func Test_parseUpgradeConfig(t *testing.T) {
+	t.Parallel()
+
 	flags := []string{"upgrade-config"}
 
 	tests := []struct {
@@ -200,6 +202,8 @@ func Test_parseUpgradeConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			ctx, err := parseFlags(t, flags, tt.args)
 			if err != nil {
 				t.Fatalf("error parsing flags: %v", err)

--- a/cmd/osv-scanner/internal/cmd/helpers_test.go
+++ b/cmd/osv-scanner/internal/cmd/helpers_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func Test_insertDefaultCommand(t *testing.T) {
+	t.Parallel()
+
 	commands := []*cli.Command{
 		{Name: "default"},
 		{Name: "helpers.go"},

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func Test_run(t *testing.T) {
+	t.Parallel()
+
 	tests := []testcmd.Case{
 		{
 			Name: "",
@@ -22,12 +24,16 @@ func Test_run(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
 			testcmd.RunAndMatchSnapshots(t, tt)
 		})
 	}
 }
 
 func Test_run_SubCommands(t *testing.T) {
+	t.Parallel()
+
 	tests := []testcmd.Case{
 		// without subcommands
 		{
@@ -51,6 +57,8 @@ func Test_run_SubCommands(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
 			testcmd.RunAndMatchSnapshots(t, tt)
 		})
 	}

--- a/cmd/osv-scanner/scan/image/command_test.go
+++ b/cmd/osv-scanner/scan/image/command_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestCommand_Docker(t *testing.T) {
+	t.Parallel()
+
 	testutility.SkipIfNotAcceptanceTesting(t, "Takes a long time to pull down images")
 
 	tests := []testcmd.Case{
@@ -43,6 +45,8 @@ func TestCommand_Docker(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
 			// Only test on linux, and mac/windows CI/CD does not come with docker preinstalled
 			if runtime.GOOS != "linux" {
 				testutility.Skip(t, "Skipping Docker-based test as only Linux has Docker installed in CI")
@@ -54,6 +58,8 @@ func TestCommand_Docker(t *testing.T) {
 }
 
 func TestCommand_OCIImage(t *testing.T) {
+	t.Parallel()
+
 	testutility.SkipIfNotAcceptanceTesting(t, "Takes a while to run")
 
 	tests := []testcmd.Case{
@@ -125,6 +131,8 @@ func TestCommand_OCIImage(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
 			// point out that we need the images to be built and saved separately
 			for _, arg := range tt.Args {
 				if strings.HasPrefix(arg, "../../../../internal/image/fixtures/") && strings.HasSuffix(arg, ".tar") {
@@ -140,6 +148,8 @@ func TestCommand_OCIImage(t *testing.T) {
 }
 
 func TestCommand_OCIImageAllPackagesJSON(t *testing.T) {
+	t.Parallel()
+
 	testutility.SkipIfNotAcceptanceTesting(t, "Takes a while to run")
 
 	if runtime.GOOS == "windows" {
@@ -200,6 +210,8 @@ func TestCommand_OCIImageAllPackagesJSON(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
 			// point out that we need the images to be built and saved separately
 			for _, arg := range tt.Args {
 				if strings.HasPrefix(arg, "../../../../internal/image/fixtures/") && strings.HasSuffix(arg, ".tar") {

--- a/cmd/osv-scanner/update/command_test.go
+++ b/cmd/osv-scanner/update/command_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestCommand(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		args     []string
@@ -27,6 +29,8 @@ func TestCommand(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			tc := testcmd.Case{
 				Name: tt.name,
 				Args: slices.Clone(tt.args),


### PR DESCRIPTION
Thanks to #1798 we can now blanket require that all tests are run in parallel with the linter, which has also revealed a few existing cmd tests that were not made parallel