### PR TITLE
refactor: use tagged switches

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -113,8 +113,6 @@ linters:
       checks:
         - all
         - -QF1001 # apply De Morgan's law
-        - -QF1002 # use tagged switch on base
-        - -QF1003 # use tagged switch on prefix
         - -QF1006 # lift into loop condition
         - -QF1008 # remove embedded field from selector
   exclusions:

--- a/internal/identifiers/identifiers.go
+++ b/internal/identifiers/identifiers.go
@@ -5,13 +5,14 @@ import (
 )
 
 func prefixOrder(prefix string) int {
-	if prefix == "DSA" || prefix == "USN" {
+	switch prefix {
+	case "DSA", "USN":
 		// Special case: For container scanning, DSA contains multiple CVEs and is more accurate.
 		return 3
-	} else if prefix == "CVE" {
+	case "CVE":
 		// Highest precedence for normal cases
 		return 2
-	} else if prefix == "GHSA" {
+	case "GHSA":
 		// Lowest precedence
 		return 0
 	}
@@ -20,9 +21,10 @@ func prefixOrder(prefix string) int {
 }
 
 func prefixOrderForDescription(prefix string) int {
-	if prefix == "CVE" {
+	switch prefix {
+	case "CVE":
 		return 0
-	} else if prefix == "GHSA" {
+	case "GHSA":
 		return 1
 	}
 

--- a/internal/resolution/lockfile/lockfile.go
+++ b/internal/resolution/lockfile/lockfile.go
@@ -50,8 +50,8 @@ func Overwrite(rw ReadWriter, filename string, patches []DependencyPatch) error 
 
 func GetReadWriter(pathToLockfile string) (ReadWriter, error) {
 	base := filepath.Base(pathToLockfile)
-	switch {
-	case base == "package-lock.json":
+	switch base {
+	case "package-lock.json":
 		return NpmReadWriter{}, nil
 	default:
 		return nil, fmt.Errorf("unsupported lockfile type: %s", base)

--- a/internal/resolution/manifest/manifest.go
+++ b/internal/resolution/manifest/manifest.go
@@ -94,10 +94,10 @@ func Overwrite(rw ReadWriter, filename string, p Patch) error {
 
 func GetReadWriter(pathToManifest string, registry string) (ReadWriter, error) {
 	base := filepath.Base(pathToManifest)
-	switch {
-	case base == "pom.xml":
+	switch base {
+	case "pom.xml":
 		return NewMavenReadWriter(registry)
-	case base == "package.json":
+	case "package.json":
 		return NpmReadWriter{}, nil
 	default:
 		return nil, fmt.Errorf("unsupported manifest type: %s", base)


### PR DESCRIPTION
This makes the code more readable by reducing duplicate operators