### PR TITLE
fix(output): don't include package type in name for vertical format

### DIFF
--- a/internal/output/__snapshots__/output_result_test.snap
+++ b/internal/output/__snapshots__/output_result_test.snap
@@ -6,7 +6,7 @@
       "Name": "npm",
       "Sources": [
         {
-          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Name": "<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
           "Ecosystem": "npm",
           "PackageTypeCount": {
@@ -238,7 +238,7 @@
           "LicenseViolationsCount": 0
         },
         {
-          "Name": "sbom:<rootdir>/path/to/my/second/lockfile",
+          "Name": "<rootdir>/path/to/my/second/lockfile",
           "Type": "sbom",
           "Ecosystem": "npm",
           "PackageTypeCount": {
@@ -522,7 +522,7 @@
       "Name": "npm",
       "Sources": [
         {
-          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Name": "<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
           "Ecosystem": "npm",
           "PackageTypeCount": {
@@ -754,7 +754,7 @@
           "LicenseViolationsCount": 0
         },
         {
-          "Name": "sbom:<rootdir>/path/to/my/second/lockfile",
+          "Name": "<rootdir>/path/to/my/second/lockfile",
           "Type": "sbom",
           "Ecosystem": "npm",
           "PackageTypeCount": {
@@ -1038,7 +1038,7 @@
       "Name": "npm",
       "Sources": [
         {
-          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Name": "<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
           "Ecosystem": "npm",
           "PackageTypeCount": {
@@ -1148,7 +1148,7 @@
           "LicenseViolationsCount": 0
         },
         {
-          "Name": "sbom:<rootdir>/path/to/my/second/lockfile",
+          "Name": "<rootdir>/path/to/my/second/lockfile",
           "Type": "sbom",
           "Ecosystem": "npm",
           "PackageTypeCount": {
@@ -1339,7 +1339,7 @@
           "LicenseViolationsCount": 0
         },
         {
-          "Name": "unknown:<rootdir>/path/to/my/third/lockfile",
+          "Name": "<rootdir>/path/to/my/third/lockfile",
           "Type": "unknown",
           "Ecosystem": "npm",
           "PackageTypeCount": {
@@ -1582,7 +1582,7 @@
       "Name": "npm",
       "Sources": [
         {
-          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Name": "<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
           "Ecosystem": "npm",
           "PackageTypeCount": {
@@ -1706,7 +1706,7 @@
           "LicenseViolationsCount": 0
         },
         {
-          "Name": "sbom:<rootdir>/path/to/my/second/lockfile",
+          "Name": "<rootdir>/path/to/my/second/lockfile",
           "Type": "sbom",
           "Ecosystem": "npm",
           "PackageTypeCount": {
@@ -1911,7 +1911,7 @@
           "LicenseViolationsCount": 0
         },
         {
-          "Name": "unknown:<rootdir>/path/to/my/third/lockfile",
+          "Name": "<rootdir>/path/to/my/third/lockfile",
           "Type": "unknown",
           "Ecosystem": "npm",
           "PackageTypeCount": {
@@ -2168,7 +2168,7 @@
       "Name": "NuGet",
       "Sources": [
         {
-          "Name": "sbom:<rootdir>/path/to/my/second/lockfile",
+          "Name": "<rootdir>/path/to/my/second/lockfile",
           "Type": "sbom",
           "Ecosystem": "NuGet",
           "PackageTypeCount": {
@@ -2298,7 +2298,7 @@
       "Name": "Packagist",
       "Sources": [
         {
-          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Name": "<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
           "Ecosystem": "Packagist",
           "PackageTypeCount": {
@@ -2435,7 +2435,7 @@
           "LicenseViolationsCount": 0
         },
         {
-          "Name": "sbom:<rootdir>/path/to/my/second/lockfile",
+          "Name": "<rootdir>/path/to/my/second/lockfile",
           "Type": "sbom",
           "Ecosystem": "Packagist",
           "PackageTypeCount": {
@@ -2578,7 +2578,7 @@
       "Name": "npm",
       "Sources": [
         {
-          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Name": "<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
           "Ecosystem": "npm",
           "PackageTypeCount": {
@@ -2754,7 +2754,7 @@
       "Name": "NuGet",
       "Sources": [
         {
-          "Name": "sbom:<rootdir>/path/to/my/second/lockfile",
+          "Name": "<rootdir>/path/to/my/second/lockfile",
           "Type": "sbom",
           "Ecosystem": "NuGet",
           "PackageTypeCount": {
@@ -2884,7 +2884,7 @@
       "Name": "Packagist",
       "Sources": [
         {
-          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Name": "<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
           "Ecosystem": "Packagist",
           "PackageTypeCount": {
@@ -3022,7 +3022,7 @@
           "LicenseViolationsCount": 0
         },
         {
-          "Name": "sbom:<rootdir>/path/to/my/second/lockfile",
+          "Name": "<rootdir>/path/to/my/second/lockfile",
           "Type": "sbom",
           "Ecosystem": "Packagist",
           "PackageTypeCount": {
@@ -3165,7 +3165,7 @@
       "Name": "npm",
       "Sources": [
         {
-          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Name": "<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
           "Ecosystem": "npm",
           "PackageTypeCount": {
@@ -3341,7 +3341,7 @@
       "Name": "NuGet",
       "Sources": [
         {
-          "Name": "sbom:<rootdir>/path/to/my/second/lockfile",
+          "Name": "<rootdir>/path/to/my/second/lockfile",
           "Type": "sbom",
           "Ecosystem": "NuGet",
           "PackageTypeCount": {
@@ -3471,7 +3471,7 @@
       "Name": "Packagist",
       "Sources": [
         {
-          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Name": "<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
           "Ecosystem": "Packagist",
           "PackageTypeCount": {
@@ -3608,7 +3608,7 @@
           "LicenseViolationsCount": 0
         },
         {
-          "Name": "sbom:<rootdir>/path/to/my/second/lockfile",
+          "Name": "<rootdir>/path/to/my/second/lockfile",
           "Type": "sbom",
           "Ecosystem": "Packagist",
           "PackageTypeCount": {
@@ -3751,7 +3751,7 @@
       "Name": "npm",
       "Sources": [
         {
-          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Name": "<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
           "Ecosystem": "npm",
           "PackageTypeCount": {
@@ -3927,7 +3927,7 @@
       "Name": "",
       "Sources": [
         {
-          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Name": "<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
           "Ecosystem": "",
           "PackageTypeCount": {
@@ -3955,7 +3955,7 @@
           "LicenseViolationsCount": 0
         },
         {
-          "Name": "sbom:<rootdir>/path/to/my/second/lockfile",
+          "Name": "<rootdir>/path/to/my/second/lockfile",
           "Type": "sbom",
           "Ecosystem": "",
           "PackageTypeCount": {
@@ -3983,7 +3983,7 @@
           "LicenseViolationsCount": 0
         },
         {
-          "Name": "unknown:<rootdir>/path/to/my/third/lockfile",
+          "Name": "<rootdir>/path/to/my/third/lockfile",
           "Type": "unknown",
           "Ecosystem": "",
           "PackageTypeCount": {
@@ -4108,7 +4108,7 @@
       "Name": "",
       "Sources": [
         {
-          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Name": "<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
           "Ecosystem": "",
           "PackageTypeCount": {
@@ -4188,7 +4188,7 @@
       "Name": "npm",
       "Sources": [
         {
-          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Name": "<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
           "Ecosystem": "npm",
           "PackageTypeCount": {
@@ -4350,7 +4350,7 @@
       "Name": "npm",
       "Sources": [
         {
-          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Name": "<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
           "Ecosystem": "npm",
           "PackageTypeCount": {
@@ -4540,7 +4540,7 @@
       "Name": "npm",
       "Sources": [
         {
-          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Name": "<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
           "Ecosystem": "npm",
           "PackageTypeCount": {
@@ -4716,7 +4716,7 @@
       "Name": "npm",
       "Sources": [
         {
-          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Name": "<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
           "Ecosystem": "npm",
           "PackageTypeCount": {
@@ -4892,7 +4892,7 @@
       "Name": "npm",
       "Sources": [
         {
-          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Name": "<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
           "Ecosystem": "npm",
           "PackageTypeCount": {
@@ -5068,7 +5068,7 @@
       "Name": "npm",
       "Sources": [
         {
-          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Name": "<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
           "Ecosystem": "npm",
           "PackageTypeCount": {
@@ -5244,7 +5244,7 @@
       "Name": "npm",
       "Sources": [
         {
-          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Name": "<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
           "Ecosystem": "npm",
           "PackageTypeCount": {
@@ -5423,7 +5423,7 @@
       "Name": "npm",
       "Sources": [
         {
-          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Name": "<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
           "Ecosystem": "npm",
           "PackageTypeCount": {
@@ -5602,7 +5602,7 @@
       "Name": "npm",
       "Sources": [
         {
-          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Name": "<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
           "Ecosystem": "npm",
           "PackageTypeCount": {
@@ -5778,7 +5778,7 @@
       "Name": "npm",
       "Sources": [
         {
-          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Name": "<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
           "Ecosystem": "npm",
           "PackageTypeCount": {
@@ -5954,7 +5954,7 @@
       "Name": "npm",
       "Sources": [
         {
-          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Name": "<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
           "Ecosystem": "npm",
           "PackageTypeCount": {
@@ -6225,7 +6225,7 @@
       "Name": "npm",
       "Sources": [
         {
-          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Name": "<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
           "Ecosystem": "npm",
           "PackageTypeCount": {
@@ -6349,7 +6349,7 @@
           "LicenseViolationsCount": 0
         },
         {
-          "Name": "sbom:<rootdir>/path/to/my/second/lockfile",
+          "Name": "<rootdir>/path/to/my/second/lockfile",
           "Type": "sbom",
           "Ecosystem": "npm",
           "PackageTypeCount": {
@@ -6511,7 +6511,7 @@
       "Name": "npm",
       "Sources": [
         {
-          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Name": "<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
           "Ecosystem": "npm",
           "PackageTypeCount": {
@@ -6635,7 +6635,7 @@
           "LicenseViolationsCount": 0
         },
         {
-          "Name": "sbom:<rootdir>/path/to/my/second/lockfile",
+          "Name": "<rootdir>/path/to/my/second/lockfile",
           "Type": "sbom",
           "Ecosystem": "npm",
           "PackageTypeCount": {

--- a/internal/output/__snapshots__/vertical_test.snap
+++ b/internal/output/__snapshots__/vertical_test.snap
@@ -6,15 +6,15 @@ Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medi
 
 npm
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
   no known vulnerabilities found
   no license violations found
 
-sbom:<rootdir>/path/to/my/second/lockfile: found 0 packages with issues
+<rootdir>/path/to/my/second/lockfile: found 0 packages with issues
   no known vulnerabilities found
   no license violations found
 
-unknown:<rootdir>/path/to/my/third/lockfile: found 0 packages with issues
+<rootdir>/path/to/my/third/lockfile: found 0 packages with issues
   no known vulnerabilities found
   no license violations found
 
@@ -28,29 +28,29 @@ Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medi
 
 npm
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
   no known vulnerabilities found
 
   license violations found:
     mine1@1.2.3 (MIT)
 
-  1 license violation found in lockfile:<rootdir>/path/to/my/first/lockfile
+  1 license violation found in <rootdir>/path/to/my/first/lockfile
 
-sbom:<rootdir>/path/to/my/second/lockfile: found 0 packages with issues
+<rootdir>/path/to/my/second/lockfile: found 0 packages with issues
   no known vulnerabilities found
 
   license violations found:
     mine2@3.2.5 (Apache-2.0)
 
-  1 license violation found in sbom:<rootdir>/path/to/my/second/lockfile
+  1 license violation found in <rootdir>/path/to/my/second/lockfile
 
-unknown:<rootdir>/path/to/my/third/lockfile: found 0 packages with issues
+<rootdir>/path/to/my/third/lockfile: found 0 packages with issues
   no known vulnerabilities found
 
   license violations found:
     mine1@1.2.3 (MIT)
 
-  1 license violation found in unknown:<rootdir>/path/to/my/third/lockfile
+  1 license violation found in <rootdir>/path/to/my/third/lockfile
 
 
 ---
@@ -62,13 +62,13 @@ Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medi
 
 npm
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
   no known vulnerabilities found
 
-sbom:<rootdir>/path/to/my/second/lockfile: found 0 packages with issues
+<rootdir>/path/to/my/second/lockfile: found 0 packages with issues
   no known vulnerabilities found
 
-unknown:<rootdir>/path/to/my/third/lockfile: found 0 packages with issues
+<rootdir>/path/to/my/third/lockfile: found 0 packages with issues
   no known vulnerabilities found
 
 
@@ -81,37 +81,37 @@ Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medi
 
 NuGet
 
-unknown:<rootdir>/path/to/my/third/lockfile: found 0 packages with issues
+<rootdir>/path/to/my/third/lockfile: found 0 packages with issues
   no known vulnerabilities found
   no license violations found
 
 Packagist
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
   no known vulnerabilities found
 
   license violations found:
     author1/mine1@1.2.3 (MIT)
 
-  1 license violation found in lockfile:<rootdir>/path/to/my/first/lockfile
+  1 license violation found in <rootdir>/path/to/my/first/lockfile
 
-unknown:<rootdir>/path/to/my/third/lockfile: found 0 packages with issues
+<rootdir>/path/to/my/third/lockfile: found 0 packages with issues
   no known vulnerabilities found
 
   license violations found:
     author1/mine1@1.2.3 (MIT)
 
-  1 license violation found in unknown:<rootdir>/path/to/my/third/lockfile
+  1 license violation found in <rootdir>/path/to/my/third/lockfile
 
 npm
 
-sbom:<rootdir>/path/to/my/second/lockfile: found 0 packages with issues
+<rootdir>/path/to/my/second/lockfile: found 0 packages with issues
   no known vulnerabilities found
 
   license violations found:
     mine2@3.2.5 (Apache-2.0)
 
-  1 license violation found in sbom:<rootdir>/path/to/my/second/lockfile
+  1 license violation found in <rootdir>/path/to/my/second/lockfile
 
 
 ---
@@ -123,29 +123,29 @@ Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medi
 
 npm
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
   no known vulnerabilities found
 
   license violations found:
     mine1@1.2.3 (MIT)
 
-  1 license violation found in lockfile:<rootdir>/path/to/my/first/lockfile
+  1 license violation found in <rootdir>/path/to/my/first/lockfile
 
-sbom:<rootdir>/path/to/my/second/lockfile: found 0 packages with issues
+<rootdir>/path/to/my/second/lockfile: found 0 packages with issues
   no known vulnerabilities found
 
   license violations found:
     mine2@3.2.5 (Apache-2.0)
 
-  1 license violation found in sbom:<rootdir>/path/to/my/second/lockfile
+  1 license violation found in <rootdir>/path/to/my/second/lockfile
 
-unknown:<rootdir>/path/to/my/third/lockfile: found 0 packages with issues
+<rootdir>/path/to/my/third/lockfile: found 0 packages with issues
   no known vulnerabilities found
 
   license violations found:
     mine1@1.2.3 (MIT)
 
-  1 license violation found in unknown:<rootdir>/path/to/my/third/lockfile
+  1 license violation found in <rootdir>/path/to/my/third/lockfile
 
 
 ---
@@ -157,15 +157,15 @@ Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medi
 
 
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
   no known vulnerabilities found
   no license violations found
 
-sbom:<rootdir>/path/to/my/second/lockfile: found 0 packages with issues
+<rootdir>/path/to/my/second/lockfile: found 0 packages with issues
   no known vulnerabilities found
   no license violations found
 
-unknown:<rootdir>/path/to/my/third/lockfile: found 0 packages with issues
+<rootdir>/path/to/my/third/lockfile: found 0 packages with issues
   no known vulnerabilities found
   no license violations found
 
@@ -188,7 +188,7 @@ Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medi
 
 
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
   no known vulnerabilities found
   no license violations found
 
@@ -202,7 +202,7 @@ Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medi
 
 npm
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
   no known vulnerabilities found
   no license violations found
 
@@ -216,7 +216,7 @@ Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medi
 
 npm
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
   no known vulnerabilities found
   no license violations found
 
@@ -230,7 +230,7 @@ Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medi
 
 npm
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
   no known vulnerabilities found
   no license violations found
 
@@ -244,13 +244,13 @@ Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medi
 
 npm
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
   no known vulnerabilities found
 
   license violations found:
     mine1@1.2.3 (MIT, Apache-2.0)
 
-  2 license violations found in lockfile:<rootdir>/path/to/my/first/lockfile
+  2 license violations found in <rootdir>/path/to/my/first/lockfile
 
 
 ---
@@ -262,13 +262,13 @@ Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medi
 
 npm
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
   no known vulnerabilities found
 
   license violations found:
     mine1@1.2.3 (MIT)
 
-  1 license violation found in lockfile:<rootdir>/path/to/my/first/lockfile
+  1 license violation found in <rootdir>/path/to/my/first/lockfile
 
 
 ---
@@ -280,13 +280,13 @@ Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medi
 
 npm
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
   no known vulnerabilities found
 
   license violations found:
     mine1@1.2.3 (MIT)
 
-  1 license violation found in lockfile:<rootdir>/path/to/my/first/lockfile
+  1 license violation found in <rootdir>/path/to/my/first/lockfile
 
 
 ---
@@ -298,13 +298,13 @@ Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medi
 
 npm
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
   no known vulnerabilities found
 
   license violations found:
     mine1@1.2.3 (MIT)
 
-  1 license violation found in lockfile:<rootdir>/path/to/my/first/lockfile
+  1 license violation found in <rootdir>/path/to/my/first/lockfile
 
 
 ---
@@ -316,13 +316,13 @@ Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medi
 
 npm
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
   no known vulnerabilities found
 
   license violations found:
     mine1@ (MIT)
 
-  1 license violation found in lockfile:<rootdir>/path/to/my/first/lockfile
+  1 license violation found in <rootdir>/path/to/my/first/lockfile
 
 
 ---
@@ -334,15 +334,15 @@ Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medi
 
 npm
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
   no known vulnerabilities found
 
   license violations found:
     mine1@1.2.3 (MIT)
 
-  1 license violation found in lockfile:<rootdir>/path/to/my/first/lockfile
+  1 license violation found in <rootdir>/path/to/my/first/lockfile
 
-sbom:<rootdir>/path/to/my/second/lockfile: found 0 packages with issues
+<rootdir>/path/to/my/second/lockfile: found 0 packages with issues
   no known vulnerabilities found
   no license violations found
 
@@ -356,30 +356,30 @@ Total 1 package affected by 1 known vulnerability (0 Critical, 0 High, 0 Medium,
 
 npm
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
 Hiding 1 number of vulnerabilities deemed unimportant, use --all-vulns to show them.
 
   license violations found:
     mine1@1.2.3 (MIT)
 
-  1 license violation found in lockfile:<rootdir>/path/to/my/first/lockfile
+  1 license violation found in <rootdir>/path/to/my/first/lockfile
 
-sbom:<rootdir>/path/to/my/second/lockfile: found 1 package with issues
+<rootdir>/path/to/my/second/lockfile: found 1 package with issues
 
   mine2@3.2.5 has the following known vulnerabilities:
     OSV-2: Something less scary! (https://osv.dev/OSV-2)
 
-  1 known vulnerability found in sbom:<rootdir>/path/to/my/second/lockfile
+  1 known vulnerability found in <rootdir>/path/to/my/second/lockfile
   no license violations found
 
-unknown:<rootdir>/path/to/my/third/lockfile: found 0 packages with issues
+<rootdir>/path/to/my/third/lockfile: found 0 packages with issues
 Hiding 1 number of vulnerabilities deemed unimportant, use --all-vulns to show them.
 
   license violations found:
     mine1@1.2.3 (Apache-2.0)
     mine1@1.3.5 (MIT)
 
-  2 license violations found in unknown:<rootdir>/path/to/my/third/lockfile
+  2 license violations found in <rootdir>/path/to/my/third/lockfile
 
 
 ---
@@ -391,38 +391,38 @@ Total 3 packages affected by 3 known vulnerabilities (0 Critical, 0 High, 0 Medi
 
 npm
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 1 package with issues
+<rootdir>/path/to/my/first/lockfile: found 1 package with issues
 
   mine1@1.2.3 has the following known vulnerabilities:
     OSV-1: Something scary! (https://osv.dev/OSV-1)
 
-  1 known vulnerability found in lockfile:<rootdir>/path/to/my/first/lockfile
+  1 known vulnerability found in <rootdir>/path/to/my/first/lockfile
 
   license violations found:
     mine1@1.2.3 (MIT)
 
-  1 license violation found in lockfile:<rootdir>/path/to/my/first/lockfile
+  1 license violation found in <rootdir>/path/to/my/first/lockfile
 
-sbom:<rootdir>/path/to/my/second/lockfile: found 1 package with issues
+<rootdir>/path/to/my/second/lockfile: found 1 package with issues
 
   mine2@3.2.5 has the following known vulnerabilities:
     OSV-2: Something less scary! (https://osv.dev/OSV-2)
 
-  1 known vulnerability found in sbom:<rootdir>/path/to/my/second/lockfile
+  1 known vulnerability found in <rootdir>/path/to/my/second/lockfile
   no license violations found
 
-unknown:<rootdir>/path/to/my/third/lockfile: found 1 package with issues
+<rootdir>/path/to/my/third/lockfile: found 1 package with issues
 
   mine1@1.2.3 has the following known vulnerabilities:
     OSV-1: Something scary! (https://osv.dev/OSV-1)
 
-  1 known vulnerability found in unknown:<rootdir>/path/to/my/third/lockfile
+  1 known vulnerability found in <rootdir>/path/to/my/third/lockfile
 
   license violations found:
     mine1@1.2.3 (Apache-2.0)
     mine1@1.3.5 (MIT)
 
-  2 license violations found in unknown:<rootdir>/path/to/my/third/lockfile
+  2 license violations found in <rootdir>/path/to/my/third/lockfile
 
 
 ---
@@ -434,38 +434,38 @@ Total 3 packages affected by 3 known vulnerabilities (0 Critical, 0 High, 0 Medi
 
 npm
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 1 package with issues
+<rootdir>/path/to/my/first/lockfile: found 1 package with issues
 
   mine1@1.2.3 has the following known vulnerabilities:
     OSV-1: Something scary! (https://osv.dev/OSV-1)
 
-  1 known vulnerability found in lockfile:<rootdir>/path/to/my/first/lockfile
+  1 known vulnerability found in <rootdir>/path/to/my/first/lockfile
 
   license violations found:
     mine1@1.2.3 (MIT)
 
-  1 license violation found in lockfile:<rootdir>/path/to/my/first/lockfile
+  1 license violation found in <rootdir>/path/to/my/first/lockfile
 
-sbom:<rootdir>/path/to/my/second/lockfile: found 1 package with issues
+<rootdir>/path/to/my/second/lockfile: found 1 package with issues
 
   mine2@ has the following known vulnerabilities:
     OSV-2: Something less scary! (https://osv.dev/OSV-2)
 
-  1 known vulnerability found in sbom:<rootdir>/path/to/my/second/lockfile
+  1 known vulnerability found in <rootdir>/path/to/my/second/lockfile
   no license violations found
 
-unknown:<rootdir>/path/to/my/third/lockfile: found 1 package with issues
+<rootdir>/path/to/my/third/lockfile: found 1 package with issues
 
   mine1@1.2.3 has the following known vulnerabilities:
     OSV-1: Something scary! (https://osv.dev/OSV-1)
 
-  1 known vulnerability found in unknown:<rootdir>/path/to/my/third/lockfile
+  1 known vulnerability found in <rootdir>/path/to/my/third/lockfile
 
   license violations found:
     mine1@1.2.3 (Apache-2.0)
     mine1@1.3.5 (MIT)
 
-  2 license violations found in unknown:<rootdir>/path/to/my/third/lockfile
+  2 license violations found in <rootdir>/path/to/my/third/lockfile
 
 
 ---
@@ -477,17 +477,17 @@ Total 1 package affected by 1 known vulnerability (0 Critical, 0 High, 0 Medium,
 
 npm
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 1 package with issues
+<rootdir>/path/to/my/first/lockfile: found 1 package with issues
 
   mine1@1.2.3 has the following known vulnerabilities:
     OSV-1: Something scary! (https://osv.dev/OSV-1)
 
-  1 known vulnerability found in lockfile:<rootdir>/path/to/my/first/lockfile
+  1 known vulnerability found in <rootdir>/path/to/my/first/lockfile
 
   license violations found:
     mine1@1.2.3 (MIT)
 
-  1 license violation found in lockfile:<rootdir>/path/to/my/first/lockfile
+  1 license violation found in <rootdir>/path/to/my/first/lockfile
 
 
 ---
@@ -499,17 +499,17 @@ Total 1 package affected by 1 known vulnerability (0 Critical, 0 High, 0 Medium,
 
 npm
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 1 package with issues
+<rootdir>/path/to/my/first/lockfile: found 1 package with issues
 
   mine1@1.2.3 has the following known vulnerabilities:
     OSV-1: Something scary! (https://osv.dev/OSV-1)
 
-  1 known vulnerability found in lockfile:<rootdir>/path/to/my/first/lockfile
+  1 known vulnerability found in <rootdir>/path/to/my/first/lockfile
 
   license violations found:
     mine1@1.2.3 (MIT)
 
-  1 license violation found in lockfile:<rootdir>/path/to/my/first/lockfile
+  1 license violation found in <rootdir>/path/to/my/first/lockfile
 
 
 ---
@@ -521,13 +521,13 @@ Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medi
 
 npm
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
 Hiding 1 number of vulnerabilities deemed unimportant, use --all-vulns to show them.
 
   license violations found:
     mine1@1.2.3 (MIT)
 
-  1 license violation found in lockfile:<rootdir>/path/to/my/first/lockfile
+  1 license violation found in <rootdir>/path/to/my/first/lockfile
 
 
 ---
@@ -539,17 +539,17 @@ Total 1 package affected by 1 known vulnerability (0 Critical, 0 High, 0 Medium,
 
 npm
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 1 package with issues
+<rootdir>/path/to/my/first/lockfile: found 1 package with issues
 
   mine1@1.2.3 has the following known vulnerabilities:
     OSV-1: Something scary! (https://osv.dev/OSV-1)
 
-  1 known vulnerability found in lockfile:<rootdir>/path/to/my/first/lockfile
+  1 known vulnerability found in <rootdir>/path/to/my/first/lockfile
 
   license violations found:
     mine1@1.2.3 (MIT)
 
-  1 license violation found in lockfile:<rootdir>/path/to/my/first/lockfile
+  1 license violation found in <rootdir>/path/to/my/first/lockfile
 
 
 ---
@@ -561,21 +561,21 @@ Total 1 package affected by 1 known vulnerability (0 Critical, 0 High, 0 Medium,
 
 npm
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 1 package with issues
+<rootdir>/path/to/my/first/lockfile: found 1 package with issues
 
   mine1@1.2.3 has the following known vulnerabilities:
     OSV-1: Something scary! (https://osv.dev/OSV-1)
 
-  1 known vulnerability found in lockfile:<rootdir>/path/to/my/first/lockfile
+  1 known vulnerability found in <rootdir>/path/to/my/first/lockfile
   no license violations found
 
-sbom:<rootdir>/path/to/my/second/lockfile: found 0 packages with issues
+<rootdir>/path/to/my/second/lockfile: found 0 packages with issues
   no known vulnerabilities found
 
   license violations found:
     mine2@5.9.0 (MIT)
 
-  1 license violation found in sbom:<rootdir>/path/to/my/second/lockfile
+  1 license violation found in <rootdir>/path/to/my/second/lockfile
 
 
 ---
@@ -587,7 +587,7 @@ Total 4 packages affected by 6 known vulnerabilities (0 Critical, 0 High, 0 Medi
 
 npm
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 2 packages with issues
+<rootdir>/path/to/my/first/lockfile: found 2 packages with issues
 
   mine1@1.2.2 has the following known vulnerabilities:
     OSV-1: Something scary! (https://osv.dev/OSV-1)
@@ -595,9 +595,9 @@ lockfile:<rootdir>/path/to/my/first/lockfile: found 2 packages with issues
     OSV-1: Something scary! (https://osv.dev/OSV-1)
     OSV-5: Something scarier! (https://osv.dev/OSV-5)
 
-  3 known vulnerabilities found in lockfile:<rootdir>/path/to/my/first/lockfile
+  3 known vulnerabilities found in <rootdir>/path/to/my/first/lockfile
 
-sbom:<rootdir>/path/to/my/second/lockfile: found 2 packages with issues
+<rootdir>/path/to/my/second/lockfile: found 2 packages with issues
 
   mine2@3.2.5 has the following known vulnerabilities:
     OSV-2: Something less scary! (https://osv.dev/OSV-2)
@@ -605,7 +605,7 @@ sbom:<rootdir>/path/to/my/second/lockfile: found 2 packages with issues
     OSV-3: Something mildly scary! (https://osv.dev/OSV-3)
     OSV-5: Something scarier! (https://osv.dev/OSV-5)
 
-  3 known vulnerabilities found in sbom:<rootdir>/path/to/my/second/lockfile
+  3 known vulnerabilities found in <rootdir>/path/to/my/second/lockfile
 
 
 ---
@@ -617,7 +617,7 @@ Total 4 packages affected by 6 known vulnerabilities (0 Critical, 0 High, 0 Medi
 
 npm
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 2 packages with issues
+<rootdir>/path/to/my/first/lockfile: found 2 packages with issues
 
   mine1@1.2.2 has the following known vulnerabilities:
     OSV-1: Something scary! (https://osv.dev/OSV-1)
@@ -625,9 +625,9 @@ lockfile:<rootdir>/path/to/my/first/lockfile: found 2 packages with issues
     OSV-1: Something scary! (https://osv.dev/OSV-1)
     OSV-5: Something scarier! (https://osv.dev/OSV-5)
 
-  3 known vulnerabilities found in lockfile:<rootdir>/path/to/my/first/lockfile
+  3 known vulnerabilities found in <rootdir>/path/to/my/first/lockfile
 
-sbom:<rootdir>/path/to/my/second/lockfile: found 2 packages with issues
+<rootdir>/path/to/my/second/lockfile: found 2 packages with issues
 
   mine2@3.2.5 has the following known vulnerabilities:
     OSV-2: Something less scary! (https://osv.dev/OSV-2)
@@ -635,7 +635,7 @@ sbom:<rootdir>/path/to/my/second/lockfile: found 2 packages with issues
     OSV-3: Something mildly scary! (https://osv.dev/OSV-3)
     OSV-5: Something scarier! (https://osv.dev/OSV-5)
 
-  3 known vulnerabilities found in sbom:<rootdir>/path/to/my/second/lockfile
+  3 known vulnerabilities found in <rootdir>/path/to/my/second/lockfile
 
 
 ---
@@ -647,13 +647,13 @@ Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medi
 
 npm
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
   no known vulnerabilities found
 
-sbom:<rootdir>/path/to/my/second/lockfile: found 0 packages with issues
+<rootdir>/path/to/my/second/lockfile: found 0 packages with issues
   no known vulnerabilities found
 
-unknown:<rootdir>/path/to/my/third/lockfile: found 0 packages with issues
+<rootdir>/path/to/my/third/lockfile: found 0 packages with issues
   no known vulnerabilities found
 
 
@@ -666,26 +666,26 @@ Total 3 packages affected by 3 known vulnerabilities (0 Critical, 0 High, 0 Medi
 
 npm
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 1 package with issues
+<rootdir>/path/to/my/first/lockfile: found 1 package with issues
 
   mine1@1.2.3 has the following known vulnerabilities:
     OSV-1: Something scary! (https://osv.dev/OSV-1)
 
-  1 known vulnerability found in lockfile:<rootdir>/path/to/my/first/lockfile
+  1 known vulnerability found in <rootdir>/path/to/my/first/lockfile
 
-sbom:<rootdir>/path/to/my/second/lockfile: found 1 package with issues
+<rootdir>/path/to/my/second/lockfile: found 1 package with issues
 
   mine2@3.2.5 has the following known vulnerabilities:
     OSV-2: Something less scary! (https://osv.dev/OSV-2)
 
-  1 known vulnerability found in sbom:<rootdir>/path/to/my/second/lockfile
+  1 known vulnerability found in <rootdir>/path/to/my/second/lockfile
 
-unknown:<rootdir>/path/to/my/third/lockfile: found 1 package with issues
+<rootdir>/path/to/my/third/lockfile: found 1 package with issues
 
   mine1@1.2.3 has the following known vulnerabilities:
     OSV-1: Something scary! (https://osv.dev/OSV-1)
 
-  1 known vulnerability found in unknown:<rootdir>/path/to/my/third/lockfile
+  1 known vulnerability found in <rootdir>/path/to/my/third/lockfile
 
 
 ---
@@ -697,39 +697,39 @@ Total 4 packages affected by 6 known vulnerabilities (0 Critical, 0 High, 0 Medi
 
 NuGet
 
-sbom:<rootdir>/path/to/my/second/lockfile: found 1 package with issues
+<rootdir>/path/to/my/second/lockfile: found 1 package with issues
 
   mine2@3.2.5 has the following known vulnerabilities:
     OSV-2: Something less scary! (https://osv.dev/OSV-2)
 
-  1 known vulnerability found in sbom:<rootdir>/path/to/my/second/lockfile
+  1 known vulnerability found in <rootdir>/path/to/my/second/lockfile
 
 Packagist
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 1 package with issues
+<rootdir>/path/to/my/first/lockfile: found 1 package with issues
 
   author1/mine1@1.2.3 has the following known vulnerabilities:
     OSV-1: Something scary! (https://osv.dev/OSV-1)
     OSV-5: Something scarier! (https://osv.dev/OSV-5)
 
-  2 known vulnerabilities found in lockfile:<rootdir>/path/to/my/first/lockfile
+  2 known vulnerabilities found in <rootdir>/path/to/my/first/lockfile
 
-sbom:<rootdir>/path/to/my/second/lockfile: found 1 package with issues
+<rootdir>/path/to/my/second/lockfile: found 1 package with issues
 
   author3/mine3@0.4.1 has the following known vulnerabilities:
     OSV-3: Something mildly scary! (https://osv.dev/OSV-3)
     OSV-5: Something scarier! (https://osv.dev/OSV-5)
 
-  2 known vulnerabilities found in sbom:<rootdir>/path/to/my/second/lockfile
+  2 known vulnerabilities found in <rootdir>/path/to/my/second/lockfile
 
 npm
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 1 package with issues
+<rootdir>/path/to/my/first/lockfile: found 1 package with issues
 
   mine1@1.2.2 has the following known vulnerabilities:
     OSV-1: Something scary! (https://osv.dev/OSV-1)
 
-  1 known vulnerability found in lockfile:<rootdir>/path/to/my/first/lockfile
+  1 known vulnerability found in <rootdir>/path/to/my/first/lockfile
 
 
 ---
@@ -741,43 +741,43 @@ Total 4 packages affected by 5 known vulnerabilities (0 Critical, 0 High, 0 Medi
 
 NuGet
 
-sbom:<rootdir>/path/to/my/second/lockfile: found 1 package with issues
+<rootdir>/path/to/my/second/lockfile: found 1 package with issues
 
   mine2@3.2.5 has the following known vulnerabilities:
     OSV-2: Something less scary! (https://osv.dev/OSV-2)
 
-  1 known vulnerability found in sbom:<rootdir>/path/to/my/second/lockfile
+  1 known vulnerability found in <rootdir>/path/to/my/second/lockfile
 
 Packagist
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 1 package with issues
+<rootdir>/path/to/my/first/lockfile: found 1 package with issues
 
   author1/mine1@1.2.3 has the following known vulnerabilities:
     OSV-5: Something scarier! (https://osv.dev/OSV-5)
 
-  1 known vulnerability found in lockfile:<rootdir>/path/to/my/first/lockfile
+  1 known vulnerability found in <rootdir>/path/to/my/first/lockfile
 
   author1/mine1@1.2.3 has the following uncalled vulnerabilities:
     OSV-1: Something scary! (https://osv.dev/OSV-1)
 
-  1 uncalled/unimportant vulnerability found in lockfile:<rootdir>/path/to/my/first/lockfile (filtered out)
+  1 uncalled/unimportant vulnerability found in <rootdir>/path/to/my/first/lockfile (filtered out)
 
-sbom:<rootdir>/path/to/my/second/lockfile: found 1 package with issues
+<rootdir>/path/to/my/second/lockfile: found 1 package with issues
 
   author3/mine3@0.4.1 has the following known vulnerabilities:
     OSV-3: Something mildly scary! (https://osv.dev/OSV-3)
     OSV-5: Something scarier! (https://osv.dev/OSV-5)
 
-  2 known vulnerabilities found in sbom:<rootdir>/path/to/my/second/lockfile
+  2 known vulnerabilities found in <rootdir>/path/to/my/second/lockfile
 
 npm
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 1 package with issues
+<rootdir>/path/to/my/first/lockfile: found 1 package with issues
 
   mine1@1.2.2 has the following known vulnerabilities:
     OSV-1: Something scary! (https://osv.dev/OSV-1)
 
-  1 known vulnerability found in lockfile:<rootdir>/path/to/my/first/lockfile
+  1 known vulnerability found in <rootdir>/path/to/my/first/lockfile
 
 
 ---
@@ -789,39 +789,39 @@ Total 4 packages affected by 6 known vulnerabilities (0 Critical, 0 High, 0 Medi
 
 NuGet
 
-sbom:<rootdir>/path/to/my/second/lockfile: found 1 package with issues
+<rootdir>/path/to/my/second/lockfile: found 1 package with issues
 
   mine2@3.2.5 has the following known vulnerabilities:
     OSV-2: Something less scary! (https://osv.dev/OSV-2)
 
-  1 known vulnerability found in sbom:<rootdir>/path/to/my/second/lockfile
+  1 known vulnerability found in <rootdir>/path/to/my/second/lockfile
 
 Packagist
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 1 package with issues
+<rootdir>/path/to/my/first/lockfile: found 1 package with issues
 
   author1/mine1@1.2.3 has the following known vulnerabilities:
     OSV-1: Something scary! (https://osv.dev/OSV-1)
     OSV-5: Something scarier! (https://osv.dev/OSV-5)
 
-  2 known vulnerabilities found in lockfile:<rootdir>/path/to/my/first/lockfile
+  2 known vulnerabilities found in <rootdir>/path/to/my/first/lockfile
 
-sbom:<rootdir>/path/to/my/second/lockfile: found 1 package with issues
+<rootdir>/path/to/my/second/lockfile: found 1 package with issues
 
   author3/mine3@0.4.1 has the following known vulnerabilities:
     OSV-3: Something mildly scary! (https://osv.dev/OSV-3)
     OSV-5: Something scarier! (https://osv.dev/OSV-5)
 
-  2 known vulnerabilities found in sbom:<rootdir>/path/to/my/second/lockfile
+  2 known vulnerabilities found in <rootdir>/path/to/my/second/lockfile
 
 npm
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 1 package with issues
+<rootdir>/path/to/my/first/lockfile: found 1 package with issues
 
   mine1@ has the following known vulnerabilities:
     OSV-1: Something scary! (https://osv.dev/OSV-1)
 
-  1 known vulnerability found in lockfile:<rootdir>/path/to/my/first/lockfile
+  1 known vulnerability found in <rootdir>/path/to/my/first/lockfile
 
 
 ---
@@ -833,13 +833,13 @@ Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medi
 
 
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
   no known vulnerabilities found
 
-sbom:<rootdir>/path/to/my/second/lockfile: found 0 packages with issues
+<rootdir>/path/to/my/second/lockfile: found 0 packages with issues
   no known vulnerabilities found
 
-unknown:<rootdir>/path/to/my/third/lockfile: found 0 packages with issues
+<rootdir>/path/to/my/third/lockfile: found 0 packages with issues
   no known vulnerabilities found
 
 
@@ -861,7 +861,7 @@ Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medi
 
 
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
   no known vulnerabilities found
 
 
@@ -874,7 +874,7 @@ Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medi
 
 npm
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
   no known vulnerabilities found
 
 
@@ -887,17 +887,17 @@ Total 1 package affected by 1 known vulnerability (0 Critical, 0 High, 0 Medium,
 
 npm
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 1 package with issues
+<rootdir>/path/to/my/first/lockfile: found 1 package with issues
 
   mine1@1.2.3 has the following known vulnerabilities:
     OSV-1: Something scary! (https://osv.dev/OSV-1)
 
-  1 known vulnerability found in lockfile:<rootdir>/path/to/my/first/lockfile
+  1 known vulnerability found in <rootdir>/path/to/my/first/lockfile
 
   mine1@1.2.3 has the following uncalled vulnerabilities:
     GHSA-123: Something scarier! (https://osv.dev/GHSA-123)
 
-  1 uncalled/unimportant vulnerability found in lockfile:<rootdir>/path/to/my/first/lockfile (filtered out)
+  1 uncalled/unimportant vulnerability found in <rootdir>/path/to/my/first/lockfile (filtered out)
 
 
 ---
@@ -909,12 +909,12 @@ Total 1 package affected by 1 known vulnerability (0 Critical, 0 High, 0 Medium,
 
 npm
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 1 package with issues
+<rootdir>/path/to/my/first/lockfile: found 1 package with issues
 
   mine1@1.2.3 has the following known vulnerabilities:
     OSV-1: Something scary! (https://osv.dev/OSV-1)
 
-  1 known vulnerability found in lockfile:<rootdir>/path/to/my/first/lockfile
+  1 known vulnerability found in <rootdir>/path/to/my/first/lockfile
 
 
 ---
@@ -926,12 +926,12 @@ Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medi
 
 npm
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
 
   mine1@1.2.3 has the following uncalled vulnerabilities:
     OSV-1: Something scary! (https://osv.dev/OSV-1)
 
-  1 uncalled/unimportant vulnerability found in lockfile:<rootdir>/path/to/my/first/lockfile (filtered out)
+  1 uncalled/unimportant vulnerability found in <rootdir>/path/to/my/first/lockfile (filtered out)
 
 
 ---
@@ -943,12 +943,12 @@ Total 1 package affected by 1 known vulnerability (0 Critical, 0 High, 0 Medium,
 
 npm
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 1 package with issues
+<rootdir>/path/to/my/first/lockfile: found 1 package with issues
 
   mine1@1.2.3 has the following known vulnerabilities:
     OSV-1: Something scary! (https://osv.dev/OSV-1)
 
-  1 known vulnerability found in lockfile:<rootdir>/path/to/my/first/lockfile
+  1 known vulnerability found in <rootdir>/path/to/my/first/lockfile
 
 
 ---
@@ -960,12 +960,12 @@ Total 1 package affected by 1 known vulnerability (0 Critical, 0 High, 0 Medium,
 
 npm
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 1 package with issues
+<rootdir>/path/to/my/first/lockfile: found 1 package with issues
 
   mine1@1.2.3 has the following known vulnerabilities:
     OSV-1: Something scary! (https://osv.dev/OSV-1)
 
-  1 known vulnerability found in lockfile:<rootdir>/path/to/my/first/lockfile
+  1 known vulnerability found in <rootdir>/path/to/my/first/lockfile
 
 
 ---
@@ -977,12 +977,12 @@ Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medi
 
 npm
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
 
   mine1@1.2.3 has the following uncalled vulnerabilities:
     OSV-1: Something scary! (https://osv.dev/OSV-1)
 
-  1 uncalled/unimportant vulnerability found in lockfile:<rootdir>/path/to/my/first/lockfile (filtered out)
+  1 uncalled/unimportant vulnerability found in <rootdir>/path/to/my/first/lockfile (filtered out)
 
 
 ---
@@ -994,12 +994,12 @@ Total 1 package affected by 1 known vulnerability (0 Critical, 0 High, 0 Medium,
 
 npm
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 1 package with issues
+<rootdir>/path/to/my/first/lockfile: found 1 package with issues
 
   mine1@1.2.3 has the following known vulnerabilities:
     OSV-1: Something scary! (https://osv.dev/OSV-1)
 
-  1 known vulnerability found in lockfile:<rootdir>/path/to/my/first/lockfile
+  1 known vulnerability found in <rootdir>/path/to/my/first/lockfile
 
 
 ---
@@ -1011,12 +1011,12 @@ Total 1 package affected by 1 known vulnerability (0 Critical, 0 High, 0 Medium,
 
 npm
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 1 package with issues
+<rootdir>/path/to/my/first/lockfile: found 1 package with issues
 
   mine1@1.2.3 has the following known vulnerabilities:
     OSV-1: Something scary! (https://osv.dev/OSV-1)
 
-  1 known vulnerability found in lockfile:<rootdir>/path/to/my/first/lockfile
+  1 known vulnerability found in <rootdir>/path/to/my/first/lockfile
 
 
 ---
@@ -1028,12 +1028,12 @@ Total 1 package affected by 1 known vulnerability (0 Critical, 0 High, 0 Medium,
 
 npm
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 1 package with issues
+<rootdir>/path/to/my/first/lockfile: found 1 package with issues
 
   mine1@ has the following known vulnerabilities:
     OSV-1: Something scary! (https://osv.dev/OSV-1)
 
-  1 known vulnerability found in lockfile:<rootdir>/path/to/my/first/lockfile
+  1 known vulnerability found in <rootdir>/path/to/my/first/lockfile
 
 
 ---
@@ -1045,14 +1045,14 @@ Total 2 packages affected by 2 known vulnerabilities (0 Critical, 0 High, 0 Medi
 
 npm
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 2 packages with issues
+<rootdir>/path/to/my/first/lockfile: found 2 packages with issues
 
   mine1@1.2.3 has the following known vulnerabilities:
     OSV-1: This vulnerability allows for some very scary stuff to happen - seriously,... (https://osv.dev/OSV-1)
   mine3@0.10.2-rc has the following known vulnerabilities:
     OSV-2: (no details available) (https://osv.dev/OSV-2)
 
-  2 known vulnerabilities found in lockfile:<rootdir>/path/to/my/first/lockfile
+  2 known vulnerabilities found in <rootdir>/path/to/my/first/lockfile
 
 
 ---
@@ -1064,14 +1064,14 @@ Total 1 package affected by 1 known vulnerability (0 Critical, 0 High, 0 Medium,
 
 npm
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 1 package with issues
+<rootdir>/path/to/my/first/lockfile: found 1 package with issues
 
   mine1@1.2.3 has the following known vulnerabilities:
     OSV-1: Something scary! (https://osv.dev/OSV-1)
 
-  1 known vulnerability found in lockfile:<rootdir>/path/to/my/first/lockfile
+  1 known vulnerability found in <rootdir>/path/to/my/first/lockfile
 
-sbom:<rootdir>/path/to/my/second/lockfile: found 0 packages with issues
+<rootdir>/path/to/my/second/lockfile: found 0 packages with issues
   no known vulnerabilities found
 
 
@@ -1084,19 +1084,19 @@ Total 2 packages affected by 2 known vulnerabilities (0 Critical, 0 High, 0 Medi
 
 npm
 
-lockfile:<rootdir>/path/to/my/first/lockfile: found 1 package with issues
+<rootdir>/path/to/my/first/lockfile: found 1 package with issues
 
   mine1@1.2.3 has the following known vulnerabilities:
     OSV-1: Something scary! (https://osv.dev/OSV-1)
 
-  1 known vulnerability found in lockfile:<rootdir>/path/to/my/first/lockfile
+  1 known vulnerability found in <rootdir>/path/to/my/first/lockfile
 
-sbom:<rootdir>/path/to/my/second/lockfile: found 1 package with issues
+<rootdir>/path/to/my/second/lockfile: found 1 package with issues
 
   mine1@1.2.3 has the following known vulnerabilities:
     OSV-1: Something scary! (https://osv.dev/OSV-1)
 
-  1 known vulnerability found in sbom:<rootdir>/path/to/my/second/lockfile
+  1 known vulnerability found in <rootdir>/path/to/my/second/lockfile
 
 
 ---

--- a/internal/output/output_result.go
+++ b/internal/output/output_result.go
@@ -372,7 +372,7 @@ func processSource(packageSource models.PackageSource) map[string]SourceResult {
 	// If no packages with issues are found, mark the ecosystem as empty.
 	if len(packageSource.Packages) == 0 {
 		sourceResults[""] = SourceResult{
-			Name:      packageSource.Source.String(),
+			Name:      packageSource.Source.Path,
 			Type:      packageSource.Source.Type,
 			Ecosystem: "",
 			Packages:  []PackageResult{},
@@ -384,7 +384,7 @@ func processSource(packageSource models.PackageSource) map[string]SourceResult {
 	for _, vulnPkg := range packageSource.Packages {
 		if _, exists := sourceResults[vulnPkg.Package.Ecosystem]; !exists {
 			sourceResults[vulnPkg.Package.Ecosystem] = SourceResult{
-				Name:      packageSource.Source.String(),
+				Name:      packageSource.Source.Path,
 				Type:      packageSource.Source.Type,
 				Ecosystem: vulnPkg.Package.Ecosystem,
 			}

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -310,9 +310,7 @@ func tableBuilderInner(result Result, vulnAnalysisType VulnAnalysisType) []tbInn
 					}
 
 					// todo: see if we want to start including any of this information
-					p := strings.TrimPrefix(source.Name, ":")
-					p = strings.TrimPrefix(p, string(source.Type))
-					p = strings.TrimPrefix(p, ":")
+					p := source.Name
 					p = strings.TrimPrefix(p, filepath.ToSlash(workingDir))
 					p = strings.TrimPrefix(p, "/")
 


### PR DESCRIPTION
It doesn't seem like it's that useful and we don't include it in other formats - i fact right now we're explicitly removing it as part of the table format