### PR TITLE
test: remove root directory normalization workaround

### DIFF
--- a/cmd/osv-scanner/__snapshots__/main_test.snap
+++ b/cmd/osv-scanner/__snapshots__/main_test.snap
@@ -35,8 +35,8 @@ built at: n/a
 
 [Test_run_SubCommands/scan_with_a_flag - 1]
 Scanning dir ./fixtures/locks-one-with-nested
-Scanned <rootdir>/osv-scanner/fixtures/locks-one-with-nested/nested/composer.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/fixtures/locks-one-with-nested/yarn.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-one-with-nested/nested/composer.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-one-with-nested/yarn.lock file and found 1 package
 No issues found
 
 ---
@@ -48,8 +48,8 @@ Warning: `scan` exists as both a subcommand of OSV-Scanner and as a file on the 
 
 [Test_run_SubCommands/with_no_subcommand - 1]
 Scanning dir ./fixtures/locks-many/composer.lock
-Scanned <rootdir>/osv-scanner/fixtures/locks-many/composer.lock file and found 1 package
-Loaded filter from: <rootdir>/osv-scanner/fixtures/locks-many/osv-scanner.toml
+Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
+Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
 No issues found
 
 ---
@@ -60,8 +60,8 @@ No issues found
 
 [Test_run_SubCommands/with_scan_subcommand - 1]
 Scanning dir ./fixtures/locks-many/composer.lock
-Scanned <rootdir>/osv-scanner/fixtures/locks-many/composer.lock file and found 1 package
-Loaded filter from: <rootdir>/osv-scanner/fixtures/locks-many/osv-scanner.toml
+Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
+Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
 No issues found
 
 ---

--- a/cmd/osv-scanner/scan/__snapshots__/command_test.snap
+++ b/cmd/osv-scanner/scan/__snapshots__/command_test.snap
@@ -1,8 +1,8 @@
 
 [TestCommand_SubCommands/scan_with_a_flag - 1]
 Scanning dir ./fixtures/locks-one-with-nested
-Scanned <rootdir>/osv-scanner/scan/fixtures/locks-one-with-nested/nested/composer.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/fixtures/locks-one-with-nested/yarn.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-one-with-nested/nested/composer.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-one-with-nested/yarn.lock file and found 1 package
 No issues found
 
 ---
@@ -13,8 +13,8 @@ No issues found
 
 [TestCommand_SubCommands/with_no_subcommand - 1]
 Scanning dir ./fixtures/locks-many/composer.lock
-Scanned <rootdir>/osv-scanner/scan/fixtures/locks-many/composer.lock file and found 1 package
-Loaded filter from: <rootdir>/osv-scanner/scan/fixtures/locks-many/osv-scanner.toml
+Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
+Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
 No issues found
 
 ---
@@ -25,8 +25,8 @@ No issues found
 
 [TestCommand_SubCommands/with_scan_subcommand - 1]
 Scanning dir ./fixtures/locks-many/composer.lock
-Scanned <rootdir>/osv-scanner/scan/fixtures/locks-many/composer.lock file and found 1 package
-Loaded filter from: <rootdir>/osv-scanner/scan/fixtures/locks-many/osv-scanner.toml
+Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
+Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
 No issues found
 
 ---

--- a/cmd/osv-scanner/scan/source/__snapshots__/command_test.snap
+++ b/cmd/osv-scanner/scan/source/__snapshots__/command_test.snap
@@ -1,8 +1,8 @@
 
 [TestCommand/.gitignored_files - 1]
 Scanning dir ./fixtures/locks-gitignore
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-gitignore/Gemfile.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-gitignore/subdir/yarn.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-gitignore/Gemfile.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-gitignore/subdir/yarn.lock file and found 1 package
 No issues found
 
 ---
@@ -25,8 +25,8 @@ No issues found
 
 [TestCommand/Empty_cyclonedx_1.4_output - 2]
 Scanning dir ./fixtures/locks-many/composer.lock
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/composer.lock file and found 1 package
-Loaded filter from: <rootdir>/osv-scanner/scan/source/fixtures/locks-many/osv-scanner.toml
+Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
+Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
 
 ---
 
@@ -44,8 +44,8 @@ Loaded filter from: <rootdir>/osv-scanner/scan/source/fixtures/locks-many/osv-sc
 
 [TestCommand/Empty_cyclonedx_1.5_output - 2]
 Scanning dir ./fixtures/locks-many/composer.lock
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/composer.lock file and found 1 package
-Loaded filter from: <rootdir>/osv-scanner/scan/source/fixtures/locks-many/osv-scanner.toml
+Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
+Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
 
 ---
 
@@ -55,8 +55,8 @@ Loaded filter from: <rootdir>/osv-scanner/scan/source/fixtures/locks-many/osv-sc
 
 [TestCommand/Empty_gh-annotations_output - 2]
 Scanning dir ./fixtures/locks-many/composer.lock
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/composer.lock file and found 1 package
-Loaded filter from: <rootdir>/osv-scanner/scan/source/fixtures/locks-many/osv-scanner.toml
+Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
+Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
 
 ---
 
@@ -83,14 +83,14 @@ Loaded filter from: <rootdir>/osv-scanner/scan/source/fixtures/locks-many/osv-sc
 
 [TestCommand/Empty_sarif_output - 2]
 Scanning dir ./fixtures/locks-many/composer.lock
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/composer.lock file and found 1 package
-Loaded filter from: <rootdir>/osv-scanner/scan/source/fixtures/locks-many/osv-scanner.toml
+Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
+Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
 
 ---
 
 [TestCommand/Go_project_with_an_overridden_go_version - 1]
 Scanning dir ./fixtures/go-project
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/go-project/go.mod file and found 1 package
+Scanned <rootdir>/fixtures/go-project/go.mod file and found 1 package
 +------------------------------+------+-----------+---------+---------+----------------------------+
 | OSV URL                      | CVSS | ECOSYSTEM | PACKAGE | VERSION | SOURCE                     |
 +------------------------------+------+-----------+---------+---------+----------------------------+
@@ -122,8 +122,8 @@ Scanned <rootdir>/osv-scanner/scan/source/fixtures/go-project/go.mod file and fo
 
 [TestCommand/Go_project_with_an_overridden_go_version,_recursive - 1]
 Scanning dir ./fixtures/go-project
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/go-project/go.mod file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/go-project/nested/go.mod file and found 1 package
+Scanned <rootdir>/fixtures/go-project/go.mod file and found 1 package
+Scanned <rootdir>/fixtures/go-project/nested/go.mod file and found 1 package
 +------------------------------+------+-----------+---------+---------+-----------------------------------+
 | OSV URL                      | CVSS | ECOSYSTEM | PACKAGE | VERSION | SOURCE                            |
 +------------------------------+------+-----------+---------+---------+-----------------------------------+
@@ -171,7 +171,7 @@ Scanned <rootdir>/osv-scanner/scan/source/fixtures/go-project/nested/go.mod file
 
 [TestCommand/PURL_SBOM_case_sensitivity_(api) - 1]
 Scanning dir ./fixtures/sbom-insecure/alpine.cdx.xml
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/sbom-insecure/alpine.cdx.xml file and found 15 packages
+Scanned <rootdir>/fixtures/sbom-insecure/alpine.cdx.xml file and found 15 packages
 Filtered 1 local/unscannable package/s from the scan.
 +--------------------------------+------+-----------+---------+-----------+---------------------------------------+
 | OSV URL                        | CVSS | ECOSYSTEM | PACKAGE | VERSION   | SOURCE                                |
@@ -189,7 +189,7 @@ Filtered 1 local/unscannable package/s from the scan.
 
 [TestCommand/PURL_SBOM_case_sensitivity_(local) - 1]
 Scanning dir ./fixtures/sbom-insecure/alpine.cdx.xml
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/sbom-insecure/alpine.cdx.xml file and found 15 packages
+Scanned <rootdir>/fixtures/sbom-insecure/alpine.cdx.xml file and found 15 packages
 Filtered 1 local/unscannable package/s from the scan.
 Loaded Alpine local db from <tempdir>/osv-scanner/Alpine/all.zip
 +--------------------------------+------+-----------+---------+-----------+---------------------------------------+
