### PR TITLE
test(fix): use public package

### DIFF
--- a/cmd/osv-scanner/fix/testmain_test.go
+++ b/cmd/osv-scanner/fix/testmain_test.go
@@ -1,4 +1,4 @@
-package fix
+package fix_test
 
 import (
 	"log/slog"


### PR DESCRIPTION
I forgot to change this when doing #1737, as the `fix` tests were originally in the package itself