### PR TITLE
chore: Remove renovatebot constraint

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,9 +26,6 @@
       "enabled": false
     }
   ],
-  "constraints": {
-    "go": "1.23"
-  },
   "ignorePaths": ["**/fixtures/**", "**/fixtures-go/**"],
   "ignoreDeps": ["golang.org/x/vuln"]
 }


### PR DESCRIPTION
We are now no longer staying on the older release of go, so no need for the constraint (and it also breaks renovatebot right now)