### PR TITLE
chore: have Prettier ignore generated sites files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,4 +2,5 @@
 **/testdata/**
 **/fixtures-go/**
 /docs/vendor/**
+/docs/_sites/**
 /internal/output/html/*.gohtml


### PR DESCRIPTION
These don't need to be formatted