@@ -236,8 +236,8 @@ Loaded Alpine local db from <tempdir>/osv-scanner/Alpine/all.zip
                 "GHSA-whgm-jr23-g3j9"
               ],
               "help": {
-                "text": "**Your dependency is vulnerable to [CVE-2021-23424](https://osv.dev/list?q=CVE-2021-23424)**.\n\n## [GHSA-whgm-jr23-g3j9](https://osv.dev/vulnerability/GHSA-whgm-jr23-g3j9)\n\n\u003cdetails\u003e\n\u003csummary\u003eDetails\u003c/summary\u003e\n\n\u003e This affects all versions of package ansi-html. If an attacker provides a malicious string, it will get stuck processing the input for an extremely long time.\n\n\u003c/details\u003e\n\n---\n\n### Affected Packages\n\n| Source | Package Name | Package Version |\n| --- | --- | --- |\n| lockfile:<rootdir>/osv-scanner/scan/source/fixtures/locks-many/package-lock.json | ansi-html | 0.0.1 |\n\n## Remediation\n\nTo fix these vulnerabilities, update the vulnerabilities past the listed fixed versions below.\n\n### Fixed Versions\n\n| Vulnerability ID | Package Name | Fixed Version |\n| --- | --- | --- |\n| GHSA-whgm-jr23-g3j9 | ansi-html | 0.0.8 |\n\nIf you believe these vulnerabilities do not affect your code and wish to ignore them, add them to the ignore list in an\n`osv-scanner.toml` file located in the same directory as the lockfile containing the vulnerable dependency.\n\nSee the format and more options in our documentation here: https://google.github.io/osv-scanner/configuration/\n\nAdd or append these values to the following config files to ignore this vulnerability:\n\n`<rootdir>/osv-scanner/scan/source/fixtures/locks-many/osv-scanner.toml`\n\n```\n[[IgnoredVulns]]\nid = \"CVE-2021-23424\"\nreason = \"Your reason for ignoring this vulnerability\"\n```\n",
-                "markdown": "**Your dependency is vulnerable to [CVE-2021-23424](https://osv.dev/list?q=CVE-2021-23424)**.\n\n## [GHSA-whgm-jr23-g3j9](https://osv.dev/vulnerability/GHSA-whgm-jr23-g3j9)\n\n\u003cdetails\u003e\n\u003csummary\u003eDetails\u003c/summary\u003e\n\n\u003e This affects all versions of package ansi-html. If an attacker provides a malicious string, it will get stuck processing the input for an extremely long time.\n\n\u003c/details\u003e\n\n---\n\n### Affected Packages\n\n| Source | Package Name | Package Version |\n| --- | --- | --- |\n| lockfile:<rootdir>/osv-scanner/scan/source/fixtures/locks-many/package-lock.json | ansi-html | 0.0.1 |\n\n## Remediation\n\nTo fix these vulnerabilities, update the vulnerabilities past the listed fixed versions below.\n\n### Fixed Versions\n\n| Vulnerability ID | Package Name | Fixed Version |\n| --- | --- | --- |\n| GHSA-whgm-jr23-g3j9 | ansi-html | 0.0.8 |\n\nIf you believe these vulnerabilities do not affect your code and wish to ignore them, add them to the ignore list in an\n`osv-scanner.toml` file located in the same directory as the lockfile containing the vulnerable dependency.\n\nSee the format and more options in our documentation here: https://google.github.io/osv-scanner/configuration/\n\nAdd or append these values to the following config files to ignore this vulnerability:\n\n`<rootdir>/osv-scanner/scan/source/fixtures/locks-many/osv-scanner.toml`\n\n```\n[[IgnoredVulns]]\nid = \"CVE-2021-23424\"\nreason = \"Your reason for ignoring this vulnerability\"\n```\n"
+                "text": "**Your dependency is vulnerable to [CVE-2021-23424](https://osv.dev/list?q=CVE-2021-23424)**.\n\n## [GHSA-whgm-jr23-g3j9](https://osv.dev/vulnerability/GHSA-whgm-jr23-g3j9)\n\n\u003cdetails\u003e\n\u003csummary\u003eDetails\u003c/summary\u003e\n\n\u003e This affects all versions of package ansi-html. If an attacker provides a malicious string, it will get stuck processing the input for an extremely long time.\n\n\u003c/details\u003e\n\n---\n\n### Affected Packages\n\n| Source | Package Name | Package Version |\n| --- | --- | --- |\n| lockfile:<rootdir>/fixtures/locks-many/package-lock.json | ansi-html | 0.0.1 |\n\n## Remediation\n\nTo fix these vulnerabilities, update the vulnerabilities past the listed fixed versions below.\n\n### Fixed Versions\n\n| Vulnerability ID | Package Name | Fixed Version |\n| --- | --- | --- |\n| GHSA-whgm-jr23-g3j9 | ansi-html | 0.0.8 |\n\nIf you believe these vulnerabilities do not affect your code and wish to ignore them, add them to the ignore list in an\n`osv-scanner.toml` file located in the same directory as the lockfile containing the vulnerable dependency.\n\nSee the format and more options in our documentation here: https://google.github.io/osv-scanner/configuration/\n\nAdd or append these values to the following config files to ignore this vulnerability:\n\n`<rootdir>/fixtures/locks-many/osv-scanner.toml`\n\n```\n[[IgnoredVulns]]\nid = \"CVE-2021-23424\"\nreason = \"Your reason for ignoring this vulnerability\"\n```\n",
+                "markdown": "**Your dependency is vulnerable to [CVE-2021-23424](https://osv.dev/list?q=CVE-2021-23424)**.\n\n## [GHSA-whgm-jr23-g3j9](https://osv.dev/vulnerability/GHSA-whgm-jr23-g3j9)\n\n\u003cdetails\u003e\n\u003csummary\u003eDetails\u003c/summary\u003e\n\n\u003e This affects all versions of package ansi-html. If an attacker provides a malicious string, it will get stuck processing the input for an extremely long time.\n\n\u003c/details\u003e\n\n---\n\n### Affected Packages\n\n| Source | Package Name | Package Version |\n| --- | --- | --- |\n| lockfile:<rootdir>/fixtures/locks-many/package-lock.json | ansi-html | 0.0.1 |\n\n## Remediation\n\nTo fix these vulnerabilities, update the vulnerabilities past the listed fixed versions below.\n\n### Fixed Versions\n\n| Vulnerability ID | Package Name | Fixed Version |\n| --- | --- | --- |\n| GHSA-whgm-jr23-g3j9 | ansi-html | 0.0.8 |\n\nIf you believe these vulnerabilities do not affect your code and wish to ignore them, add them to the ignore list in an\n`osv-scanner.toml` file located in the same directory as the lockfile containing the vulnerable dependency.\n\nSee the format and more options in our documentation here: https://google.github.io/osv-scanner/configuration/\n\nAdd or append these values to the following config files to ignore this vulnerability:\n\n`<rootdir>/fixtures/locks-many/osv-scanner.toml`\n\n```\n[[IgnoredVulns]]\nid = \"CVE-2021-23424\"\nreason = \"Your reason for ignoring this vulnerability\"\n```\n"
               },
               "properties": {
                 "security-severity": "7.5"
@@ -250,7 +250,7 @@ Loaded Alpine local db from <tempdir>/osv-scanner/Alpine/all.zip
       "artifacts": [
         {
           "location": {
-            "uri": "file://<rootdir>/osv-scanner/scan/source/fixtures/locks-many/package-lock.json"
+            "uri": "file://<rootdir>/fixtures/locks-many/package-lock.json"
           },
           "length": -1
         }
@@ -267,7 +267,7 @@ Loaded Alpine local db from <tempdir>/osv-scanner/Alpine/all.zip
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file://<rootdir>/osv-scanner/scan/source/fixtures/locks-many/package-lock.json"
+                  "uri": "file://<rootdir>/fixtures/locks-many/package-lock.json"
                 }
               }
             }
@@ -282,19 +282,19 @@ Loaded Alpine local db from <tempdir>/osv-scanner/Alpine/all.zip
 
 [TestCommand/Sarif_with_vulns - 2]
 Scanning dir ./fixtures/locks-many/package-lock.json
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/package-lock.json file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
 
 ---
 
 [TestCommand/Scan_locks-many - 1]
 Scanning dir ./fixtures/locks-many
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/Gemfile.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/alpine.cdx.xml file and found 15 packages
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/composer.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/package-lock.json file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/yarn.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/Gemfile.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/alpine.cdx.xml file and found 15 packages
+Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/yarn.lock file and found 1 package
 Filtered 1 local/unscannable package/s from the scan.
-Loaded filter from: <rootdir>/osv-scanner/scan/source/fixtures/locks-many/osv-scanner.toml
+Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
 CVE-2025-26519 has been filtered out because: Test manifest file (alpine.cdx.xml)
 GHSA-whgm-jr23-g3j9 and 1 alias have been filtered out because: Test manifest file
 Filtered 2 vulnerabilities from output
@@ -308,29 +308,29 @@ No issues found
 
 [TestCommand/all_supported_lockfiles_in_the_directory_should_be_checked - 1]
 Scanning dir ./fixtures/locks-many-with-invalid
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many-with-invalid/Gemfile.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many-with-invalid/yarn.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many-with-invalid/Gemfile.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many-with-invalid/yarn.lock file and found 1 package
 
 ---
 
 [TestCommand/all_supported_lockfiles_in_the_directory_should_be_checked - 2]
-Error during extraction: (extracting as php/composerlock) could not extract from <rootdir>/osv-scanner/scan/source/fixtures/locks-many-with-invalid/composer.lock: invalid character ',' looking for beginning of object key string
+Error during extraction: (extracting as php/composerlock) could not extract from <rootdir>/fixtures/locks-many-with-invalid/composer.lock: invalid character ',' looking for beginning of object key string
 
 ---
 
 [TestCommand/config_file_can_be_broad - 1]
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/osv-scanner-flutter-deps.json file as a osv-scanner and found 3 packages
+Scanned <rootdir>/fixtures/locks-insecure/osv-scanner-flutter-deps.json file as a osv-scanner and found 3 packages
 Scanning dir ./fixtures/locks-many
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/Gemfile.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/alpine.cdx.xml file and found 15 packages
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/composer.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/package-lock.json file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/yarn.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/Gemfile.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/alpine.cdx.xml file and found 15 packages
+Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/yarn.lock file and found 1 package
 Scanning dir ./fixtures/locks-insecure
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/bun.lock file and found 2 packages
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/composer.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-insecure/bun.lock file and found 2 packages
+Scanned <rootdir>/fixtures/locks-insecure/composer.lock file and found 1 package
 Scanning dir ./fixtures/maven-transitive
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/maven-transitive/pom.xml file and found 3 packages
+Scanned <rootdir>/fixtures/maven-transitive/pom.xml file and found 3 packages
 Filtered 1 local/unscannable package/s from the scan.
 Package npm/ansi-html/0.0.1 has been filtered out because: (no reason given)
 Package npm/balanced-match/1.0.2 has been filtered out because: (no reason given)
@@ -388,12 +388,12 @@ overriding license for package Packagist/league/flysystem/1.0.8 with 0BSD
 
 [TestCommand/config_file_is_invalid - 1]
 Scanning dir ./fixtures/config-invalid
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/config-invalid/composer.lock file and found 1 package
+Scanned <rootdir>/fixtures/config-invalid/composer.lock file and found 1 package
 
 ---
 
 [TestCommand/config_file_is_invalid - 2]
-Ignored invalid config file at <rootdir>/osv-scanner/scan/source/fixtures/config-invalid/osv-scanner.toml because: toml: line 1: expected '.' or '=', but got '!' instead
+Ignored invalid config file at <rootdir>/fixtures/config-invalid/osv-scanner.toml because: toml: line 1: expected '.' or '=', but got '!' instead
 
 ---
 
@@ -410,11 +410,11 @@ unknown keys in config file: RustVersionOverride, PackageOverrides.skip, Package
 [TestCommand/config_files_should_not_have_multiple_ignores_with_the_same_id - 1]
 warning: ./fixtures/osv-scanner-duplicate-config.toml has multiple ignores for GO-2022-0274 - only the first will be used!
 Scanning dir ./fixtures/locks-many
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/Gemfile.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/alpine.cdx.xml file and found 15 packages
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/composer.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/package-lock.json file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/yarn.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/Gemfile.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/alpine.cdx.xml file and found 15 packages
+Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/yarn.lock file and found 1 package
 Filtered 1 local/unscannable package/s from the scan.
 CVE-2025-26519 has been filtered out because: (no reason given)
 GHSA-whgm-jr23-g3j9 and 1 alias have been filtered out because: (no reason given)
@@ -499,8 +499,8 @@ No issues found
 
 [TestCommand/cyclonedx_1.4_output - 2]
 Scanning dir ./fixtures/locks-insecure
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/bun.lock file and found 2 packages
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/composer.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-insecure/bun.lock file and found 2 packages
+Scanned <rootdir>/fixtures/locks-insecure/composer.lock file and found 1 package
 
 ---
 
@@ -576,17 +576,17 @@ Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/composer.lock 
 
 [TestCommand/cyclonedx_1.5_output - 2]
 Scanning dir ./fixtures/locks-insecure
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/bun.lock file and found 2 packages
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/composer.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-insecure/bun.lock file and found 2 packages
+Scanned <rootdir>/fixtures/locks-insecure/composer.lock file and found 1 package
 
 ---
 
 [TestCommand/folder_of_supported_sbom_with_vulns - 1]
 Scanning dir ./fixtures/sbom-insecure/
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/sbom-insecure/alpine.cdx.xml file and found 15 packages
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/sbom-insecure/bad-purls.cdx.xml file and found 15 packages
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/sbom-insecure/postgres-stretch.cdx.xml file and found 136 packages
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/sbom-insecure/with-duplicates.cdx.xml file and found 15 packages
+Scanned <rootdir>/fixtures/sbom-insecure/alpine.cdx.xml file and found 15 packages
+Scanned <rootdir>/fixtures/sbom-insecure/bad-purls.cdx.xml file and found 15 packages
+Scanned <rootdir>/fixtures/sbom-insecure/postgres-stretch.cdx.xml file and found 136 packages
+Scanned <rootdir>/fixtures/sbom-insecure/with-duplicates.cdx.xml file and found 15 packages
 Filtered 9 local/unscannable package/s from the scan.
 +-------------------------------------+------+-----------+--------------------------------+------------------------------------+-------------------------------------------------+
 | OSV URL                             | CVSS | ECOSYSTEM | PACKAGE                        | VERSION                            | SOURCE                                          |
