### PR TITLE
feat(grouping): Include upstream field in grouping

### DIFF
--- a/internal/grouper/grouper_models.go
+++ b/internal/grouper/grouper_models.go
@@ -1,8 +1,10 @@
 package grouper
 
 import (
+	"slices"
 	"strings"
 
+	"github.com/google/osv-scanner/v2/internal/identifiers"
 	"github.com/ossf/osv-schema/bindings/go/osvschema"
 )
 
@@ -13,6 +15,9 @@ type IDAliases struct {
 
 func ConvertVulnerabilityToIDAliases(c []osvschema.Vulnerability) []IDAliases {
 	output := []IDAliases{}
+
+	slices.SortFunc(c, identifiers.MostUpstreamsOrder)
+
 	for _, v := range c {
 		idAliases := IDAliases{
 			ID:      v.ID,
@@ -23,12 +28,14 @@ func ConvertVulnerabilityToIDAliases(c []osvschema.Vulnerability) []IDAliases {
 		// all related CVEs should be bundled together, as they are part of this DSA.
 		// TODO(gongh@): Revisit and provide a universal way to handle all Linux distro advisories.
 		if strings.Split(v.ID, "-")[0] == "DSA" {
+			idAliases.Aliases = append(idAliases.Aliases, v.Upstream...)
 			idAliases.Aliases = append(idAliases.Aliases, v.Related...)
 		}
 
 		// For Ubuntu Security Advisory data,
 		// all related CVEs should be bundled together, as they are part of this USN.
 		if strings.Split(v.ID, "-")[0] == "USN" {
+			idAliases.Aliases = append(idAliases.Aliases, v.Upstream...)
 			idAliases.Aliases = append(idAliases.Aliases, v.Related...)
 		}
 

--- a/internal/identifiers/identifiers.go
+++ b/internal/identifiers/identifiers.go
@@ -2,7 +2,21 @@ package identifiers
 
 import (
 	"strings"
+
+	"github.com/ossf/osv-schema/bindings/go/osvschema"
 )
+
+// MostUpstreamsOrder orders by which vuln has the most upstreams,
+// thereby finding the furthest downstream vuln identifier.
+func MostUpstreamsOrder(a, b osvschema.Vulnerability) int {
+	if len(a.Upstream) > len(b.Upstream) {
+		return -1
+	} else if len(a.Upstream) < len(b.Upstream) {
+		return 1
+	} else {
+		return IDSortFunc(a.ID, b.ID)
+	}
+}
 
 func prefixOrder(prefix string) int {
 	switch prefix {

--- a/internal/output/output_result.go
+++ b/internal/output/output_result.go
@@ -491,9 +491,6 @@ func processVulnGroups(vulnPkg models.PackageVulns) (map[string]VulnResult, map[
 	hiddenVulnMap := make(map[string]VulnResult)
 
 	for _, group := range vulnPkg.Groups {
-		slices.SortFunc(group.IDs, identifiers.IDSortFunc)
-		slices.SortFunc(group.Aliases, identifiers.IDSortFunc)
-
 		representID := group.IDs[0]
 		aliases := group.Aliases
 		if len(group.Aliases) > 0 && group.Aliases[0] == representID {


### PR DESCRIPTION
Closes #2027 and reduces reliance on hard coding prefix ordering. 

Instead, we are utilizing the logic that the furthest downstream vuln will always have more upstreams than its upstream to order and display the furthest downstream report.