### PR TITLE
test(cmd): use package-local fixtures for extractor cases

### DIFF
--- a/cmd/osv-scanner/scan/source/__snapshots__/command_test.snap
+++ b/cmd/osv-scanner/scan/source/__snapshots__/command_test.snap
@@ -1244,10 +1244,10 @@ at least one extractor must be enabled
 ---
 
 [TestCommand_ExplicitExtractors/scanning_directory_with_a_couple_of_specific_extractors_enabled_individually - 1]
-Scanning dir ../../fixtures/locks-many
-Scanned <rootdir>/osv-scanner/fixtures/locks-many/composer.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/fixtures/locks-many/package-lock.json file and found 1 package
-Loaded filter from: <rootdir>/osv-scanner/fixtures/locks-many/osv-scanner.toml
+Scanning dir ./fixtures/locks-many
+Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/composer.lock file and found 1 package
+Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/package-lock.json file and found 1 package
+Loaded filter from: <rootdir>/osv-scanner/scan/source/fixtures/locks-many/osv-scanner.toml
 GHSA-whgm-jr23-g3j9 and 1 alias have been filtered out because: Test manifest file
 Filtered 1 vulnerability from output
 No issues found
@@ -1259,10 +1259,10 @@ No issues found
 ---
 
 [TestCommand_ExplicitExtractors/scanning_directory_with_a_couple_of_specific_extractors_enabled_specified_together - 1]
-Scanning dir ../../fixtures/locks-many
-Scanned <rootdir>/osv-scanner/fixtures/locks-many/composer.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/fixtures/locks-many/package-lock.json file and found 1 package
-Loaded filter from: <rootdir>/osv-scanner/fixtures/locks-many/osv-scanner.toml
+Scanning dir ./fixtures/locks-many
+Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/composer.lock file and found 1 package
+Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/package-lock.json file and found 1 package
+Loaded filter from: <rootdir>/osv-scanner/scan/source/fixtures/locks-many/osv-scanner.toml
 GHSA-whgm-jr23-g3j9 and 1 alias have been filtered out because: Test manifest file
 Filtered 1 vulnerability from output
 No issues found
@@ -1274,9 +1274,9 @@ No issues found
 ---
 
 [TestCommand_ExplicitExtractors/scanning_directory_with_an_extractor_that_does_not_exist - 1]
-Scanning dir ../../fixtures/locks-many
-Scanned <rootdir>/osv-scanner/fixtures/locks-many/package-lock.json file and found 1 package
-Loaded filter from: <rootdir>/osv-scanner/fixtures/locks-many/osv-scanner.toml
+Scanning dir ./fixtures/locks-many
+Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/package-lock.json file and found 1 package
+Loaded filter from: <rootdir>/osv-scanner/scan/source/fixtures/locks-many/osv-scanner.toml
 GHSA-whgm-jr23-g3j9 and 1 alias have been filtered out because: Test manifest file
 Filtered 1 vulnerability from output
 
@@ -1288,13 +1288,13 @@ Unknown extractor custom/extractor
 ---
 
 [TestCommand_ExplicitExtractors/scanning_directory_with_one_specific_extractor_disabled - 1]
-Scanning dir ../../fixtures/locks-many
-Scanned <rootdir>/osv-scanner/fixtures/locks-many/Gemfile.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/fixtures/locks-many/alpine.cdx.xml file and found 15 packages
-Scanned <rootdir>/osv-scanner/fixtures/locks-many/composer.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/fixtures/locks-many/yarn.lock file and found 1 package
+Scanning dir ./fixtures/locks-many
+Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/Gemfile.lock file and found 1 package
+Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/alpine.cdx.xml file and found 15 packages
+Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/composer.lock file and found 1 package
+Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/yarn.lock file and found 1 package
 Filtered 1 local/unscannable package/s from the scan.
-Loaded filter from: <rootdir>/osv-scanner/fixtures/locks-many/osv-scanner.toml
+Loaded filter from: <rootdir>/osv-scanner/scan/source/fixtures/locks-many/osv-scanner.toml
 CVE-2025-26519 has been filtered out because: Test manifest file (alpine.cdx.xml)
 Filtered 1 vulnerability from output
 No issues found
@@ -1306,9 +1306,9 @@ No issues found
 ---
 
 [TestCommand_ExplicitExtractors/scanning_directory_with_one_specific_extractor_enabled - 1]
-Scanning dir ../../fixtures/locks-many
-Scanned <rootdir>/osv-scanner/fixtures/locks-many/package-lock.json file and found 1 package
-Loaded filter from: <rootdir>/osv-scanner/fixtures/locks-many/osv-scanner.toml
+Scanning dir ./fixtures/locks-many
+Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/package-lock.json file and found 1 package
+Loaded filter from: <rootdir>/osv-scanner/scan/source/fixtures/locks-many/osv-scanner.toml
 GHSA-whgm-jr23-g3j9 and 1 alias have been filtered out because: Test manifest file
 Filtered 1 vulnerability from output
 No issues found