@@ -863,15 +863,15 @@ Filtered 9 local/unscannable package/s from the scan.
 
 [TestCommand/gh-annotations_with_vulns - 2]
 Scanning dir ./fixtures/locks-many/package-lock.json
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/package-lock.json file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
 ::error file=fixtures/locks-many/package-lock.json::fixtures/locks-many/package-lock.json%0A+-----------+-------------------------------------+------+-----------------+---------------+%0A| PACKAGE   | VULNERABILITY ID                    | CVSS | CURRENT VERSION | FIXED VERSION |%0A+-----------+-------------------------------------+------+-----------------+---------------+%0A| ansi-html | https://osv.dev/GHSA-whgm-jr23-g3j9 | 7.5  | 0.0.1           | 0.0.8         |%0A+-----------+-------------------------------------+------+-----------------+---------------+
 ---
 
 [TestCommand/ignores_without_reason_should_be_explicitly_called_out - 1]
 Scanning dir ./fixtures/locks-many/package-lock.json
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/package-lock.json file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
 Scanning dir ./fixtures/locks-many/composer.lock
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/composer.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
 Package Packagist/sentry/sdk/2.0.4 has been filtered out because: (no reason given)
 Filtered 1 ignored package/s from the scan.
 GHSA-whgm-jr23-g3j9 and 1 alias have been filtered out because: (no reason given)
@@ -886,14 +886,14 @@ No issues found
 
 [TestCommand/ignoring_.gitignore - 1]
 Scanning dir ./fixtures/locks-gitignore
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-gitignore/Gemfile.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-gitignore/composer.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-gitignore/ignored/Gemfile.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-gitignore/ignored/yarn.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-gitignore/subdir/Gemfile.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-gitignore/subdir/composer.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-gitignore/subdir/yarn.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-gitignore/yarn.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-gitignore/Gemfile.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-gitignore/composer.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-gitignore/ignored/Gemfile.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-gitignore/ignored/yarn.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-gitignore/subdir/Gemfile.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-gitignore/subdir/composer.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-gitignore/subdir/yarn.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-gitignore/yarn.lock file and found 1 package
 No issues found
 
 ---
@@ -926,15 +926,15 @@ invalid verbosity level "unknown" - must be one of: error, warn, info
 
 [TestCommand/json_output - 2]
 Scanning dir ./fixtures/locks-many/composer.lock
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/composer.lock file and found 1 package
-Loaded filter from: <rootdir>/osv-scanner/scan/source/fixtures/locks-many/osv-scanner.toml
+Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
+Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
 
 ---
 
 [TestCommand/nested_directories_are_checked_when_`--recursive`_is_passed - 1]
 Scanning dir ./fixtures/locks-one-with-nested
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-one-with-nested/nested/composer.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-one-with-nested/yarn.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-one-with-nested/nested/composer.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-one-with-nested/yarn.lock file and found 1 package
 No issues found
 
 ---
@@ -944,7 +944,7 @@ No issues found
 ---
 
 [TestCommand/one_file_that_does_not_match_the_supported_sbom_file_names - 1]
-Failed to parse SBOM "<rootdir>/osv-scanner/scan/source/fixtures/locks-many/composer.lock" with error: could not determine extractor suitable to this file
+Failed to parse SBOM "<rootdir>/fixtures/locks-many/composer.lock" with error: could not determine extractor suitable to this file
 If you believe this is a valid SBOM, make sure the filename follows format per your SBOMs specification.
 
 ---
@@ -956,8 +956,8 @@ could not determine extractor suitable to this file
 
 [TestCommand/one_specific_supported_lockfile - 1]
 Scanning dir ./fixtures/locks-many/composer.lock
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/composer.lock file and found 1 package
-Loaded filter from: <rootdir>/osv-scanner/scan/source/fixtures/locks-many/osv-scanner.toml
+Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
+Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
 No issues found
 
 ---
@@ -968,8 +968,8 @@ No issues found
 
 [TestCommand/one_specific_supported_lockfile_with_ignore - 1]
 Scanning dir ./fixtures/locks-test-ignore/package-lock.json
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-test-ignore/package-lock.json file and found 1 package
-Loaded filter from: <rootdir>/osv-scanner/scan/source/fixtures/locks-test-ignore/osv-scanner.toml
+Scanned <rootdir>/fixtures/locks-test-ignore/package-lock.json file and found 1 package
+Loaded filter from: <rootdir>/fixtures/locks-test-ignore/osv-scanner.toml
 CVE-2021-23424 and 1 alias have been filtered out because: Test manifest file (alpine.cdx.xml)
 Filtered 1 vulnerability from output
 No issues found
@@ -982,8 +982,8 @@ No issues found
 
 [TestCommand/one_specific_supported_lockfile_with_offline_explicitly_false - 1]
 Scanning dir ./fixtures/locks-many/composer.lock
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/composer.lock file and found 1 package
-Loaded filter from: <rootdir>/osv-scanner/scan/source/fixtures/locks-many/osv-scanner.toml
+Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
+Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
 No issues found
 
 ---
@@ -993,7 +993,7 @@ No issues found
 ---
 
 [TestCommand/one_specific_supported_sbom_with_duplicate_PURLs - 1]
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/sbom-insecure/with-duplicates.cdx.xml file and found 15 packages
+Scanned <rootdir>/fixtures/sbom-insecure/with-duplicates.cdx.xml file and found 15 packages
 Filtered 1 local/unscannable package/s from the scan.
 +--------------------------------+------+-----------+---------+-----------+------------------------------------------------+
 | OSV URL                        | CVSS | ECOSYSTEM | PACKAGE | VERSION   | SOURCE                                         |
@@ -1010,7 +1010,7 @@ Filtered 1 local/unscannable package/s from the scan.
 ---
 
 [TestCommand/one_specific_supported_sbom_with_invalid_PURLs - 1]
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/sbom-insecure/bad-purls.cdx.xml file and found 15 packages
+Scanned <rootdir>/fixtures/sbom-insecure/bad-purls.cdx.xml file and found 15 packages
 Filtered 7 local/unscannable package/s from the scan.
 No issues found
 
@@ -1021,7 +1021,7 @@ No issues found
 ---
 
 [TestCommand/one_specific_supported_sbom_with_vulns - 1]
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/sbom-insecure/alpine.cdx.xml file and found 15 packages
+Scanned <rootdir>/fixtures/sbom-insecure/alpine.cdx.xml file and found 15 packages
 Filtered 1 local/unscannable package/s from the scan.
 +--------------------------------+------+-----------+---------+-----------+---------------------------------------+
 | OSV URL                        | CVSS | ECOSYSTEM | PACKAGE | VERSION   | SOURCE                                |
@@ -1049,7 +1049,7 @@ No package sources found, --help for usage information.
 
 [TestCommand/only_the_files_in_the_given_directories_are_checked_by_default_(no_recursion) - 1]
 Scanning dir ./fixtures/locks-one-with-nested
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-one-with-nested/yarn.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-one-with-nested/yarn.lock file and found 1 package
 No issues found
 
 ---
@@ -1060,7 +1060,7 @@ No issues found
 
 [TestCommand/output_format:_markdown_table - 1]
 Scanning dir ./fixtures/locks-many/package-lock.json
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/package-lock.json file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
 | OSV URL | CVSS | Ecosystem | Package | Version | Source |
 | --- | --- | --- | --- | --- | --- |
 | https://osv.dev/GHSA-whgm-jr23-g3j9 | 7.5 | npm | ansi-html | 0.0.1 | fixtures/locks-many/package-lock.json |
@@ -1082,11 +1082,11 @@ unsupported output format "unknown" - must be one of: table, html, vertical, jso
 
 [TestCommand/requirements.txt_can_have_all_kinds_of_names - 1]
 Scanning dir ./fixtures/locks-requirements
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-requirements/my-requirements.txt file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-requirements/requirements-dev.txt file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-requirements/requirements.prod.txt file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-requirements/requirements.txt file and found 3 packages
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-requirements/the_requirements_for_test.txt file and found 1 package
+Scanned <rootdir>/fixtures/locks-requirements/my-requirements.txt file and found 1 package
+Scanned <rootdir>/fixtures/locks-requirements/requirements-dev.txt file and found 1 package
+Scanned <rootdir>/fixtures/locks-requirements/requirements.prod.txt file and found 1 package
+Scanned <rootdir>/fixtures/locks-requirements/requirements.txt file and found 3 packages
+Scanned <rootdir>/fixtures/locks-requirements/the_requirements_for_test.txt file and found 1 package
 +-------------------------------------+------+-----------+------------+---------+---------------------------------------------------+
 | OSV URL                             | CVSS | ECOSYSTEM | PACKAGE    | VERSION | SOURCE                                            |
 +-------------------------------------+------+-----------+------------+---------+---------------------------------------------------+
@@ -1142,8 +1142,8 @@ No issues found
 
 [TestCommand/verbosity_level_=_info - 1]
 Scanning dir ./fixtures/locks-many/composer.lock
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/composer.lock file and found 1 package
-Loaded filter from: <rootdir>/osv-scanner/scan/source/fixtures/locks-many/osv-scanner.toml
+Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
+Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
 No issues found
 
 ---
@@ -1154,7 +1154,7 @@ No issues found
 
 [TestCommand_CallAnalysis/Run_with_govulncheck - 1]
 Scanning dir ./fixtures/call-analysis-go-project
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/call-analysis-go-project/go.mod file and found 4 packages
+Scanned <rootdir>/fixtures/call-analysis-go-project/go.mod file and found 4 packages
 GO-2025-3447 and 2 aliases have been filtered out because: This is called in Go v1.23, but not in v1.24
 Filtered 1 vulnerability from output
 +-------------------------------------+------+-----------+-----------------------------+---------+------------------------------------------+
@@ -1245,9 +1245,9 @@ at least one extractor must be enabled
 
 [TestCommand_ExplicitExtractors/scanning_directory_with_a_couple_of_specific_extractors_enabled_individually - 1]
 Scanning dir ./fixtures/locks-many
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/composer.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/package-lock.json file and found 1 package
-Loaded filter from: <rootdir>/osv-scanner/scan/source/fixtures/locks-many/osv-scanner.toml
+Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
+Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
 GHSA-whgm-jr23-g3j9 and 1 alias have been filtered out because: Test manifest file
 Filtered 1 vulnerability from output
 No issues found
@@ -1260,9 +1260,9 @@ No issues found
 
 [TestCommand_ExplicitExtractors/scanning_directory_with_a_couple_of_specific_extractors_enabled_specified_together - 1]
 Scanning dir ./fixtures/locks-many
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/composer.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/package-lock.json file and found 1 package
-Loaded filter from: <rootdir>/osv-scanner/scan/source/fixtures/locks-many/osv-scanner.toml
+Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
+Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
 GHSA-whgm-jr23-g3j9 and 1 alias have been filtered out because: Test manifest file
 Filtered 1 vulnerability from output
 No issues found
@@ -1275,8 +1275,8 @@ No issues found
 
 [TestCommand_ExplicitExtractors/scanning_directory_with_an_extractor_that_does_not_exist - 1]
 Scanning dir ./fixtures/locks-many
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/package-lock.json file and found 1 package
-Loaded filter from: <rootdir>/osv-scanner/scan/source/fixtures/locks-many/osv-scanner.toml
+Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
+Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
 GHSA-whgm-jr23-g3j9 and 1 alias have been filtered out because: Test manifest file
 Filtered 1 vulnerability from output
 
