### PR TITLE
test: only include specific command under test in `cmd` package tests

### DIFF
--- a/cmd/osv-scanner/fix/testmain_test.go
+++ b/cmd/osv-scanner/fix/testmain_test.go
@@ -4,12 +4,15 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/google/osv-scanner/v2/cmd/osv-scanner/internal/cmd"
+	"github.com/google/osv-scanner/v2/cmd/osv-scanner/internal/testcmd"
 	"github.com/google/osv-scanner/v2/internal/testlogger"
 	"github.com/google/osv-scanner/v2/internal/testutility"
 )
 
 func TestMain(m *testing.M) {
 	slog.SetDefault(slog.New(testlogger.New()))
+	testcmd.CommandsUnderTest = []cmd.CommandBuilder{Command}
 	m.Run()
 
 	testutility.CleanSnapshots(m)

--- a/cmd/osv-scanner/internal/cmd/run.go
+++ b/cmd/osv-scanner/internal/cmd/run.go
@@ -7,9 +7,6 @@ import (
 	"log/slog"
 	"testing"
 
-	"github.com/google/osv-scanner/v2/cmd/osv-scanner/fix"
-	"github.com/google/osv-scanner/v2/cmd/osv-scanner/scan"
-	"github.com/google/osv-scanner/v2/cmd/osv-scanner/update"
 	"github.com/google/osv-scanner/v2/internal/cmdlogger"
 	"github.com/google/osv-scanner/v2/internal/testlogger"
 	"github.com/google/osv-scanner/v2/internal/version"
@@ -22,7 +19,9 @@ var (
 	date   = "n/a"
 )
 
-func Run(args []string, stdout, stderr io.Writer) int {
+type CommandBuilder = func(stdout, stderr io.Writer) *cli.Command
+
+func Run(args []string, stdout, stderr io.Writer, commands []CommandBuilder) int {
 	// --- Setup Logger ---
 	logHandler := cmdlogger.New(stdout, stderr)
 
@@ -47,6 +46,11 @@ func Run(args []string, stdout, stderr io.Writer) int {
 		slog.Info("built at: " + date)
 	}
 
+	cmds := make([]*cli.Command, 0, len(commands))
+	for _, cmd := range commands {
+		cmds = append(cmds, cmd(stdout, stderr))
+	}
+
 	app := &cli.App{
 		Name:           "osv-scanner",
 		Version:        version.OSVVersion,
@@ -55,11 +59,8 @@ func Run(args []string, stdout, stderr io.Writer) int {
 		Writer:         stdout,
 		ErrWriter:      stderr,
 		DefaultCommand: "scan",
-		Commands: []*cli.Command{
-			scan.Command(stdout, stderr),
-			fix.Command(stdout, stderr),
-			update.Command(stdout, stderr),
-		},
+		Commands:       cmds,
+
 		CustomAppHelpTemplate: getCustomHelpTemplate(),
 	}
 

--- a/cmd/osv-scanner/internal/cmd/run.go
+++ b/cmd/osv-scanner/internal/cmd/run.go
@@ -58,7 +58,7 @@ func Run(args []string, stdout, stderr io.Writer) int {
 		Commands: []*cli.Command{
 			scan.Command(stdout, stderr),
 			fix.Command(stdout, stderr),
-			update.Command(),
+			update.Command(stdout, stderr),
 		},
 		CustomAppHelpTemplate: getCustomHelpTemplate(),
 	}

--- a/cmd/osv-scanner/internal/testcmd/run.go
+++ b/cmd/osv-scanner/internal/testcmd/run.go
@@ -5,7 +5,10 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/google/osv-scanner/v2/cmd/osv-scanner/fix"
 	"github.com/google/osv-scanner/v2/cmd/osv-scanner/internal/cmd"
+	"github.com/google/osv-scanner/v2/cmd/osv-scanner/scan"
+	"github.com/google/osv-scanner/v2/cmd/osv-scanner/update"
 	"github.com/google/osv-scanner/v2/internal/testutility"
 )
 
@@ -15,7 +18,11 @@ func run(t *testing.T, tc Case) (string, string) {
 	stdout := newMuffledWriter()
 	stderr := newMuffledWriter()
 
-	ec := cmd.Run(tc.Args, stdout, stderr)
+	ec := cmd.Run(tc.Args, stdout, stderr, []cmd.CommandBuilder{
+		scan.Command,
+		fix.Command,
+		update.Command,
+	})
 
 	if ec != tc.Exit {
 		t.Errorf("cli exited with code %d, not %d", ec, tc.Exit)

--- a/cmd/osv-scanner/internal/testcmd/run.go
+++ b/cmd/osv-scanner/internal/testcmd/run.go
@@ -3,14 +3,38 @@ package testcmd
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
+	"io"
 	"testing"
 
-	"github.com/google/osv-scanner/v2/cmd/osv-scanner/fix"
 	"github.com/google/osv-scanner/v2/cmd/osv-scanner/internal/cmd"
-	"github.com/google/osv-scanner/v2/cmd/osv-scanner/scan"
-	"github.com/google/osv-scanner/v2/cmd/osv-scanner/update"
 	"github.com/google/osv-scanner/v2/internal/testutility"
+	"github.com/urfave/cli/v2"
 )
+
+// CommandsUnderTest should be set in TestMain by every cmd package test
+var CommandsUnderTest []cmd.CommandBuilder
+
+// fetchCommandsToTest returns the commands that should be tested, ensuring that
+// the default "scan" command is included to avoid a panic
+func fetchCommandsToTest() []cmd.CommandBuilder {
+	for _, builder := range CommandsUnderTest {
+		command := builder(nil, nil)
+
+		if command.Name == "scan" {
+			return CommandsUnderTest
+		}
+	}
+
+	return append(CommandsUnderTest, func(_, _ io.Writer) *cli.Command {
+		return &cli.Command{
+			Name: "scan",
+			Action: func(_ *cli.Context) error {
+				return errors.New("<this test is unexpectedly calling the default scan command>")
+			},
+		}
+	})
+}
 
 func run(t *testing.T, tc Case) (string, string) {
 	t.Helper()
@@ -18,11 +42,7 @@ func run(t *testing.T, tc Case) (string, string) {
 	stdout := newMuffledWriter()
 	stderr := newMuffledWriter()
 
-	ec := cmd.Run(tc.Args, stdout, stderr, []cmd.CommandBuilder{
-		scan.Command,
-		fix.Command,
-		update.Command,
-	})
+	ec := cmd.Run(tc.Args, stdout, stderr, fetchCommandsToTest())
 
 	if ec != tc.Exit {
 		t.Errorf("cli exited with code %d, not %d", ec, tc.Exit)

--- a/cmd/osv-scanner/main.go
+++ b/cmd/osv-scanner/main.go
@@ -3,11 +3,18 @@ package main
 import (
 	"os"
 
+	"github.com/google/osv-scanner/v2/cmd/osv-scanner/fix"
 	"github.com/google/osv-scanner/v2/cmd/osv-scanner/internal/cmd"
+	"github.com/google/osv-scanner/v2/cmd/osv-scanner/scan"
+	"github.com/google/osv-scanner/v2/cmd/osv-scanner/update"
 )
 
 func main() {
 	os.Exit(
-		cmd.Run(os.Args, os.Stdout, os.Stderr),
+		cmd.Run(os.Args, os.Stdout, os.Stderr, []cmd.CommandBuilder{
+			scan.Command,
+			fix.Command,
+			update.Command,
+		}),
 	)
 }

--- a/cmd/osv-scanner/scan/image/command_test.go
+++ b/cmd/osv-scanner/scan/image/command_test.go
@@ -19,27 +19,27 @@ func TestCommand_Docker(t *testing.T) {
 	tests := []testcmd.Case{
 		{
 			Name: "Fake alpine image",
-			Args: []string{"", "scan", "image", "alpine:non-existent-tag"},
+			Args: []string{"", "image", "alpine:non-existent-tag"},
 			Exit: 127,
 		},
 		{
 			Name: "Fake image entirely",
-			Args: []string{"", "scan", "image", "this-image-definitely-does-not-exist-abcde:with-tag"},
+			Args: []string{"", "image", "this-image-definitely-does-not-exist-abcde:with-tag"},
 			Exit: 127,
 		},
 		{
 			Name: "Real empty image with no tag, invalid scan target",
-			Args: []string{"", "scan", "image", "hello-world"},
+			Args: []string{"", "image", "hello-world"},
 			Exit: 127, // Invalid scan target
 		},
 		{
 			Name: "Real empty image with tag",
-			Args: []string{"", "scan", "image", "hello-world:linux"},
+			Args: []string{"", "image", "hello-world:linux"},
 			Exit: 128, // No package found
 		},
 		{
 			Name: "Real Alpine image",
-			Args: []string{"", "scan", "image", "alpine:3.18.9"},
+			Args: []string{"", "image", "alpine:3.18.9"},
 			Exit: 1,
 		},
 	}
@@ -65,67 +65,67 @@ func TestCommand_OCIImage(t *testing.T) {
 	tests := []testcmd.Case{
 		{
 			Name: "Invalid path",
-			Args: []string{"", "scan", "image", "--archive", "../../fixtures/locks-manyoci-image/no-file-here.tar"},
+			Args: []string{"", "image", "--archive", "../../fixtures/locks-manyoci-image/no-file-here.tar"},
 			Exit: 127,
 		},
 		{
 			Name: "Alpine 3.10 image tar with 3.18 version file",
-			Args: []string{"", "scan", "image", "--archive", "../../../../internal/image/fixtures/test-alpine.tar"},
+			Args: []string{"", "image", "--archive", "../../../../internal/image/fixtures/test-alpine.tar"},
 			Exit: 1,
 		},
 		{
 			Name: "Empty Ubuntu 22.04 image tar",
-			Args: []string{"", "scan", "image", "--archive", "../../../../internal/image/fixtures/test-ubuntu.tar"},
+			Args: []string{"", "image", "--archive", "../../../../internal/image/fixtures/test-ubuntu.tar"},
 			Exit: 1,
 		},
 		{
 			Name: "Scanning python image with some packages",
-			Args: []string{"", "scan", "image", "--archive", "../../../../internal/image/fixtures/test-python-full.tar"},
+			Args: []string{"", "image", "--archive", "../../../../internal/image/fixtures/test-python-full.tar"},
 			Exit: 1,
 		},
 		{
 			Name: "Scanning python image with no packages",
-			Args: []string{"", "scan", "image", "--archive", "../../../../internal/image/fixtures/test-python-empty.tar"},
+			Args: []string{"", "image", "--archive", "../../../../internal/image/fixtures/test-python-empty.tar"},
 			Exit: 1,
 		},
 		{
 			Name: "Scanning java image with some packages",
-			Args: []string{"", "scan", "image", "--archive", "../../../../internal/image/fixtures/test-java-full.tar"},
+			Args: []string{"", "image", "--archive", "../../../../internal/image/fixtures/test-java-full.tar"},
 			Exit: 1,
 		},
 		{
 			Name: "scanning node_modules using npm with no packages",
-			Args: []string{"", "scan", "image", "--archive", "../../../../internal/image/fixtures/test-node_modules-npm-empty.tar"},
+			Args: []string{"", "image", "--archive", "../../../../internal/image/fixtures/test-node_modules-npm-empty.tar"},
 			Exit: 1,
 		},
 		{
 			Name: "scanning node_modules using npm with some packages",
-			Args: []string{"", "scan", "image", "--archive", "../../../../internal/image/fixtures/test-node_modules-npm-full.tar"},
+			Args: []string{"", "image", "--archive", "../../../../internal/image/fixtures/test-node_modules-npm-full.tar"},
 			Exit: 1,
 		},
 		{
 			Name: "scanning node_modules using yarn with no packages",
-			Args: []string{"", "scan", "image", "--archive", "../../../../internal/image/fixtures/test-node_modules-yarn-empty.tar"},
+			Args: []string{"", "image", "--archive", "../../../../internal/image/fixtures/test-node_modules-yarn-empty.tar"},
 			Exit: 1,
 		},
 		{
 			Name: "scanning node_modules using yarn with some packages",
-			Args: []string{"", "scan", "image", "--archive", "../../../../internal/image/fixtures/test-node_modules-yarn-full.tar"},
+			Args: []string{"", "image", "--archive", "../../../../internal/image/fixtures/test-node_modules-yarn-full.tar"},
 			Exit: 1,
 		},
 		{
 			Name: "scanning node_modules using pnpm with no packages",
-			Args: []string{"", "scan", "image", "--archive", "../../../../internal/image/fixtures/test-node_modules-pnpm-empty.tar"},
+			Args: []string{"", "image", "--archive", "../../../../internal/image/fixtures/test-node_modules-pnpm-empty.tar"},
 			Exit: 1,
 		},
 		{
 			Name: "scanning node_modules using pnpm with some packages",
-			Args: []string{"", "scan", "image", "--archive", "../../../../internal/image/fixtures/test-node_modules-pnpm-full.tar"},
+			Args: []string{"", "image", "--archive", "../../../../internal/image/fixtures/test-node_modules-pnpm-full.tar"},
 			Exit: 1,
 		},
 		{
 			Name: "scanning image with go binary",
-			Args: []string{"", "scan", "image", "--archive", "../../../../internal/image/fixtures/test-package-tracing.tar"},
+			Args: []string{"", "image", "--archive", "../../../../internal/image/fixtures/test-package-tracing.tar"},
 			Exit: 1,
 		},
 	}
@@ -160,7 +160,7 @@ func TestCommand_OCIImageAllPackagesJSON(t *testing.T) {
 	tests := []testcmd.Case{
 		{
 			Name: "Scanning python image with some packages",
-			Args: []string{"", "scan", "image", "--archive", "--format=json", "../../../../internal/image/fixtures/test-python-full.tar"},
+			Args: []string{"", "image", "--archive", "--format=json", "../../../../internal/image/fixtures/test-python-full.tar"},
 			Exit: 1,
 			ReplaceRules: []testcmd.JSONReplaceRule{
 				testcmd.GroupsAsArrayLen,
@@ -173,7 +173,7 @@ func TestCommand_OCIImageAllPackagesJSON(t *testing.T) {
 		},
 		{
 			Name: "scanning node_modules using npm with some packages",
-			Args: []string{"", "scan", "image", "--archive", "--format=json", "../../../../internal/image/fixtures/test-node_modules-npm-full.tar"},
+			Args: []string{"", "image", "--archive", "--format=json", "../../../../internal/image/fixtures/test-node_modules-npm-full.tar"},
 			Exit: 1,
 			ReplaceRules: []testcmd.JSONReplaceRule{
 				testcmd.GroupsAsArrayLen,
@@ -186,7 +186,7 @@ func TestCommand_OCIImageAllPackagesJSON(t *testing.T) {
 		},
 		{
 			Name: "scanning image with go binary",
-			Args: []string{"", "scan", "image", "--archive", "--all-packages", "--format=json", "../../../../internal/image/fixtures/test-go-binary.tar"},
+			Args: []string{"", "image", "--archive", "--all-packages", "--format=json", "../../../../internal/image/fixtures/test-go-binary.tar"},
 			Exit: 1,
 			ReplaceRules: []testcmd.JSONReplaceRule{
 				testcmd.GroupsAsArrayLen,
@@ -198,7 +198,7 @@ func TestCommand_OCIImageAllPackagesJSON(t *testing.T) {
 		},
 		{
 			Name: "scanning ubuntu image in json format",
-			Args: []string{"", "scan", "image", "--archive", "--format=json", "../../../../internal/image/fixtures/test-ubuntu.tar"},
+			Args: []string{"", "image", "--archive", "--format=json", "../../../../internal/image/fixtures/test-ubuntu.tar"},
 			Exit: 1,
 			ReplaceRules: []testcmd.JSONReplaceRule{
 				testcmd.GroupsAsArrayLen,

--- a/cmd/osv-scanner/scan/image/testmain_test.go
+++ b/cmd/osv-scanner/scan/image/testmain_test.go
@@ -4,12 +4,16 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/google/osv-scanner/v2/cmd/osv-scanner/internal/cmd"
+	"github.com/google/osv-scanner/v2/cmd/osv-scanner/internal/testcmd"
+	"github.com/google/osv-scanner/v2/cmd/osv-scanner/scan/image"
 	"github.com/google/osv-scanner/v2/internal/testlogger"
 	"github.com/google/osv-scanner/v2/internal/testutility"
 )
 
 func TestMain(m *testing.M) {
 	slog.SetDefault(slog.New(testlogger.New()))
+	testcmd.CommandsUnderTest = []cmd.CommandBuilder{image.Command}
 	m.Run()
 
 	testutility.CleanSnapshots(m)

--- a/cmd/osv-scanner/scan/source/command_test.go
+++ b/cmd/osv-scanner/scan/source/command_test.go
@@ -15,219 +15,219 @@ func TestCommand(t *testing.T) {
 		// one specific supported lockfile
 		{
 			Name: "one specific supported lockfile",
-			Args: []string{"", "scan", "source", "./fixtures/locks-many/composer.lock"},
+			Args: []string{"", "source", "./fixtures/locks-many/composer.lock"},
 			Exit: 0,
 		},
 		// one specific supported sbom with vulns
 		{
 			Name: "folder of supported sbom with vulns",
-			Args: []string{"", "scan", "source", "--config=./fixtures/osv-scanner-empty-config.toml", "./fixtures/sbom-insecure/"},
+			Args: []string{"", "source", "--config=./fixtures/osv-scanner-empty-config.toml", "./fixtures/sbom-insecure/"},
 			Exit: 1,
 		},
 		// one specific supported sbom with vulns
 		{
 			Name: "one specific supported sbom with vulns",
-			Args: []string{"", "scan", "source", "--config=./fixtures/osv-scanner-empty-config.toml", "--sbom", "./fixtures/sbom-insecure/alpine.cdx.xml"},
+			Args: []string{"", "source", "--config=./fixtures/osv-scanner-empty-config.toml", "--sbom", "./fixtures/sbom-insecure/alpine.cdx.xml"},
 			Exit: 1,
 		},
 		// one specific supported sbom with vulns and invalid PURLs
 		{
 			Name: "one specific supported sbom with invalid PURLs",
-			Args: []string{"", "scan", "source", "--config=./fixtures/osv-scanner-empty-config.toml", "--sbom", "./fixtures/sbom-insecure/bad-purls.cdx.xml"},
+			Args: []string{"", "source", "--config=./fixtures/osv-scanner-empty-config.toml", "--sbom", "./fixtures/sbom-insecure/bad-purls.cdx.xml"},
 			Exit: 0,
 		},
 		// one specific supported sbom with duplicate PURLs
 		{
 			Name: "one specific supported sbom with duplicate PURLs",
-			Args: []string{"", "scan", "source", "--config=./fixtures/osv-scanner-empty-config.toml", "--sbom", "./fixtures/sbom-insecure/with-duplicates.cdx.xml"},
+			Args: []string{"", "source", "--config=./fixtures/osv-scanner-empty-config.toml", "--sbom", "./fixtures/sbom-insecure/with-duplicates.cdx.xml"},
 			Exit: 1,
 		},
 		// one file that does not match the supported sbom file names
 		{
 			Name: "one file that does not match the supported sbom file names",
-			Args: []string{"", "scan", "source", "--config=./fixtures/osv-scanner-empty-config.toml", "--sbom", "./fixtures/locks-many/composer.lock"},
+			Args: []string{"", "source", "--config=./fixtures/osv-scanner-empty-config.toml", "--sbom", "./fixtures/locks-many/composer.lock"},
 			Exit: 127,
 		},
 		// one specific unsupported lockfile
 		{
 			Name: "one specific unsupported lockfile",
-			Args: []string{"", "scan", "source", "./fixtures/locks-many/not-a-lockfile.toml"},
+			Args: []string{"", "source", "./fixtures/locks-many/not-a-lockfile.toml"},
 			Exit: 128,
 		},
 		// all supported lockfiles in the directory should be checked
 		{
 			Name: "Scan locks-many",
-			Args: []string{"", "scan", "source", "./fixtures/locks-many"},
+			Args: []string{"", "source", "./fixtures/locks-many"},
 			Exit: 0,
 		},
 		// all supported lockfiles in the directory should be checked
 		{
 			Name: "all supported lockfiles in the directory should be checked",
-			Args: []string{"", "scan", "source", "./fixtures/locks-many-with-invalid"},
+			Args: []string{"", "source", "./fixtures/locks-many-with-invalid"},
 			Exit: 127,
 		},
 		// only the files in the given directories are checked by default (no recursion)
 		{
 			Name: "only the files in the given directories are checked by default (no recursion)",
-			Args: []string{"", "scan", "source", "./fixtures/locks-one-with-nested"},
+			Args: []string{"", "source", "./fixtures/locks-one-with-nested"},
 			Exit: 0,
 		},
 		// nested directories are checked when `--recursive` is passed
 		{
 			Name: "nested directories are checked when `--recursive` is passed",
-			Args: []string{"", "scan", "source", "--recursive", "./fixtures/locks-one-with-nested"},
+			Args: []string{"", "source", "--recursive", "./fixtures/locks-one-with-nested"},
 			Exit: 0,
 		},
 		// .gitignored files
 		{
 			Name: ".gitignored files",
-			Args: []string{"", "scan", "source", "--recursive", "./fixtures/locks-gitignore"},
+			Args: []string{"", "source", "--recursive", "./fixtures/locks-gitignore"},
 			Exit: 0,
 		},
 		// ignoring .gitignore
 		{
 			Name: "ignoring .gitignore",
-			Args: []string{"", "scan", "source", "--recursive", "--no-ignore", "./fixtures/locks-gitignore"},
+			Args: []string{"", "source", "--recursive", "--no-ignore", "./fixtures/locks-gitignore"},
 			Exit: 0,
 		},
 		{
 			Name: "json output",
-			Args: []string{"", "scan", "source", "--format", "json", "./fixtures/locks-many/composer.lock"},
+			Args: []string{"", "source", "--format", "json", "./fixtures/locks-many/composer.lock"},
 			Exit: 0,
 		},
 		// output format: sarif
 		{
 			Name: "Empty sarif output",
-			Args: []string{"", "scan", "source", "--format", "sarif", "./fixtures/locks-many/composer.lock"},
+			Args: []string{"", "source", "--format", "sarif", "./fixtures/locks-many/composer.lock"},
 			Exit: 0,
 		},
 		{
 			Name: "Sarif with vulns",
-			Args: []string{"", "scan", "source", "--format", "sarif", "--config", "./fixtures/osv-scanner-empty-config.toml", "./fixtures/locks-many/package-lock.json"},
+			Args: []string{"", "source", "--format", "sarif", "--config", "./fixtures/osv-scanner-empty-config.toml", "./fixtures/locks-many/package-lock.json"},
 			Exit: 1,
 		},
 		// output format: gh-annotations
 		{
 			Name: "Empty gh-annotations output",
-			Args: []string{"", "scan", "source", "--format", "gh-annotations", "./fixtures/locks-many/composer.lock"},
+			Args: []string{"", "source", "--format", "gh-annotations", "./fixtures/locks-many/composer.lock"},
 			Exit: 0,
 		},
 		{
 			Name: "gh-annotations with vulns",
-			Args: []string{"", "scan", "source", "--format", "gh-annotations", "--config", "./fixtures/osv-scanner-empty-config.toml", "./fixtures/locks-many/package-lock.json"},
+			Args: []string{"", "source", "--format", "gh-annotations", "--config", "./fixtures/osv-scanner-empty-config.toml", "./fixtures/locks-many/package-lock.json"},
 			Exit: 1,
 		},
 		// output format: markdown table
 		{
 			Name: "output format: markdown table",
-			Args: []string{"", "scan", "source", "--format", "markdown", "--config", "./fixtures/osv-scanner-empty-config.toml", "./fixtures/locks-many/package-lock.json"},
+			Args: []string{"", "source", "--format", "markdown", "--config", "./fixtures/osv-scanner-empty-config.toml", "./fixtures/locks-many/package-lock.json"},
 			Exit: 1,
 		},
 		// output format: cyclonedx 1.4
 		{
 			Name: "Empty cyclonedx 1.4 output",
-			Args: []string{"", "scan", "source", "--format", "cyclonedx-1-4", "./fixtures/locks-many/composer.lock"},
+			Args: []string{"", "source", "--format", "cyclonedx-1-4", "./fixtures/locks-many/composer.lock"},
 			Exit: 0,
 		},
 		{
 			Name: "cyclonedx 1.4 output",
-			Args: []string{"", "scan", "source", "--config=./fixtures/osv-scanner-empty-config.toml", "--format", "cyclonedx-1-4", "--all-packages", "./fixtures/locks-insecure"},
+			Args: []string{"", "source", "--config=./fixtures/osv-scanner-empty-config.toml", "--format", "cyclonedx-1-4", "--all-packages", "./fixtures/locks-insecure"},
 			Exit: 1,
 		},
 		// output format: cyclonedx 1.5
 		{
 			Name: "Empty cyclonedx 1.5 output",
-			Args: []string{"", "scan", "source", "--format", "cyclonedx-1-5", "./fixtures/locks-many/composer.lock"},
+			Args: []string{"", "source", "--format", "cyclonedx-1-5", "./fixtures/locks-many/composer.lock"},
 			Exit: 0,
 		},
 		{
 			Name: "cyclonedx 1.5 output",
-			Args: []string{"", "scan", "source", "--config=./fixtures/osv-scanner-empty-config.toml", "--format", "cyclonedx-1-5", "--all-packages", "./fixtures/locks-insecure"},
+			Args: []string{"", "source", "--config=./fixtures/osv-scanner-empty-config.toml", "--format", "cyclonedx-1-5", "--all-packages", "./fixtures/locks-insecure"},
 			Exit: 1,
 		},
 		// output format: unsupported
 		{
 			Name: "output format: unsupported",
-			Args: []string{"", "scan", "source", "--format", "unknown", "./fixtures/locks-many/composer.lock"},
+			Args: []string{"", "source", "--format", "unknown", "./fixtures/locks-many/composer.lock"},
 			Exit: 127,
 		},
 		// one specific supported lockfile with ignore
 		{
 			Name: "one specific supported lockfile with ignore",
-			Args: []string{"", "scan", "source", "./fixtures/locks-test-ignore/package-lock.json"},
+			Args: []string{"", "source", "./fixtures/locks-test-ignore/package-lock.json"},
 			Exit: 0,
 		},
 		{
 			Name: "invalid --verbosity value",
-			Args: []string{"", "scan", "source", "--verbosity", "unknown", "./fixtures/locks-many/composer.lock"},
+			Args: []string{"", "source", "--verbosity", "unknown", "./fixtures/locks-many/composer.lock"},
 			Exit: 127,
 		},
 		{
 			Name: "verbosity level = error",
-			Args: []string{"", "scan", "source", "--verbosity", "error", "--format", "table", "./fixtures/locks-many/composer.lock"},
+			Args: []string{"", "source", "--verbosity", "error", "--format", "table", "./fixtures/locks-many/composer.lock"},
 			Exit: 0,
 		},
 		{
 			Name: "verbosity level = info",
-			Args: []string{"", "scan", "source", "--verbosity", "info", "--format", "table", "./fixtures/locks-many/composer.lock"},
+			Args: []string{"", "source", "--verbosity", "info", "--format", "table", "./fixtures/locks-many/composer.lock"},
 			Exit: 0,
 		},
 		{
 			Name: "PURL SBOM case sensitivity (api)",
-			Args: []string{"", "scan", "source", "--config=./fixtures/osv-scanner-empty-config.toml", "--format", "table", "./fixtures/sbom-insecure/alpine.cdx.xml"},
+			Args: []string{"", "source", "--config=./fixtures/osv-scanner-empty-config.toml", "--format", "table", "./fixtures/sbom-insecure/alpine.cdx.xml"},
 			Exit: 1,
 		},
 		{
 			Name: "PURL SBOM case sensitivity (local)",
-			Args: []string{"", "scan", "source", "--config=./fixtures/osv-scanner-empty-config.toml", "--offline", "--download-offline-databases", "--format", "table", "./fixtures/sbom-insecure/alpine.cdx.xml"},
+			Args: []string{"", "source", "--config=./fixtures/osv-scanner-empty-config.toml", "--offline", "--download-offline-databases", "--format", "table", "./fixtures/sbom-insecure/alpine.cdx.xml"},
 			Exit: 1,
 		},
 		// Go project with an overridden go version
 		{
 			Name: "Go project with an overridden go version",
-			Args: []string{"", "scan", "source", "--config=./fixtures/go-project/go-version-config.toml", "./fixtures/go-project"},
+			Args: []string{"", "source", "--config=./fixtures/go-project/go-version-config.toml", "./fixtures/go-project"},
 			Exit: 0,
 		},
 		// Go project with an overridden go version, recursive
 		{
 			Name: "Go project with an overridden go version, recursive",
-			Args: []string{"", "scan", "source", "--config=./fixtures/go-project/go-version-config.toml", "-r", "./fixtures/go-project"},
+			Args: []string{"", "source", "--config=./fixtures/go-project/go-version-config.toml", "-r", "./fixtures/go-project"},
 			Exit: 0,
 		},
 		// broad config file that overrides a whole ecosystem
 		{
 			Name: "config file can be broad",
-			Args: []string{"", "scan", "source", "--config=./fixtures/osv-scanner-composite-config.toml", "--licenses=MIT", "-L", "osv-scanner:./fixtures/locks-insecure/osv-scanner-flutter-deps.json", "./fixtures/locks-many", "./fixtures/locks-insecure", "./fixtures/maven-transitive"},
+			Args: []string{"", "source", "--config=./fixtures/osv-scanner-composite-config.toml", "--licenses=MIT", "-L", "osv-scanner:./fixtures/locks-insecure/osv-scanner-flutter-deps.json", "./fixtures/locks-many", "./fixtures/locks-insecure", "./fixtures/maven-transitive"},
 			Exit: 1,
 		},
 		// ignored vulnerabilities and packages without a reason should be called out
 		{
 			Name: "ignores without reason should be explicitly called out",
-			Args: []string{"", "scan", "source", "--config=./fixtures/osv-scanner-reasonless-ignores-config.toml", "./fixtures/locks-many/package-lock.json", "./fixtures/locks-many/composer.lock"},
+			Args: []string{"", "source", "--config=./fixtures/osv-scanner-reasonless-ignores-config.toml", "./fixtures/locks-many/package-lock.json", "./fixtures/locks-many/composer.lock"},
 			Exit: 0,
 		},
 		// invalid config file
 		{
 			Name: "config file is invalid",
-			Args: []string{"", "scan", "source", "./fixtures/config-invalid"},
+			Args: []string{"", "source", "./fixtures/config-invalid"},
 			Exit: 127,
 		},
 		// config file with unknown keys
 		{
 			Name: "config files cannot have unknown keys",
-			Args: []string{"", "scan", "source", "--config=./fixtures/osv-scanner-unknown-config.toml", "./fixtures/locks-many"},
+			Args: []string{"", "source", "--config=./fixtures/osv-scanner-unknown-config.toml", "./fixtures/locks-many"},
 			Exit: 127,
 		},
 		// config file with multiple ignores with the same id
 		{
 			Name: "config files should not have multiple ignores with the same id",
-			Args: []string{"", "scan", "source", "--config=./fixtures/osv-scanner-duplicate-config.toml", "./fixtures/locks-many"},
+			Args: []string{"", "source", "--config=./fixtures/osv-scanner-duplicate-config.toml", "./fixtures/locks-many"},
 			Exit: 0,
 		},
 		// a bunch of requirements.txt files with different names
 		{
 			Name: "requirements.txt can have all kinds of names",
-			Args: []string{"", "scan", "source", "--config=./fixtures/osv-scanner-empty-config.toml", "./fixtures/locks-requirements"},
+			Args: []string{"", "source", "--config=./fixtures/osv-scanner-empty-config.toml", "./fixtures/locks-requirements"},
 			Exit: 1,
 		},
 	}
@@ -248,7 +248,7 @@ func TestCommand_CallAnalysis(t *testing.T) {
 	tests := []testcmd.Case{
 		{
 			Name: "Run with govulncheck",
-			Args: []string{"", "scan", "source",
+			Args: []string{"", "source",
 				"--call-analysis=go",
 				"--config=./fixtures/osv-scanner-call-analysis-config.toml",
 				"./fixtures/call-analysis-go-project"},
@@ -269,13 +269,14 @@ func TestCommand_LockfileWithExplicitParseAs(t *testing.T) {
 	tests := []testcmd.Case{
 		{
 			Name: "unsupported parse-as",
-			Args: []string{"", "scan", "source", "-L", "my-file:./fixtures/locks-many/composer.lock"},
+			Args: []string{"", "source", "-L", "my-file:./fixtures/locks-many/composer.lock"},
 			Exit: 127,
 		},
 		{
 			Name: "empty is default",
 			Args: []string{
 				"",
+				"source",
 				"-L",
 				":" + filepath.FromSlash("./fixtures/locks-many/composer.lock"),
 			},
@@ -285,6 +286,7 @@ func TestCommand_LockfileWithExplicitParseAs(t *testing.T) {
 			Name: "empty works as an escape (no fixture because it's not valid on Windows)",
 			Args: []string{
 				"",
+				"source",
 				"-L",
 				":" + filepath.FromSlash("./path/to/my:file"),
 			},
@@ -294,6 +296,7 @@ func TestCommand_LockfileWithExplicitParseAs(t *testing.T) {
 			Name: "empty works as an escape (no fixture because it's not valid on Windows)",
 			Args: []string{
 				"",
+				"source",
 				"-L",
 				":" + filepath.FromSlash("./path/to/my:project/package-lock.json"),
 			},
@@ -301,13 +304,14 @@ func TestCommand_LockfileWithExplicitParseAs(t *testing.T) {
 		},
 		{
 			Name: "one lockfile with local path",
-			Args: []string{"", "scan", "source", "--lockfile=go.mod:./fixtures/locks-many/replace-local.mod"},
+			Args: []string{"", "source", "--lockfile=go.mod:./fixtures/locks-many/replace-local.mod"},
 			Exit: 0,
 		},
 		{
 			Name: "when an explicit parse-as is given, it's applied to that file",
 			Args: []string{
 				"",
+				"source",
 				"--config=./fixtures/osv-scanner-empty-config.toml",
 				"-L",
 				"package-lock.json:" + filepath.FromSlash("./fixtures/locks-insecure/my-package-lock.json"),
@@ -319,6 +323,7 @@ func TestCommand_LockfileWithExplicitParseAs(t *testing.T) {
 			Name: "multiple, + output order is deterministic",
 			Args: []string{
 				"",
+				"source",
 				"--config=./fixtures/osv-scanner-empty-config.toml",
 				"-L", "package-lock.json:" + filepath.FromSlash("./fixtures/locks-insecure/my-package-lock.json"),
 				"-L", "yarn.lock:" + filepath.FromSlash("./fixtures/locks-insecure/my-yarn.lock"),
@@ -330,6 +335,7 @@ func TestCommand_LockfileWithExplicitParseAs(t *testing.T) {
 			Name: "multiple, + output order is deterministic 2",
 			Args: []string{
 				"",
+				"source",
 				"--config=./fixtures/osv-scanner-empty-config.toml",
 				"-L", "yarn.lock:" + filepath.FromSlash("./fixtures/locks-insecure/my-yarn.lock"),
 				"-L", "package-lock.json:" + filepath.FromSlash("./fixtures/locks-insecure/my-package-lock.json"),
@@ -341,6 +347,7 @@ func TestCommand_LockfileWithExplicitParseAs(t *testing.T) {
 			Name: "files that error on parsing stop parsable files from being checked",
 			Args: []string{
 				"",
+				"source",
 				"-L",
 				"Cargo.lock:" + filepath.FromSlash("./fixtures/locks-insecure/my-package-lock.json"),
 				filepath.FromSlash("./fixtures/locks-insecure"),
@@ -352,6 +359,7 @@ func TestCommand_LockfileWithExplicitParseAs(t *testing.T) {
 			Name: "parse-as takes priority, even if it's wrong",
 			Args: []string{
 				"",
+				"source",
 				"-L",
 				"package-lock.json:" + filepath.FromSlash("./fixtures/locks-many/yarn.lock"),
 			},
@@ -361,6 +369,7 @@ func TestCommand_LockfileWithExplicitParseAs(t *testing.T) {
 			Name: "\"apk-installed\" is supported",
 			Args: []string{
 				"",
+				"source",
 				"-L",
 				"apk-installed:" + filepath.FromSlash("./fixtures/locks-many/installed"),
 			},
@@ -370,6 +379,7 @@ func TestCommand_LockfileWithExplicitParseAs(t *testing.T) {
 			Name: "\"dpkg-status\" is supported",
 			Args: []string{
 				"",
+				"source",
 				"-L",
 				"dpkg-status:" + filepath.FromSlash("./fixtures/locks-many/status"),
 			},
@@ -391,12 +401,12 @@ func TestCommand_GithubActions(t *testing.T) {
 	tests := []testcmd.Case{
 		{
 			Name: "scanning osv-scanner custom format",
-			Args: []string{"", "scan", "source", "--config=./fixtures/osv-scanner-empty-config.toml", "-L", "osv-scanner:./fixtures/locks-insecure/osv-scanner-flutter-deps.json"},
+			Args: []string{"", "source", "--config=./fixtures/osv-scanner-empty-config.toml", "-L", "osv-scanner:./fixtures/locks-insecure/osv-scanner-flutter-deps.json"},
 			Exit: 1,
 		},
 		{
 			Name: "scanning osv-scanner custom format output json",
-			Args: []string{"", "scan", "source", "--config=./fixtures/osv-scanner-empty-config.toml", "-L", "osv-scanner:./fixtures/locks-insecure/osv-scanner-flutter-deps.json", "--format=sarif"},
+			Args: []string{"", "source", "--config=./fixtures/osv-scanner-empty-config.toml", "-L", "osv-scanner:./fixtures/locks-insecure/osv-scanner-flutter-deps.json", "--format=sarif"},
 			Exit: 1,
 		},
 	}
@@ -414,62 +424,62 @@ func TestCommand_LocalDatabases(t *testing.T) {
 	tests := []testcmd.Case{
 		{
 			Name: "one specific supported lockfile",
-			Args: []string{"", "scan", "source", "--offline", "--download-offline-databases", "./fixtures/locks-many/composer.lock"},
+			Args: []string{"", "source", "--offline", "--download-offline-databases", "./fixtures/locks-many/composer.lock"},
 			Exit: 0,
 		},
 		{
 			Name: "one specific supported sbom with vulns",
-			Args: []string{"", "scan", "source", "--offline", "--download-offline-databases", "--config=./fixtures/osv-scanner-empty-config.toml", "./fixtures/sbom-insecure/postgres-stretch.cdx.xml"},
+			Args: []string{"", "source", "--offline", "--download-offline-databases", "--config=./fixtures/osv-scanner-empty-config.toml", "./fixtures/sbom-insecure/postgres-stretch.cdx.xml"},
 			Exit: 1,
 		},
 		{
 			Name: "one specific unsupported lockfile",
-			Args: []string{"", "scan", "source", "--offline", "--download-offline-databases", "./fixtures/locks-many/not-a-lockfile.toml"},
+			Args: []string{"", "source", "--offline", "--download-offline-databases", "./fixtures/locks-many/not-a-lockfile.toml"},
 			Exit: 128,
 		},
 		{
 			Name: "all supported lockfiles in the directory should be checked",
-			Args: []string{"", "scan", "source", "--offline", "--download-offline-databases", "./fixtures/locks-many"},
+			Args: []string{"", "source", "--offline", "--download-offline-databases", "./fixtures/locks-many"},
 			Exit: 0,
 		},
 		{
 			Name: "all supported lockfiles in the directory should be checked",
-			Args: []string{"", "scan", "source", "--offline", "--download-offline-databases", "./fixtures/locks-many-with-invalid"},
+			Args: []string{"", "source", "--offline", "--download-offline-databases", "./fixtures/locks-many-with-invalid"},
 			Exit: 127,
 		},
 		{
 			Name: "only the files in the given directories are checked by default (no recursion)",
-			Args: []string{"", "scan", "source", "--offline", "--download-offline-databases", "./fixtures/locks-one-with-nested"},
+			Args: []string{"", "source", "--offline", "--download-offline-databases", "./fixtures/locks-one-with-nested"},
 			Exit: 0,
 		},
 		{
 			Name: "nested directories are checked when `--recursive` is passed",
-			Args: []string{"", "scan", "source", "--offline", "--download-offline-databases", "--recursive", "./fixtures/locks-one-with-nested"},
+			Args: []string{"", "source", "--offline", "--download-offline-databases", "--recursive", "./fixtures/locks-one-with-nested"},
 			Exit: 0,
 		},
 		{
 			Name: ".gitignored files",
-			Args: []string{"", "scan", "source", "--offline", "--download-offline-databases", "--recursive", "./fixtures/locks-gitignore"},
+			Args: []string{"", "source", "--offline", "--download-offline-databases", "--recursive", "./fixtures/locks-gitignore"},
 			Exit: 0,
 		},
 		{
 			Name: "ignoring .gitignore",
-			Args: []string{"", "scan", "source", "--offline", "--download-offline-databases", "--recursive", "--no-ignore", "./fixtures/locks-gitignore"},
+			Args: []string{"", "source", "--offline", "--download-offline-databases", "--recursive", "--no-ignore", "./fixtures/locks-gitignore"},
 			Exit: 0,
 		},
 		{
 			Name: "output with json",
-			Args: []string{"", "scan", "source", "--offline", "--download-offline-databases", "--format", "json", "./fixtures/locks-many/composer.lock"},
+			Args: []string{"", "source", "--offline", "--download-offline-databases", "--format", "json", "./fixtures/locks-many/composer.lock"},
 			Exit: 0,
 		},
 		{
 			Name: "output format: markdown table",
-			Args: []string{"", "scan", "source", "--offline", "--download-offline-databases", "--format", "markdown", "./fixtures/locks-many/composer.lock"},
+			Args: []string{"", "source", "--offline", "--download-offline-databases", "--format", "markdown", "./fixtures/locks-many/composer.lock"},
 			Exit: 0,
 		},
 		{
 			Name: "database should be downloaded only when offline is set",
-			Args: []string{"", "scan", "source", "--download-offline-databases", "./fixtures/locks-many"},
+			Args: []string{"", "source", "--download-offline-databases", "./fixtures/locks-many"},
 			Exit: 127,
 		},
 	}
@@ -480,8 +490,8 @@ func TestCommand_LocalDatabases(t *testing.T) {
 			if testutility.IsAcceptanceTesting() {
 				testDir := testutility.CreateTestDir(t)
 				old := tt.Args
-				tt.Args = []string{"", "scan", "source", "--local-db-path", testDir}
-				tt.Args = append(tt.Args, old[3:]...)
+				tt.Args = []string{"", "source", "--local-db-path", testDir}
+				tt.Args = append(tt.Args, old[2:]...)
 			}
 
 			// run each test twice since they should provide the same output,
@@ -498,7 +508,7 @@ func TestCommand_LocalDatabases_AlwaysOffline(t *testing.T) {
 	tests := []testcmd.Case{
 		{
 			Name: "a bunch of different lockfiles and ecosystem",
-			Args: []string{"", "scan", "source", "--config=./fixtures/osv-scanner-empty-config.toml", "--offline", "./fixtures/locks-requirements", "./fixtures/locks-many"},
+			Args: []string{"", "source", "--config=./fixtures/osv-scanner-empty-config.toml", "--offline", "./fixtures/locks-requirements", "./fixtures/locks-many"},
 			Exit: 127,
 		},
 	}
@@ -508,8 +518,8 @@ func TestCommand_LocalDatabases_AlwaysOffline(t *testing.T) {
 			t.Parallel()
 			testDir := testutility.CreateTestDir(t)
 			old := tt.Args
-			tt.Args = []string{"", "scan", "source", "--local-db-path", testDir}
-			tt.Args = append(tt.Args, old[3:]...)
+			tt.Args = []string{"", "source", "--local-db-path", testDir}
+			tt.Args = append(tt.Args, old[2:]...)
 
 			// run each test twice since they should provide the same output,
 			// and the second run should be fast as the db is already available
@@ -525,67 +535,67 @@ func TestCommand_Licenses(t *testing.T) {
 	tests := []testcmd.Case{
 		{
 			Name: "No vulnerabilities with license summary",
-			Args: []string{"", "scan", "source", "--licenses", "./fixtures/locks-many"},
+			Args: []string{"", "source", "--licenses", "./fixtures/locks-many"},
 			Exit: 0,
 		},
 		{
 			Name: "No vulnerabilities with license summary in markdown",
-			Args: []string{"", "scan", "source", "--licenses", "--format=markdown", "./fixtures/locks-many"},
+			Args: []string{"", "source", "--licenses", "--format=markdown", "./fixtures/locks-many"},
 			Exit: 0,
 		},
 		{
 			Name: "Vulnerabilities and license summary",
-			Args: []string{"", "scan", "source", "--licenses", "--config=./fixtures/osv-scanner-empty-config.toml", "./fixtures/locks-many/package-lock.json"},
+			Args: []string{"", "source", "--licenses", "--config=./fixtures/osv-scanner-empty-config.toml", "./fixtures/locks-many/package-lock.json"},
 			Exit: 1,
 		},
 		{
 			Name: "Vulnerabilities and license violations with allowlist",
-			Args: []string{"", "scan", "source", "--licenses=MIT", "--config=./fixtures/osv-scanner-empty-config.toml", "./fixtures/locks-many/package-lock.json"},
+			Args: []string{"", "source", "--licenses=MIT", "--config=./fixtures/osv-scanner-empty-config.toml", "./fixtures/locks-many/package-lock.json"},
 			Exit: 1,
 		},
 		{
 			Name: "Vulnerabilities and all license violations allowlisted",
-			Args: []string{"", "scan", "source", "--licenses=Apache-2.0", "--config=./fixtures/osv-scanner-empty-config.toml", "./fixtures/locks-many/package-lock.json"},
+			Args: []string{"", "source", "--licenses=Apache-2.0", "--config=./fixtures/osv-scanner-empty-config.toml", "./fixtures/locks-many/package-lock.json"},
 			Exit: 1,
 		},
 		{
 			Name: "Some packages with license violations and show-all-packages in json",
-			Args: []string{"", "scan", "source", "--format=json", "--licenses=MIT", "--all-packages", "./fixtures/locks-licenses/package-lock.json"},
+			Args: []string{"", "source", "--format=json", "--licenses=MIT", "--all-packages", "./fixtures/locks-licenses/package-lock.json"},
 			Exit: 1,
 		},
 		{
 			Name: "Some packages with ignored licenses",
-			Args: []string{"", "scan", "source", "--config=./fixtures/osv-scanner-complex-licenses-config.toml", "--licenses=MIT", "./fixtures/locks-many", "./fixtures/locks-insecure"},
+			Args: []string{"", "source", "--config=./fixtures/osv-scanner-complex-licenses-config.toml", "--licenses=MIT", "./fixtures/locks-many", "./fixtures/locks-insecure"},
 			Exit: 1,
 		},
 		{
 			Name: "Some packages with license violations in json",
-			Args: []string{"", "scan", "source", "--format=json", "--licenses=MIT", "./fixtures/locks-licenses/package-lock.json"},
+			Args: []string{"", "source", "--format=json", "--licenses=MIT", "./fixtures/locks-licenses/package-lock.json"},
 			Exit: 1,
 		},
 		{
 			Name: "No license violations and show-all-packages in json",
-			Args: []string{"", "scan", "source", "--format=json", "--licenses=MIT,Apache-2.0", "--all-packages", "./fixtures/locks-licenses/package-lock.json"},
+			Args: []string{"", "source", "--format=json", "--licenses=MIT,Apache-2.0", "--all-packages", "./fixtures/locks-licenses/package-lock.json"},
 			Exit: 0,
 		},
 		{
 			Name: "Show all Packages with license summary in json",
-			Args: []string{"", "scan", "source", "--format=json", "--licenses", "--all-packages", "./fixtures/locks-licenses/package-lock.json"},
+			Args: []string{"", "source", "--format=json", "--licenses", "--all-packages", "./fixtures/locks-licenses/package-lock.json"},
 			Exit: 0,
 		},
 		{
 			Name: "Licenses in summary mode json",
-			Args: []string{"", "scan", "source", "--format=json", "--licenses", "./fixtures/locks-licenses/package-lock.json"},
+			Args: []string{"", "source", "--format=json", "--licenses", "./fixtures/locks-licenses/package-lock.json"},
 			Exit: 0,
 		},
 		{
 			Name: "Licenses with expressions",
-			Args: []string{"", "scan", "source", "--config=./fixtures/osv-scanner-expressive-licenses-config.toml", "--licenses=MIT,BSD-3-Clause", "./fixtures/locks-licenses/package-lock.json"},
+			Args: []string{"", "source", "--config=./fixtures/osv-scanner-expressive-licenses-config.toml", "--licenses=MIT,BSD-3-Clause", "./fixtures/locks-licenses/package-lock.json"},
 			Exit: 1,
 		},
 		{
 			Name: "Licenses with invalid expression",
-			Args: []string{"", "scan", "source", "--config=./fixtures/osv-scanner-invalid-licenses-config.toml", "--licenses=MIT,BSD-3-Clause", "./fixtures/locks-licenses/package-lock.json"},
+			Args: []string{"", "source", "--config=./fixtures/osv-scanner-invalid-licenses-config.toml", "--licenses=MIT,BSD-3-Clause", "./fixtures/locks-licenses/package-lock.json"},
 			Exit: 1,
 		},
 	}
@@ -604,39 +614,39 @@ func TestCommand_MavenTransitive(t *testing.T) {
 	tests := []testcmd.Case{
 		{
 			Name: "scans transitive dependencies for pom.xml by default",
-			Args: []string{"", "scan", "source", "--config=./fixtures/osv-scanner-empty-config.toml", "./fixtures/maven-transitive/pom.xml"},
+			Args: []string{"", "source", "--config=./fixtures/osv-scanner-empty-config.toml", "./fixtures/maven-transitive/pom.xml"},
 			Exit: 1,
 		},
 		{
 			Name: "scans transitive dependencies by specifying pom.xml",
-			Args: []string{"", "scan", "source", "--config=./fixtures/osv-scanner-empty-config.toml", "-L", "pom.xml:./fixtures/maven-transitive/abc.xml"},
+			Args: []string{"", "source", "--config=./fixtures/osv-scanner-empty-config.toml", "-L", "pom.xml:./fixtures/maven-transitive/abc.xml"},
 			Exit: 1,
 		},
 		{
 			Name: "scans pom.xml with non UTF-8 encoding",
-			Args: []string{"", "scan", "source", "--config=./fixtures/osv-scanner-empty-config.toml", "-L", "pom.xml:./fixtures/maven-transitive/encoding.xml"},
+			Args: []string{"", "source", "--config=./fixtures/osv-scanner-empty-config.toml", "-L", "pom.xml:./fixtures/maven-transitive/encoding.xml"},
 			Exit: 1,
 		},
 		{
 			// Direct dependencies do not have any vulnerability.
 			Name: "does not scan transitive dependencies for pom.xml with offline mode",
-			Args: []string{"", "scan", "source", "--config=./fixtures/osv-scanner-empty-config.toml", "--offline", "--download-offline-databases", "./fixtures/maven-transitive/pom.xml"},
+			Args: []string{"", "source", "--config=./fixtures/osv-scanner-empty-config.toml", "--offline", "--download-offline-databases", "./fixtures/maven-transitive/pom.xml"},
 			Exit: 0,
 		},
 		{
 			// Direct dependencies do not have any vulnerability.
 			Name: "does not scan transitive dependencies for pom.xml with no-resolve",
-			Args: []string{"", "scan", "source", "--config=./fixtures/osv-scanner-empty-config.toml", "--no-resolve", "./fixtures/maven-transitive/pom.xml"},
+			Args: []string{"", "source", "--config=./fixtures/osv-scanner-empty-config.toml", "--no-resolve", "./fixtures/maven-transitive/pom.xml"},
 			Exit: 0,
 		},
 		{
 			Name: "scans dependencies from multiple registries",
-			Args: []string{"", "scan", "source", "--config=./fixtures/osv-scanner-empty-config.toml", "-L", "pom.xml:./fixtures/maven-transitive/registry.xml"},
+			Args: []string{"", "source", "--config=./fixtures/osv-scanner-empty-config.toml", "-L", "pom.xml:./fixtures/maven-transitive/registry.xml"},
 			Exit: 1,
 		},
 		{
 			Name: "resolve transitive dependencies with native data source",
-			Args: []string{"", "scan", "source", "--config=./fixtures/osv-scanner-empty-config.toml", "--data-source=native", "-L", "pom.xml:./fixtures/maven-transitive/registry.xml"},
+			Args: []string{"", "source", "--config=./fixtures/osv-scanner-empty-config.toml", "--data-source=native", "-L", "pom.xml:./fixtures/maven-transitive/registry.xml"},
 			Exit: 1,
 		},
 	}
@@ -655,38 +665,38 @@ func TestCommand_MoreLockfiles(t *testing.T) {
 	tests := []testcmd.Case{
 		{
 			Name: "uv.lock",
-			Args: []string{"", "scan", "source", "-L", "./fixtures/locks-scalibr/uv.lock"},
+			Args: []string{"", "source", "-L", "./fixtures/locks-scalibr/uv.lock"},
 			Exit: 0,
 		},
 		{
 			Name: "depsjson",
-			Args: []string{"", "scan", "source", "-L", "deps.json:./fixtures/locks-scalibr/depsjson"},
+			Args: []string{"", "source", "-L", "deps.json:./fixtures/locks-scalibr/depsjson"},
 			Exit: 1,
 		},
 		{
 			Name: "cabal.project.freeze",
-			Args: []string{"", "scan", "source", "-L", "./fixtures/locks-scalibr/cabal.project.freeze"},
+			Args: []string{"", "source", "-L", "./fixtures/locks-scalibr/cabal.project.freeze"},
 			Exit: 1,
 		},
 		{
 			Name: "stack.yaml.lock",
-			Args: []string{"", "scan", "source", "-L", "./fixtures/locks-scalibr/stack.yaml.lock"},
+			Args: []string{"", "source", "-L", "./fixtures/locks-scalibr/stack.yaml.lock"},
 			Exit: 0,
 		},
 		{
 			Name: "packages.config",
-			Args: []string{"", "scan", "source", "-L", "./fixtures/locks-scalibr/packages.config"},
+			Args: []string{"", "source", "-L", "./fixtures/locks-scalibr/packages.config"},
 			Exit: 0,
 		},
 		{
 			Name: "packages.lock.json",
-			Args: []string{"", "scan", "source", "-L", "./fixtures/locks-scalibr/packages.lock.json"},
+			Args: []string{"", "source", "-L", "./fixtures/locks-scalibr/packages.lock.json"},
 			Exit: 0,
 		},
 		/*
 			{
 				name: "Package.resolved",
-				args: []string{"", "scan", "source", "-L", "./fixtures/locks-scalibr/Package.resolved"},
+				args: []string{"", "source", "-L", "./fixtures/locks-scalibr/Package.resolved"},
 				exit: 0,
 			},
 		*/

--- a/cmd/osv-scanner/scan/source/testmain_test.go
+++ b/cmd/osv-scanner/scan/source/testmain_test.go
@@ -6,6 +6,9 @@ import (
 	"testing"
 
 	"github.com/go-git/go-git/v5"
+	"github.com/google/osv-scanner/v2/cmd/osv-scanner/internal/cmd"
+	"github.com/google/osv-scanner/v2/cmd/osv-scanner/internal/testcmd"
+	"github.com/google/osv-scanner/v2/cmd/osv-scanner/scan/source"
 	"github.com/google/osv-scanner/v2/internal/testlogger"
 	"github.com/google/osv-scanner/v2/internal/testutility"
 )
@@ -22,6 +25,7 @@ func TestMain(m *testing.M) {
 	}
 
 	slog.SetDefault(slog.New(testlogger.New()))
+	testcmd.CommandsUnderTest = []cmd.CommandBuilder{source.Command}
 	m.Run()
 
 	testutility.CleanSnapshots(m)

--- a/cmd/osv-scanner/scan/testmain_test.go
+++ b/cmd/osv-scanner/scan/testmain_test.go
@@ -4,12 +4,16 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/google/osv-scanner/v2/cmd/osv-scanner/internal/cmd"
+	"github.com/google/osv-scanner/v2/cmd/osv-scanner/internal/testcmd"
+	"github.com/google/osv-scanner/v2/cmd/osv-scanner/scan"
 	"github.com/google/osv-scanner/v2/internal/testlogger"
 	"github.com/google/osv-scanner/v2/internal/testutility"
 )
 
 func TestMain(m *testing.M) {
 	slog.SetDefault(slog.New(testlogger.New()))
+	testcmd.CommandsUnderTest = []cmd.CommandBuilder{scan.Command}
 	m.Run()
 
 	testutility.CleanSnapshots(m)

--- a/cmd/osv-scanner/testmain_test.go
+++ b/cmd/osv-scanner/testmain_test.go
@@ -6,6 +6,11 @@ import (
 	"testing"
 
 	"github.com/go-git/go-git/v5"
+	"github.com/google/osv-scanner/v2/cmd/osv-scanner/fix"
+	"github.com/google/osv-scanner/v2/cmd/osv-scanner/internal/cmd"
+	"github.com/google/osv-scanner/v2/cmd/osv-scanner/internal/testcmd"
+	"github.com/google/osv-scanner/v2/cmd/osv-scanner/scan"
+	"github.com/google/osv-scanner/v2/cmd/osv-scanner/update"
 	"github.com/google/osv-scanner/v2/internal/testlogger"
 	"github.com/google/osv-scanner/v2/internal/testutility"
 )
@@ -22,6 +27,11 @@ func TestMain(m *testing.M) {
 	}
 
 	slog.SetDefault(slog.New(testlogger.New()))
+	testcmd.CommandsUnderTest = []cmd.CommandBuilder{
+		scan.Command,
+		fix.Command,
+		update.Command,
+	}
 	m.Run()
 
 	testutility.CleanSnapshots(m)

--- a/cmd/osv-scanner/update/command.go
+++ b/cmd/osv-scanner/update/command.go
@@ -3,6 +3,7 @@ package update
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 
 	"deps.dev/util/resolve"
@@ -16,7 +17,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func Command() *cli.Command {
+func Command(_, _ io.Writer) *cli.Command {
 	return &cli.Command{
 		Hidden: true,
 		Name:   "update",

--- a/cmd/osv-scanner/update/testmain_test.go
+++ b/cmd/osv-scanner/update/testmain_test.go
@@ -4,12 +4,16 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/google/osv-scanner/v2/cmd/osv-scanner/internal/cmd"
+	"github.com/google/osv-scanner/v2/cmd/osv-scanner/internal/testcmd"
+	"github.com/google/osv-scanner/v2/cmd/osv-scanner/update"
 	"github.com/google/osv-scanner/v2/internal/testlogger"
 	"github.com/google/osv-scanner/v2/internal/testutility"
 )
 
 func TestMain(m *testing.M) {
 	slog.SetDefault(slog.New(testlogger.New()))
+	testcmd.CommandsUnderTest = []cmd.CommandBuilder{update.Command}
 	m.Run()
 
 	testutility.CleanSnapshots(m)


### PR DESCRIPTION
Currently because all commands are included in all `cmd` tests any code change will invalid the test cache for all `cmd` packages regardless of if the change is actually impactful to them - we can avoid this by having the setup for each `cmd` package explicitly set the commands to include in the test, as the cost of a minor change to the app builder function