### PR TITLE
ci: add job to ensure that Docker image should work

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -130,3 +130,41 @@ jobs:
         uses: ./.github/workflows/test-action
         with:
           codecov_token: ${{ secrets.CODECOV_TOKEN }}
+  docker:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+    runs-on: ubuntu-latest
+    env:
+      # Required for buildx on docker 19.x
+      DOCKER_CLI_EXPERIMENTAL: "enabled"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+        with:
+          go-version: stable
+          check-latest: true
+      - uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3
+      - uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
+      - name: Run GoReleaser
+        id: run-goreleaser
+        uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # v6.3.0
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean --snapshot
+      - run: |
+          echo '${{ steps.run-goreleaser.outputs.artifacts }}' > output.json
+          jq -r '.[] | select(
+            .type == "Docker Image" and
+            .goarch == "amd64" and
+            .goos == "linux" and
+            .extra.DockerConfig.dockerfile == "goreleaser.dockerfile"
+          ) | .name' output.json | while read -r image; do
+            echo "Testing image $image"
+            docker run $image -h
+            docker run -v ${PWD}:/src $image -L /src/go.mod
+          done


### PR DESCRIPTION
Currently we're actually just testing the Linux AMD64 `osv-scanner` image, but it's still better than nothing