@@ -1289,12 +1289,12 @@ Unknown extractor custom/extractor
 
 [TestCommand_ExplicitExtractors/scanning_directory_with_one_specific_extractor_disabled - 1]
 Scanning dir ./fixtures/locks-many
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/Gemfile.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/alpine.cdx.xml file and found 15 packages
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/composer.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/yarn.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/Gemfile.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/alpine.cdx.xml file and found 15 packages
+Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/yarn.lock file and found 1 package
 Filtered 1 local/unscannable package/s from the scan.
-Loaded filter from: <rootdir>/osv-scanner/scan/source/fixtures/locks-many/osv-scanner.toml
+Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
 CVE-2025-26519 has been filtered out because: Test manifest file (alpine.cdx.xml)
 Filtered 1 vulnerability from output
 No issues found
@@ -1307,8 +1307,8 @@ No issues found
 
 [TestCommand_ExplicitExtractors/scanning_directory_with_one_specific_extractor_enabled - 1]
 Scanning dir ./fixtures/locks-many
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/package-lock.json file and found 1 package
-Loaded filter from: <rootdir>/osv-scanner/scan/source/fixtures/locks-many/osv-scanner.toml
+Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
+Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
 GHSA-whgm-jr23-g3j9 and 1 alias have been filtered out because: Test manifest file
 Filtered 1 vulnerability from output
 No issues found
@@ -1331,8 +1331,8 @@ No package sources found, --help for usage information.
 
 [TestCommand_ExplicitExtractors/scanning_file_with_one_specific_extractor_enabled - 1]
 Scanning dir ./fixtures/locks-many/package-lock.json
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/package-lock.json file and found 1 package
-Loaded filter from: <rootdir>/osv-scanner/scan/source/fixtures/locks-many/osv-scanner.toml
+Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
+Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
 GHSA-whgm-jr23-g3j9 and 1 alias have been filtered out because: Test manifest file
 Filtered 1 vulnerability from output
 No issues found
@@ -1353,7 +1353,7 @@ could not determine extractor, requested package-lock.json
 ---
 
 [TestCommand_GithubActions/scanning_osv-scanner_custom_format - 1]
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/osv-scanner-flutter-deps.json file as a osv-scanner and found 3 packages
+Scanned <rootdir>/fixtures/locks-insecure/osv-scanner-flutter-deps.json file as a osv-scanner and found 3 packages
 +--------------------------------+------+-----------+----------------------------+-----------------------------+-------------------------------------------------------+
 | OSV URL                        | CVSS | ECOSYSTEM | PACKAGE                    | VERSION                     | SOURCE                                                |
 +--------------------------------+------+-----------+----------------------------+-----------------------------+-------------------------------------------------------+
@@ -1393,8 +1393,8 @@ Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/osv-scanner-fl
                 "GHSA-r285-q736-9v95"
               ],
               "help": {
-                "text": "**Your dependency is vulnerable to [CVE-2023-39137](https://osv.dev/list?q=CVE-2023-39137)**.\n\n## [CVE-2023-39137](https://osv.dev/vulnerability/CVE-2023-39137)\n\n\u003cdetails\u003e\n\u003csummary\u003eDetails\u003c/summary\u003e\n\n\u003e An issue in Archive v3.3.7 allows attackers to spoof zip filenames which can lead to inconsistent filename parsing.\n\n\u003c/details\u003e\n\n---\n\n### Affected Packages\n\n| Source | Package Name | Package Version |\n| --- | --- | --- |\n| lockfile:<rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/osv-scanner-flutter-deps.json | https://github.com/brendan-duncan/archive.git | 9de7a0544457c6aba755ccb65abb41b0dc1db70d |\n\n## Remediation\n\nIf you believe these vulnerabilities do not affect your code and wish to ignore them, add them to the ignore list in an\n`osv-scanner.toml` file located in the same directory as the lockfile containing the vulnerable dependency.\n\nSee the format and more options in our documentation here: https://google.github.io/osv-scanner/configuration/\n\nAdd or append these values to the following config files to ignore this vulnerability:\n\n`<rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/osv-scanner.toml`\n\n```\n[[IgnoredVulns]]\nid = \"CVE-2023-39137\"\nreason = \"Your reason for ignoring this vulnerability\"\n```\n",
-                "markdown": "**Your dependency is vulnerable to [CVE-2023-39137](https://osv.dev/list?q=CVE-2023-39137)**.\n\n## [CVE-2023-39137](https://osv.dev/vulnerability/CVE-2023-39137)\n\n\u003cdetails\u003e\n\u003csummary\u003eDetails\u003c/summary\u003e\n\n\u003e An issue in Archive v3.3.7 allows attackers to spoof zip filenames which can lead to inconsistent filename parsing.\n\n\u003c/details\u003e\n\n---\n\n### Affected Packages\n\n| Source | Package Name | Package Version |\n| --- | --- | --- |\n| lockfile:<rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/osv-scanner-flutter-deps.json | https://github.com/brendan-duncan/archive.git | 9de7a0544457c6aba755ccb65abb41b0dc1db70d |\n\n## Remediation\n\nIf you believe these vulnerabilities do not affect your code and wish to ignore them, add them to the ignore list in an\n`osv-scanner.toml` file located in the same directory as the lockfile containing the vulnerable dependency.\n\nSee the format and more options in our documentation here: https://google.github.io/osv-scanner/configuration/\n\nAdd or append these values to the following config files to ignore this vulnerability:\n\n`<rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/osv-scanner.toml`\n\n```\n[[IgnoredVulns]]\nid = \"CVE-2023-39137\"\nreason = \"Your reason for ignoring this vulnerability\"\n```\n"
+                "text": "**Your dependency is vulnerable to [CVE-2023-39137](https://osv.dev/list?q=CVE-2023-39137)**.\n\n## [CVE-2023-39137](https://osv.dev/vulnerability/CVE-2023-39137)\n\n\u003cdetails\u003e\n\u003csummary\u003eDetails\u003c/summary\u003e\n\n\u003e An issue in Archive v3.3.7 allows attackers to spoof zip filenames which can lead to inconsistent filename parsing.\n\n\u003c/details\u003e\n\n---\n\n### Affected Packages\n\n| Source | Package Name | Package Version |\n| --- | --- | --- |\n| lockfile:<rootdir>/fixtures/locks-insecure/osv-scanner-flutter-deps.json | https://github.com/brendan-duncan/archive.git | 9de7a0544457c6aba755ccb65abb41b0dc1db70d |\n\n## Remediation\n\nIf you believe these vulnerabilities do not affect your code and wish to ignore them, add them to the ignore list in an\n`osv-scanner.toml` file located in the same directory as the lockfile containing the vulnerable dependency.\n\nSee the format and more options in our documentation here: https://google.github.io/osv-scanner/configuration/\n\nAdd or append these values to the following config files to ignore this vulnerability:\n\n`<rootdir>/fixtures/locks-insecure/osv-scanner.toml`\n\n```\n[[IgnoredVulns]]\nid = \"CVE-2023-39137\"\nreason = \"Your reason for ignoring this vulnerability\"\n```\n",
+                "markdown": "**Your dependency is vulnerable to [CVE-2023-39137](https://osv.dev/list?q=CVE-2023-39137)**.\n\n## [CVE-2023-39137](https://osv.dev/vulnerability/CVE-2023-39137)\n\n\u003cdetails\u003e\n\u003csummary\u003eDetails\u003c/summary\u003e\n\n\u003e An issue in Archive v3.3.7 allows attackers to spoof zip filenames which can lead to inconsistent filename parsing.\n\n\u003c/details\u003e\n\n---\n\n### Affected Packages\n\n| Source | Package Name | Package Version |\n| --- | --- | --- |\n| lockfile:<rootdir>/fixtures/locks-insecure/osv-scanner-flutter-deps.json | https://github.com/brendan-duncan/archive.git | 9de7a0544457c6aba755ccb65abb41b0dc1db70d |\n\n## Remediation\n\nIf you believe these vulnerabilities do not affect your code and wish to ignore them, add them to the ignore list in an\n`osv-scanner.toml` file located in the same directory as the lockfile containing the vulnerable dependency.\n\nSee the format and more options in our documentation here: https://google.github.io/osv-scanner/configuration/\n\nAdd or append these values to the following config files to ignore this vulnerability:\n\n`<rootdir>/fixtures/locks-insecure/osv-scanner.toml`\n\n```\n[[IgnoredVulns]]\nid = \"CVE-2023-39137\"\nreason = \"Your reason for ignoring this vulnerability\"\n```\n"
               },
               "properties": {
                 "security-severity": "7.8"
@@ -1415,8 +1415,8 @@ Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/osv-scanner-fl
                 "GHSA-9v85-q87q-g4vg"
               ],
               "help": {
-                "text": "**Your dependency is vulnerable to [CVE-2023-39139](https://osv.dev/list?q=CVE-2023-39139)**.\n\n## [CVE-2023-39139](https://osv.dev/vulnerability/CVE-2023-39139)\n\n\u003cdetails\u003e\n\u003csummary\u003eDetails\u003c/summary\u003e\n\n\u003e An issue in Archive v3.3.7 allows attackers to execute a path traversal via extracting a crafted zip file.\n\n\u003c/details\u003e\n\n---\n\n### Affected Packages\n\n| Source | Package Name | Package Version |\n| --- | --- | --- |\n| lockfile:<rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/osv-scanner-flutter-deps.json | https://github.com/brendan-duncan/archive.git | 9de7a0544457c6aba755ccb65abb41b0dc1db70d |\n\n## Remediation\n\nIf you believe these vulnerabilities do not affect your code and wish to ignore them, add them to the ignore list in an\n`osv-scanner.toml` file located in the same directory as the lockfile containing the vulnerable dependency.\n\nSee the format and more options in our documentation here: https://google.github.io/osv-scanner/configuration/\n\nAdd or append these values to the following config files to ignore this vulnerability:\n\n`<rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/osv-scanner.toml`\n\n```\n[[IgnoredVulns]]\nid = \"CVE-2023-39139\"\nreason = \"Your reason for ignoring this vulnerability\"\n```\n",
-                "markdown": "**Your dependency is vulnerable to [CVE-2023-39139](https://osv.dev/list?q=CVE-2023-39139)**.\n\n## [CVE-2023-39139](https://osv.dev/vulnerability/CVE-2023-39139)\n\n\u003cdetails\u003e\n\u003csummary\u003eDetails\u003c/summary\u003e\n\n\u003e An issue in Archive v3.3.7 allows attackers to execute a path traversal via extracting a crafted zip file.\n\n\u003c/details\u003e\n\n---\n\n### Affected Packages\n\n| Source | Package Name | Package Version |\n| --- | --- | --- |\n| lockfile:<rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/osv-scanner-flutter-deps.json | https://github.com/brendan-duncan/archive.git | 9de7a0544457c6aba755ccb65abb41b0dc1db70d |\n\n## Remediation\n\nIf you believe these vulnerabilities do not affect your code and wish to ignore them, add them to the ignore list in an\n`osv-scanner.toml` file located in the same directory as the lockfile containing the vulnerable dependency.\n\nSee the format and more options in our documentation here: https://google.github.io/osv-scanner/configuration/\n\nAdd or append these values to the following config files to ignore this vulnerability:\n\n`<rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/osv-scanner.toml`\n\n```\n[[IgnoredVulns]]\nid = \"CVE-2023-39139\"\nreason = \"Your reason for ignoring this vulnerability\"\n```\n"
+                "text": "**Your dependency is vulnerable to [CVE-2023-39139](https://osv.dev/list?q=CVE-2023-39139)**.\n\n## [CVE-2023-39139](https://osv.dev/vulnerability/CVE-2023-39139)\n\n\u003cdetails\u003e\n\u003csummary\u003eDetails\u003c/summary\u003e\n\n\u003e An issue in Archive v3.3.7 allows attackers to execute a path traversal via extracting a crafted zip file.\n\n\u003c/details\u003e\n\n---\n\n### Affected Packages\n\n| Source | Package Name | Package Version |\n| --- | --- | --- |\n| lockfile:<rootdir>/fixtures/locks-insecure/osv-scanner-flutter-deps.json | https://github.com/brendan-duncan/archive.git | 9de7a0544457c6aba755ccb65abb41b0dc1db70d |\n\n## Remediation\n\nIf you believe these vulnerabilities do not affect your code and wish to ignore them, add them to the ignore list in an\n`osv-scanner.toml` file located in the same directory as the lockfile containing the vulnerable dependency.\n\nSee the format and more options in our documentation here: https://google.github.io/osv-scanner/configuration/\n\nAdd or append these values to the following config files to ignore this vulnerability:\n\n`<rootdir>/fixtures/locks-insecure/osv-scanner.toml`\n\n```\n[[IgnoredVulns]]\nid = \"CVE-2023-39139\"\nreason = \"Your reason for ignoring this vulnerability\"\n```\n",
+                "markdown": "**Your dependency is vulnerable to [CVE-2023-39139](https://osv.dev/list?q=CVE-2023-39139)**.\n\n## [CVE-2023-39139](https://osv.dev/vulnerability/CVE-2023-39139)\n\n\u003cdetails\u003e\n\u003csummary\u003eDetails\u003c/summary\u003e\n\n\u003e An issue in Archive v3.3.7 allows attackers to execute a path traversal via extracting a crafted zip file.\n\n\u003c/details\u003e\n\n---\n\n### Affected Packages\n\n| Source | Package Name | Package Version |\n| --- | --- | --- |\n| lockfile:<rootdir>/fixtures/locks-insecure/osv-scanner-flutter-deps.json | https://github.com/brendan-duncan/archive.git | 9de7a0544457c6aba755ccb65abb41b0dc1db70d |\n\n## Remediation\n\nIf you believe these vulnerabilities do not affect your code and wish to ignore them, add them to the ignore list in an\n`osv-scanner.toml` file located in the same directory as the lockfile containing the vulnerable dependency.\n\nSee the format and more options in our documentation here: https://google.github.io/osv-scanner/configuration/\n\nAdd or append these values to the following config files to ignore this vulnerability:\n\n`<rootdir>/fixtures/locks-insecure/osv-scanner.toml`\n\n```\n[[IgnoredVulns]]\nid = \"CVE-2023-39139\"\nreason = \"Your reason for ignoring this vulnerability\"\n```\n"
               },
               "properties": {
                 "security-severity": "7.8"
@@ -1429,7 +1429,7 @@ Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/osv-scanner-fl
       "artifacts": [
         {
           "location": {
-            "uri": "file://<rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/osv-scanner-flutter-deps.json"
+            "uri": "file://<rootdir>/fixtures/locks-insecure/osv-scanner-flutter-deps.json"
           },
           "length": -1
         }
@@ -1446,7 +1446,7 @@ Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/osv-scanner-fl
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file://<rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/osv-scanner-flutter-deps.json"
+                  "uri": "file://<rootdir>/fixtures/locks-insecure/osv-scanner-flutter-deps.json"
                 }
               }
             }
