### PR TITLE
refactor: ensure all extractors have a single interface check at the bottom of the file

### DIFF
--- a/internal/scalibrextract/ecosystemmock/extractor.go
+++ b/internal/scalibrextract/ecosystemmock/extractor.go
@@ -16,8 +16,6 @@ type Extractor struct {
 	MockEcosystem string
 }
 
-var _ filesystem.Extractor = Extractor{}
-
 func (e Extractor) Name() string { return "ecosystemmock" }
 
 func (e Extractor) Version() int { return 0 }

--- a/internal/scalibrextract/filesystem/vendored/vendored.go
+++ b/internal/scalibrextract/filesystem/vendored/vendored.go
@@ -62,8 +62,6 @@ type Extractor struct {
 	OSVClient  *osvdev.OSVClient
 }
 
-var _ filesystem.Extractor = Extractor{}
-
 // Name of the extractor.
 func (e Extractor) Name() string { return "filesystem/vendored" }
 
@@ -191,3 +189,5 @@ func (e Extractor) queryDetermineVersions(ctx context.Context, repoDir string, f
 
 	return result, nil
 }
+
+var _ filesystem.Extractor = Extractor{}

--- a/internal/scalibrextract/language/javascript/nodemodules/extractor.go
+++ b/internal/scalibrextract/language/javascript/nodemodules/extractor.go
@@ -16,8 +16,6 @@ type Extractor struct {
 	actualExtractor packagelockjson.Extractor
 }
 
-var _ filesystem.Extractor = Extractor{}
-
 // Name of the extractor.
 func (e Extractor) Name() string { return "javascript/nodemodules" }
 

--- a/internal/scalibrextract/vcs/gitrepo/extractor.go
+++ b/internal/scalibrextract/vcs/gitrepo/extractor.go
@@ -19,8 +19,6 @@ type Extractor struct {
 	IncludeRootGit bool
 }
 
-var _ filesystem.Extractor = Extractor{}
-
 func getCommitSHA(repo *git.Repository) (string, error) {
 	head, err := repo.Head()
 	if err != nil {


### PR DESCRIPTION
This is mainly about removing the duplicate check we have in most extractors, though I've also favored the check itself being at the bottom to be consistent with `osv-scalibr`