### PR TITLE
chore: Changelog for v2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v2.0.2
+
+### Fixes:
+
+- [Bug #1842](https://github.com/google/osv-scanner/pull/1842) Fix an issue in the GitHub Action where call analysis for Go projects using the `tool` directive (Go 1.24+) in `go.mod` files would fail. The scanner image has been updated to use a newer Go version.
+- [Bug #1806](https://github.com/google/osv-scanner/pull/1806) Fix an issue where license overrides were not correctly reflected in the final scan results and license summary.
+- [Fix #1825](https://github.com/google/osv-scanner/pull/1825), [#1809](https://github.com/google/osv-scanner/pull/1809), [#1805](https://github.com/google/osv-scanner/pull/1805), [#1803](https://github.com/google/osv-scanner/pull/1803), [#1787](https://github.com/google/osv-scanner/pull/1787) Enhance XML output stability and consistency by preserving original formatting (including text, character data, attribute spacing) and minimizing unnecessary escaping. This helps reduce differences when XML files are processed.
+
 # v2.0.1
 
 ### Features:

--- a/cmd/osv-scanner/__snapshots__/main_test.snap
+++ b/cmd/osv-scanner/__snapshots__/main_test.snap
@@ -24,7 +24,7 @@ OPTIONS:
 ---
 
 [Test_run/version - 1]
-osv-scanner version: 2.0.1
+osv-scanner version: 2.0.2
 commit: n/a
 built at: n/a
 

--- a/cmd/osv-scanner/scan/source/__snapshots__/command_test.snap
+++ b/cmd/osv-scanner/scan/source/__snapshots__/command_test.snap
@@ -71,7 +71,7 @@ Loaded filter from: <rootdir>/osv-scanner/scan/source/fixtures/locks-many/osv-sc
           "informationUri": "https://github.com/google/osv-scanner",
           "name": "osv-scanner",
           "rules": [],
-          "version": "2.0.1"
+          "version": "2.0.2"
         }
       },
       "results": []
@@ -244,7 +244,7 @@ Loaded Alpine local db from <tempdir>/osv-scanner/Alpine/all.zip
               }
             }
           ],
-          "version": "2.0.1"
+          "version": "2.0.2"
         }
       },
       "artifacts": [
@@ -1229,7 +1229,7 @@ Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/osv-scanner-fl
               }
             }
           ],
-          "version": "2.0.1"
+          "version": "2.0.2"
         }
       },
       "artifacts": [

--- a/internal/output/__snapshots__/sarif_test.snap
+++ b/internal/output/__snapshots__/sarif_test.snap
@@ -65,7 +65,7 @@
               }
             }
           ],
-          "version": "2.0.1"
+          "version": "2.0.2"
         }
       },
       "artifacts": [
@@ -152,7 +152,7 @@
           "informationUri": "https://github.com/google/osv-scanner",
           "name": "osv-scanner",
           "rules": [],
-          "version": "2.0.1"
+          "version": "2.0.2"
         }
       },
       "results": []
@@ -173,7 +173,7 @@
           "informationUri": "https://github.com/google/osv-scanner",
           "name": "osv-scanner",
           "rules": [],
-          "version": "2.0.1"
+          "version": "2.0.2"
         }
       },
       "results": []
@@ -194,7 +194,7 @@
           "informationUri": "https://github.com/google/osv-scanner",
           "name": "osv-scanner",
           "rules": [],
-          "version": "2.0.1"
+          "version": "2.0.2"
         }
       },
       "results": []
@@ -215,7 +215,7 @@
           "informationUri": "https://github.com/google/osv-scanner",
           "name": "osv-scanner",
           "rules": [],
-          "version": "2.0.1"
+          "version": "2.0.2"
         }
       },
       "results": []
@@ -236,7 +236,7 @@
           "informationUri": "https://github.com/google/osv-scanner",
           "name": "osv-scanner",
           "rules": [],