@@ -1463,7 +1463,7 @@ Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/osv-scanner-fl
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file://<rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/osv-scanner-flutter-deps.json"
+                  "uri": "file://<rootdir>/fixtures/locks-insecure/osv-scanner-flutter-deps.json"
                 }
               }
             }
@@ -1477,7 +1477,7 @@ Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/osv-scanner-fl
 ---
 
 [TestCommand_GithubActions/scanning_osv-scanner_custom_format_output_json - 2]
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/osv-scanner-flutter-deps.json file as a osv-scanner and found 3 packages
+Scanned <rootdir>/fixtures/locks-insecure/osv-scanner-flutter-deps.json file as a osv-scanner and found 3 packages
 
 ---
 
@@ -1510,13 +1510,13 @@ Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/osv-scanner-fl
 
 [TestCommand_Licenses/Licenses_in_summary_mode_json - 2]
 Scanning dir ./fixtures/locks-licenses/package-lock.json
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-licenses/package-lock.json file and found 4 packages
+Scanned <rootdir>/fixtures/locks-licenses/package-lock.json file and found 4 packages
 
 ---
 
 [TestCommand_Licenses/Licenses_with_expressions - 1]
 Scanning dir ./fixtures/locks-licenses/package-lock.json
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-licenses/package-lock.json file and found 4 packages
+Scanned <rootdir>/fixtures/locks-licenses/package-lock.json file and found 4 packages
 overriding license for package npm/babel/6.23.0 with MIT AND (LGPL-2.1-or-later OR BSD-3-Clause)
 overriding license for package npm/human-signals/5.0.0 with LGPL-2.1-only OR MIT OR BSD-3-Clause
 overriding license for package npm/ms/2.1.3 with MIT WITH Bison-exception-2.2
@@ -1542,7 +1542,7 @@ overriding license for package npm/ms/2.1.3 with MIT WITH Bison-exception-2.2
 
 [TestCommand_Licenses/Licenses_with_invalid_expression_in_config - 1]
 Scanning dir ./fixtures/locks-licenses/package-lock.json
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-licenses/package-lock.json file and found 4 packages
+Scanned <rootdir>/fixtures/locks-licenses/package-lock.json file and found 4 packages
 overriding license for package npm/babel/6.23.0 with MIT AND (LGPL-2.1-or-later OR BSD-3-Clause))
 overriding license for package npm/human-signals/5.0.0 with LGPL-2.1-only OR OR BSD-3-Clause
 overriding license for package npm/ms/2.1.3 with MIT WITH (Bison-exception-2.2 AND somethingelse)
