### PR TITLE
refactor: use scalibr function for building extractors by name

### DIFF
--- a/cmd/osv-scanner/scan/source/__snapshots__/command_test.snap
+++ b/cmd/osv-scanner/scan/source/__snapshots__/command_test.snap
@@ -1324,7 +1324,7 @@ Filtered 1 vulnerability from output
 ---
 
 [TestCommand_ExplicitExtractors/scanning_directory_with_an_extractor_that_does_not_exist - 2]
-Unknown extractor custom/extractor
+unknown extractor "custom/extractor"
 
 ---
 

--- a/internal/builders/extractors.go
+++ b/internal/builders/extractors.go
@@ -2,37 +2,7 @@ package builders
 
 import (
 	"github.com/google/osv-scalibr/extractor/filesystem"
-	"github.com/google/osv-scalibr/extractor/filesystem/language/cpp/conanlock"
-	"github.com/google/osv-scalibr/extractor/filesystem/language/dart/pubspec"
-	"github.com/google/osv-scalibr/extractor/filesystem/language/dotnet/depsjson"
-	"github.com/google/osv-scalibr/extractor/filesystem/language/dotnet/packagesconfig"
-	"github.com/google/osv-scalibr/extractor/filesystem/language/dotnet/packageslockjson"
-	"github.com/google/osv-scalibr/extractor/filesystem/language/erlang/mixlock"
-	"github.com/google/osv-scalibr/extractor/filesystem/language/golang/gobinary"
-	"github.com/google/osv-scalibr/extractor/filesystem/language/golang/gomod"
-	"github.com/google/osv-scalibr/extractor/filesystem/language/haskell/cabal"
-	"github.com/google/osv-scalibr/extractor/filesystem/language/haskell/stacklock"
-	"github.com/google/osv-scalibr/extractor/filesystem/language/java/archive"
-	"github.com/google/osv-scalibr/extractor/filesystem/language/java/gradlelockfile"
-	"github.com/google/osv-scalibr/extractor/filesystem/language/java/gradleverificationmetadataxml"
-	"github.com/google/osv-scalibr/extractor/filesystem/language/javascript/bunlock"
-	"github.com/google/osv-scalibr/extractor/filesystem/language/javascript/packagelockjson"
-	"github.com/google/osv-scalibr/extractor/filesystem/language/javascript/pnpmlock"
-	"github.com/google/osv-scalibr/extractor/filesystem/language/javascript/yarnlock"
-	"github.com/google/osv-scalibr/extractor/filesystem/language/php/composerlock"
-	"github.com/google/osv-scalibr/extractor/filesystem/language/python/pdmlock"
-	"github.com/google/osv-scalibr/extractor/filesystem/language/python/pipfilelock"
-	"github.com/google/osv-scalibr/extractor/filesystem/language/python/poetrylock"
-	"github.com/google/osv-scalibr/extractor/filesystem/language/python/uvlock"
-	"github.com/google/osv-scalibr/extractor/filesystem/language/python/wheelegg"
-	"github.com/google/osv-scalibr/extractor/filesystem/language/r/renvlock"
-	"github.com/google/osv-scalibr/extractor/filesystem/language/ruby/gemfilelock"
-	"github.com/google/osv-scalibr/extractor/filesystem/language/rust/cargoauditable"
-	"github.com/google/osv-scalibr/extractor/filesystem/language/rust/cargolock"
-	"github.com/google/osv-scalibr/extractor/filesystem/os/apk"
-	"github.com/google/osv-scalibr/extractor/filesystem/os/dpkg"
-	"github.com/google/osv-scalibr/extractor/filesystem/sbom/cdx"
-	"github.com/google/osv-scalibr/extractor/filesystem/sbom/spdx"
+	"github.com/google/osv-scalibr/extractor/filesystem/list"
 	"github.com/google/osv-scanner/v2/internal/cmdlogger"
 	"github.com/google/osv-scanner/v2/internal/scalibrextract/filesystem/vendored"
 	"github.com/google/osv-scanner/v2/internal/scalibrextract/language/java/pomxmlenhanceable"
@@ -41,129 +11,40 @@ import (
 	"github.com/google/osv-scanner/v2/internal/scalibrextract/vcs/gitrepo"
 )
 
-func build(name string) filesystem.Extractor {
+func build(name string) []filesystem.Extractor {
 	switch name {
-	// Alpine
-	case apk.Name:
-		return apk.NewDefault()
-
-	// C
-	case conanlock.Name:
-		return conanlock.New()
-
-	// Debian
-	case dpkg.Name:
-		return dpkg.NewDefault()
-
-	// Erlang
-	case mixlock.Name:
-		return mixlock.New()
-
-	// Flutter
-	case pubspec.Name:
-		return pubspec.New()
-
-	// Go
-	case gomod.Name:
-		return gomod.New()
-	case gobinary.Name:
-		return gobinary.NewDefault()
-
-	// Haskell
-	case cabal.Name:
-		return cabal.NewDefault()
-	case stacklock.Name:
-		return stacklock.NewDefault()
-
 	// Java
-	case gradlelockfile.Name:
-		return gradlelockfile.New()
-	case gradleverificationmetadataxml.Name:
-		return gradleverificationmetadataxml.New()
 	case pomxmlenhanceable.Name:
-		return pomxmlenhanceable.New()
-	case archive.Name:
-		return archive.NewDefault()
-
+		return []filesystem.Extractor{pomxmlenhanceable.New()}
 	// Javascript
-	case packagelockjson.Name:
-		return packagelockjson.NewDefault()
-	case pnpmlock.Name:
-		return pnpmlock.New()
-	case yarnlock.Name:
-		return yarnlock.New()
-	case bunlock.Name:
-		return bunlock.New()
 	case nodemodules.Name:
-		return nodemodules.Extractor{}
-
-	// NuGet
-	case depsjson.Name:
-		return depsjson.NewDefault()
-	case packagesconfig.Name:
-		return packagesconfig.NewDefault()
-	case packageslockjson.Name:
-		return packageslockjson.NewDefault()
-
-	// PHP
-	case composerlock.Name:
-		return composerlock.New()
-
+		return []filesystem.Extractor{nodemodules.Extractor{}}
 	// Python
-	case pipfilelock.Name:
-		return pipfilelock.New()
-	case pdmlock.Name:
-		return pdmlock.New()
-	case poetrylock.Name:
-		return poetrylock.New()
 	case requirementsenhancable.Name:
-		return requirementsenhancable.New()
-	case uvlock.Name:
-		return uvlock.New()
-	case wheelegg.Name:
-		return wheelegg.NewDefault()
-
-	// R
-	case renvlock.Name:
-		return renvlock.New()
-
-	// Ruby
-	case gemfilelock.Name:
-		return gemfilelock.New()
-
-	// Rust
-	case cargolock.Name:
-		return cargolock.New()
-	case cargoauditable.Name:
-		return cargoauditable.NewDefault()
-
-	// SBOM
-	case spdx.Name:
-		return spdx.New()
-	case cdx.Name:
-		return cdx.New()
-
+		return []filesystem.Extractor{requirementsenhancable.New()}
 	// Directories
 	case vendored.Name:
-		return &vendored.Extractor{}
+		return []filesystem.Extractor{&vendored.Extractor{}}
 	case gitrepo.Name:
-		return &gitrepo.Extractor{}
+		return []filesystem.Extractor{&gitrepo.Extractor{}}
 	}
 
-	return nil
+	extractors, err := list.ExtractorsFromName(name)
+
+	if err != nil {
+		cmdlogger.Errorf("%s", err)
+
+		return nil
+	}
+
+	return extractors
 }
 
 func BuildExtractors(names []string) []filesystem.Extractor {
 	extractors := make([]filesystem.Extractor, 0, len(names))
 
 	for _, name := range names {
-		extractor := build(name)
-
-		if extractor == nil {
-			cmdlogger.Errorf("Unknown extractor %s", name)
-		} else {
-			extractors = append(extractors, build(name))
-		}
+		extractors = append(extractors, build(name)...)
 	}
 
 	return extractors

--- a/internal/builders/extractors.go
+++ b/internal/builders/extractors.go
@@ -11,40 +11,36 @@ import (
 	"github.com/google/osv-scanner/v2/internal/scalibrextract/vcs/gitrepo"
 )
 
-func build(name string) []filesystem.Extractor {
-	switch name {
-	// Java
-	case pomxmlenhanceable.Name:
-		return []filesystem.Extractor{pomxmlenhanceable.New()}
-	// Javascript
-	case nodemodules.Name:
-		return []filesystem.Extractor{nodemodules.Extractor{}}
-	// Python
-	case requirementsenhancable.Name:
-		return []filesystem.Extractor{requirementsenhancable.New()}
-	// Directories
-	case vendored.Name:
-		return []filesystem.Extractor{&vendored.Extractor{}}
-	case gitrepo.Name:
-		return []filesystem.Extractor{&gitrepo.Extractor{}}
-	}
-
-	extractors, err := list.ExtractorsFromName(name)
-
-	if err != nil {
-		cmdlogger.Errorf("%s", err)
-
-		return nil
-	}
-
-	return extractors
-}
-
 func BuildExtractors(names []string) []filesystem.Extractor {
 	extractors := make([]filesystem.Extractor, 0, len(names))
 
 	for _, name := range names {
-		extractors = append(extractors, build(name)...)
+		switch name {
+		// Java
+		case pomxmlenhanceable.Name:
+			extractors = append(extractors, pomxmlenhanceable.New())
+		// Javascript
+		case nodemodules.Name:
+			extractors = append(extractors, nodemodules.Extractor{})
+		// Python
+		case requirementsenhancable.Name:
+			extractors = append(extractors, requirementsenhancable.New())
+		// Directories
+		case vendored.Name:
+			extractors = append(extractors, &vendored.Extractor{})
+		case gitrepo.Name:
+			extractors = append(extractors, &gitrepo.Extractor{})
+		default:
+			extras, err := list.ExtractorsFromName(name)
+
+			if err != nil {
+				cmdlogger.Errorf("%s", err)
+
+				continue
+			}
+
+			extractors = append(extractors, extras...)
+		}
 	}
 
 	return extractors


### PR DESCRIPTION
This should make it easier to enable support for extractors as they're shipped in `osv-scalibr`, though it does come at the cost of making it more opaque what extractors consumers can provide but we can deal with that problem at a later date especially since the CLI side is still experimental