-          "version": "2.0.1"
+          "version": "2.0.2"
         }
       },
       "results": []
@@ -257,7 +257,7 @@
           "informationUri": "https://github.com/google/osv-scanner",
           "name": "osv-scanner",
           "rules": [],
-          "version": "2.0.1"
+          "version": "2.0.2"
         }
       },
       "results": []
@@ -278,7 +278,7 @@
           "informationUri": "https://github.com/google/osv-scanner",
           "name": "osv-scanner",
           "rules": [],
-          "version": "2.0.1"
+          "version": "2.0.2"
         }
       },
       "results": []
@@ -299,7 +299,7 @@
           "informationUri": "https://github.com/google/osv-scanner",
           "name": "osv-scanner",
           "rules": [],
-          "version": "2.0.1"
+          "version": "2.0.2"
         }
       },
       "results": []
@@ -320,7 +320,7 @@
           "informationUri": "https://github.com/google/osv-scanner",
           "name": "osv-scanner",
           "rules": [],
-          "version": "2.0.1"
+          "version": "2.0.2"
         }
       },
       "results": []
@@ -341,7 +341,7 @@
           "informationUri": "https://github.com/google/osv-scanner",
           "name": "osv-scanner",
           "rules": [],
-          "version": "2.0.1"
+          "version": "2.0.2"
         }
       },
       "results": []
@@ -362,7 +362,7 @@
           "informationUri": "https://github.com/google/osv-scanner",
           "name": "osv-scanner",
           "rules": [],
-          "version": "2.0.1"
+          "version": "2.0.2"
         }
       },
       "results": []
@@ -383,7 +383,7 @@
           "informationUri": "https://github.com/google/osv-scanner",
           "name": "osv-scanner",
           "rules": [],
-          "version": "2.0.1"
+          "version": "2.0.2"
         }
       },
       "results": []
@@ -404,7 +404,7 @@
           "informationUri": "https://github.com/google/osv-scanner",
           "name": "osv-scanner",
           "rules": [],
-          "version": "2.0.1"
+          "version": "2.0.2"
         }
       },
       "results": []
@@ -425,7 +425,7 @@
           "informationUri": "https://github.com/google/osv-scanner",
           "name": "osv-scanner",
           "rules": [],
-          "version": "2.0.1"
+          "version": "2.0.2"
         }
       },
       "results": []
@@ -446,7 +446,7 @@
           "informationUri": "https://github.com/google/osv-scanner",
           "name": "osv-scanner",
           "rules": [],
-          "version": "2.0.1"
+          "version": "2.0.2"
         }
       },
       "results": []
@@ -504,7 +504,7 @@
               }
             }
           ],
-          "version": "2.0.1"
+          "version": "2.0.2"
         }
       },
       "artifacts": [
@@ -634,7 +634,7 @@
               }
             }
           ],
-          "version": "2.0.1"
+          "version": "2.0.2"
         }
       },
       "artifacts": [
@@ -746,7 +746,7 @@
               }
             }
           ],
-          "version": "2.0.1"
+          "version": "2.0.2"
         }
       },
       "artifacts": [
@@ -812,7 +812,7 @@
               }
             }
           ],
-          "version": "2.0.1"
+          "version": "2.0.2"
         }
       },
       "artifacts": [
@@ -878,7 +878,7 @@
               }
             }
           ],
-          "version": "2.0.1"
+          "version": "2.0.2"
         }
       },
       "artifacts": [
@@ -944,7 +944,7 @@
               }
             }
           ],
-          "version": "2.0.1"
+          "version": "2.0.2"
         }
       },
       "artifacts": [
@@ -1064,7 +1064,7 @@
               }
             }
           ],
-          "version": "2.0.1"
+          "version": "2.0.2"
         }
       },
       "artifacts": [
@@ -1275,7 +1275,7 @@
               }
             }
           ],
