### PR TITLE
test(scan): add license cases for when invalid and offline

### DIFF
--- a/cmd/osv-scanner/scan/source/__snapshots__/command_test.snap
+++ b/cmd/osv-scanner/scan/source/__snapshots__/command_test.snap
@@ -1391,7 +1391,7 @@ overriding license for package npm/ms/2.1.3 with MIT WITH Bison-exception-2.2
 
 ---
 
-[TestCommand_Licenses/Licenses_with_invalid_expression - 1]
+[TestCommand_Licenses/Licenses_with_invalid_expression_in_config - 1]
 Scanning dir ./fixtures/locks-licenses/package-lock.json
 Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-licenses/package-lock.json file and found 4 packages
 overriding license for package npm/babel/6.23.0 with MIT AND (LGPL-2.1-or-later OR BSD-3-Clause))
@@ -1414,9 +1414,18 @@ overriding license for package npm/ms/2.1.3 with MIT WITH (Bison-exception-2.2 A
 
 ---
 
-[TestCommand_Licenses/Licenses_with_invalid_expression - 2]
+[TestCommand_Licenses/Licenses_with_invalid_expression_in_config - 2]
 license LGPL-2.1-only OR OR BSD-3-Clause for package npm/human-signals/5.0.0 is invalid: unexpected OR after OR
 license MIT WITH (Bison-exception-2.2 AND somethingelse) for package npm/ms/2.1.3 is invalid: unexpected ( after WITH
+
+---
+
+[TestCommand_Licenses/Licenses_with_invalid_licenses_in_flag - 1]
+
+---
+
+[TestCommand_Licenses/Licenses_with_invalid_licenses_in_flag - 2]
+--licenses requires comma-separated spdx licenses. The following license(s) are not recognized as spdx: something-something
 
 ---
 
@@ -1902,6 +1911,33 @@ Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/package-lock.json 
 ---
 
 [TestCommand_Licenses/Vulnerabilities_and_license_violations_with_allowlist - 2]
+
+---
+
+[TestCommand_Licenses/When_offline_licenses_are_still_validated - 1]
+
+---
+
+[TestCommand_Licenses/When_offline_licenses_are_still_validated - 2]
+--licenses requires comma-separated spdx licenses. The following license(s) are not recognized as spdx: something-something
+
+---
+
+[TestCommand_Licenses/When_offline_licenses_cannot_be_checked - 1]
+
+---
+
+[TestCommand_Licenses/When_offline_licenses_cannot_be_checked - 2]
+cannot retrieve licenses locally
+
+---
+
+[TestCommand_Licenses/When_offline_licenses_summary_cannot_be_printed - 1]
+
+---
+
+[TestCommand_Licenses/When_offline_licenses_summary_cannot_be_printed - 2]
+cannot retrieve licenses locally
 
 ---
 

--- a/cmd/osv-scanner/scan/source/command_test.go
+++ b/cmd/osv-scanner/scan/source/command_test.go
@@ -600,9 +600,29 @@ func TestCommand_Licenses(t *testing.T) {
 			Exit: 1,
 		},
 		{
-			Name: "Licenses with invalid expression",
+			Name: "Licenses with invalid licenses in flag",
+			Args: []string{"", "source", "--licenses=MIT,something-something", "./fixtures/locks-licenses/package-lock.json"},
+			Exit: 127,
+		},
+		{
+			Name: "Licenses with invalid expression in config",
 			Args: []string{"", "source", "--config=./fixtures/osv-scanner-invalid-licenses-config.toml", "--licenses=MIT,BSD-3-Clause", "./fixtures/locks-licenses/package-lock.json"},
 			Exit: 1,
+		},
+		{
+			Name: "When offline licenses summary cannot be printed",
+			Args: []string{"", "source", "--offline", "--licenses", "--config=./fixtures/osv-scanner-empty-config.toml", "./fixtures/locks-many/package-lock.json"},
+			Exit: 127,
+		},
+		{
+			Name: "When offline licenses cannot be checked",
+			Args: []string{"", "source", "--offline", "--licenses=MIT", "--config=./fixtures/osv-scanner-empty-config.toml", "./fixtures/locks-many/package-lock.json"},
+			Exit: 127,
+		},
+		{
+			Name: "When offline licenses are still validated",
+			Args: []string{"", "source", "--offline", "--licenses=MIT,something-something", "./fixtures/locks-many/package-lock.json"},
+			Exit: 127,
 		},
 	}
 


### PR DESCRIPTION
Among other things, this covers the fact that we currently check if we're offline _after_ we validate the licenses since we could flip that to simplify our implementation but currently doing so would not reveal that it changes our behaviour