### PR TITLE
test: run JSON format image cases on Windows

### DIFF
--- a/cmd/osv-scanner/scan/image/command_test.go
+++ b/cmd/osv-scanner/scan/image/command_test.go
@@ -228,11 +228,6 @@ func TestCommand_OCIImageAllPackagesJSON(t *testing.T) {
 
 	testutility.SkipIfNotAcceptanceTesting(t, "Takes a while to run")
 
-	if runtime.GOOS == "windows" {
-		// Windows messes with the file paths to break the output
-		testutility.Skip(t)
-	}
-
 	tests := []testcmd.Case{
 		{
 			Name: "Scanning python image with some packages",


### PR DESCRIPTION
Looks like these started working on Windows at some point likely as a result of the refactoring we've done to the JSON and snapshot normalization handling 🤷 