### PR TITLE
refactor: don't shadow import names

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -88,6 +88,8 @@ linters:
           disabled: false
         - name: import-alias-naming
           disabled: false
+        - name: import-shadowing
+          disabled: false
         - name: indent-error-flow
           disabled: false
         - name: package-comments

--- a/internal/clients/clientimpl/localmatcher/localmatcher.go
+++ b/internal/clients/clientimpl/localmatcher/localmatcher.go
@@ -81,26 +81,26 @@ func (matcher *LocalMatcher) MatchVulnerabilities(ctx context.Context, invs []*e
 
 // LoadEcosystem tries to preload the ecosystem into the cache, and returns an error if the ecosystem
 // cannot be loaded.
-func (matcher *LocalMatcher) LoadEcosystem(ctx context.Context, ecosystem ecosystem.Parsed) error {
-	_, err := matcher.loadDBFromCache(ctx, ecosystem)
+func (matcher *LocalMatcher) LoadEcosystem(ctx context.Context, eco ecosystem.Parsed) error {
+	_, err := matcher.loadDBFromCache(ctx, eco)
 
 	return err
 }
 
-func (matcher *LocalMatcher) loadDBFromCache(ctx context.Context, ecosystem ecosystem.Parsed) (*ZipDB, error) {
-	if db, ok := matcher.dbs[ecosystem.Ecosystem]; ok {
+func (matcher *LocalMatcher) loadDBFromCache(ctx context.Context, eco ecosystem.Parsed) (*ZipDB, error) {
+	if db, ok := matcher.dbs[eco.Ecosystem]; ok {
 		return db, nil
 	}
 
-	if matcher.failedDBs[ecosystem.Ecosystem] != nil {
-		return nil, matcher.failedDBs[ecosystem.Ecosystem]
+	if matcher.failedDBs[eco.Ecosystem] != nil {
+		return nil, matcher.failedDBs[eco.Ecosystem]
 	}
 
-	db, err := NewZippedDB(ctx, matcher.dbBasePath, string(ecosystem.Ecosystem), fmt.Sprintf("%s/%s/all.zip", zippedDBRemoteHost, ecosystem.Ecosystem), matcher.userAgent, !matcher.downloadDB)
+	db, err := NewZippedDB(ctx, matcher.dbBasePath, string(eco.Ecosystem), fmt.Sprintf("%s/%s/all.zip", zippedDBRemoteHost, eco.Ecosystem), matcher.userAgent, !matcher.downloadDB)
 
 	if err != nil {
-		matcher.failedDBs[ecosystem.Ecosystem] = err
-		cmdlogger.Errorf("could not load db for %s ecosystem: %v", ecosystem.Ecosystem, err)
+		matcher.failedDBs[eco.Ecosystem] = err
+		cmdlogger.Errorf("could not load db for %s ecosystem: %v", eco.Ecosystem, err)
 
 		return nil, err
 	}
@@ -108,7 +108,7 @@ func (matcher *LocalMatcher) loadDBFromCache(ctx context.Context, ecosystem ecos
 	// TODO(v2 logging): Replace with slog / another logger
 	cmdlogger.Infof("Loaded %s local db from %s", db.Name, db.StoredAt)
 
-	matcher.dbs[ecosystem.Ecosystem] = db
+	matcher.dbs[eco.Ecosystem] = db
 
 	return db, nil
 }

--- a/internal/datasource/maven_registry.go
+++ b/internal/datasource/maven_registry.go
@@ -210,9 +210,9 @@ func (m *MavenRegistryAPIClient) getArtifactMetadata(ctx context.Context, regist
 	return metadata, nil
 }
 
-func (m *MavenRegistryAPIClient) get(ctx context.Context, auth *HTTPAuthentication, url string, dst any) error {
-	resp, err := m.responses.Get(url, func() (response, error) {
-		resp, err := auth.Get(ctx, http.DefaultClient, url)
+func (m *MavenRegistryAPIClient) get(ctx context.Context, auth *HTTPAuthentication, apiURL string, dst any) error {
+	resp, err := m.responses.Get(apiURL, func() (response, error) {
+		resp, err := auth.Get(ctx, http.DefaultClient, apiURL)
 		if err != nil {
 			return response{}, fmt.Errorf("%w: Maven registry query failed: %w", errAPIFailed, err)
 		}

--- a/internal/output/result.go
+++ b/internal/output/result.go
@@ -119,11 +119,11 @@ type groupedSARIFFinding struct {
 
 // mapIDsToGroupedSARIFFinding creates a map over all vulnerability IDs, with aliased vuln IDs
 // pointing to the same groupedSARIFFinding object
-func mapIDsToGroupedSARIFFinding(vulns *models.VulnerabilityResults) map[string]*groupedSARIFFinding {
+func mapIDsToGroupedSARIFFinding(vulnResults *models.VulnerabilityResults) map[string]*groupedSARIFFinding {
 	// Map of vuln IDs to their respective groupedSARIFFinding
 	results := map[string]*groupedSARIFFinding{}
 
-	for _, res := range vulns.Results {
+	for _, res := range vulnResults.Results {
 		for _, pkg := range res.Packages {
 			for _, gi := range pkg.Groups {
 				var data *groupedSARIFFinding

--- a/internal/output/sarif.go
+++ b/internal/output/sarif.go
@@ -130,14 +130,14 @@ func createSARIFAffectedPkgTable(pkgWithSrc []pkgWithSource) table.Writer {
 	helpTable.AppendHeader(table.Row{"Source", "Package Name", "Package Version"})
 
 	for _, ps := range pkgWithSrc {
-		version := ps.Package.Version
+		ver := ps.Package.Version
 		if ps.Package.Commit != "" {
-			version = ps.Package.Commit
+			ver = ps.Package.Commit
 		}
 		helpTable.AppendRow(table.Row{
 			ps.Source.String(),
 			ps.Package.Name,
-			version,
+			ver,
 		})
 	}
 

--- a/internal/remediation/in_place.go
+++ b/internal/remediation/in_place.go
@@ -115,9 +115,9 @@ func ComputeInPlacePatches(ctx context.Context, cl client.ResolutionClient, grap
 
 	// Compute the overall constraints imposed by the dependent packages on the vulnerable nodes
 	vkDependentConstraint := make(map[resolve.VersionKey]semver.Set)
-	for vk, vulns := range res.vkVulns {
+	for vk, vkVulns := range res.vkVulns {
 		reqVers := make(map[string]struct{})
-		for _, vuln := range vulns {
+		for _, vuln := range vkVulns {
 			for _, sg := range vuln.Subgraphs {
 				for _, e := range sg.Nodes[sg.Dependency].Parents {
 					reqVers[e.Requirement] = struct{}{}
@@ -265,8 +265,8 @@ func inPlaceVulnsNodes(ctx context.Context, m clientinterfaces.VulnerabilityMatc
 	// Construct resolution.Vulnerability for all vulnerable packages
 	// combining nodes with the same package & versions number
 	var nodeIDs []resolve.NodeID
-	for nID, vulns := range nodeVulns {
-		if len(vulns) > 0 {
+	for nID, nVulns := range nodeVulns {
+		if len(nVulns) > 0 {
 			nodeIDs = append(nodeIDs, resolve.NodeID(nID))
 		}
 	}

--- a/internal/resolution/manifest/maven.go
+++ b/internal/resolution/manifest/maven.go
@@ -120,9 +120,9 @@ func (m MavenReadWriter) Read(df depfile.DepFile) (Manifest, error) {
 	// For dependency management imports, the dependencies that imports
 	// dependencies from other projects will be replaced by the imported
 	// dependencies, so add them to requirements first.
-	for _, dep := range project.DependencyManagement.Dependencies {
-		if dep.Scope == "import" && dep.Type == "pom" {
-			reqsForUpdates = append(reqsForUpdates, makeRequirementVersion(dep, mavenutil.OriginManagement))
+	for _, dmDep := range project.DependencyManagement.Dependencies {
+		if dmDep.Scope == "import" && dmDep.Type == "pom" {
+			reqsForUpdates = append(reqsForUpdates, makeRequirementVersion(dmDep, mavenutil.OriginManagement))
 		}
 	}
 
@@ -258,23 +258,23 @@ func buildOriginalRequirements(project maven.Project, originPrefix string) []Dep
 //   - prefix indicates it is from profile or plugin
 //   - identifier to locate the profile/plugin which is profile ID or plugin name
 //   - (optional) suffix indicates if this is a dependency management
-func makeRequirementVersion(dep maven.Dependency, origin string) resolve.RequirementVersion {
+func makeRequirementVersion(dependency maven.Dependency, origin string) resolve.RequirementVersion {
 	// Treat test & optional dependencies as regular dependencies to force the resolver to resolve them.
-	if dep.Scope == "test" {
-		dep.Scope = ""
+	if dependency.Scope == "test" {
+		dependency.Scope = ""
 	}
-	dep.Optional = ""
+	dependency.Optional = ""
 
 	return resolve.RequirementVersion{
 		VersionKey: resolve.VersionKey{
 			PackageKey: resolve.PackageKey{
 				System: resolve.Maven,
-				Name:   dep.Name(),
+				Name:   dependency.Name(),
 			},
 			VersionType: resolve.Requirement,
-			Version:     string(dep.Version),
+			Version:     string(dependency.Version),
 		},
-		Type: resolve.MavenDepType(dep, origin),
+		Type: resolve.MavenDepType(dependency, origin),
 	}
 }
 

--- a/internal/scalibrextract/filesystem/vendored/vendored.go
+++ b/internal/scalibrextract/filesystem/vendored/vendored.go
@@ -228,8 +228,8 @@ func (e *Extractor) Configure(config Config) {
 
 var _ configurable = &Extractor{}
 
-func Configure(extractor extractor.Extractor, config Config) {
-	us, ok := extractor.(configurable)
+func Configure(extrac extractor.Extractor, config Config) {
+	us, ok := extrac.(configurable)
 
 	if ok {
 		us.Configure(config)

--- a/internal/scalibrextract/language/osv/osvscannerjson/extractor.go
+++ b/internal/scalibrextract/language/osv/osvscannerjson/extractor.go
@@ -50,7 +50,7 @@ func (e Extractor) Extract(_ context.Context, input *filesystem.ScanInput) (inve
 	packages := []*extractor.Package{}
 	for _, res := range parsedResults.Results {
 		for _, pkg := range res.Packages {
-			inventory := extractor.Package{
+			inv := extractor.Package{
 				Name:    pkg.Package.Name,
 				Version: pkg.Package.Version,
 				Metadata: Metadata{
@@ -60,12 +60,12 @@ func (e Extractor) Extract(_ context.Context, input *filesystem.ScanInput) (inve
 				Locations: []string{input.Path},
 			}
 			if pkg.Package.Commit != "" {
-				inventory.SourceCode = &extractor.SourceCodeIdentifier{
+				inv.SourceCode = &extractor.SourceCodeIdentifier{
 					Commit: pkg.Package.Commit,
 				}
 			}
 
-			packages = append(packages, &inventory)
+			packages = append(packages, &inv)
 		}
 	}
 

--- a/internal/scalibrextract/vcs/gitrepo/extractor.go
+++ b/internal/scalibrextract/vcs/gitrepo/extractor.go
@@ -59,12 +59,12 @@ func getSubmodules(repo *git.Repository) (submodules []*git.SubmoduleStatus, err
 	return submodules, nil
 }
 
-func createCommitQueryInventory(commit string, path string) *extractor.Package {
+func createCommitQueryInventory(commit string, location string) *extractor.Package {
 	return &extractor.Package{
 		SourceCode: &extractor.SourceCodeIdentifier{
 			Commit: commit,
 		},
-		Locations: []string{path},
+		Locations: []string{location},
 	}
 }
 
@@ -116,7 +116,7 @@ func (e *Extractor) Extract(_ context.Context, input *filesystem.ScanInput) (inv
 		return inventory.Inventory{}, err
 	}
 
-	var inventory inventory.Inventory
+	var inv inventory.Inventory
 
 	if e.IncludeRootGit {
 		commitSHA, err := getCommitSHA(repo)
@@ -124,22 +124,22 @@ func (e *Extractor) Extract(_ context.Context, input *filesystem.ScanInput) (inv
 		// If error is not nil, then ignore this and continue, as it is not fatal.
 		// The error could be because there are no commits in the repository
 		if err == nil {
-			inventory.Packages = append(inventory.Packages, createCommitQueryInventory(commitSHA, input.Path))
+			inv.Packages = append(inv.Packages, createCommitQueryInventory(commitSHA, input.Path))
 		}
 	}
 
 	// If we can't get submodules, just return with what we have.
 	submodules, err := getSubmodules(repo)
 	if err != nil {
-		return inventory, err
+		return inv, err
 	}
 
 	for _, s := range submodules {
 		// r.Infof("Scanning submodule %s at commit %s\n", s.Path, s.Expected.String())
-		inventory.Packages = append(inventory.Packages, createCommitQueryInventory(s.Expected.String(), path.Join(input.Path, s.Path)))
+		inv.Packages = append(inv.Packages, createCommitQueryInventory(s.Expected.String(), path.Join(input.Path, s.Path)))
 	}
 
-	return inventory, nil
+	return inv, nil
 }
 
 // ToPURL converts an inventory created by this extractor into a PURL.
@@ -165,8 +165,8 @@ func (e *Extractor) Configure(config Config) {
 
 var _ configurable = &Extractor{}
 
-func Configure(extractor extractor.Extractor, config Config) {
-	us, ok := extractor.(configurable)
+func Configure(extrac extractor.Extractor, config Config) {
+	us, ok := extrac.(configurable)
 
 	if ok {
 		us.Configure(config)

--- a/internal/tui/vuln-list.go
+++ b/internal/tui/vuln-list.go
@@ -180,8 +180,8 @@ func (d vulnListItemDelegate) Render(w io.Writer, m list.Model, index int, listI
 		idStyle = idStyle.Inherit(SelectedTextStyle)
 	}
 	id := idStyle.Render(vuln.OSV.ID)
-	severity := RenderSeverityShort(vuln.OSV.Severity)
-	str := fmt.Sprintf("%s %s  %s  ", cursor, id, severity)
+	sev := RenderSeverityShort(vuln.OSV.Severity)
+	str := fmt.Sprintf("%s %s  %s  ", cursor, id, sev)
 	fmt.Fprint(w, str)
 	fmt.Fprint(w, truncate.StringWithTail(vuln.OSV.Summary, uint(m.Width()-lipgloss.Width(str)), "…")) //nolint:gosec
 }

--- a/pkg/osvscanner/filter.go
+++ b/pkg/osvscanner/filter.go
@@ -90,10 +90,10 @@ func filterIgnoredPackages(scanResults *results.ScanResults) {
 }
 
 // Filters results according to config, preserving order. Returns total number of vulnerabilities removed.
-func filterResults(results *models.VulnerabilityResults, configManager *config.Manager, allPackages bool) int {
+func filterResults(vulnResults *models.VulnerabilityResults, configManager *config.Manager, allPackages bool) int {
 	removedCount := 0
 	newResults := []models.PackageSource{} // Want 0 vulnerabilities to show in JSON as an empty list, not null.
-	for _, pkgSrc := range results.Results {
+	for _, pkgSrc := range vulnResults.Results {
 		configToUse := configManager.Get(pkgSrc.Source.Path)
 		var newPackages []models.PackageVulns
 		for _, pkgVulns := range pkgSrc.Packages {
@@ -109,7 +109,7 @@ func filterResults(results *models.VulnerabilityResults, configManager *config.M
 			newResults = append(newResults, pkgSrc)
 		}
 	}
-	results.Results = newResults
+	vulnResults.Results = newResults
 
 	return removedCount
 }

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -454,12 +454,12 @@ func buildLicenseSummary(scanResult *results.ScanResults) []models.LicenseCount 
 
 // determineReturnErr determines whether we found a "vulnerability" or not,
 // and therefore whether we should return a ErrVulnerabilityFound error.
-func determineReturnErr(results models.VulnerabilityResults, showAllVulns bool, isContainerScanning bool) error {
-	if len(results.Results) > 0 {
+func determineReturnErr(vulnResults models.VulnerabilityResults, showAllVulns bool, isContainerScanning bool) error {
+	if len(vulnResults.Results) > 0 {
 		var vuln bool
 		onlyUnimportantVuln := true
 		var licenseViolation bool
-		for _, vf := range results.Flatten() {
+		for _, vf := range vulnResults.Flatten() {
 			if vf.Vulnerability.ID != "" {
 				vuln = true
 				// TODO(gongh): rewrite the logic once we support reachability analysis for container scanning.

--- a/pkg/osvscanner/vulnerability_result.go
+++ b/pkg/osvscanner/vulnerability_result.go
@@ -25,7 +25,7 @@ func buildVulnerabilityResults(
 	actions ScannerActions,
 	scanResults *results.ScanResults,
 ) models.VulnerabilityResults {
-	results := models.VulnerabilityResults{
+	vulnResults := models.VulnerabilityResults{
 		Results:       []models.PackageSource{},
 		ImageMetadata: scanResults.ImageMetadata,
 	}
@@ -141,31 +141,31 @@ func buildVulnerabilityResults(
 	// TODO(v2): Move source analysis out of here.
 	for source, packages := range groupedBySource {
 		sourceanalysis.Run(source, packages.pvs, actions.CallAnalysisStates)
-		results.Results = append(results.Results, models.PackageSource{
+		vulnResults.Results = append(vulnResults.Results, models.PackageSource{
 			Source:                  source,
 			ExperimentalAnnotations: packages.annotations,
 			Packages:                packages.pvs,
 		})
 	}
 
-	sort.Slice(results.Results, func(i, j int) bool {
-		if results.Results[i].Source.Path == results.Results[j].Source.Path {
-			return results.Results[i].Source.Type < results.Results[j].Source.Type
+	sort.Slice(vulnResults.Results, func(i, j int) bool {
+		if vulnResults.Results[i].Source.Path == vulnResults.Results[j].Source.Path {
+			return vulnResults.Results[i].Source.Type < vulnResults.Results[j].Source.Type
 		}
 
-		return results.Results[i].Source.Path < results.Results[j].Source.Path
+		return vulnResults.Results[i].Source.Path < vulnResults.Results[j].Source.Path
 	})
 
 	if len(actions.ScanLicensesAllowlist) > 0 || actions.ScanLicensesSummary {
-		results.ExperimentalAnalysisConfig.Licenses.Summary = actions.ScanLicensesSummary
+		vulnResults.ExperimentalAnalysisConfig.Licenses.Summary = actions.ScanLicensesSummary
 		allowlist := make([]models.License, len(actions.ScanLicensesAllowlist))
 		for i, l := range actions.ScanLicensesAllowlist {
 			allowlist[i] = models.License(l)
 		}
-		results.ExperimentalAnalysisConfig.Licenses.Allowlist = allowlist
+		vulnResults.ExperimentalAnalysisConfig.Licenses.Allowlist = allowlist
 	}
 
-	return results
+	return vulnResults
 }
 
 // setUnimportant marks vulnerabilities in a PackageVulns as unimportant


### PR DESCRIPTION
It's generally considered a good idea to avoid shadowing the name of imports, in part because it can help you identify package names that could be too generic.

I think most of the resulting refactors are ok, but there are a couple I wish there was an alternative name for either the variable or packages such as `url` and `extractor` (which originally I replaced with `extracto`, which I thought was cute but then `misspell` complained it was a misspelling of "extraction" 😅)