### PR TITLE
chore: disable link checker for some specific links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,6 +117,7 @@ Please follow these steps to successfully contribute documentation.
 1. Fork the repository.
 2. Make desired documentation changes.
 3. Preview the changes by spinning up a GitHub page for your fork, building from your working branch.
+   <!-- markdown-link-check-disable-next-line -->
    - On your fork, go to the settings tab and then the GitHub page settings. Sample URL: https://github.com/{your-github-profile}/osv-scanner/settings/pages
    - Under "Build and deployment" select "Deploy from a branch"
    - Set the branch to your working branch

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 <picture>
     <source srcset="/docs/images/osv-scanner-full-logo-darkmode.svg"  media="(prefers-color-scheme: dark)">
+    <!-- markdown-link-check-disable-next-line -->
     <img src="/docs/images/osv-scanner-full-logo-lightmode.svg">
 </picture>
 

--- a/docs/guided-remediation.md
+++ b/docs/guided-remediation.md
@@ -38,11 +38,11 @@ This feature is experimental and might change or be removed with only a minor ve
 
 We currently support remediating vulnerabilities in the following files:
 
-| Ecosystem | File Format (Type)                               | Supported [Remediation Strategies](#remediation-strategies) |
-| :-------- | :----------------------------------------------- | :---------------------------------------------------------- |
-| npm       | `package-lock.json` (lockfile)                   | [`in-place`](#in-place-lockfile-changes)                    |
-| npm       | `package.json` (manifest)                        | [`relock`](#relock-and-relax-direct-dependencies)           |
-| Maven     | `pom.xml` (manifest)<sup>[note](#pom-note)</sup> | [`override`](#override-dependency-versions)                 |
+| Ecosystem | File Format (Type)                                                                        | Supported [Remediation Strategies](#remediation-strategies) |
+| :-------- | :---------------------------------------------------------------------------------------- | :---------------------------------------------------------- |
+| npm       | `package-lock.json` (lockfile)                                                            | [`in-place`](#in-place-lockfile-changes)                    |
+| npm       | `package.json` (manifest)                                                                 | [`relock`](#relock-and-relax-direct-dependencies)           |
+| Maven     | `pom.xml` (manifest)<sup><!-- markdown-link-check-disable-line -->[note](#pom-note)</sup> | [`override`](#override-dependency-versions)                 |
 
 {: .note #pom-note}
 By default, the tool only checks dependencies that are actually present in a POM's dependency graph - it will not detect vulnerabilities in `<dependencyManagement>` dependencies if they are not actually used when resolving the POM. The [`--maven-fix-management`](#maven-flags) flag can be used to also fix them.


### PR DESCRIPTION
* `CONTRIBUTING.md`: this link is not expected to exist, as it's an example with a placeholder
* `README.md`: technically it's an absolute URL, but it's in HTML and ultimately I didn't want to mess with it since GitHub and IntelliJ both seem to resolve it correctly
* `docs/guided-remediation.md`: the hash is rendered by the `.note` helper which the checker cannot understand