### PR TITLE
feat: Adding prefix v to stable tag image (#1976)

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -44,7 +44,7 @@ jobs:
         # semantic version pattern (MAJOR.MINOR.PATCH, e.g., 1.2.3)
         run: |
           TAG="${GITHUB_REF_NAME}"
-          if [[ "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "STABLE=true" >> $GITHUB_ENV
           else
             echo "STABLE=false" >> $GITHUB_ENV


### PR DESCRIPTION
# Description

This pull request resolves Issue #1976
Minor change to add a prefix `v` to stable container image tags because images are tagged 
in this format `v1.0.0` instead of `1.0.0`