### PR TITLE
refactor: omit embedded field from accessor chain

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -113,7 +113,6 @@ linters:
       checks:
         - all
         - -QF1006 # lift into loop condition
-        - -QF1008 # remove embedded field from selector
   exclusions:
     generated: lax
     presets:

--- a/cmd/osv-scanner/fix/noninteractive.go
+++ b/cmd/osv-scanner/fix/noninteractive.go
@@ -295,7 +295,7 @@ func autoOverride(ctx context.Context, opts osvFixOptions, maxUpgrades int) erro
 					SnapshotsEnabled: repo.Snapshots.Enabled.Boolean(),
 				}
 			}
-			if err := opts.Client.DependencyClient.AddRegistries(registries); err != nil {
+			if err := opts.Client.AddRegistries(registries); err != nil {
 				return err
 			}
 		}

--- a/internal/imodels/imodels.go
+++ b/internal/imodels/imodels.go
@@ -83,7 +83,7 @@ func (pkg *PackageInfo) Name() string {
 	}
 
 	// Patch Maven archive extractor package names
-	if metadata, ok := pkg.Package.Metadata.(*archivemetadata.Metadata); ok {
+	if metadata, ok := pkg.Metadata.(*archivemetadata.Metadata); ok {
 		// Debian uses source name on osv.dev
 		// (fallback to using the normal name if source name is empty)
 		if metadata.ArtifactID != "" && metadata.GroupID != "" {
@@ -92,7 +92,7 @@ func (pkg *PackageInfo) Name() string {
 	}
 
 	// --- OS metadata ---
-	if metadata, ok := pkg.Package.Metadata.(*dpkgmetadata.Metadata); ok {
+	if metadata, ok := pkg.Metadata.(*dpkgmetadata.Metadata); ok {
 		// Debian uses source name on osv.dev
 		// (fallback to using the normal name if source name is empty)
 		if metadata.SourceName != "" {
@@ -100,7 +100,7 @@ func (pkg *PackageInfo) Name() string {
 		}
 	}
 
-	if metadata, ok := pkg.Package.Metadata.(*apkmetadata.Metadata); ok {
+	if metadata, ok := pkg.Metadata.(*apkmetadata.Metadata); ok {
 		if metadata.OriginName != "" {
 			return metadata.OriginName
 		}
@@ -158,27 +158,27 @@ func (pkg *PackageInfo) Version() string {
 }
 
 func (pkg *PackageInfo) Location() string {
-	if len(pkg.Package.Locations) > 0 {
-		return pkg.Package.Locations[0]
+	if len(pkg.Locations) > 0 {
+		return pkg.Locations[0]
 	}
 
 	return ""
 }
 
 func (pkg *PackageInfo) Commit() string {
-	if pkg.Package.SourceCode != nil {
-		return pkg.Package.SourceCode.Commit
+	if pkg.SourceCode != nil {
+		return pkg.SourceCode.Commit
 	}
 
 	return ""
 }
 
 func (pkg *PackageInfo) SourceType() models.SourceType {
-	if len(pkg.Package.Plugins) == 0 {
+	if len(pkg.Plugins) == 0 {
 		return models.SourceTypeUnknown
 	}
 
-	for _, extractorName := range pkg.Package.Plugins {
+	for _, extractorName := range pkg.Plugins {
 		if _, ok := osExtractors[extractorName]; ok {
 			return models.SourceTypeOSPackage
 		} else if _, ok := sbomExtractors[extractorName]; ok {
@@ -194,7 +194,7 @@ func (pkg *PackageInfo) SourceType() models.SourceType {
 }
 
 func (pkg *PackageInfo) DepGroups() []string {
-	if dg, ok := pkg.Package.Metadata.(scalibrosv.DepGroups); ok {
+	if dg, ok := pkg.Metadata.(scalibrosv.DepGroups); ok {
 		return dg.DepGroups()
 	}
 
@@ -202,13 +202,13 @@ func (pkg *PackageInfo) DepGroups() []string {
 }
 
 func (pkg *PackageInfo) OSPackageName() string {
-	if metadata, ok := pkg.Package.Metadata.(*apkmetadata.Metadata); ok {
+	if metadata, ok := pkg.Metadata.(*apkmetadata.Metadata); ok {
 		return metadata.PackageName
 	}
-	if metadata, ok := pkg.Package.Metadata.(*dpkgmetadata.Metadata); ok {
+	if metadata, ok := pkg.Metadata.(*dpkgmetadata.Metadata); ok {
 		return metadata.PackageName
 	}
-	if metadata, ok := pkg.Package.Metadata.(*rpmmetadata.Metadata); ok {
+	if metadata, ok := pkg.Metadata.(*rpmmetadata.Metadata); ok {
 		return metadata.PackageName
 	}
 

--- a/internal/remediation/override.go
+++ b/internal/remediation/override.go
@@ -239,7 +239,7 @@ func overridePatchVulns(ctx context.Context, cl client.ResolutionClient, result 
 
 	// Sort the patches for deterministic output.
 	slices.SortFunc(effectivePatches, func(a, b overridePatch) int {
-		if c := a.PackageKey.Compare(b.PackageKey); c != 0 {
+		if c := a.Compare(b.PackageKey); c != 0 {
 			return c
 		}
 

--- a/internal/resolution/manifest/maven.go
+++ b/internal/resolution/manifest/maven.go
@@ -83,7 +83,7 @@ func (m MavenReadWriter) Read(df depfile.DepFile) (Manifest, error) {
 			VersionKey: resolve.VersionKey{
 				PackageKey: resolve.PackageKey{
 					System: resolve.Maven,
-					Name:   project.Parent.ProjectKey.Name(),
+					Name:   project.Parent.Name(),
 				},
 				// Parent version is a concrete version, but we model parent as dependency here.
 				VersionType: resolve.Requirement,
@@ -100,7 +100,7 @@ func (m MavenReadWriter) Read(df depfile.DepFile) (Manifest, error) {
 
 	// TODO: there may be properties in repo.Releases.Enabled and repo.Snapshots.Enabled
 	for _, repo := range project.Repositories {
-		if err := m.MavenRegistryAPIClient.AddRegistry(datasource.MavenRegistry{
+		if err := m.AddRegistry(datasource.MavenRegistry{
 			URL:              string(repo.URL),
 			ID:               string(repo.ID),
 			ReleasesEnabled:  repo.Releases.Enabled.Boolean(),
@@ -243,7 +243,7 @@ func buildOriginalRequirements(project maven.Project, originPrefix string) []Dep
 		for _, d := range plugin.Dependencies {
 			dependencies = append(dependencies, DependencyWithOrigin{
 				Dependency: d,
-				Origin:     mavenOrigin(originPrefix, mavenutil.OriginPlugin, plugin.ProjectKey.Name()),
+				Origin:     mavenOrigin(originPrefix, mavenutil.OriginPlugin, plugin.Name()),
 			})
 		}
 	}
@@ -805,7 +805,7 @@ func writeProject(w io.Writer, enc *internalxml.Encoder, raw, prefix, id string,
 				if err := dec.DecodeElement(&rawPlugin, &tt); err != nil {
 					return err
 				}
-				if err := writeProject(w, enc, "<plugin>"+rawPlugin.InnerXML+"</plugin>", mavenutil.OriginPlugin, rawPlugin.ProjectKey.Name(), patches, properties, updated); err != nil {
+				if err := writeProject(w, enc, "<plugin>"+rawPlugin.InnerXML+"</plugin>", mavenutil.OriginPlugin, rawPlugin.Name(), patches, properties, updated); err != nil {
 					return fmt.Errorf("updating profile: %w", err)
 				}
 

--- a/internal/testutility/mock_http.go
+++ b/internal/testutility/mock_http.go
@@ -25,7 +25,7 @@ func NewMockHTTPServer(t *testing.T) *MockHTTPServer {
 	t.Helper()
 	mock := &MockHTTPServer{response: make(map[string][]byte)}
 	mock.Server = httptest.NewServer(mock)
-	t.Cleanup(func() { mock.Server.Close() })
+	t.Cleanup(func() { mock.Close() })
 
 	return mock
 }

--- a/internal/tui/in-place-info.go
+++ b/internal/tui/in-place-info.go
@@ -120,7 +120,7 @@ func (ip *inPlaceInfo) Update(msg tea.Msg) (ViewModel, tea.Cmd) {
 		case key.Matches(msg, Keys.Quit):
 			return ip, CloseViewModel
 		case key.Matches(msg, Keys.Select):
-			vuln := ip.vulns[ip.Model.Cursor()]
+			vuln := ip.vulns[ip.Cursor()]
 			ip.currVulnInfo = NewVulnInfo(vuln)
 			ip.currVulnInfo.Resize(ip.Width(), ip.Height())
 

--- a/internal/tui/vuln-list.go
+++ b/internal/tui/vuln-list.go
@@ -115,7 +115,7 @@ func (v *vulnList) Update(msg tea.Msg) (ViewModel, tea.Cmd) {
 		case key.Matches(msg, Keys.Quit):
 			return v, CloseViewModel
 		case key.Matches(msg, Keys.Select):
-			vuln := v.Model.SelectedItem().(vulnListItem)
+			vuln := v.SelectedItem().(vulnListItem)
 			v.currVulnInfo = NewVulnInfo(vuln.Vulnerability)
 			v.currVulnInfo.Resize(v.Width(), v.Height())
 

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -152,13 +152,13 @@ func initializeExternalAccessors(actions ScannerActions) (ExternalAccessors, err
 	externalAccessors.OSVDevClient = osvdev.DefaultClient()
 
 	// --- No Transitive Scanning ---
-	if actions.TransitiveScanningActions.Disabled {
+	if actions.Disabled {
 		return externalAccessors, nil
 	}
 
 	// --- Transitive Scanning Clients ---
 	externalAccessors.MavenRegistryAPIClient, err = datasource.NewMavenRegistryAPIClient(datasource.MavenRegistry{
-		URL:             actions.TransitiveScanningActions.MavenRegistry,
+		URL:             actions.MavenRegistry,
 		ReleasesEnabled: true,
 	}, "")
 
@@ -166,10 +166,10 @@ func initializeExternalAccessors(actions ScannerActions) (ExternalAccessors, err
 		return ExternalAccessors{}, err
 	}
 
-	if !actions.TransitiveScanningActions.NativeDataSource {
+	if !actions.NativeDataSource {
 		externalAccessors.DependencyClients[osvschema.EcosystemMaven], err = resolution.NewDepsDevClient(depsdev.DepsdevAPI, "osv-scanner_scan/"+version.OSVVersion)
 	} else {
-		externalAccessors.DependencyClients[osvschema.EcosystemMaven], err = resolution.NewMavenRegistryClient(actions.TransitiveScanningActions.MavenRegistry, "")
+		externalAccessors.DependencyClients[osvschema.EcosystemMaven], err = resolution.NewMavenRegistryClient(actions.MavenRegistry, "")
 	}
 
 	if err != nil {
@@ -371,7 +371,7 @@ func DoContainerScan(actions ScannerActions) (models.VulnerabilityResults, error
 	for _, psr := range scanResult.PackageScanResults {
 		if (strings.HasPrefix(psr.PackageInfo.Location(), "usr/") && psr.PackageInfo.Ecosystem().Ecosystem == osvschema.EcosystemGo) ||
 			strings.Contains(psr.PackageInfo.Location(), "dist-packages/") && psr.PackageInfo.Ecosystem().Ecosystem == osvschema.EcosystemPyPI {
-			psr.PackageInfo.Package.Annotations = append(psr.PackageInfo.Package.Annotations, extractor.InsideOSPackage)
+			psr.PackageInfo.Annotations = append(psr.PackageInfo.Annotations, extractor.InsideOSPackage)
 		}
 	}
 

--- a/pkg/osvscanner/vulnerability_result.go
+++ b/pkg/osvscanner/vulnerability_result.go
@@ -135,7 +135,7 @@ func buildVulnerabilityResults(
 
 			groupedBySource[source].pvs = append(groupedBySource[source].pvs, pkg)
 			// Overwrite annotations as it should be the same for the same package.
-			groupedBySource[source].annotations = p.Package.Annotations
+			groupedBySource[source].annotations = p.Annotations
 		}
 	}
 


### PR DESCRIPTION
This slightly reduces coupling since the caller does not have to know about the embedded field in the middle, in addition to just overall being less code