### PR TITLE
docs: remove references to v2 beta

### DIFF
--- a/docs/output.md
+++ b/docs/output.md
@@ -115,9 +115,6 @@ And additionally for container image scanning:
 - Image layer information
 - Base image identification
 
-{: .note }
-This feature is in beta as part of OSV-Scanner v2, please [share your feedback here](https://github.com/google/osv-scanner/discussions/1529).
-
 <details markdown="1">
 <summary><b>Sample HTML output</b></summary>
 

--- a/docs/scan-image.md
+++ b/docs/scan-image.md
@@ -19,9 +19,6 @@ nav_order: 1
 {:toc}
 </details>
 
-{: .note }
-This feature is in beta, please share your feedback here: <https://github.com/google/osv-scanner/discussions/1521>
-
 OSV-Scanner analyzes container images by extracting package information and matching it against known vulnerabilities in the OSV.dev database. This helps identify potential security risks in your containerized applications.
 
 ### Prerequisites

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -8,7 +8,7 @@ nav_order: 4
 # Usage Guide
 
 {: .note }
-This documentation is for the beta V2 release. For the older, V1 release documentation, check out <https://google.github.io/osv-scanner-v1>.
+This documentation is for the V2 release. For the older, V1 release documentation, check out <https://google.github.io/osv-scanner-v1>.
 
 {: .no_toc }
 


### PR DESCRIPTION
Let me know if there's any discussion links we're like to restore