-          "version": "2.0.1"
+          "version": "2.0.2"
         }
       },
       "artifacts": [
@@ -1413,7 +1413,7 @@
           "informationUri": "https://github.com/google/osv-scanner",
           "name": "osv-scanner",
           "rules": [],
-          "version": "2.0.1"
+          "version": "2.0.2"
         }
       },
       "results": []
@@ -1471,7 +1471,7 @@
               }
             }
           ],
-          "version": "2.0.1"
+          "version": "2.0.2"
         }
       },
       "artifacts": [
@@ -1637,7 +1637,7 @@
               }
             }
           ],
-          "version": "2.0.1"
+          "version": "2.0.2"
         }
       },
       "artifacts": [
@@ -1848,7 +1848,7 @@
               }
             }
           ],
-          "version": "2.0.1"
+          "version": "2.0.2"
         }
       },
       "artifacts": [
@@ -1986,7 +1986,7 @@
           "informationUri": "https://github.com/google/osv-scanner",
           "name": "osv-scanner",
           "rules": [],
-          "version": "2.0.1"
+          "version": "2.0.2"
         }
       },
       "results": []
@@ -2007,7 +2007,7 @@
           "informationUri": "https://github.com/google/osv-scanner",
           "name": "osv-scanner",
           "rules": [],
-          "version": "2.0.1"
+          "version": "2.0.2"
         }
       },
       "results": []
@@ -2028,7 +2028,7 @@
           "informationUri": "https://github.com/google/osv-scanner",
           "name": "osv-scanner",
           "rules": [],
-          "version": "2.0.1"
+          "version": "2.0.2"
         }
       },
       "results": []
@@ -2049,7 +2049,7 @@
           "informationUri": "https://github.com/google/osv-scanner",
           "name": "osv-scanner",
           "rules": [],
-          "version": "2.0.1"
+          "version": "2.0.2"
         }
       },
       "results": []
@@ -2107,7 +2107,7 @@
               }
             }
           ],
-          "version": "2.0.1"
+          "version": "2.0.2"
         }
       },
       "artifacts": [
@@ -2190,7 +2190,7 @@
               }
             }
           ],
-          "version": "2.0.1"
+          "version": "2.0.2"
         }
       },
       "artifacts": [
@@ -2256,7 +2256,7 @@
               }
             }
           ],
-          "version": "2.0.1"
+          "version": "2.0.2"
         }
       },
       "artifacts": [
@@ -2322,7 +2322,7 @@
               }
             }
           ],
-          "version": "2.0.1"
+          "version": "2.0.2"
         }
       },
       "artifacts": [
@@ -2388,7 +2388,7 @@
               }
             }
           ],
-          "version": "2.0.1"
+          "version": "2.0.2"
         }
       },
       "artifacts": [
@@ -2455,7 +2455,7 @@
               }
             }
           ],
-          "version": "2.0.1"
+          "version": "2.0.2"
         }
       },
       "artifacts": [
@@ -2539,7 +2539,7 @@
               }
             }
           ],
-          "version": "2.0.1"
+          "version": "2.0.2"
         }
       },
       "artifacts": [
@@ -2640,7 +2640,7 @@
               }
             }
           ],
-          "version": "2.0.1"
+          "version": "2.0.2"
         }
       },
       "artifacts": [
@@ -2723,7 +2723,7 @@
               }
             }
           ],
-          "version": "2.0.1"
+          "version": "2.0.2"
         }
       },
       "artifacts": [
@@ -2789,7 +2789,7 @@
               }
             }
           ],
-          "version": "2.0.1"
+          "version": "2.0.2"
         }
       },
       "artifacts": [

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // OSVVersion is the current release version, you should update this variable when doing a release
-const OSVVersion = "2.0.1"
+const OSVVersion = "2.0.2"


### PR DESCRIPTION
Changelog for the v2.0.2 release, which has some bug fixes and some refactors in the background.

I specifically did not mention SPDX output support, as I think we should push that out with all the other OSV-Scalibr and OSV-Scanner feature parity announcements next month. 