### PR TITLE
docs: make headers and titles consistent

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,11 +1,10 @@
 ---
 layout: page
-title: Configuration
 permalink: /configuration/
 nav_order: 5
 ---
 
-# Configure OSV-Scanner
+# Configuration
 
 To configure scanning, place an osv-scanner.toml file in the scanned file's directory. This does not propagate to child directories.
 

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -1,6 +1,5 @@
 ---
 layout: page
-title: Contribute
 permalink: /contribute/
 nav_order: 9
 ---

--- a/docs/experimental.md
+++ b/docs/experimental.md
@@ -1,6 +1,5 @@
 ---
 layout: page
-title: Experimental Features
 permalink: /experimental/
 nav_order: 8
 has_children: true

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -1,6 +1,5 @@
 ---
 layout: page
-title: GitHub Action
 permalink: /github-action/
 nav_order: 7
 ---

--- a/docs/guided-remediation.md
+++ b/docs/guided-remediation.md
@@ -1,6 +1,5 @@
 ---
 layout: page
-title: Guided Remediation
 permalink: /experimental/guided-remediation/
 parent: Experimental Features
 nav_order: 3

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,5 @@
 ---
 layout: page
-title: Installation
 permalink: /installation/
 nav_order: 3
 ---

--- a/docs/license-scanning.md
+++ b/docs/license-scanning.md
@@ -1,6 +1,5 @@
 ---
 layout: page
-title: License Scanning
 permalink: /usage/license-scanning/
 parent: Usage
 nav_order: 3

--- a/docs/offline-mode.md
+++ b/docs/offline-mode.md
@@ -1,6 +1,5 @@
 ---
 layout: page
-title: Offline Mode
 permalink: /usage/offline-mode/
 parent: Usage
 nav_order: 4

--- a/docs/output.md
+++ b/docs/output.md
@@ -1,6 +1,5 @@
 ---
 layout: page
-title: Output
 permalink: /output/
 nav_order: 6
 ---

--- a/docs/scan-image.md
+++ b/docs/scan-image.md
@@ -1,6 +1,5 @@
 ---
 layout: page
-title: Container Image Scanning
 parent: Usage
 permalink: /usage/scan-image
 nav_order: 1

--- a/docs/scan-source.md
+++ b/docs/scan-source.md
@@ -1,12 +1,11 @@
 ---
 layout: page
-title: Project Source Scanning
 parent: Usage
 permalink: /usage/scan-source
 nav_order: 2
 ---
 
-# Source Scanning
+# Project Source Scanning
 
 OSV-Scanner can be used to scan your project source and lockfiles to find vulnerabilities in your dependencies.
 

--- a/docs/supported_languages_and_lockfiles.md
+++ b/docs/supported_languages_and_lockfiles.md
@@ -1,6 +1,5 @@
 ---
 layout: page
-title: Supported Artifacts and Manifests
 permalink: /supported-languages-and-lockfiles/
 nav_order: 2
 ---

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,11 +1,10 @@
 ---
 layout: page
-title: Usage
 permalink: /usage/
 nav_order: 4
 ---
 
-# Usage Guide
+# Usage
 
 {: .note }
 This documentation is for the beta V2 release. For the older, V1 release documentation, check out <https://google.github.io/osv-scanner-v1>.


### PR DESCRIPTION
Since Jekyll uses the first header element it finds in the markdown as the title, we don't need to repeat it in the frontmatter of every doc