@@ -1583,7 +1583,7 @@ license MIT WITH (Bison-exception-2.2 AND somethingelse) for package npm/ms/2.1.
   "results": [
     {
       "source": {
-        "path": "<rootdir>/osv-scanner/scan/source/fixtures/locks-licenses/package-lock.json",
+        "path": "<rootdir>/fixtures/locks-licenses/package-lock.json",
         "type": "lockfile"
       },
       "packages": [
@@ -1659,19 +1659,19 @@ license MIT WITH (Bison-exception-2.2 AND somethingelse) for package npm/ms/2.1.
 
 [TestCommand_Licenses/No_license_violations_and_show-all-packages_in_json - 2]
 Scanning dir ./fixtures/locks-licenses/package-lock.json
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-licenses/package-lock.json file and found 4 packages
+Scanned <rootdir>/fixtures/locks-licenses/package-lock.json file and found 4 packages
 
 ---
 
 [TestCommand_Licenses/No_vulnerabilities_with_license_summary - 1]
 Scanning dir ./fixtures/locks-many
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/Gemfile.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/alpine.cdx.xml file and found 15 packages
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/composer.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/package-lock.json file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/yarn.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/Gemfile.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/alpine.cdx.xml file and found 15 packages
+Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/yarn.lock file and found 1 package
 Filtered 1 local/unscannable package/s from the scan.
-Loaded filter from: <rootdir>/osv-scanner/scan/source/fixtures/locks-many/osv-scanner.toml
+Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
 CVE-2025-26519 has been filtered out because: Test manifest file (alpine.cdx.xml)
 GHSA-whgm-jr23-g3j9 and 1 alias have been filtered out because: Test manifest file
 Filtered 2 vulnerabilities from output
@@ -1691,13 +1691,13 @@ Filtered 2 vulnerabilities from output
 
 [TestCommand_Licenses/No_vulnerabilities_with_license_summary_in_markdown - 1]
 Scanning dir ./fixtures/locks-many
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/Gemfile.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/alpine.cdx.xml file and found 15 packages
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/composer.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/package-lock.json file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/yarn.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/Gemfile.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/alpine.cdx.xml file and found 15 packages
+Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/yarn.lock file and found 1 package
 Filtered 1 local/unscannable package/s from the scan.
-Loaded filter from: <rootdir>/osv-scanner/scan/source/fixtures/locks-many/osv-scanner.toml
+Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
 CVE-2025-26519 has been filtered out because: Test manifest file (alpine.cdx.xml)
 GHSA-whgm-jr23-g3j9 and 1 alias have been filtered out because: Test manifest file
 Filtered 2 vulnerabilities from output
@@ -1718,7 +1718,7 @@ Filtered 2 vulnerabilities from output
   "results": [
     {
       "source": {
-        "path": "<rootdir>/osv-scanner/scan/source/fixtures/locks-licenses/package-lock.json",
+        "path": "<rootdir>/fixtures/locks-licenses/package-lock.json",
         "type": "lockfile"
       },
       "packages": [
@@ -1791,20 +1791,20 @@ Filtered 2 vulnerabilities from output
 
 [TestCommand_Licenses/Show_all_Packages_with_license_summary_in_json - 2]
 Scanning dir ./fixtures/locks-licenses/package-lock.json
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-licenses/package-lock.json file and found 4 packages
+Scanned <rootdir>/fixtures/locks-licenses/package-lock.json file and found 4 packages
 
 ---
 
 [TestCommand_Licenses/Some_packages_with_ignored_licenses - 1]
 Scanning dir ./fixtures/locks-many
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/Gemfile.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/alpine.cdx.xml file and found 15 packages
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/composer.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/package-lock.json file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/yarn.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/Gemfile.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/alpine.cdx.xml file and found 15 packages
+Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/yarn.lock file and found 1 package
 Scanning dir ./fixtures/locks-insecure
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/bun.lock file and found 2 packages
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/composer.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-insecure/bun.lock file and found 2 packages
+Scanned <rootdir>/fixtures/locks-insecure/composer.lock file and found 1 package
 Filtered 1 local/unscannable package/s from the scan.
 Package npm/ansi-html/0.0.1 has been filtered out because: (no reason given)
 Package npm/balanced-match/1.0.2 has been filtered out because: (no reason given)
@@ -1859,7 +1859,7 @@ overriding license for package Packagist/league/flysystem/1.0.8 with 0BSD
   "results": [
     {
       "source": {
-        "path": "<rootdir>/osv-scanner/scan/source/fixtures/locks-licenses/package-lock.json",
+        "path": "<rootdir>/fixtures/locks-licenses/package-lock.json",
         "type": "lockfile"
       },
       "packages": [
@@ -1937,7 +1937,7 @@ overriding license for package Packagist/league/flysystem/1.0.8 with 0BSD
 
 [TestCommand_Licenses/Some_packages_with_license_violations_and_show-all-packages_in_json - 2]
 Scanning dir ./fixtures/locks-licenses/package-lock.json
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-licenses/package-lock.json file and found 4 packages
+Scanned <rootdir>/fixtures/locks-licenses/package-lock.json file and found 4 packages
 
 ---
 
@@ -1946,7 +1946,7 @@ Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-licenses/package-lock.j
   "results": [
     {
       "source": {
-        "path": "<rootdir>/osv-scanner/scan/source/fixtures/locks-licenses/package-lock.json",
+        "path": "<rootdir>/fixtures/locks-licenses/package-lock.json",
         "type": "lockfile"
       },
       "packages": [
@@ -1994,13 +1994,13 @@ Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-licenses/package-lock.j
 
 [TestCommand_Licenses/Some_packages_with_license_violations_in_json - 2]
 Scanning dir ./fixtures/locks-licenses/package-lock.json
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-licenses/package-lock.json file and found 4 packages
+Scanned <rootdir>/fixtures/locks-licenses/package-lock.json file and found 4 packages
 
 ---
 
 [TestCommand_Licenses/Vulnerabilities_and_all_license_violations_allowlisted - 1]
 Scanning dir ./fixtures/locks-many/package-lock.json
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/package-lock.json file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
 +-------------------------------------+------+-----------+-----------+---------+---------------------------------------+
 | OSV URL                             | CVSS | ECOSYSTEM | PACKAGE   | VERSION | SOURCE                                |
 +-------------------------------------+------+-----------+-----------+---------+---------------------------------------+
@@ -2020,7 +2020,7 @@ Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/package-lock.json 
 
 [TestCommand_Licenses/Vulnerabilities_and_license_summary - 1]
 Scanning dir ./fixtures/locks-many/package-lock.json
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/package-lock.json file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
 +-------------------------------------+------+-----------+-----------+---------+---------------------------------------+
 | OSV URL                             | CVSS | ECOSYSTEM | PACKAGE   | VERSION | SOURCE                                |
 +-------------------------------------+------+-----------+-----------+---------+---------------------------------------+
@@ -2040,7 +2040,7 @@ Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/package-lock.json 
 
 [TestCommand_Licenses/Vulnerabilities_and_license_violations_with_allowlist - 1]
 Scanning dir ./fixtures/locks-many/package-lock.json
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/package-lock.json file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
 +-------------------------------------+------+-----------+-----------+---------+---------------------------------------+
 | OSV URL                             | CVSS | ECOSYSTEM | PACKAGE   | VERSION | SOURCE                                |
 +-------------------------------------+------+-----------+-----------+---------+---------------------------------------+
@@ -2092,8 +2092,8 @@ cannot retrieve licenses locally
 
 [TestCommand_LocalDatabases/.gitignored_files - 1]
 Scanning dir ./fixtures/locks-gitignore
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-gitignore/Gemfile.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-gitignore/subdir/yarn.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-gitignore/Gemfile.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-gitignore/subdir/yarn.lock file and found 1 package
 Loaded RubyGems local db from <tempdir>/osv-scanner/RubyGems/all.zip
 Loaded npm local db from <tempdir>/osv-scanner/npm/all.zip
 No issues found
@@ -2106,8 +2106,8 @@ No issues found
 
 [TestCommand_LocalDatabases/.gitignored_files - 3]
 Scanning dir ./fixtures/locks-gitignore
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-gitignore/Gemfile.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-gitignore/subdir/yarn.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-gitignore/Gemfile.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-gitignore/subdir/yarn.lock file and found 1 package
 Loaded RubyGems local db from <tempdir>/osv-scanner/RubyGems/all.zip
 Loaded npm local db from <tempdir>/osv-scanner/npm/all.zip
 No issues found
@@ -2120,13 +2120,13 @@ No issues found
 
 [TestCommand_LocalDatabases/all_supported_lockfiles_in_the_directory_should_be_checked - 1]
 Scanning dir ./fixtures/locks-many
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/Gemfile.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/alpine.cdx.xml file and found 15 packages
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/composer.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/package-lock.json file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/yarn.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/Gemfile.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/alpine.cdx.xml file and found 15 packages
+Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/yarn.lock file and found 1 package
 Filtered 1 local/unscannable package/s from the scan.
-Loaded filter from: <rootdir>/osv-scanner/scan/source/fixtures/locks-many/osv-scanner.toml
+Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
 Loaded RubyGems local db from <tempdir>/osv-scanner/RubyGems/all.zip
 Loaded Alpine local db from <tempdir>/osv-scanner/Alpine/all.zip
 Loaded Packagist local db from <tempdir>/osv-scanner/Packagist/all.zip
@@ -2144,13 +2144,13 @@ No issues found
 
 [TestCommand_LocalDatabases/all_supported_lockfiles_in_the_directory_should_be_checked - 3]
 Scanning dir ./fixtures/locks-many
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/Gemfile.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/alpine.cdx.xml file and found 15 packages
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/composer.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/package-lock.json file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/yarn.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/Gemfile.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/alpine.cdx.xml file and found 15 packages
+Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/yarn.lock file and found 1 package
 Filtered 1 local/unscannable package/s from the scan.
-Loaded filter from: <rootdir>/osv-scanner/scan/source/fixtures/locks-many/osv-scanner.toml
+Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
 Loaded RubyGems local db from <tempdir>/osv-scanner/RubyGems/all.zip
 Loaded Alpine local db from <tempdir>/osv-scanner/Alpine/all.zip
 Loaded Packagist local db from <tempdir>/osv-scanner/Packagist/all.zip
@@ -2168,29 +2168,29 @@ No issues found
 
 [TestCommand_LocalDatabases/all_supported_lockfiles_in_the_directory_should_be_checked#01 - 1]
 Scanning dir ./fixtures/locks-many-with-invalid
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many-with-invalid/Gemfile.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many-with-invalid/yarn.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many-with-invalid/Gemfile.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many-with-invalid/yarn.lock file and found 1 package
 Loaded RubyGems local db from <tempdir>/osv-scanner/RubyGems/all.zip
 Loaded npm local db from <tempdir>/osv-scanner/npm/all.zip
 
 ---
 
 [TestCommand_LocalDatabases/all_supported_lockfiles_in_the_directory_should_be_checked#01 - 2]
-Error during extraction: (extracting as php/composerlock) could not extract from <rootdir>/osv-scanner/scan/source/fixtures/locks-many-with-invalid/composer.lock: invalid character ',' looking for beginning of object key string
+Error during extraction: (extracting as php/composerlock) could not extract from <rootdir>/fixtures/locks-many-with-invalid/composer.lock: invalid character ',' looking for beginning of object key string
 
 ---
 
 [TestCommand_LocalDatabases/all_supported_lockfiles_in_the_directory_should_be_checked#01 - 3]
 Scanning dir ./fixtures/locks-many-with-invalid
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many-with-invalid/Gemfile.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many-with-invalid/yarn.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many-with-invalid/Gemfile.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many-with-invalid/yarn.lock file and found 1 package
 Loaded RubyGems local db from <tempdir>/osv-scanner/RubyGems/all.zip
 Loaded npm local db from <tempdir>/osv-scanner/npm/all.zip
 
 ---
 
 [TestCommand_LocalDatabases/all_supported_lockfiles_in_the_directory_should_be_checked#01 - 4]
-Error during extraction: (extracting as php/composerlock) could not extract from <rootdir>/osv-scanner/scan/source/fixtures/locks-many-with-invalid/composer.lock: invalid character ',' looking for beginning of object key string
+Error during extraction: (extracting as php/composerlock) could not extract from <rootdir>/fixtures/locks-many-with-invalid/composer.lock: invalid character ',' looking for beginning of object key string
 
 ---
 
@@ -2214,14 +2214,14 @@ databases can only be downloaded when running in offline mode
 
 [TestCommand_LocalDatabases/ignoring_.gitignore - 1]
 Scanning dir ./fixtures/locks-gitignore
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-gitignore/Gemfile.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-gitignore/composer.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-gitignore/ignored/Gemfile.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-gitignore/ignored/yarn.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-gitignore/subdir/Gemfile.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-gitignore/subdir/composer.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-gitignore/subdir/yarn.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-gitignore/yarn.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-gitignore/Gemfile.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-gitignore/composer.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-gitignore/ignored/Gemfile.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-gitignore/ignored/yarn.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-gitignore/subdir/Gemfile.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-gitignore/subdir/composer.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-gitignore/subdir/yarn.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-gitignore/yarn.lock file and found 1 package
 Loaded RubyGems local db from <tempdir>/osv-scanner/RubyGems/all.zip
 Loaded Packagist local db from <tempdir>/osv-scanner/Packagist/all.zip
 Loaded npm local db from <tempdir>/osv-scanner/npm/all.zip
@@ -2235,14 +2235,14 @@ No issues found
 
 [TestCommand_LocalDatabases/ignoring_.gitignore - 3]
 Scanning dir ./fixtures/locks-gitignore
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-gitignore/Gemfile.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-gitignore/composer.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-gitignore/ignored/Gemfile.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-gitignore/ignored/yarn.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-gitignore/subdir/Gemfile.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-gitignore/subdir/composer.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-gitignore/subdir/yarn.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-gitignore/yarn.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-gitignore/Gemfile.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-gitignore/composer.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-gitignore/ignored/Gemfile.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-gitignore/ignored/yarn.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-gitignore/subdir/Gemfile.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-gitignore/subdir/composer.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-gitignore/subdir/yarn.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-gitignore/yarn.lock file and found 1 package
 Loaded RubyGems local db from <tempdir>/osv-scanner/RubyGems/all.zip
 Loaded Packagist local db from <tempdir>/osv-scanner/Packagist/all.zip
 Loaded npm local db from <tempdir>/osv-scanner/npm/all.zip
@@ -2256,8 +2256,8 @@ No issues found
 
 [TestCommand_LocalDatabases/nested_directories_are_checked_when_`--recursive`_is_passed - 1]
 Scanning dir ./fixtures/locks-one-with-nested
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-one-with-nested/nested/composer.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-one-with-nested/yarn.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-one-with-nested/nested/composer.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-one-with-nested/yarn.lock file and found 1 package
 Loaded Packagist local db from <tempdir>/osv-scanner/Packagist/all.zip
 Loaded npm local db from <tempdir>/osv-scanner/npm/all.zip
 No issues found
@@ -2270,8 +2270,8 @@ No issues found
 
 [TestCommand_LocalDatabases/nested_directories_are_checked_when_`--recursive`_is_passed - 3]
 Scanning dir ./fixtures/locks-one-with-nested
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-one-with-nested/nested/composer.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-one-with-nested/yarn.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-one-with-nested/nested/composer.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-one-with-nested/yarn.lock file and found 1 package
 Loaded Packagist local db from <tempdir>/osv-scanner/Packagist/all.zip
 Loaded npm local db from <tempdir>/osv-scanner/npm/all.zip
 No issues found
@@ -2284,8 +2284,8 @@ No issues found
 
 [TestCommand_LocalDatabases/one_specific_supported_lockfile - 1]
 Scanning dir ./fixtures/locks-many/composer.lock
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/composer.lock file and found 1 package
-Loaded filter from: <rootdir>/osv-scanner/scan/source/fixtures/locks-many/osv-scanner.toml
+Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
+Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
 Loaded Packagist local db from <tempdir>/osv-scanner/Packagist/all.zip
 No issues found
 
@@ -2297,8 +2297,8 @@ No issues found
 
 [TestCommand_LocalDatabases/one_specific_supported_lockfile - 3]
 Scanning dir ./fixtures/locks-many/composer.lock
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/composer.lock file and found 1 package
-Loaded filter from: <rootdir>/osv-scanner/scan/source/fixtures/locks-many/osv-scanner.toml
+Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
+Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
 Loaded Packagist local db from <tempdir>/osv-scanner/Packagist/all.zip
 No issues found
 
@@ -2310,7 +2310,7 @@ No issues found
 
 [TestCommand_LocalDatabases/one_specific_supported_sbom_with_vulns - 1]
 Scanning dir ./fixtures/sbom-insecure/postgres-stretch.cdx.xml
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/sbom-insecure/postgres-stretch.cdx.xml file and found 136 packages
+Scanned <rootdir>/fixtures/sbom-insecure/postgres-stretch.cdx.xml file and found 136 packages
 Loaded Debian local db from <tempdir>/osv-scanner/Debian/all.zip
 Loaded Go local db from <tempdir>/osv-scanner/Go/all.zip
 Loaded OSS-Fuzz local db from <tempdir>/osv-scanner/OSS-Fuzz/all.zip
@@ -2579,7 +2579,7 @@ Loaded OSS-Fuzz local db from <tempdir>/osv-scanner/OSS-Fuzz/all.zip
 
 [TestCommand_LocalDatabases/one_specific_supported_sbom_with_vulns - 3]
 Scanning dir ./fixtures/sbom-insecure/postgres-stretch.cdx.xml
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/sbom-insecure/postgres-stretch.cdx.xml file and found 136 packages
+Scanned <rootdir>/fixtures/sbom-insecure/postgres-stretch.cdx.xml file and found 136 packages
 Loaded Debian local db from <tempdir>/osv-scanner/Debian/all.zip
 Loaded Go local db from <tempdir>/osv-scanner/Go/all.zip
 Loaded OSS-Fuzz local db from <tempdir>/osv-scanner/OSS-Fuzz/all.zip
@@ -2868,7 +2868,7 @@ No package sources found, --help for usage information.
 
 [TestCommand_LocalDatabases/only_the_files_in_the_given_directories_are_checked_by_default_(no_recursion) - 1]
 Scanning dir ./fixtures/locks-one-with-nested
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-one-with-nested/yarn.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-one-with-nested/yarn.lock file and found 1 package
 Loaded npm local db from <tempdir>/osv-scanner/npm/all.zip
 No issues found
 
@@ -2880,7 +2880,7 @@ No issues found
 
 [TestCommand_LocalDatabases/only_the_files_in_the_given_directories_are_checked_by_default_(no_recursion) - 3]
 Scanning dir ./fixtures/locks-one-with-nested
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-one-with-nested/yarn.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-one-with-nested/yarn.lock file and found 1 package
 Loaded npm local db from <tempdir>/osv-scanner/npm/all.zip
 No issues found
 
@@ -2892,8 +2892,8 @@ No issues found
 
 [TestCommand_LocalDatabases/output_format:_markdown_table - 1]
 Scanning dir ./fixtures/locks-many/composer.lock
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/composer.lock file and found 1 package
-Loaded filter from: <rootdir>/osv-scanner/scan/source/fixtures/locks-many/osv-scanner.toml
+Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
+Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
 Loaded Packagist local db from <tempdir>/osv-scanner/Packagist/all.zip
 No issues found
 
@@ -2905,8 +2905,8 @@ No issues found
 
 [TestCommand_LocalDatabases/output_format:_markdown_table - 3]
 Scanning dir ./fixtures/locks-many/composer.lock
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/composer.lock file and found 1 package
-Loaded filter from: <rootdir>/osv-scanner/scan/source/fixtures/locks-many/osv-scanner.toml
+Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
+Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
 Loaded Packagist local db from <tempdir>/osv-scanner/Packagist/all.zip
 No issues found
 
@@ -2931,8 +2931,8 @@ No issues found
 
 [TestCommand_LocalDatabases/output_with_json - 2]
 Scanning dir ./fixtures/locks-many/composer.lock
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/composer.lock file and found 1 package
-Loaded filter from: <rootdir>/osv-scanner/scan/source/fixtures/locks-many/osv-scanner.toml
+Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
+Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
 Loaded Packagist local db from <tempdir>/osv-scanner/Packagist/all.zip
 
 ---
@@ -2952,25 +2952,25 @@ Loaded Packagist local db from <tempdir>/osv-scanner/Packagist/all.zip
 
 [TestCommand_LocalDatabases/output_with_json - 4]
 Scanning dir ./fixtures/locks-many/composer.lock
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/composer.lock file and found 1 package
-Loaded filter from: <rootdir>/osv-scanner/scan/source/fixtures/locks-many/osv-scanner.toml
+Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
+Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
 Loaded Packagist local db from <tempdir>/osv-scanner/Packagist/all.zip
 
 ---
 
 [TestCommand_LocalDatabases_AlwaysOffline/a_bunch_of_different_lockfiles_and_ecosystem - 1]
 Scanning dir ./fixtures/locks-requirements
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-requirements/my-requirements.txt file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-requirements/requirements-dev.txt file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-requirements/requirements.prod.txt file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-requirements/requirements.txt file and found 3 packages
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-requirements/the_requirements_for_test.txt file and found 1 package
+Scanned <rootdir>/fixtures/locks-requirements/my-requirements.txt file and found 1 package
+Scanned <rootdir>/fixtures/locks-requirements/requirements-dev.txt file and found 1 package
+Scanned <rootdir>/fixtures/locks-requirements/requirements.prod.txt file and found 1 package
+Scanned <rootdir>/fixtures/locks-requirements/requirements.txt file and found 3 packages
+Scanned <rootdir>/fixtures/locks-requirements/the_requirements_for_test.txt file and found 1 package
 Scanning dir ./fixtures/locks-many
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/Gemfile.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/alpine.cdx.xml file and found 15 packages
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/composer.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/package-lock.json file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/yarn.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/Gemfile.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/alpine.cdx.xml file and found 15 packages
+Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/yarn.lock file and found 1 package
 Filtered 1 local/unscannable package/s from the scan.
 
 ---
@@ -2986,17 +2986,17 @@ could not load db for npm ecosystem: unable to fetch OSV database: no offline ve
 
 [TestCommand_LocalDatabases_AlwaysOffline/a_bunch_of_different_lockfiles_and_ecosystem - 3]
 Scanning dir ./fixtures/locks-requirements
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-requirements/my-requirements.txt file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-requirements/requirements-dev.txt file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-requirements/requirements.prod.txt file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-requirements/requirements.txt file and found 3 packages
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-requirements/the_requirements_for_test.txt file and found 1 package
+Scanned <rootdir>/fixtures/locks-requirements/my-requirements.txt file and found 1 package
+Scanned <rootdir>/fixtures/locks-requirements/requirements-dev.txt file and found 1 package
+Scanned <rootdir>/fixtures/locks-requirements/requirements.prod.txt file and found 1 package
+Scanned <rootdir>/fixtures/locks-requirements/requirements.txt file and found 3 packages
+Scanned <rootdir>/fixtures/locks-requirements/the_requirements_for_test.txt file and found 1 package
 Scanning dir ./fixtures/locks-many
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/Gemfile.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/alpine.cdx.xml file and found 15 packages
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/composer.lock file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/package-lock.json file and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/yarn.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/Gemfile.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/alpine.cdx.xml file and found 15 packages
+Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
+Scanned <rootdir>/fixtures/locks-many/yarn.lock file and found 1 package
 Filtered 1 local/unscannable package/s from the scan.
 
 ---
@@ -3011,8 +3011,8 @@ could not load db for npm ecosystem: unable to fetch OSV database: no offline ve
 ---
 
 [TestCommand_LockfileWithExplicitParseAs/"apk-installed"_is_supported - 1]
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/installed file as a apk-installed and found 1 package
-Loaded filter from: <rootdir>/osv-scanner/scan/source/fixtures/locks-many/osv-scanner.toml
+Scanned <rootdir>/fixtures/locks-many/installed file as a apk-installed and found 1 package
+Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
 No issues found
 
 ---
@@ -3022,8 +3022,8 @@ No issues found
 ---
 
 [TestCommand_LockfileWithExplicitParseAs/"dpkg-status"_is_supported - 1]
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/status file as a dpkg-status and found 1 package
-Loaded filter from: <rootdir>/osv-scanner/scan/source/fixtures/locks-many/osv-scanner.toml
+Scanned <rootdir>/fixtures/locks-many/status file as a dpkg-status and found 1 package
+Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
 No issues found
 
 ---
@@ -3033,8 +3033,8 @@ No issues found
 ---
 
 [TestCommand_LockfileWithExplicitParseAs/empty_is_default - 1]
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/composer.lock file and found 1 package
-Loaded filter from: <rootdir>/osv-scanner/scan/source/fixtures/locks-many/osv-scanner.toml
+Scanned <rootdir>/fixtures/locks-many/composer.lock file and found 1 package
+Loaded filter from: <rootdir>/fixtures/locks-many/osv-scanner.toml
 No issues found
 
 ---
@@ -3048,7 +3048,7 @@ No issues found
 ---
 
 [TestCommand_LockfileWithExplicitParseAs/empty_works_as_an_escape_(no_fixture_because_it's_not_valid_on_Windows) - 2]
-stat <rootdir>/osv-scanner/scan/source/path/to/my:file: no such file or directory
+stat <rootdir>/path/to/my:file: no such file or directory
 
 ---
 
@@ -3057,7 +3057,7 @@ stat <rootdir>/osv-scanner/scan/source/path/to/my:file: no such file or director
 ---
 
 [TestCommand_LockfileWithExplicitParseAs/empty_works_as_an_escape_(no_fixture_because_it's_not_valid_on_Windows)#01 - 2]
-stat <rootdir>/osv-scanner/scan/source/path/to/my:project/package-lock.json: no such file or directory
+stat <rootdir>/path/to/my:project/package-lock.json: no such file or directory
 
 ---
 
@@ -3066,16 +3066,16 @@ stat <rootdir>/osv-scanner/scan/source/path/to/my:project/package-lock.json: no 
 ---
 
 [TestCommand_LockfileWithExplicitParseAs/files_that_error_on_parsing_stop_parsable_files_from_being_checked - 2]
-(extracting as rust/cargolock) could not extract from <rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/my-package-lock.json: toml: line 1: expected '.' or '=', but got '{' instead
+(extracting as rust/cargolock) could not extract from <rootdir>/fixtures/locks-insecure/my-package-lock.json: toml: line 1: expected '.' or '=', but got '{' instead
 
 ---
 
 [TestCommand_LockfileWithExplicitParseAs/multiple,_+_output_order_is_deterministic - 1]
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/my-package-lock.json file as a package-lock.json and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/my-yarn.lock file as a yarn.lock and found 1 package
+Scanned <rootdir>/fixtures/locks-insecure/my-package-lock.json file as a package-lock.json and found 1 package
+Scanned <rootdir>/fixtures/locks-insecure/my-yarn.lock file as a yarn.lock and found 1 package
 Scanning dir ./fixtures/locks-insecure
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/bun.lock file and found 2 packages
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/composer.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-insecure/bun.lock file and found 2 packages
+Scanned <rootdir>/fixtures/locks-insecure/composer.lock file and found 1 package
 +-------------------------------------+------+-----------+------------------+---------+----------------------------------------------+
 | OSV URL                             | CVSS | ECOSYSTEM | PACKAGE          | VERSION | SOURCE                                       |
 +-------------------------------------+------+-----------+------------------+---------+----------------------------------------------+
@@ -3091,11 +3091,11 @@ Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/composer.lock 
 ---
 
 [TestCommand_LockfileWithExplicitParseAs/multiple,_+_output_order_is_deterministic_2 - 1]
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/my-yarn.lock file as a yarn.lock and found 1 package
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/my-package-lock.json file as a package-lock.json and found 1 package
+Scanned <rootdir>/fixtures/locks-insecure/my-yarn.lock file as a yarn.lock and found 1 package
+Scanned <rootdir>/fixtures/locks-insecure/my-package-lock.json file as a package-lock.json and found 1 package
 Scanning dir ./fixtures/locks-insecure
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/bun.lock file and found 2 packages
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/composer.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-insecure/bun.lock file and found 2 packages
+Scanned <rootdir>/fixtures/locks-insecure/composer.lock file and found 1 package
 +-------------------------------------+------+-----------+------------------+---------+----------------------------------------------+
 | OSV URL                             | CVSS | ECOSYSTEM | PACKAGE          | VERSION | SOURCE                                       |
 +-------------------------------------+------+-----------+------------------+---------+----------------------------------------------+
@@ -3111,7 +3111,7 @@ Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/composer.lock 
 ---
 
 [TestCommand_LockfileWithExplicitParseAs/one_lockfile_with_local_path - 1]
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-many/replace-local.mod file as a go.mod and found 1 package
+Scanned <rootdir>/fixtures/locks-many/replace-local.mod file as a go.mod and found 1 package
 Filtered 1 local/unscannable package/s from the scan.
 No issues found
 
@@ -3126,7 +3126,7 @@ No issues found
 ---
 
 [TestCommand_LockfileWithExplicitParseAs/parse-as_takes_priority,_even_if_it's_wrong - 2]
-(extracting as javascript/packagelockjson) could not extract from "<rootdir>/osv-scanner/scan/source/fixtures/locks-many/yarn.lock": invalid character '#' looking for beginning of value
+(extracting as javascript/packagelockjson) could not extract from "<rootdir>/fixtures/locks-many/yarn.lock": invalid character '#' looking for beginning of value
 
 ---
 
@@ -3140,10 +3140,10 @@ could not determine extractor, requested my-file
 ---
 
 [TestCommand_LockfileWithExplicitParseAs/when_an_explicit_parse-as_is_given,_it's_applied_to_that_file - 1]
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/my-package-lock.json file as a package-lock.json and found 1 package
+Scanned <rootdir>/fixtures/locks-insecure/my-package-lock.json file as a package-lock.json and found 1 package
 Scanning dir ./fixtures/locks-insecure
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/bun.lock file and found 2 packages
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/composer.lock file and found 1 package
+Scanned <rootdir>/fixtures/locks-insecure/bun.lock file and found 2 packages
+Scanned <rootdir>/fixtures/locks-insecure/composer.lock file and found 1 package
 +-------------------------------------+------+-----------+------------------+---------+----------------------------------------------+
 | OSV URL                             | CVSS | ECOSYSTEM | PACKAGE          | VERSION | SOURCE                                       |
 +-------------------------------------+------+-----------+------------------+---------+----------------------------------------------+
@@ -3159,7 +3159,7 @@ Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-insecure/composer.lock 
 
 [TestCommand_MavenTransitive/does_not_scan_transitive_dependencies_for_pom.xml_with_no-resolve - 1]
 Scanning dir ./fixtures/maven-transitive/pom.xml
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/maven-transitive/pom.xml file and found 1 package
+Scanned <rootdir>/fixtures/maven-transitive/pom.xml file and found 1 package
 No issues found
 
 ---
@@ -3170,7 +3170,7 @@ No issues found
 
 [TestCommand_MavenTransitive/does_not_scan_transitive_dependencies_for_pom.xml_with_offline_mode - 1]
 Scanning dir ./fixtures/maven-transitive/pom.xml
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/maven-transitive/pom.xml file and found 1 package
+Scanned <rootdir>/fixtures/maven-transitive/pom.xml file and found 1 package
 Loaded Maven local db from <tempdir>/osv-scanner/Maven/all.zip
 No issues found
 
@@ -3181,7 +3181,7 @@ No issues found
 ---
 
 [TestCommand_MavenTransitive/resolve_transitive_dependencies_with_native_data_source - 1]
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/maven-transitive/registry.xml file as a pom.xml and found 59 packages
+Scanned <rootdir>/fixtures/maven-transitive/registry.xml file as a pom.xml and found 59 packages
 +-------------------------------------+------+-----------+-----------------------------------------------+---------+----------------------------------------+
 | OSV URL                             | CVSS | ECOSYSTEM | PACKAGE                                       | VERSION | SOURCE                                 |
 +-------------------------------------+------+-----------+-----------------------------------------------+---------+----------------------------------------+
@@ -3199,7 +3199,7 @@ Scanned <rootdir>/osv-scanner/scan/source/fixtures/maven-transitive/registry.xml
 ---
 
 [TestCommand_MavenTransitive/scans_dependencies_from_multiple_registries - 1]
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/maven-transitive/registry.xml file as a pom.xml and found 59 packages
+Scanned <rootdir>/fixtures/maven-transitive/registry.xml file as a pom.xml and found 59 packages
 +-------------------------------------+------+-----------+-----------------------------------------------+---------+----------------------------------------+
 | OSV URL                             | CVSS | ECOSYSTEM | PACKAGE                                       | VERSION | SOURCE                                 |
 +-------------------------------------+------+-----------+-----------------------------------------------+---------+----------------------------------------+
@@ -3217,7 +3217,7 @@ Scanned <rootdir>/osv-scanner/scan/source/fixtures/maven-transitive/registry.xml
 ---
 
 [TestCommand_MavenTransitive/scans_pom.xml_with_non_UTF-8_encoding - 1]
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/maven-transitive/encoding.xml file as a pom.xml and found 2 packages
+Scanned <rootdir>/fixtures/maven-transitive/encoding.xml file as a pom.xml and found 2 packages
 +-------------------------------------+------+-----------+-------------+---------+----------------------------------------+
 | OSV URL                             | CVSS | ECOSYSTEM | PACKAGE     | VERSION | SOURCE                                 |
 +-------------------------------------+------+-----------+-------------+---------+----------------------------------------+
@@ -3231,7 +3231,7 @@ Scanned <rootdir>/osv-scanner/scan/source/fixtures/maven-transitive/encoding.xml
 ---
 
 [TestCommand_MavenTransitive/scans_transitive_dependencies_by_specifying_pom.xml - 1]
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/maven-transitive/abc.xml file as a pom.xml and found 3 packages
+Scanned <rootdir>/fixtures/maven-transitive/abc.xml file as a pom.xml and found 3 packages
 +-------------------------------------+------+-----------+-------------------------------------+---------+-----------------------------------+
 | OSV URL                             | CVSS | ECOSYSTEM | PACKAGE                             | VERSION | SOURCE                            |
 +-------------------------------------+------+-----------+-------------------------------------+---------+-----------------------------------+
@@ -3249,7 +3249,7 @@ Scanned <rootdir>/osv-scanner/scan/source/fixtures/maven-transitive/abc.xml file
 
 [TestCommand_MavenTransitive/scans_transitive_dependencies_for_pom.xml_by_default - 1]
 Scanning dir ./fixtures/maven-transitive/pom.xml
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/maven-transitive/pom.xml file and found 3 packages
+Scanned <rootdir>/fixtures/maven-transitive/pom.xml file and found 3 packages
 +-------------------------------------+------+-----------+-------------------------------------+---------+-----------------------------------+
 | OSV URL                             | CVSS | ECOSYSTEM | PACKAGE                             | VERSION | SOURCE                            |
 +-------------------------------------+------+-----------+-------------------------------------+---------+-----------------------------------+
@@ -3266,7 +3266,7 @@ Scanned <rootdir>/osv-scanner/scan/source/fixtures/maven-transitive/pom.xml file
 ---
 
 [TestCommand_MoreLockfiles/cabal.project.freeze - 1]
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-scalibr/cabal.project.freeze file and found 6 packages
+Scanned <rootdir>/fixtures/locks-scalibr/cabal.project.freeze file and found 6 packages
 +--------------------------------+------+-----------+-----------------+---------+---------------------------------------------+
 | OSV URL                        | CVSS | ECOSYSTEM | PACKAGE         | VERSION | SOURCE                                      |
 +--------------------------------+------+-----------+-----------------+---------+---------------------------------------------+
@@ -3280,7 +3280,7 @@ Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-scalibr/cabal.project.f
 ---
 
 [TestCommand_MoreLockfiles/depsjson - 1]
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-scalibr/depsjson file as a deps.json and found 4 packages
+Scanned <rootdir>/fixtures/locks-scalibr/depsjson file as a deps.json and found 4 packages
 +-------------------------------------+------+-----------+--------------------------+---------+---------------------------------+
 | OSV URL                             | CVSS | ECOSYSTEM | PACKAGE                  | VERSION | SOURCE                          |
 +-------------------------------------+------+-----------+--------------------------+---------+---------------------------------+
@@ -3294,7 +3294,7 @@ Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-scalibr/depsjson file a
 ---
 
 [TestCommand_MoreLockfiles/packages.config - 1]
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-scalibr/packages.config file and found 2 packages
+Scanned <rootdir>/fixtures/locks-scalibr/packages.config file and found 2 packages
 No issues found
 
 ---
@@ -3304,7 +3304,7 @@ No issues found
 ---
 
 [TestCommand_MoreLockfiles/packages.lock.json - 1]
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-scalibr/packages.lock.json file and found 1 package
+Scanned <rootdir>/fixtures/locks-scalibr/packages.lock.json file and found 1 package
 No issues found
 
 ---
@@ -3314,7 +3314,7 @@ No issues found
 ---
 
 [TestCommand_MoreLockfiles/stack.yaml.lock - 1]
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-scalibr/stack.yaml.lock file and found 4 packages
+Scanned <rootdir>/fixtures/locks-scalibr/stack.yaml.lock file and found 4 packages
 No issues found
 
 ---
@@ -3324,7 +3324,7 @@ No issues found
 ---
 
 [TestCommand_MoreLockfiles/uv.lock - 1]
-Scanned <rootdir>/osv-scanner/scan/source/fixtures/locks-scalibr/uv.lock file and found 2 packages
+Scanned <rootdir>/fixtures/locks-scalibr/uv.lock file and found 2 packages
 No issues found
 
 ---

--- a/internal/testutility/normalize.go
+++ b/internal/testutility/normalize.go
@@ -3,7 +3,6 @@ package testutility
 import (
 	"bufio"
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -61,23 +60,6 @@ func normalizeRootDirectory(t *testing.T, str string) string {
 	}
 
 	cwd = normalizeFilePaths(t, cwd)
-
-	// todo: currently this is a workaround for the osv-scanner/cmd/scan tests to
-	//  avoid having to move the fixtures and make other changes right now but
-	//  we should be able to remove this in future, e.g. by moving the fixtures
-	//  e.g. /home/me/projects/osv-scanner/cmd/osv-scanner/scan will be come
-	//  /home/me/projects/osv-scanner, and then get matched for the rootdir
-	if strings.Contains(cwd, "osv-scanner/cmd") {
-		for {
-			if strings.HasSuffix(cwd, "osv-scanner/cmd") {
-				break
-			}
-
-			// because we normalize the path to use forward slashes,
-			// we need to use the not-os-specific path.Dir for this
-			cwd = path.Dir(cwd)
-		}
-	}
 
 	// file uris with Windows end up with three slashes, so we normalize that too
 	str = strings.ReplaceAll(str, "file:///"+cwd, "file://<rootdir>")


### PR DESCRIPTION
As we've adjusted our `cmd` tests to use package-local fixtures, we no longer need this workaround 🎉