### PR TITLE
fix: update pkg assignment in vulnerability_result

### DIFF
--- a/pkg/osvscanner/vulnerability_result.go
+++ b/pkg/osvscanner/vulnerability_result.go
@@ -50,12 +50,10 @@ func buildVulnerabilityResults(
 		}
 
 		if p.Version() != "" && !p.Ecosystem().IsEmpty() {
-			pkg.Package = models.PackageInfo{
-				Name:          p.Name(),
-				Version:       p.Version(),
-				Ecosystem:     p.Ecosystem().String(),
-				OSPackageName: p.OSPackageName(),
-			}
+			pkg.Package.Name = p.Name()
+			pkg.Package.Version = p.Version()
+			pkg.Package.Ecosystem = p.Ecosystem().String()
+			pkg.Package.OSPackageName = p.OSPackageName()
 		}
 
 		if psr.LayerDetails != nil {


### PR DESCRIPTION
https://github.com/google/osv-scanner/pull/1776 added inventory to `Package`, but this didn't actually work because the package was subsequently overwritten when assigned `pkg.Package` to a new struct. 

Updates the package assignment to prevent this issue in the future.