### PR TITLE
fix: prevent panic when batchResp is nil in MatchVulnerabilities

### DIFF
--- a/internal/clients/clientimpl/osvmatcher/osvmatcher.go
+++ b/internal/clients/clientimpl/osvmatcher/osvmatcher.go
@@ -58,7 +58,7 @@ func (matcher *OSVMatcher) MatchVulnerabilities(ctx context.Context, pkgs []*ext
 			}
 		}
 
-		// No results found - this could be due to a timeout or no vulnerabilities being found
+		// No results found - this could be due to a timeout
 		if batchResp == nil {
 			return nil, err
 		}

--- a/internal/clients/clientimpl/osvmatcher/osvmatcher.go
+++ b/internal/clients/clientimpl/osvmatcher/osvmatcher.go
@@ -28,6 +28,7 @@ type OSVMatcher struct {
 	InitialQueryTimeout time.Duration
 }
 
+// MatchVulnerabilities matches vulnerabilities for a list of packages.
 func (matcher *OSVMatcher) MatchVulnerabilities(ctx context.Context, pkgs []*extractor.Package) ([][]*osvschema.Vulnerability, error) {
 	var batchResp *osvdev.BatchedResponse
 	deadlineExceeded := false
@@ -55,6 +56,11 @@ func (matcher *OSVMatcher) MatchVulnerabilities(ctx context.Context, pkgs []*ext
 			} else {
 				return nil, err
 			}
+		}
+
+		// No results found - this could be due to a timeout or no vulnerabilities being found
+		if batchResp == nil {
+			return nil, err
 		}
 	}
 

--- a/internal/clients/clientimpl/osvmatcher/osvmatcher_test.go
+++ b/internal/clients/clientimpl/osvmatcher/osvmatcher_test.go
@@ -15,13 +15,14 @@ import (
 )
 
 func TestOSVMatcher_MatchVulnerabilities(t *testing.T) {
+	t.Parallel()
+
 	type fields struct {
 		Client              osvdev.OSVClient
 		InitialQueryTimeout time.Duration
 	}
 
 	type args struct {
-		ctx  context.Context
 		pkgs []*extractor.Package
 	}
 
@@ -39,7 +40,6 @@ func TestOSVMatcher_MatchVulnerabilities(t *testing.T) {
 				InitialQueryTimeout: 1 * time.Millisecond,
 			},
 			args: args{
-				ctx: context.Background(),
 				pkgs: []*extractor.Package{
 					{
 						Name:    "lib1",
@@ -55,15 +55,18 @@ func TestOSVMatcher_MatchVulnerabilities(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
+	for i := range tests {
+		tt := tests[i]
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			matcher := &OSVMatcher{
 				Client:              tt.fields.Client,
 				InitialQueryTimeout: tt.fields.InitialQueryTimeout,
 			}
 
-			got, err := matcher.MatchVulnerabilities(tt.args.ctx, tt.args.pkgs)
-			if err != tt.wantErr && !errors.Is(err, tt.wantErr) {
+			got, err := matcher.MatchVulnerabilities(t.Context(), tt.args.pkgs)
+			if !errors.Is(err, tt.wantErr) {
 				t.Errorf("OSVMatcher.MatchVulnerabilities() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}

--- a/internal/clients/clientimpl/osvmatcher/osvmatcher_test.go
+++ b/internal/clients/clientimpl/osvmatcher/osvmatcher_test.go
@@ -1,0 +1,76 @@
+package osvmatcher
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/ossf/osv-schema/bindings/go/osvschema"
+	"osv.dev/bindings/go/osvdev"
+
+	"github.com/google/osv-scanner/v2/internal/scalibrextract/ecosystemmock"
+)
+
+func TestOSVMatcher_MatchVulnerabilities(t *testing.T) {
+	type fields struct {
+		Client              osvdev.OSVClient
+		InitialQueryTimeout time.Duration
+	}
+
+	type args struct {
+		ctx  context.Context
+		pkgs []*extractor.Package
+	}
+
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    [][]*osvschema.Vulnerability
+		wantErr error
+	}{
+		{
+			name: "Timeout returns deadline exceeded error",
+			fields: fields{
+				Client:              *osvdev.DefaultClient(),
+				InitialQueryTimeout: 1 * time.Millisecond,
+			},
+			args: args{
+				ctx: context.Background(),
+				pkgs: []*extractor.Package{
+					{
+						Name:    "lib1",
+						Version: "1.0.1",
+						Extractor: ecosystemmock.Extractor{
+							MockEcosystem: "Go",
+						},
+					},
+				},
+			},
+			want:    nil,
+			wantErr: context.DeadlineExceeded,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matcher := &OSVMatcher{
+				Client:              tt.fields.Client,
+				InitialQueryTimeout: tt.fields.InitialQueryTimeout,
+			}
+
+			got, err := matcher.MatchVulnerabilities(tt.args.ctx, tt.args.pkgs)
+			if err != tt.wantErr && !errors.Is(err, tt.wantErr) {
+				t.Errorf("OSVMatcher.MatchVulnerabilities() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("OSVMatcher.MatchVulnerabilities() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Problem
The `MatchVulnerabilities` method in `osvmatcher.go` could panic when accessing `batchResp.Results` if `batchResp` is nil.

### Solution
- Added nil check for `batchResp` before accessing its `Results` field

### Testing
- Added test case `"Timeout returns deadline exceeded error"` to verify the timeout behavior
- Test ensures the method returns `context.DeadlineExceeded` error without panicking

### Changes
- `internal/clients/clientimpl/osvmatcher/osvmatcher.go`: Added nil check and documentation
- `internal/clients/clientimpl/osvmatcher/osvmatcher_test.go`: New test file with timeout test case
