### PR TITLE
feat: guess the indentation for <dependency> element when writing XML

### DIFF
--- a/cmd/osv-scanner/fix/__snapshots__/command_test.snap
+++ b/cmd/osv-scanner/fix/__snapshots__/command_test.snap
@@ -3892,25 +3892,25 @@ Rewriting <tempdir>/pom.xml...
     <httpclient.version>4.5.13</httpclient.version>
   </properties>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>commons-io</groupId>
-        <artifactId>commons-io</artifactId>
-        <version>2.14.0</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jsoup</groupId>
-        <artifactId>jsoup</artifactId>
-        <version>1.15.3</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.httpcomponents</groupId>
-        <artifactId>httpclient</artifactId>
-        <version>${httpclient.version}</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
+    <dependencyManagement>
+      <dependencies>
+        <dependency>
+          <groupId>commons-io</groupId>
+          <artifactId>commons-io</artifactId>
+          <version>2.14.0</version>
+        </dependency>
+        <dependency>
+          <groupId>org.jsoup</groupId>
+          <artifactId>jsoup</artifactId>
+          <version>1.15.3</version>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+          <version>${httpclient.version}</version>
+        </dependency>
+      </dependencies>
+    </dependencyManagement>
 
   <dependencies>
     <dependency>
@@ -4082,25 +4082,25 @@ Rewriting <tempdir>/pom.xml...
     <httpclient.version>4.5.13</httpclient.version>
   </properties>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>commons-io</groupId>
-        <artifactId>commons-io</artifactId>
-        <version>2.14.0</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jsoup</groupId>
-        <artifactId>jsoup</artifactId>
-        <version>1.15.3</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.httpcomponents</groupId>
-        <artifactId>httpclient</artifactId>
-        <version>${httpclient.version}</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
+    <dependencyManagement>
+      <dependencies>
+        <dependency>
+          <groupId>commons-io</groupId>
+          <artifactId>commons-io</artifactId>
+          <version>2.14.0</version>
+        </dependency>
+        <dependency>
+          <groupId>org.jsoup</groupId>
+          <artifactId>jsoup</artifactId>
+          <version>1.15.3</version>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+          <version>${httpclient.version}</version>
+        </dependency>
+      </dependencies>
+    </dependencyManagement>
 
   <dependencies>
     <dependency>

--- a/cmd/osv-scanner/fix/fixtures/override-maven/pom.xml
+++ b/cmd/osv-scanner/fix/fixtures/override-maven/pom.xml
@@ -9,20 +9,20 @@
     <httpclient.version>4.0</httpclient.version>
   </properties>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.jsoup</groupId>
-        <artifactId>jsoup</artifactId>
-        <version>1.14.1</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.httpcomponents</groupId>
-        <artifactId>httpclient</artifactId>
-        <version>${httpclient.version}</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
+    <dependencyManagement>
+      <dependencies>
+        <dependency>
+          <groupId>org.jsoup</groupId>
+          <artifactId>jsoup</artifactId>
+          <version>1.14.1</version>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+          <version>${httpclient.version}</version>
+        </dependency>
+      </dependencies>
+    </dependencyManagement>
 
   <dependencies>
     <dependency>

--- a/internal/resolution/manifest/maven.go
+++ b/internal/resolution/manifest/maven.go
@@ -854,6 +854,32 @@ func writeProject(w io.Writer, enc *internalxml.Encoder, raw, prefix, id string,
 	return enc.Flush()
 }
 
+// indentation returns the indentation of the dependency element.
+// If dependencies or dependency elements are not found, the default
+// indentation (four space) is returned.
+func indentation(raw string) string {
+	i := strings.Index(raw, "<dependencies>")
+	if i < 0 {
+		return "    "
+	}
+
+	raw = raw[i+len("<dependencies>"):]
+	// Find the first dependency element.
+	j := strings.Index(raw, "<dependency>")
+	if j < 0 {
+		return "    "
+	}
+
+	raw = raw[:j]
+	// Find the last new line and get the space between.
+	k := strings.LastIndex(raw, "\n")
+	if k < 0 {
+		return "    "
+	}
+
+	return raw[k+1:]
+}
+
 func writeDependency(w io.Writer, enc *internalxml.Encoder, raw string, patches map[MavenPatch]bool) error {
 	dec := internalxml.NewDecoder(bytes.NewReader([]byte(raw)))
 	for {
@@ -889,7 +915,8 @@ func writeDependency(w io.Writer, enc *internalxml.Encoder, raw string, patches 
 				// Sort dependencies for consistency in testing.
 				slices.SortFunc(deps, compareDependency)
 
-				enc.Indent("      ", "  ")
+				enc.Indent(indentation(raw), "  ")
+
 				// Write a new line to keep the format.
 				if _, err := w.Write([]byte("\n")); err != nil {
 					return err


### PR DESCRIPTION
Currently we use the common indentation when writing `<dependency>` elements. This PR improves the writer behaviour by getting the indentation of the first `<dependency>` element in dependencies so the newly added XMLs are more readable.