### PR TITLE
docs: remove reference to v1 flag

### DIFF
--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -279,7 +279,6 @@ jobs:
       scan-args: |-
         --lockfile=osv-scanner:osv-scanner-deps.json
         --recursive
-        --skip-git
         ./
     permissions:
       security-events: write


### PR DESCRIPTION
This flag was removed in v2 in favor of `--include-git-root` which is an opt-in flag so doesn't need to be added here