### PR TITLE
refactor: follow package naming conventions for import aliases

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -83,6 +83,8 @@ linters:
           disabled: false
         - name: exported
           disabled: false
+        - name: import-alias-naming
+          disabled: false
         - name: indent-error-flow
           disabled: false
         - name: package-comments

--- a/internal/resolution/dependency_subgraph.go
+++ b/internal/resolution/dependency_subgraph.go
@@ -8,7 +8,7 @@ import (
 	"deps.dev/util/resolve/dep"
 	"github.com/google/osv-scanner/v2/internal/resolution/manifest"
 	"github.com/google/osv-scanner/v2/internal/resolution/util"
-	vulnUtil "github.com/google/osv-scanner/v2/internal/utility/vulns"
+	"github.com/google/osv-scanner/v2/internal/utility/vulns"
 	"github.com/ossf/osv-schema/bindings/go/osvschema"
 )
 
@@ -173,7 +173,7 @@ func (ds *DependencySubgraph) ConstrainingSubgraph(ctx context.Context, cl resol
 		}
 		bestVK := vers[len(vers)-1] // This should be the highest version for npm
 
-		if vulnUtil.IsAffected(*vuln, util.VKToPackageInfo(bestVK.VersionKey)) {
+		if vulns.IsAffected(*vuln, util.VKToPackageInfo(bestVK.VersionKey)) {
 			newParents = append(newParents, pEdge)
 		}
 	}


### PR DESCRIPTION
Import aliases should follow the same conventions as package names for consistency, though for our single violation we don't actually need an alias in the first place