### PR TITLE
fix: properly flag if running on Linux or Mac OSs

### DIFF
--- a/pkg/osvscanner/scan.go
+++ b/pkg/osvscanner/scan.go
@@ -148,21 +148,19 @@ func scan(accessors ExternalAccessors, actions ScannerActions) ([]imodels.Packag
 	}
 
 	testlogger.BeginDirScanMarker()
+	osCapability := determineOS()
+
 	// For each root, run scalibr's scan() once.
 	for root, paths := range rootMap {
 		capabilities := plugin.Capabilities{
 			DirectFS:      true,
 			RunningSystem: true,
 			Network:       plugin.NetworkOnline,
-			OS:            plugin.OSUnix,
+			OS:            osCapability,
 		}
 
 		if actions.CompareOffline {
 			capabilities.Network = plugin.NetworkOffline
-		}
-
-		if runtime.GOOS == "windows" {
-			capabilities.OS = plugin.OSWindows
 		}
 
 		plugins := make([]plugin.Plugin, len(dirExtractors))
@@ -239,4 +237,17 @@ func getRootDir(path string) string {
 	}
 
 	return ""
+}
+
+func determineOS() plugin.OS {
+	switch runtime.GOOS {
+	case "windows":
+		return plugin.OSWindows
+	case "darwin":
+		return plugin.OSMac
+	case "linux":
+		return plugin.OSLinux
+	default:
+		return plugin.OSAny
+	}
 }

--- a/pkg/osvscanner/scan.go
+++ b/pkg/osvscanner/scan.go
@@ -248,6 +248,8 @@ func determineOS() plugin.OS {
 	case "linux":
 		return plugin.OSLinux
 	default:
+		cmdlogger.Warnf("Unknown OS \"%s\" - results might be inaccurate", runtime.GOOS)
+
 		return plugin.OSAny
 	}
 }


### PR DESCRIPTION
The `OSUnix` value is only meant to be used by plugins to indicate they're fine working with either Linux or macOS, but [the OS still needs to be one of those values](https://github.com/google/osv-scalibr/blob/ed2676c6ae1b/plugin/plugin.go#L119-L125) when scanning.

This is not an issue currently because we're just using extractors, but there are a few detectors that require a Unix-like OS