### PR TITLE
chore: ignore use of our own deprecated field

### DIFF
--- a/cmd/osv-scanner/scan/source/command.go
+++ b/cmd/osv-scanner/scan/source/command.go
@@ -125,6 +125,7 @@ func action(_ context.Context, cmd *cli.Command, stdout, stderr io.Writer) error
 	scannerAction := helper.GetCommonScannerActions(cmd, scanLicensesAllowlist)
 
 	scannerAction.LockfilePaths = cmd.StringSlice("lockfile")
+	//nolint:staticcheck // ignore our own deprecated field
 	scannerAction.SBOMPaths = cmd.StringSlice("sbom")
 	scannerAction.Recursive = cmd.Bool("recursive")
 	scannerAction.NoIgnore = cmd.Bool("no-ignore")


### PR DESCRIPTION
We have to use this field to maintain backwards compatibility