### PR TITLE
ci: create snapshots pull request even if tests fail

### DIFF
--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           go-version: stable
           check-latest: true
-      - run: ./scripts/run_tests.sh
+      - run: ./scripts/run_tests.sh || true
         env:
           TEST_ACCEPTANCE: true
           UPDATE_SNAPS: always


### PR DESCRIPTION
Any test failure that isn't fixed by (re)generating the snapshots should be present in the CI for the resulting pull request and if there are snapshot updates needed having those already generated will save some work - for example, the workflow is currently failing because one of our tests needs its exit code updated as previously it didn't have any vulnerabilities