### PR TITLE
test: Don't parallel the one test that can't be parallel

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -132,10 +132,6 @@ linters:
       - linters:
           - dupl
         path: _test\.go
-      - linters:
-          - tparallel
-          - paralleltest
-        path: cmd/osv-scanner/main_test.go
     paths:
       - internal/thirdparty/
       - third_party$

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -132,6 +132,10 @@ linters:
       - linters:
           - dupl
         path: _test\.go
+      - linters:
+         - tparallel
+         - paralleltest
+        path: cmd/osv-scanner/main_test.go
     paths:
       - internal/thirdparty/
       - third_party$

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -133,8 +133,8 @@ linters:
           - dupl
         path: _test\.go
       - linters:
-         - tparallel
-         - paralleltest
+          - tparallel
+          - paralleltest
         path: cmd/osv-scanner/main_test.go
     paths:
       - internal/thirdparty/

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -22,10 +22,10 @@ func Test_run(t *testing.T) {
 			Exit: 0,
 		},
 	}
+
+	// No parallel because --version output is not thread safe.
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
-			t.Parallel()
-
 			testcmd.RunAndMatchSnapshots(t, tt)
 		})
 	}

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/osv-scanner/v2/cmd/osv-scanner/internal/testcmd"
 )
 
-//nolint:tparallel,paralleltest
+//nolint:paralleltest
 func Test_run(t *testing.T) {
 	tests := []testcmd.Case{
 		{

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -9,8 +9,6 @@ import (
 
 //nolint:tparallel,paralleltest
 func Test_run(t *testing.T) {
-	t.Parallel()
-
 	tests := []testcmd.Case{
 		{
 			Name: "",

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/osv-scanner/v2/cmd/osv-scanner/internal/testcmd"
 )
 
+//nolint:tparallel,paralleltest
 func Test_run(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fix the version and help output not being thread safe by avoiding parallel for that test.

Reasoning:
cli.VersionPrinter is a global variable that gets overwritten every .Run call with a new function. I'm still not too clear on why that would cause the logs to be messed up though.