### PR TITLE
feat: make various experimental fields as stable

### DIFF
--- a/cmd/osv-scanner/internal/helper/helper.go
+++ b/cmd/osv-scanner/internal/helper/helper.go
@@ -256,14 +256,21 @@ func GetScanLicensesAllowlist(cmd *cli.Command) ([]string, error) {
 	return allowlist, nil
 }
 
-func GetExperimentalScannerActions(cmd *cli.Command, scanLicensesAllowlist []string) osvscanner.ExperimentalScannerActions {
-	return osvscanner.ExperimentalScannerActions{
-		LocalDBPath:           cmd.String("local-db-path"),
-		DownloadDatabases:     cmd.Bool("download-offline-databases"),
-		CompareOffline:        cmd.Bool("offline-vulnerabilities"),
+func GetCommonScannerActions(cmd *cli.Command, scanLicensesAllowlist []string) osvscanner.ScannerActions {
+	return osvscanner.ScannerActions{
+		IncludeGitRoot:        cmd.Bool("include-git-root"),
+		ConfigOverridePath:    cmd.String("config"),
 		ShowAllPackages:       cmd.Bool("all-packages"),
+		CompareOffline:        cmd.Bool("offline-vulnerabilities"),
+		DownloadDatabases:     cmd.Bool("download-offline-databases"),
+		LocalDBPath:           cmd.String("local-db-path"),
 		ScanLicensesSummary:   cmd.IsSet("licenses"),
 		ScanLicensesAllowlist: scanLicensesAllowlist,
+	}
+}
+
+func GetExperimentalScannerActions(cmd *cli.Command) osvscanner.ExperimentalScannerActions {
+	return osvscanner.ExperimentalScannerActions{
 		Extractors: ResolveEnabledExtractors(
 			cmd.StringSlice("experimental-extractors"),
 			cmd.StringSlice("experimental-disable-extractors"),

--- a/cmd/osv-scanner/scan/image/command.go
+++ b/cmd/osv-scanner/scan/image/command.go
@@ -69,13 +69,11 @@ func action(_ context.Context, cmd *cli.Command, stdout, stderr io.Writer) error
 		return err
 	}
 
-	scannerAction := osvscanner.ScannerActions{
-		Image:                      cmd.Args().First(),
-		ConfigOverridePath:         cmd.String("config"),
-		IsImageArchive:             cmd.Bool("archive"),
-		IncludeGitRoot:             cmd.Bool("include-git-root"),
-		ExperimentalScannerActions: helper.GetExperimentalScannerActions(cmd, scanLicensesAllowlist),
-	}
+	scannerAction := helper.GetCommonScannerActions(cmd, scanLicensesAllowlist)
+
+	scannerAction.Image = cmd.Args().First()
+	scannerAction.IsImageArchive = cmd.Bool("archive")
+	scannerAction.ExperimentalScannerActions = helper.GetExperimentalScannerActions(cmd)
 
 	if len(scannerAction.Extractors) == 0 {
 		return errors.New("at least one extractor must be enabled")

--- a/cmd/osv-scanner/scan/source/command.go
+++ b/cmd/osv-scanner/scan/source/command.go
@@ -109,7 +109,7 @@ func action(_ context.Context, cmd *cli.Command, stdout, stderr io.Writer) error
 
 	callAnalysisStates := helper.CreateCallAnalysisStates(cmd.StringSlice("call-analysis"), cmd.StringSlice("no-call-analysis"))
 
-	experimentalScannerActions := helper.GetExperimentalScannerActions(cmd, scanLicensesAllowlist)
+	experimentalScannerActions := helper.GetExperimentalScannerActions(cmd)
 	// Add `source` specific experimental configs
 	experimentalScannerActions.TransitiveScanningActions = osvscanner.TransitiveScanningActions{
 		Disabled:         cmd.Bool("no-resolve"),
@@ -117,17 +117,15 @@ func action(_ context.Context, cmd *cli.Command, stdout, stderr io.Writer) error
 		MavenRegistry:    cmd.String("maven-registry"),
 	}
 
-	scannerAction := osvscanner.ScannerActions{
-		LockfilePaths:              cmd.StringSlice("lockfile"),
-		SBOMPaths:                  cmd.StringSlice("sbom"),
-		Recursive:                  cmd.Bool("recursive"),
-		IncludeGitRoot:             cmd.Bool("include-git-root"),
-		NoIgnore:                   cmd.Bool("no-ignore"),
-		ConfigOverridePath:         cmd.String("config"),
-		DirectoryPaths:             cmd.Args().Slice(),
-		CallAnalysisStates:         callAnalysisStates,
-		ExperimentalScannerActions: experimentalScannerActions,
-	}
+	scannerAction := helper.GetCommonScannerActions(cmd, scanLicensesAllowlist)
+
+	scannerAction.LockfilePaths = cmd.StringSlice("lockfile")
+	scannerAction.SBOMPaths = cmd.StringSlice("sbom")
+	scannerAction.Recursive = cmd.Bool("recursive")
+	scannerAction.NoIgnore = cmd.Bool("no-ignore")
+	scannerAction.DirectoryPaths = cmd.Args().Slice()
+	scannerAction.CallAnalysisStates = callAnalysisStates
+	scannerAction.ExperimentalScannerActions = experimentalScannerActions
 
 	if len(experimentalScannerActions.Extractors) == 0 {
 		return errors.New("at least one extractor must be enabled")

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -50,18 +50,21 @@ type ScannerActions struct {
 	IsImageArchive     bool
 	ConfigOverridePath string
 	CallAnalysisStates map[string]bool
+	ShowAllPackages    bool
+
+	// local databases
+	CompareOffline    bool
+	DownloadDatabases bool
+	LocalDBPath       string
+
+	// license scanning
+	ScanLicensesSummary   bool
+	ScanLicensesAllowlist []string
 
 	ExperimentalScannerActions
 }
 
 type ExperimentalScannerActions struct {
-	CompareOffline        bool
-	DownloadDatabases     bool
-	ShowAllPackages       bool
-	ScanLicensesSummary   bool
-	ScanLicensesAllowlist []string
-
-	LocalDBPath string
 	TransitiveScanningActions
 
 	Extractors []filesystem.Extractor

--- a/pkg/osvscanner/vulnerability_result_internal_test.go
+++ b/pkg/osvscanner/vulnerability_result_internal_test.go
@@ -108,11 +108,9 @@ func Test_assembleResult(t *testing.T) {
 			args: args{
 				scanResults: makeScanResults(),
 				actions: ScannerActions{
-					ExperimentalScannerActions: ExperimentalScannerActions{
-						ShowAllPackages:       false,
-						ScanLicensesAllowlist: nil,
-					},
-					CallAnalysisStates: callAnalysisStates,
+					ShowAllPackages:       false,
+					ScanLicensesAllowlist: nil,
+					CallAnalysisStates:    callAnalysisStates,
 				},
 			},
 		},
@@ -121,11 +119,9 @@ func Test_assembleResult(t *testing.T) {
 			args: args{
 				scanResults: makeScanResults(),
 				actions: ScannerActions{
-					ExperimentalScannerActions: ExperimentalScannerActions{
-						ShowAllPackages:       true,
-						ScanLicensesAllowlist: nil,
-					},
-					CallAnalysisStates: callAnalysisStates,
+					ShowAllPackages:       true,
+					ScanLicensesAllowlist: nil,
+					CallAnalysisStates:    callAnalysisStates,
 				},
 			},
 		}, {
@@ -133,12 +129,10 @@ func Test_assembleResult(t *testing.T) {
 			args: args{
 				scanResults: makeScanResults(),
 				actions: ScannerActions{
-					ExperimentalScannerActions: ExperimentalScannerActions{
-						ShowAllPackages:       true,
-						ScanLicensesSummary:   true,
-						ScanLicensesAllowlist: nil,
-					},
-					CallAnalysisStates: callAnalysisStates,
+					ShowAllPackages:       true,
+					ScanLicensesSummary:   true,
+					ScanLicensesAllowlist: nil,
+					CallAnalysisStates:    callAnalysisStates,
 				},
 			},
 		}, {
@@ -147,11 +141,9 @@ func Test_assembleResult(t *testing.T) {
 				scanResults: makeScanResults(),
 
 				actions: ScannerActions{
-					ExperimentalScannerActions: ExperimentalScannerActions{
-						ShowAllPackages:       false,
-						ScanLicensesAllowlist: []string{"MIT", "0BSD"},
-					},
-					CallAnalysisStates: callAnalysisStates,
+					ShowAllPackages:       false,
+					ScanLicensesAllowlist: []string{"MIT", "0BSD"},
+					CallAnalysisStates:    callAnalysisStates,
 				},
 			},
 		}, {
@@ -159,11 +151,9 @@ func Test_assembleResult(t *testing.T) {
 			args: args{
 				scanResults: makeScanResults(),
 				actions: ScannerActions{
-					ExperimentalScannerActions: ExperimentalScannerActions{
-						ShowAllPackages:       false,
-						ScanLicensesAllowlist: []string{"MIT", "0BSD"},
-					},
-					CallAnalysisStates: callAnalysisStates,
+					ShowAllPackages:       false,
+					ScanLicensesAllowlist: []string{"MIT", "0BSD"},
+					CallAnalysisStates:    callAnalysisStates,
 				},
 				config: config.Manager{
 					OverrideConfig: &config.Config{
@@ -184,11 +174,9 @@ func Test_assembleResult(t *testing.T) {
 			args: args{
 				scanResults: makeScanResults(),
 				actions: ScannerActions{
-					ExperimentalScannerActions: ExperimentalScannerActions{
-						ShowAllPackages:       true,
-						ScanLicensesAllowlist: []string{"MIT", "0BSD"},
-					},
-					CallAnalysisStates: callAnalysisStates,
+					ShowAllPackages:       true,
+					ScanLicensesAllowlist: []string{"MIT", "0BSD"},
+					CallAnalysisStates:    callAnalysisStates,
 				},
 			},
 		},


### PR DESCRIPTION
These fields were marked as stable as part of the v2 release but we forgot to move the actual struct fields out of the experimental struct, which this does.

Technically this isn't breaking because we declare anything in the experimental struct as not being covered by semver 😅 