### PR TITLE
feat: Experimental output format for reporter

### DIFF
--- a/docs/osv-reporter.md
+++ b/docs/osv-reporter.md
@@ -31,6 +31,7 @@ $ osv-reporter --new osv-scanner.json --output=[format]:[output-path],[format2]:
 We don't provide prebuilt binaries for osv-reporter as it is very experimental and can change at any point.
 
 Currently you can install it from source via `go install`:
+
 ```bash
 $ go install github.com/google/osv-scanner/v2/cmd/osv-reporter@latest
 # Or @main for the latest commit

--- a/docs/osv-reporter.md
+++ b/docs/osv-reporter.md
@@ -1,0 +1,37 @@
+---
+layout: page
+permalink: /experimental/osv-reporter/
+parent: Experimental Features
+nav_order: 4
+---
+
+# OSV-Reporter
+
+Experimental
+{: .label }
+
+OSV-Reporter can be used to perform some experimental operations on the OSV-Scanner output JSON.
+
+## Features
+
+- Create a diff between two osv-scanner.json outputs, so you can see only new vulnerabilities.
+
+```bash
+$ osv-reporter --old previous-osv-scanner.json --new current-osv-scanner.json
+```
+
+- Output multiple different formats from a single set of scan results.
+
+```bash
+$ osv-reporter --new osv-scanner.json --output=[format]:[output-path],[format2]:[output-path2]
+```
+
+## How to install
+
+We don't provide prebuilt binaries for osv-reporter as it is very experimental and can change at any point.
+
+Currently you can install it from source via `go install`:
+```bash
+$ go install github.com/google/osv-scanner/v2/cmd/osv-reporter@latest
+# Or @main for the latest commit
+```

--- a/docs/scan-image.md
+++ b/docs/scan-image.md
@@ -39,6 +39,7 @@ You can scan container images using two primary methods:
    ```bash
    osv-scanner scan image image-name:tag
    ```
+
    - **How it works:** OSV-Scanner uses `docker save` to export the image to a temporary archive, which is then analyzed. No container code is executed during the scan.
 
 2. **Scan from Exported Image Archive:** If you have already exported your container image as a Docker archive (`.tar` file), you can scan it directly using the `--archive` flag. This method does not require Docker to be installed.
@@ -46,6 +47,7 @@ You can scan container images using two primary methods:
    ```bash
    osv-scanner scan image --archive ./path/to/my-image.tar
    ```
+
    - **How to create an image archive:** You can create an image archive using the following commands:
 
      ```bash


### PR DESCRIPTION
Playing around with output formats for the reporter, perhaps we introduce it to osv-scanner --output flag in the future to allow for multiple outputs.