### PR TITLE
feat: adding stable tag to container images in release workflow and g…

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -43,7 +43,7 @@ jobs:
         # Extracts tag name from git ref and check tag is stable
         # semantic version pattern (MAJOR.MINOR.PATCH, e.g., 1.2.3)
         run: |
-          TAG="${GITHUB_REF#refs/tags/}"
+          TAG="${GITHUB_REF_NAME}"
           if [[ "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "STABLE=true" >> $GITHUB_ENV
           else

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -38,6 +38,17 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Detect stable tag
+        id: detect_stable
+        # Extracts tag name from git ref and check tag is stable
+        # semantic version pattern (MAJOR.MINOR.PATCH, e.g., 1.2.3)
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          if [[ "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "STABLE=true" >> $GITHUB_ENV
+          else
+            echo "STABLE=false" >> $GITHUB_ENV
+          fi
       - name: Run GoReleaser
         id: run-goreleaser
         uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # v6.3.0
@@ -47,6 +58,7 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          STABLE: ${{ env.STABLE }}
       - name: Generate subject
         id: hash
         env:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -140,6 +140,11 @@ docker_manifests:
     image_templates:
       - "ghcr.io/google/osv-scanner:{{ .Tag }}-amd64"
       - "ghcr.io/google/osv-scanner:{{ .Tag }}-arm64"
+  - name_template: "ghcr.io/google/osv-scanner:stable"
+    image_templates:
+      - "ghcr.io/google/osv-scanner:{{ .Tag }}-amd64"
+      - "ghcr.io/google/osv-scanner:{{ .Tag }}-arm64"
+    skip_push: "{{ ne .Env.STABLE `true` }}"
 
 archives:
   - formats: binary


### PR DESCRIPTION
# Description

This Pull Request resolves #1563 by ensuring that the `stable` Docker tag is only created for properly versioned tags following Semantic Versioning in the format `MAJOR.MINOR.PATCH` (e.g., `2.0.0`). Tags such as `v2.0.0`, `2.0.0-beta`, or any non-compliant version will not be considered stable.

# Changes

- Added step in `goreleaser.yml` (GitHub Actions release workflow) to detect whether the current tag is a **stable semantic version** with the help of regex, the result is stored in the `STABLE` environment variable.
- In `.goreleaser.yml` file, added `docker_manifests` entry for the `stable` tag and used `skip_push` to skip pushing docker manifests in amd64 and arm64 of osv-scanner image when the `STABLE` environment variable is false.


