### PR TITLE
test: remove unneeded `strings.ReplaceAll` call

### DIFF
--- a/internal/testutility/normalize.go
+++ b/internal/testutility/normalize.go
@@ -116,7 +116,6 @@ func normalizeErrors(t *testing.T, str string) string {
 
 	str = strings.ReplaceAll(str, "The filename, directory name, or volume label syntax is incorrect.", "no such file or directory")
 	str = strings.ReplaceAll(str, "The system cannot find the path specified.", "no such file or directory")
-	str = strings.ReplaceAll(str, "The system cannot find the file specified.", "no such file or directory")
 	str = strings.ReplaceAll(str, "CreateFile", "lstat")
 	str = strings.ReplaceAll(str, "\nstat ./fixtures/", "\nlstat ./fixtures/")
 


### PR DESCRIPTION
Someone should make a linter for this..