### PR TITLE
fix: Add ubuntu namespace to dep type of purl

### DIFF
--- a/internal/utility/purl/purl_to_package.go
+++ b/internal/utility/purl/purl_to_package.go
@@ -11,7 +11,8 @@ import (
 var purlEcosystems = map[string]map[string]osvschema.Ecosystem{
 	"apk":      {"alpine": osvschema.EcosystemAlpine},
 	"cargo":    {"*": osvschema.EcosystemCratesIO},
-	"deb":      {"debian": osvschema.EcosystemDebian},
+	"deb":      {"debian": osvschema.EcosystemDebian,
+		         "ubuntu": osvschema.EcosystemUbuntu},
 	"hex":      {"*": osvschema.EcosystemHex},
 	"golang":   {"*": osvschema.EcosystemGo},
 	"maven":    {"*": osvschema.EcosystemMaven},
@@ -57,7 +58,7 @@ func ToPackage(purl string) (models.PackageInfo, error) {
 		case osvschema.EcosystemMaven:
 			// Maven uses : to separate namespace and package
 			name = parsedPURL.Namespace + ":" + parsedPURL.Name
-		case osvschema.EcosystemDebian, osvschema.EcosystemAlpine:
+		case osvschema.EcosystemDebian, osvschema.EcosystemAlpine, osvschema.EcosystemUbuntu:
 			// Debian and Alpine repeats their namespace in PURL, so don't add it to the name
 			name = parsedPURL.Name
 		default:

--- a/internal/utility/purl/purl_to_package_test.go
+++ b/internal/utility/purl/purl_to_package_test.go
@@ -65,6 +65,17 @@ func TestPURLToPackage(t *testing.T) {
 			},
 		},
 		{
+			name: "valid PURL Ubuntu",
+			args: args{
+				purl: "pkg:deb/ubuntu/docker.io@20.10.12-0ubuntu2",
+			},
+			want: models.PackageInfo{
+				Name:      "docker.io",
+				Version:   "20.10.12-0ubuntu2",
+				Ecosystem: string(osvschema.EcosystemUbuntu),
+			},
+		},
+		{
 			name: "valid PURL alpine",
 			args: args{
 				purl: "pkg:apk/alpine/zlib@1.2.13-r0?arch=x86_64upstream=zlib&distro=alpine-3.17.2",


### PR DESCRIPTION
Hi! I've added "ubuntu" namespace to deb type. Osv-scanner could not parse my custom dpkg BOM generated with osv-scalibr on Ubuntu system.