### PR TITLE
ci: only fail `docker` job if we get a non-zero exit code that does not mean "no vulns found"

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -166,6 +166,14 @@ jobs:
             .extra.DockerConfig.dockerfile == "goreleaser.dockerfile"
           ) | .name' output.json | while read -r image; do
             echo "Testing image $image"
+
             docker run $image -h
-            docker run -v ${PWD}:/src $image -L /src/go.mod
+
+            exit_code=0
+            docker run -v ${PWD}:/src $image -L /src/go.mod || exit_code=$?
+
+            # fail if we get a non-zero exit code other than "vulnerabilities were found"
+            if [[ $exit_code -ne 0 && $exit_code -ne 1  ]]; then
+              exit $exit_code
+            fi
           done


### PR DESCRIPTION
While we generally shouldn't have any vulnerabilities, it does sometimes happen due to merge delays or false positives, so we shouldn't fail this job as a result of that as it's just using our root `go.mod` to verify the image is working.

Note that by default GitHub Actions runs inline commands with `bash -e` meaning we need to extract the exit code on the same line rather than getting it afterwards