@@ -1320,7 +1320,7 @@ No issues found
 ---
 
 [TestCommand_ExplicitExtractors/scanning_file_with_one_different_extractor_enabled - 1]
-Scanning dir ../../fixtures/locks-many/composer.lock
+Scanning dir ./fixtures/locks-many/composer.lock
 
 ---
 
@@ -1330,9 +1330,9 @@ No package sources found, --help for usage information.
 ---
 
 [TestCommand_ExplicitExtractors/scanning_file_with_one_specific_extractor_enabled - 1]
-Scanning dir ../../fixtures/locks-many/package-lock.json
-Scanned <rootdir>/osv-scanner/fixtures/locks-many/package-lock.json file and found 1 package
-Loaded filter from: <rootdir>/osv-scanner/fixtures/locks-many/osv-scanner.toml
+Scanning dir ./fixtures/locks-many/package-lock.json
+Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/package-lock.json file and found 1 package
+Loaded filter from: <rootdir>/osv-scanner/scan/source/fixtures/locks-many/osv-scanner.toml
 GHSA-whgm-jr23-g3j9 and 1 alias have been filtered out because: Test manifest file
 Filtered 1 vulnerability from output
 No issues found

--- a/cmd/osv-scanner/scan/source/command_test.go
+++ b/cmd/osv-scanner/scan/source/command_test.go
@@ -289,7 +289,7 @@ func TestCommand_ExplicitExtractors(t *testing.T) {
 			Args: []string{
 				"", "source",
 				"--experimental-extractors=javascript/packagelockjson",
-				"../../fixtures/locks-many",
+				"./fixtures/locks-many",
 			},
 			Exit: 0,
 		},
@@ -300,7 +300,7 @@ func TestCommand_ExplicitExtractors(t *testing.T) {
 				"--experimental-extractors=javascript/packagelockjson",
 				"--experimental-extractors=custom/extractor",
 				"--experimental-disable-extractors=custom/anotherextractor",
-				"../../fixtures/locks-many",
+				"./fixtures/locks-many",
 			},
 			Exit: 127,
 		},
@@ -312,7 +312,7 @@ func TestCommand_ExplicitExtractors(t *testing.T) {
 				"", "source",
 				"--experimental-extractors=javascript/packagelockjson",
 				"--experimental-extractors=php/composerlock",
-				"../../fixtures/locks-many",
+				"./fixtures/locks-many",
 			},
 			Exit: 0,
 		},
@@ -323,7 +323,7 @@ func TestCommand_ExplicitExtractors(t *testing.T) {
 			Args: []string{
 				"", "source",
 				"--experimental-extractors=javascript/packagelockjson,php/composerlock",
-				"../../fixtures/locks-many",
+				"./fixtures/locks-many",
 			},
 			Exit: 0,
 		},
@@ -334,7 +334,7 @@ func TestCommand_ExplicitExtractors(t *testing.T) {
 			Args: []string{
 				"", "source",
 				"--experimental-disable-extractors=javascript/packagelockjson",
-				"../../fixtures/locks-many",
+				"./fixtures/locks-many",
 			},
 			Exit: 0,
 		},
@@ -345,7 +345,7 @@ func TestCommand_ExplicitExtractors(t *testing.T) {
 			Args: []string{
 				"", "source",
 				"--experimental-extractors=javascript/packagelockjson",
-				"../../fixtures/locks-many/package-lock.json",
+				"./fixtures/locks-many/package-lock.json",
 			},
 			Exit: 0,
 		},
@@ -356,7 +356,7 @@ func TestCommand_ExplicitExtractors(t *testing.T) {
 			Args: []string{
 				"", "source",
 				"--experimental-extractors=javascript/packagelockjson",
-				"../../fixtures/locks-many/composer.lock",
+				"./fixtures/locks-many/composer.lock",
 			},
 			Exit: 128,
 		},
@@ -368,7 +368,7 @@ func TestCommand_ExplicitExtractors(t *testing.T) {
 			Args: []string{
 				"", "source",
 				"--experimental-disable-extractors=javascript/packagelockjson",
-				"-L", "package-lock.json:../../fixtures/locks-many/composer.lock",
+				"-L", "package-lock.json:./fixtures/locks-many/composer.lock",
 			},
 			Exit: 127,
 		},


### PR DESCRIPTION
I'm just going to assume this was because my extractors implementation predated when I moved the fixtures around 😅 

Relates to #1920 and #1896