### PR TITLE
feat: use a dedicated exit code when a config is invalid

### DIFF
--- a/cmd/osv-reporter/main.go
+++ b/cmd/osv-reporter/main.go
@@ -182,7 +182,15 @@ func run(args []string, stdout, stderr io.Writer) int {
 		},
 	}
 
-	if err := app.Run(context.Background(), args); err != nil {
+	err := app.Run(context.Background(), args)
+
+	// if the config is invalid, it's possible that is why any other errors
+	// happened so that exit code takes priority
+	if logger.HasErroredBecauseInvalidConfig() {
+		return 130
+	}
+
+	if err != nil {
 		if errors.Is(err, osvscanner.ErrVulnerabilitiesFound) {
 			return 1
 		}

--- a/cmd/osv-scanner/internal/cmd/run.go
+++ b/cmd/osv-scanner/internal/cmd/run.go
@@ -90,7 +90,15 @@ func Run(args []string, stdout, stderr io.Writer, commands []CommandBuilder) int
 
 	args = insertDefaultCommand(args, app.Commands, app.DefaultCommand, stderr)
 
-	if err := app.Run(context.Background(), args); err != nil {
+	err := app.Run(context.Background(), args)
+
+	// if the config is invalid, it's possible that is why any other errors
+	// happened so that exit code takes priority
+	if logHandler.HasErroredBecauseInvalidConfig() {
+		return 130
+	}
+
+	if err != nil {
 		switch {
 		case errors.Is(err, osvscanner.ErrVulnerabilitiesFound):
 			return 1

--- a/cmd/osv-scanner/scan/source/command_test.go
+++ b/cmd/osv-scanner/scan/source/command_test.go
@@ -243,7 +243,7 @@ func TestCommand(t *testing.T) {
 		{
 			Name: "config file is invalid",
 			Args: []string{"", "source", "./fixtures/config-invalid"},
-			Exit: 127,
+			Exit: 130,
 		},
 		// config file with unknown keys
 		{

--- a/internal/cmdlogger/interface.go
+++ b/internal/cmdlogger/interface.go
@@ -6,6 +6,7 @@ type CmdLogger interface {
 	slog.Handler
 	SendEverythingToStderr()
 	HasErrored() bool
+	HasErroredBecauseInvalidConfig() bool
 	SetLevel(level slog.Leveler)
 }
 

--- a/internal/testlogger/handler.go
+++ b/internal/testlogger/handler.go
@@ -108,6 +108,12 @@ func (tl *Handler) HasErrored() bool {
 	return tl.getLogger().HasErrored()
 }
 
+// HasErroredBecauseInvalidConfig returns true if there have been any calls to
+// Handle with a level of [slog.LevelError] due to a config file being invalid
+func (tl *Handler) HasErroredBecauseInvalidConfig() bool {
+	return tl.getLogger().HasErroredBecauseInvalidConfig()
+}
+
 func (tl *Handler) WithAttrs(attrs []slog.Attr) slog.Handler {
 	return tl.getLogger().WithAttrs(attrs)
 }


### PR DESCRIPTION
This has us output a dedicated exit code in the event of an invalid configuration file to make it easier to identify those situations in an automated context.

Because we ignore invalid configs rather than hard erroring, supporting this has required adding a new method to our logger interface for tracking if we errored specifically because of an invalid config - while this might seem strange, I think it's actually fine because this is all internal code and it should be straightforward to make it more generic _if_ we find further need for this sort of thing (also tying in somewhat to doing more structured logging)

Relates to https://github.com/google/osv-scanner/issues/1221#issuecomment-2873896420