### PR TITLE
Add CDX Location field to the output source string

### DIFF
--- a/pkg/osvscanner/vulnerability_result.go
+++ b/pkg/osvscanner/vulnerability_result.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem/sbom/cdx"
 	"github.com/google/osv-scanner/v2/internal/cmdlogger"
 	"github.com/google/osv-scanner/v2/internal/grouper"
 	"github.com/google/osv-scanner/v2/internal/imodels/results"
@@ -126,6 +127,10 @@ func buildVulnerabilityResults(
 			source := models.SourceInfo{
 				Path: filepath.ToSlash(p.Location()),
 				Type: p.SourceType(),
+			}
+
+			if slices.Contains(p.Plugins, cdx.Name) && len(p.Locations) > 1 {
+				source.Path = source.Path + ":" + p.Locations[1]
 			}
 
 			if groupedBySource[source] == nil {


### PR DESCRIPTION
The CDX extractor now will output the occurrence location if it found it in the SBOM. This just adds that to the output