### PR TITLE
refactor: place embeds at the start of structs followed by a newline

### DIFF
--- a/cmd/osv-scanner/fix/command.go
+++ b/cmd/osv-scanner/fix/command.go
@@ -48,6 +48,7 @@ const (
 
 type osvFixOptions struct {
 	remediation.Options
+
 	Client      client.ResolutionClient
 	Manifest    string
 	ManifestRW  manifest.ReadWriter

--- a/internal/imodels/imodels.go
+++ b/internal/imodels/imodels.go
@@ -57,10 +57,11 @@ var artifactExtractors = map[string]struct{}{
 // PackageInfo provides getter functions for commonly used fields of inventory
 // and applies transformations when required for use in osv-scanner
 type PackageInfo struct {
+	*extractor.Package
+
 	// purlCache is used to cache the special case for SBOMs where we convert Name, Version, and Ecosystem from purls
 	// extracted from the SBOM
 	purlCache *models.PackageInfo
-	*extractor.Package
 }
 
 func (pkg *PackageInfo) Name() string {

--- a/internal/remediation/in_place.go
+++ b/internal/remediation/in_place.go
@@ -22,6 +22,7 @@ import (
 
 type InPlacePatch struct {
 	lf.DependencyPatch
+
 	ResolvedVulns []resolution.Vulnerability
 }
 

--- a/internal/remediation/override.go
+++ b/internal/remediation/override.go
@@ -21,6 +21,7 @@ import (
 
 type overridePatch struct {
 	resolve.PackageKey
+
 	OrigVersion string
 	NewVersion  string
 }

--- a/internal/remediation/remediation.go
+++ b/internal/remediation/remediation.go
@@ -41,6 +41,7 @@ func SupportsInPlace(l lockfile.ReadWriter) bool {
 
 type Options struct {
 	resolution.ResolveOpts
+
 	IgnoreVulns   []string // Vulnerability IDs to ignore
 	ExplicitVulns []string // If set, only consider these vulnerability IDs & ignore all others
 

--- a/internal/resolution/client/depsdev_client.go
+++ b/internal/resolution/client/depsdev_client.go
@@ -13,6 +13,7 @@ const depsDevCacheExt = ".resolve.deps"
 // DepsDevClient is a ResolutionClient wrapping the official resolve.APIClient
 type DepsDevClient struct {
 	resolve.APIClient
+
 	c *datasource.CachedInsightsClient
 }
 

--- a/internal/resolution/client/override_client.go
+++ b/internal/resolution/client/override_client.go
@@ -10,6 +10,7 @@ import (
 // OverrideClient wraps a DependencyClient, allowing for custom packages & versions to be added
 type OverrideClient struct {
 	DependencyClient
+
 	// Can't quite reuse resolve.LocalClient because it automatically creates dependencies
 	pkgVers map[resolve.PackageKey][]resolve.Version            // versions of a package
 	verDeps map[resolve.VersionKey][]resolve.RequirementVersion // dependencies of a version

--- a/internal/resolution/manifest/manifest.go
+++ b/internal/resolution/manifest/manifest.go
@@ -108,6 +108,7 @@ func GetReadWriter(pathToManifest string, registry string) (ReadWriter, error) {
 // It does not include the version specification.
 type RequirementKey struct {
 	resolve.PackageKey
+
 	EcosystemSpecific any
 }
 

--- a/internal/resolution/manifest/maven.go
+++ b/internal/resolution/manifest/maven.go
@@ -59,11 +59,13 @@ type MavenManifestSpecific struct {
 
 type PropertyWithOrigin struct {
 	maven.Property
+
 	Origin string // Origin indicates where the property comes from
 }
 
 type DependencyWithOrigin struct {
 	maven.Dependency
+
 	Origin string // Origin indicates where the dependency comes from
 }
 
@@ -386,6 +388,7 @@ type MavenPatches struct {
 
 type MavenPatch struct {
 	maven.DependencyKey
+
 	NewRequire string
 }
 
@@ -740,6 +743,7 @@ func writeProject(w io.Writer, enc *internalxml.Encoder, raw, prefix, id string,
 				updated["parent"] = true
 				type RawParent struct {
 					maven.ProjectKey
+
 					InnerXML string `xml:",innerxml"`
 				}
 				var rawParent RawParent
@@ -781,6 +785,7 @@ func writeProject(w io.Writer, enc *internalxml.Encoder, raw, prefix, id string,
 				}
 				type RawProfile struct {
 					maven.Profile
+
 					InnerXML string `xml:",innerxml"`
 				}
 				var rawProfile RawProfile
@@ -799,6 +804,7 @@ func writeProject(w io.Writer, enc *internalxml.Encoder, raw, prefix, id string,
 				}
 				type RawPlugin struct {
 					maven.Plugin
+
 					InnerXML string `xml:",innerxml"`
 				}
 				var rawPlugin RawPlugin
@@ -813,6 +819,7 @@ func writeProject(w io.Writer, enc *internalxml.Encoder, raw, prefix, id string,
 			case "dependencyManagement":
 				type RawDependencyManagement struct {
 					maven.DependencyManagement
+
 					InnerXML string `xml:",innerxml"`
 				}
 				var rawDepMgmt RawDependencyManagement
@@ -933,6 +940,7 @@ func writeDependency(w io.Writer, enc *internalxml.Encoder, raw string, patches 
 			if tt.Name.Local == "dependency" {
 				type RawDependency struct {
 					maven.Dependency
+
 					InnerXML string `xml:",innerxml"`
 				}
 				var rawDep RawDependency

--- a/internal/resolution/resolve.go
+++ b/internal/resolution/resolve.go
@@ -263,11 +263,12 @@ func (res *Result) FilterVulns(matchFn func(Vulnerability) bool) {
 }
 
 type Difference struct {
+	manifest.Patch
+
 	Original     *Result
 	New          *Result
 	RemovedVulns []Vulnerability
 	AddedVulns   []Vulnerability
-	manifest.Patch
 }
 
 func (res *Result) CalculateDiff(other *Result) Difference {

--- a/internal/testutility/mock_http.go
+++ b/internal/testutility/mock_http.go
@@ -12,6 +12,7 @@ import (
 
 type MockHTTPServer struct {
 	*httptest.Server
+
 	mu            sync.Mutex
 	response      map[string][]byte // path -> response
 	authorization string            // expected Authorization header contents

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -39,6 +39,8 @@ import (
 )
 
 type ScannerActions struct {
+	ExperimentalScannerActions
+
 	LockfilePaths      []string
 	DirectoryPaths     []string
 	GitCommits         []string
@@ -63,8 +65,6 @@ type ScannerActions struct {
 
 	// Deprecated: in favor of LockfilePaths
 	SBOMPaths []string
-
-	ExperimentalScannerActions
 }
 
 type ExperimentalScannerActions struct {


### PR DESCRIPTION
This will be enforced by the `embeddedstructfieldcheck` linter introduced in v2.2