### PR TITLE
feat: support ubutnu severity type

### DIFF
--- a/cmd/osv-scanner/scan/image/__snapshots__/command_test.snap
+++ b/cmd/osv-scanner/scan/image/__snapshots__/command_test.snap
@@ -191,7 +191,8 @@ Package Ubuntu:20.04/ncurses/6.2-0ubuntu2.1 has been filtered out because: Just 
 Package Ubuntu:20.04/ncurses/6.2-0ubuntu2.1 has been filtered out because: Just want to test only unimportant vulns
 Package Ubuntu:20.04/shadow/1:4.8.1-1ubuntu5.20.04.5 has been filtered out because: Just want to test only unimportant vulns
 Package Ubuntu:20.04/perl/5.30.0-9ubuntu0.5 has been filtered out because: Just want to test only unimportant vulns
-Filtered 26 ignored package/s from the scan.
+Package Ubuntu:20.04/tar/1.30+dfsg-7ubuntu0.20.04.4 has been filtered out because: Just want to test only unimportant vulns
+Filtered 27 ignored package/s from the scan.
 
 Container Scanning Result (Ubuntu 20.04.6 LTS):
 Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
@@ -237,7 +238,8 @@ Package Ubuntu:20.04/ncurses/6.2-0ubuntu2.1 has been filtered out because: Just 
 Package Ubuntu:20.04/ncurses/6.2-0ubuntu2.1 has been filtered out because: Just want to test only unimportant vulns
 Package Ubuntu:20.04/shadow/1:4.8.1-1ubuntu5.20.04.5 has been filtered out because: Just want to test only unimportant vulns
 Package Ubuntu:20.04/perl/5.30.0-9ubuntu0.5 has been filtered out because: Just want to test only unimportant vulns
-Filtered 26 ignored package/s from the scan.
+Package Ubuntu:20.04/tar/1.30+dfsg-7ubuntu0.20.04.4 has been filtered out because: Just want to test only unimportant vulns
+Filtered 27 ignored package/s from the scan.
 
 Container Scanning Result (Ubuntu 20.04.6 LTS):
 Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
@@ -265,35 +267,36 @@ You can also view the full vulnerability list in your terminal with: `osv-scanne
 Scanning local image tarball "../../../../internal/image/fixtures/test-ubuntu.tar"
 
 Container Scanning Result (Ubuntu 22.04.5 LTS):
-Total 18 packages affected by 38 known vulnerabilities (2 Critical, 9 High, 21 Medium, 4 Low, 2 Unknown) from 1 ecosystem.
-13 vulnerabilities can be fixed.
+Total 19 packages affected by 38 known vulnerabilities (2 Critical, 9 High, 22 Medium, 3 Low, 2 Unknown) from 1 ecosystem.
+18 vulnerabilities can be fixed.
 
 
 Ubuntu:22.04
-+----------------------------------------------------------------------------------------------------------------------------------------------+
-| Source:os:var/lib/dpkg/status                                                                                                                |
-+----------------+-------------------------+-------------------------+------------+-------------------------+------------------+---------------+
-| SOURCE PACKAGE | INSTALLED VERSION       | FIX AVAILABLE           | VULN COUNT | BINARY PACKAGES (COUNT) | INTRODUCED LAYER | IN BASE IMAGE |
-+----------------+-------------------------+-------------------------+------------+-------------------------+------------------+---------------+
-| coreutils      | 8.32-4.1ubuntu1.2       | No fix available        |          2 | coreutils               | # 4 Layer        | ubuntu        |
-| dpkg           | 1.21.1ubuntu2.3         | No fix available        |          1 | dpkg                    | # 4 Layer        | ubuntu        |
-| gcc-12         | 12.3.0-1ubuntu1~22.04   | No fix available        |          2 | gcc-12-base... (3)      | # 4 Layer        | ubuntu        |
-| glibc          | 2.35-0ubuntu3.8         | Fix Available           |          2 | libc-bin, libc6         | # 4 Layer        | ubuntu        |
-| gnupg2         | 2.2.27-3ubuntu2.1       | Partial fixes Available |          3 | gpgv                    | # 4 Layer        | ubuntu        |
-| gnutls28       | 3.7.3-4ubuntu1.5        | Partial fixes Available |          5 | libgnutls30             | # 4 Layer        | ubuntu        |
-| krb5           | 1.19.2-2ubuntu0.4       | Fix Available           |          2 | libgssapi-krb5-2... (4) | # 4 Layer        | ubuntu        |
-| libcap2        | 1:2.44-1ubuntu0.22.04.1 | Fix Available           |          1 | libcap2                 | # 4 Layer        | ubuntu        |
-| libgcrypt20    | 1.9.4-3ubuntu3          | No fix available        |          1 | libgcrypt20             | # 4 Layer        | ubuntu        |
-| libtasn1-6     | 4.18.0-4build1          | Partial fixes Available |          2 | libtasn1-6              | # 4 Layer        | ubuntu        |
-| libzstd        | 1.4.8+dfsg-3build1      | No fix available        |          1 | libzstd1                | # 4 Layer        | ubuntu        |
-| ncurses        | 6.3-2ubuntu0.1          | No fix available        |          3 | libncurses6... (5)      | # 4 Layer        | ubuntu        |
-| openssl        | 3.0.2-0ubuntu1.18       | Partial fixes Available |          3 | libssl3                 | # 4 Layer        | ubuntu        |
-| pam            | 1.4.0-11ubuntu2.5       | Partial fixes Available |          2 | libpam-modules... (4)   | # 4 Layer        | ubuntu        |
-| pcre2          | 10.39-3ubuntu0.1        | No fix available        |          1 | libpcre2-8-0            | # 4 Layer        | ubuntu        |
-| perl           | 5.34.0-3ubuntu1.3       | Partial fixes Available |          3 | perl-base               | # 4 Layer        | ubuntu        |
-| shadow         | 1:4.8.1-2ubuntu2.2      | No fix available        |          2 | login, passwd           | # 4 Layer        | ubuntu        |
-| systemd        | 249.11-0ubuntu3.12      | Partial fixes Available |          2 | libsystemd0... (2)      | # 4 Layer        | ubuntu        |
-+----------------+-------------------------+-------------------------+------------+-------------------------+------------------+---------------+
++---------------------------------------------------------------------------------------------------------------------------------------------------+
+| Source:os:var/lib/dpkg/status                                                                                                                     |
++----------------+------------------------------+-------------------------+------------+-------------------------+------------------+---------------+
+| SOURCE PACKAGE | INSTALLED VERSION            | FIX AVAILABLE           | VULN COUNT | BINARY PACKAGES (COUNT) | INTRODUCED LAYER | IN BASE IMAGE |
++----------------+------------------------------+-------------------------+------------+-------------------------+------------------+---------------+
+| coreutils      | 8.32-4.1ubuntu1.2            | No fix available        |          2 | coreutils               | # 4 Layer        | ubuntu        |
+| dpkg           | 1.21.1ubuntu2.3              | No fix available        |          1 | dpkg                    | # 4 Layer        | ubuntu        |
+| gcc-12         | 12.3.0-1ubuntu1~22.04        | No fix available        |          2 | gcc-12-base... (3)      | # 4 Layer        | ubuntu        |
+| glibc          | 2.35-0ubuntu3.8              | Fix Available           |          2 | libc-bin, libc6         | # 4 Layer        | ubuntu        |
+| gnupg2         | 2.2.27-3ubuntu2.1            | Partial fixes Available |          3 | gpgv                    | # 4 Layer        | ubuntu        |
+| gnutls28       | 3.7.3-4ubuntu1.5             | Fix Available           |          5 | libgnutls30             | # 4 Layer        | ubuntu        |
+| krb5           | 1.19.2-2ubuntu0.4            | Fix Available           |          2 | libgssapi-krb5-2... (4) | # 4 Layer        | ubuntu        |
+| libcap2        | 1:2.44-1ubuntu0.22.04.1      | Fix Available           |          1 | libcap2                 | # 4 Layer        | ubuntu        |
+| libgcrypt20    | 1.9.4-3ubuntu3               | No fix available        |          1 | libgcrypt20             | # 4 Layer        | ubuntu        |
+| libtasn1-6     | 4.18.0-4build1               | Partial fixes Available |          2 | libtasn1-6              | # 4 Layer        | ubuntu        |
+| libzstd        | 1.4.8+dfsg-3build1           | No fix available        |          1 | libzstd1                | # 4 Layer        | ubuntu        |
+| ncurses        | 6.3-2ubuntu0.1               | No fix available        |          3 | libncurses6... (5)      | # 4 Layer        | ubuntu        |
+| openssl        | 3.0.2-0ubuntu1.18            | Partial fixes Available |          3 | libssl3                 | # 4 Layer        | ubuntu        |
+| pam            | 1.4.0-11ubuntu2.5            | Partial fixes Available |          2 | libpam-modules... (4)   | # 4 Layer        | ubuntu        |
+| pcre2          | 10.39-3ubuntu0.1             | No fix available        |          1 | libpcre2-8-0            | # 4 Layer        | ubuntu        |
+| perl           | 5.34.0-3ubuntu1.3            | Partial fixes Available |          3 | perl-base               | # 4 Layer        | ubuntu        |
+| shadow         | 1:4.8.1-2ubuntu2.2           | No fix available        |          1 | login, passwd           | # 4 Layer        | ubuntu        |
+| systemd        | 249.11-0ubuntu3.12           | Partial fixes Available |          2 | libsystemd0... (2)      | # 4 Layer        | ubuntu        |
+| tar            | 1.34+dfsg-1ubuntu0.1.22.04.2 | Fix Available           |          1 | tar                     | # 4 Layer        | ubuntu        |
++----------------+------------------------------+-------------------------+------------+-------------------------+------------------+---------------+
 
 Hiding 4 number of vulnerabilities deemed unimportant, use --all-vulns to show them.
 For the most comprehensive scan results, we recommend using the HTML output: `osv-scanner scan image --serve <image_name>`.
@@ -309,35 +312,36 @@ You can also view the full vulnerability list in your terminal with: `osv-scanne
 Scanning local image tarball "../../../../internal/image/fixtures/test-ubuntu.tar"
 
 Container Scanning Result (Ubuntu 22.04.5 LTS):
-Total 18 packages affected by 38 known vulnerabilities (2 Critical, 9 High, 21 Medium, 4 Low, 2 Unknown) from 1 ecosystem.
-13 vulnerabilities can be fixed.
+Total 19 packages affected by 38 known vulnerabilities (2 Critical, 9 High, 22 Medium, 3 Low, 2 Unknown) from 1 ecosystem.
+18 vulnerabilities can be fixed.
 
 
 Ubuntu:22.04
-+----------------------------------------------------------------------------------------------------------------------------------------------+
-| Source:os:var/lib/dpkg/status                                                                                                                |
-+----------------+-------------------------+-------------------------+------------+-------------------------+------------------+---------------+
-| SOURCE PACKAGE | INSTALLED VERSION       | FIX AVAILABLE           | VULN COUNT | BINARY PACKAGES (COUNT) | INTRODUCED LAYER | IN BASE IMAGE |
-+----------------+-------------------------+-------------------------+------------+-------------------------+------------------+---------------+
-| coreutils      | 8.32-4.1ubuntu1.2       | No fix available        |          2 | coreutils               | # 4 Layer        | ubuntu        |
-| dpkg           | 1.21.1ubuntu2.3         | No fix available        |          1 | dpkg                    | # 4 Layer        | ubuntu        |
-| gcc-12         | 12.3.0-1ubuntu1~22.04   | No fix available        |          2 | gcc-12-base... (3)      | # 4 Layer        | ubuntu        |
-| glibc          | 2.35-0ubuntu3.8         | Fix Available           |          2 | libc-bin, libc6         | # 4 Layer        | ubuntu        |
-| gnupg2         | 2.2.27-3ubuntu2.1       | Partial fixes Available |          3 | gpgv                    | # 4 Layer        | ubuntu        |
-| gnutls28       | 3.7.3-4ubuntu1.5        | Partial fixes Available |          5 | libgnutls30             | # 4 Layer        | ubuntu        |
-| krb5           | 1.19.2-2ubuntu0.4       | Fix Available           |          2 | libgssapi-krb5-2... (4) | # 4 Layer        | ubuntu        |
-| libcap2        | 1:2.44-1ubuntu0.22.04.1 | Fix Available           |          1 | libcap2                 | # 4 Layer        | ubuntu        |
-| libgcrypt20    | 1.9.4-3ubuntu3          | No fix available        |          1 | libgcrypt20             | # 4 Layer        | ubuntu        |
-| libtasn1-6     | 4.18.0-4build1          | Partial fixes Available |          2 | libtasn1-6              | # 4 Layer        | ubuntu        |
-| libzstd        | 1.4.8+dfsg-3build1      | No fix available        |          1 | libzstd1                | # 4 Layer        | ubuntu        |
-| ncurses        | 6.3-2ubuntu0.1          | No fix available        |          3 | libncurses6... (5)      | # 4 Layer        | ubuntu        |
-| openssl        | 3.0.2-0ubuntu1.18       | Partial fixes Available |          3 | libssl3                 | # 4 Layer        | ubuntu        |
-| pam            | 1.4.0-11ubuntu2.5       | Partial fixes Available |          2 | libpam-modules... (4)   | # 4 Layer        | ubuntu        |
-| pcre2          | 10.39-3ubuntu0.1        | No fix available        |          1 | libpcre2-8-0            | # 4 Layer        | ubuntu        |
-| perl           | 5.34.0-3ubuntu1.3       | Partial fixes Available |          3 | perl-base               | # 4 Layer        | ubuntu        |
-| shadow         | 1:4.8.1-2ubuntu2.2      | No fix available        |          2 | login, passwd           | # 4 Layer        | ubuntu        |
-| systemd        | 249.11-0ubuntu3.12      | Partial fixes Available |          2 | libsystemd0... (2)      | # 4 Layer        | ubuntu        |
-+----------------+-------------------------+-------------------------+------------+-------------------------+------------------+---------------+
++---------------------------------------------------------------------------------------------------------------------------------------------------+
+| Source:os:var/lib/dpkg/status                                                                                                                     |
++----------------+------------------------------+-------------------------+------------+-------------------------+------------------+---------------+
+| SOURCE PACKAGE | INSTALLED VERSION            | FIX AVAILABLE           | VULN COUNT | BINARY PACKAGES (COUNT) | INTRODUCED LAYER | IN BASE IMAGE |
++----------------+------------------------------+-------------------------+------------+-------------------------+------------------+---------------+
+| coreutils      | 8.32-4.1ubuntu1.2            | No fix available        |          2 | coreutils               | # 4 Layer        | ubuntu        |
+| dpkg           | 1.21.1ubuntu2.3              | No fix available        |          1 | dpkg                    | # 4 Layer        | ubuntu        |
+| gcc-12         | 12.3.0-1ubuntu1~22.04        | No fix available        |          2 | gcc-12-base... (3)      | # 4 Layer        | ubuntu        |
+| glibc          | 2.35-0ubuntu3.8              | Fix Available           |          2 | libc-bin, libc6         | # 4 Layer        | ubuntu        |
+| gnupg2         | 2.2.27-3ubuntu2.1            | Partial fixes Available |          3 | gpgv                    | # 4 Layer        | ubuntu        |
+| gnutls28       | 3.7.3-4ubuntu1.5             | Fix Available           |          5 | libgnutls30             | # 4 Layer        | ubuntu        |
+| krb5           | 1.19.2-2ubuntu0.4            | Fix Available           |          2 | libgssapi-krb5-2... (4) | # 4 Layer        | ubuntu        |
+| libcap2        | 1:2.44-1ubuntu0.22.04.1      | Fix Available           |          1 | libcap2                 | # 4 Layer        | ubuntu        |
+| libgcrypt20    | 1.9.4-3ubuntu3               | No fix available        |          1 | libgcrypt20             | # 4 Layer        | ubuntu        |
+| libtasn1-6     | 4.18.0-4build1               | Partial fixes Available |          2 | libtasn1-6              | # 4 Layer        | ubuntu        |
+| libzstd        | 1.4.8+dfsg-3build1           | No fix available        |          1 | libzstd1                | # 4 Layer        | ubuntu        |
+| ncurses        | 6.3-2ubuntu0.1               | No fix available        |          3 | libncurses6... (5)      | # 4 Layer        | ubuntu        |
+| openssl        | 3.0.2-0ubuntu1.18            | Partial fixes Available |          3 | libssl3                 | # 4 Layer        | ubuntu        |
+| pam            | 1.4.0-11ubuntu2.5            | Partial fixes Available |          2 | libpam-modules... (4)   | # 4 Layer        | ubuntu        |
+| pcre2          | 10.39-3ubuntu0.1             | No fix available        |          1 | libpcre2-8-0            | # 4 Layer        | ubuntu        |
+| perl           | 5.34.0-3ubuntu1.3            | Partial fixes Available |          3 | perl-base               | # 4 Layer        | ubuntu        |
+| shadow         | 1:4.8.1-2ubuntu2.2           | No fix available        |          1 | login, passwd           | # 4 Layer        | ubuntu        |
+| systemd        | 249.11-0ubuntu3.12           | Partial fixes Available |          2 | libsystemd0... (2)      | # 4 Layer        | ubuntu        |
+| tar            | 1.34+dfsg-1ubuntu0.1.22.04.2 | Fix Available           |          1 | tar                     | # 4 Layer        | ubuntu        |
++----------------+------------------------------+-------------------------+------------+-------------------------+------------------+---------------+
 
 Filtered Vulnerabilities:
 +---------+--------------+--------------------------+---------------------+----------------+
@@ -2243,9 +2247,9 @@ Scanning local image tarball "../../../../internal/image/fixtures/test-node_modu
             }
           },
           "vulnerabilities": [
+            "UBUNTU-CVE-2022-3219",
             "USN-7412-1",
             "USN-7412-2",
-            "UBUNTU-CVE-2022-3219",
             "UBUNTU-CVE-2025-30258"
           ],
           "groups": 3
@@ -2261,9 +2265,9 @@ Scanning local image tarball "../../../../internal/image/fixtures/test-node_modu
             }
           },
           "vulnerabilities": [
+            "UBUNTU-CVE-2016-20013",
             "USN-7259-1",
             "USN-7541-1",
-            "UBUNTU-CVE-2016-20013",
             "UBUNTU-CVE-2025-0395",
             "UBUNTU-CVE-2025-4802"
           ],
@@ -2280,9 +2284,9 @@ Scanning local image tarball "../../../../internal/image/fixtures/test-node_modu
             }
           },
           "vulnerabilities": [
+            "UBUNTU-CVE-2016-20013",
             "USN-7259-1",
             "USN-7541-1",
-            "UBUNTU-CVE-2016-20013",
             "UBUNTU-CVE-2025-0395",
             "UBUNTU-CVE-2025-4802"
           ],
@@ -2366,12 +2370,12 @@ Scanning local image tarball "../../../../internal/image/fixtures/test-node_modu
             }
           },
           "vulnerabilities": [
+            "UBUNTU-CVE-2024-3596",
             "USN-7257-1",
             "USN-7314-1",
             "USN-7542-1",
             "UBUNTU-CVE-2024-26458",
             "UBUNTU-CVE-2024-26461",
-            "UBUNTU-CVE-2024-3596",
             "UBUNTU-CVE-2025-24528",
             "UBUNTU-CVE-2025-3576"
           ],
@@ -2388,12 +2392,12 @@ Scanning local image tarball "../../../../internal/image/fixtures/test-node_modu
             }
           },
           "vulnerabilities": [
+            "UBUNTU-CVE-2024-3596",
             "USN-7257-1",
             "USN-7314-1",
             "USN-7542-1",
             "UBUNTU-CVE-2024-26458",
             "UBUNTU-CVE-2024-26461",
-            "UBUNTU-CVE-2024-3596",
             "UBUNTU-CVE-2025-24528",
             "UBUNTU-CVE-2025-3576"
           ],
@@ -2410,12 +2414,12 @@ Scanning local image tarball "../../../../internal/image/fixtures/test-node_modu
             }
           },
           "vulnerabilities": [
+            "UBUNTU-CVE-2024-3596",
             "USN-7257-1",
             "USN-7314-1",
             "USN-7542-1",
             "UBUNTU-CVE-2024-26458",
             "UBUNTU-CVE-2024-26461",
-            "UBUNTU-CVE-2024-3596",
             "UBUNTU-CVE-2025-24528",
             "UBUNTU-CVE-2025-3576"
           ],
@@ -2432,12 +2436,12 @@ Scanning local image tarball "../../../../internal/image/fixtures/test-node_modu
             }
           },
           "vulnerabilities": [
+            "UBUNTU-CVE-2024-3596",
             "USN-7257-1",
             "USN-7314-1",
             "USN-7542-1",
             "UBUNTU-CVE-2024-26458",
             "UBUNTU-CVE-2024-26461",
-            "UBUNTU-CVE-2024-3596",
             "UBUNTU-CVE-2025-24528",
             "UBUNTU-CVE-2025-3576"
           ],
@@ -2488,8 +2492,8 @@ Scanning local image tarball "../../../../internal/image/fixtures/test-node_modu
             }
           },
           "vulnerabilities": [
-            "USN-7580-1",
             "UBUNTU-CVE-2024-10041",
+            "USN-7580-1",
             "UBUNTU-CVE-2025-6020"
           ],
           "groups": 2
@@ -2505,8 +2509,8 @@ Scanning local image tarball "../../../../internal/image/fixtures/test-node_modu
             }
           },
           "vulnerabilities": [
-            "USN-7580-1",
             "UBUNTU-CVE-2024-10041",
+            "USN-7580-1",
             "UBUNTU-CVE-2025-6020"
           ],
           "groups": 2
@@ -2522,8 +2526,8 @@ Scanning local image tarball "../../../../internal/image/fixtures/test-node_modu
             }
           },
           "vulnerabilities": [
-            "USN-7580-1",
             "UBUNTU-CVE-2024-10041",
+            "USN-7580-1",
             "UBUNTU-CVE-2025-6020"
           ],
           "groups": 2
@@ -2539,8 +2543,8 @@ Scanning local image tarball "../../../../internal/image/fixtures/test-node_modu
             }
           },
           "vulnerabilities": [
-            "USN-7580-1",
             "UBUNTU-CVE-2024-10041",
+            "USN-7580-1",
             "UBUNTU-CVE-2025-6020"
           ],
           "groups": 2
@@ -2586,11 +2590,11 @@ Scanning local image tarball "../../../../internal/image/fixtures/test-node_modu
             }
           },
           "vulnerabilities": [
-            "USN-7278-1",
             "UBUNTU-CVE-2024-13176",
             "UBUNTU-CVE-2024-41996",
             "UBUNTU-CVE-2024-9143",
-            "UBUNTU-CVE-2025-27587"
+            "UBUNTU-CVE-2025-27587",
+            "USN-7278-1"
           ],
           "groups": 3
         },
@@ -2704,10 +2708,9 @@ Scanning local image tarball "../../../../internal/image/fixtures/test-node_modu
             }
           },
           "vulnerabilities": [
-            "UBUNTU-CVE-2023-29383",
-            "UBUNTU-CVE-2024-56433"
+            "UBUNTU-CVE-2023-29383"
           ],
-          "groups": 2
+          "groups": 1
         },
         {
           "package": {
@@ -2754,10 +2757,9 @@ Scanning local image tarball "../../../../internal/image/fixtures/test-node_modu
             }
           },
           "vulnerabilities": [
-            "UBUNTU-CVE-2023-29383",
-            "UBUNTU-CVE-2024-56433"
+            "UBUNTU-CVE-2023-29383"
           ],
-          "groups": 2
+          "groups": 1
         },
         {
           "package": {
@@ -2770,13 +2772,28 @@ Scanning local image tarball "../../../../internal/image/fixtures/test-node_modu
             }
           },
           "vulnerabilities": [
+            "UBUNTU-CVE-2025-40909",
             "USN-7434-1",
             "UBUNTU-CVE-2023-31486",
             "UBUNTU-CVE-2023-47039",
-            "UBUNTU-CVE-2024-56406",
-            "UBUNTU-CVE-2025-40909"
+            "UBUNTU-CVE-2024-56406"
           ],
           "groups": 4
+        },
+        {
+          "package": {
+            "name": "tar",
+            "os_package_name": "tar",
+            "version": "1.34+dfsg-1ubuntu0.1.22.04.2",
+            "ecosystem": "Ubuntu:22.04",
+            "image_origin_details": {
+              "index": 4
+            }
+          },
+          "vulnerabilities": [
+            "UBUNTU-CVE-2025-45582"
+          ],
+          "groups": 1
         }
       ]
     }

--- a/cmd/osv-scanner/scan/image/__snapshots__/command_test.snap
+++ b/cmd/osv-scanner/scan/image/__snapshots__/command_test.snap
@@ -267,8 +267,8 @@ You can also view the full vulnerability list in your terminal with: `osv-scanne
 Scanning local image tarball "../../../../internal/image/fixtures/test-ubuntu.tar"
 
 Container Scanning Result (Ubuntu 22.04.5 LTS):
-Total 19 packages affected by 38 known vulnerabilities (2 Critical, 9 High, 22 Medium, 3 Low, 2 Unknown) from 1 ecosystem.
-18 vulnerabilities can be fixed.
+Total 19 packages affected by 35 known vulnerabilities (2 Critical, 9 High, 19 Medium, 3 Low, 2 Unknown) from 1 ecosystem.
+15 vulnerabilities can be fixed.
 
 
 Ubuntu:22.04
@@ -282,7 +282,7 @@ Ubuntu:22.04
 | gcc-12         | 12.3.0-1ubuntu1~22.04        | No fix available        |          2 | gcc-12-base... (3)      | # 4 Layer        | ubuntu        |
 | glibc          | 2.35-0ubuntu3.8              | Fix Available           |          2 | libc-bin, libc6         | # 4 Layer        | ubuntu        |
 | gnupg2         | 2.2.27-3ubuntu2.1            | Partial fixes Available |          3 | gpgv                    | # 4 Layer        | ubuntu        |
-| gnutls28       | 3.7.3-4ubuntu1.5             | Fix Available           |          5 | libgnutls30             | # 4 Layer        | ubuntu        |
+| gnutls28       | 3.7.3-4ubuntu1.5             | Fix Available           |          2 | libgnutls30             | # 4 Layer        | ubuntu        |
 | krb5           | 1.19.2-2ubuntu0.4            | Fix Available           |          2 | libgssapi-krb5-2... (4) | # 4 Layer        | ubuntu        |
 | libcap2        | 1:2.44-1ubuntu0.22.04.1      | Fix Available           |          1 | libcap2                 | # 4 Layer        | ubuntu        |
 | libgcrypt20    | 1.9.4-3ubuntu3               | No fix available        |          1 | libgcrypt20             | # 4 Layer        | ubuntu        |
@@ -312,8 +312,8 @@ You can also view the full vulnerability list in your terminal with: `osv-scanne
 Scanning local image tarball "../../../../internal/image/fixtures/test-ubuntu.tar"
 
 Container Scanning Result (Ubuntu 22.04.5 LTS):
-Total 19 packages affected by 38 known vulnerabilities (2 Critical, 9 High, 22 Medium, 3 Low, 2 Unknown) from 1 ecosystem.
-18 vulnerabilities can be fixed.
+Total 19 packages affected by 35 known vulnerabilities (2 Critical, 9 High, 19 Medium, 3 Low, 2 Unknown) from 1 ecosystem.
+15 vulnerabilities can be fixed.
 
 
 Ubuntu:22.04
@@ -327,7 +327,7 @@ Ubuntu:22.04
 | gcc-12         | 12.3.0-1ubuntu1~22.04        | No fix available        |          2 | gcc-12-base... (3)      | # 4 Layer        | ubuntu        |
 | glibc          | 2.35-0ubuntu3.8              | Fix Available           |          2 | libc-bin, libc6         | # 4 Layer        | ubuntu        |
 | gnupg2         | 2.2.27-3ubuntu2.1            | Partial fixes Available |          3 | gpgv                    | # 4 Layer        | ubuntu        |
-| gnutls28       | 3.7.3-4ubuntu1.5             | Fix Available           |          5 | libgnutls30             | # 4 Layer        | ubuntu        |
+| gnutls28       | 3.7.3-4ubuntu1.5             | Fix Available           |          2 | libgnutls30             | # 4 Layer        | ubuntu        |
 | krb5           | 1.19.2-2ubuntu0.4            | Fix Available           |          2 | libgssapi-krb5-2... (4) | # 4 Layer        | ubuntu        |
 | libcap2        | 1:2.44-1ubuntu0.22.04.1      | Fix Available           |          1 | libcap2                 | # 4 Layer        | ubuntu        |
 | libgcrypt20    | 1.9.4-3ubuntu3               | No fix available        |          1 | libgcrypt20             | # 4 Layer        | ubuntu        |
@@ -2350,6 +2350,7 @@ Scanning local image tarball "../../../../internal/image/fixtures/test-node_modu
             }
           },
           "vulnerabilities": [
+            "USN-7635-1",
             "UBUNTU-CVE-2025-32988",
             "UBUNTU-CVE-2025-32989",
             "UBUNTU-CVE-2025-32990",
@@ -2357,7 +2358,7 @@ Scanning local image tarball "../../../../internal/image/fixtures/test-node_modu
             "USN-7281-1",
             "UBUNTU-CVE-2024-12243"
           ],
-          "groups": 5
+          "groups": 2
         },
         {
           "package": {

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.6.7
 	github.com/muesli/reflow v0.3.0
 	github.com/opencontainers/go-digest v1.0.0
-	github.com/ossf/osv-schema/bindings/go v0.0.0-20250701001340-180f03cc6901
+	github.com/ossf/osv-schema/bindings/go v0.0.0-20250715064423-7310c9ec4b2a
 	github.com/owenrumney/go-sarif/v3 v3.2.1
 	github.com/package-url/packageurl-go v0.1.3
 	github.com/pandatix/go-cvss v0.6.2

--- a/go.sum
+++ b/go.sum
@@ -306,8 +306,8 @@ github.com/opencontainers/runtime-spec v1.2.1 h1:S4k4ryNgEpxW1dzyqffOmhI1BHYcjzU
 github.com/opencontainers/runtime-spec v1.2.1/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.12.0 h1:6n5JV4Cf+4y0KNXW48TLj5DwfXpvWlxXplUkdTrmPb8=
 github.com/opencontainers/selinux v1.12.0/go.mod h1:BTPX+bjVbWGXw7ZZWUbdENt8w0htPSrlgOOysQaU62U=
-github.com/ossf/osv-schema/bindings/go v0.0.0-20250701001340-180f03cc6901 h1:WqiL5LXnCYjEgibZc+M8+jamka8gi1ySjNiuqFWWKEE=
-github.com/ossf/osv-schema/bindings/go v0.0.0-20250701001340-180f03cc6901/go.mod h1:lILztSxHU7VsdlYqCnwgxSDBhbXMf7iEQWtldJCDXPo=
+github.com/ossf/osv-schema/bindings/go v0.0.0-20250715064423-7310c9ec4b2a h1:eff71rMluaulxKV/PaG70M0DWvw79AuEXa4K8mHJkuk=
+github.com/ossf/osv-schema/bindings/go v0.0.0-20250715064423-7310c9ec4b2a/go.mod h1:lILztSxHU7VsdlYqCnwgxSDBhbXMf7iEQWtldJCDXPo=
 github.com/owenrumney/go-sarif/v3 v3.2.1 h1:Dogf2wkOxxRkG3O/B9T6dokyDSl36q19tlMYtXOTThE=
 github.com/owenrumney/go-sarif/v3 v3.2.1/go.mod h1:S2sdyDnv0sxN5x+M8iFZIzZE2+uTX/1uXlwTRx0efT0=
 github.com/package-url/packageurl-go v0.1.3 h1:4juMED3hHiz0set3Vq3KeQ75KD1avthoXLtmE3I0PLs=

--- a/internal/image/fixtures/ubuntu20-04-unimportant-config.toml
+++ b/internal/image/fixtures/ubuntu20-04-unimportant-config.toml
@@ -67,3 +67,8 @@ ignore = true
 name = "gnutls28"
 reason = "Just want to test only unimportant vulns"
 ignore = true
+
+[[PackageOverrides]]
+name = "tar"
+reason = "Just want to test only unimportant vulns"
+ignore = true

--- a/internal/utility/severity/severity.go
+++ b/internal/utility/severity/severity.go
@@ -59,6 +59,8 @@ func CalculateScore(severity osvschema.Severity) (float64, string, error) {
 			score = vec.Score()
 			rating, err = gocvss40.Rating(score)
 		}
+	case osvschema.SeverityUbuntu:
+		rating = severity.Score
 	}
 
 	return score, rating, err

--- a/pkg/osvscanner/vulnerability_result.go
+++ b/pkg/osvscanner/vulnerability_result.go
@@ -213,7 +213,9 @@ func setUnimportant(pkg *models.PackageVulns) {
 // Ubuntu: https://ubuntu.com/security/cves/about#priority
 func isUnimportant(vuln osvschema.Vulnerability) bool {
 	for _, severity := range vuln.Severity {
-		if strings.HasPrefix(vuln.ID, "UBUNTU-CVE-") && severity.Type == osvschema.SeverityUbuntu {
+		// TODO(gongh@): remove checking empty severity type after all ubuntu records have a valid severity tag.
+		if strings.HasPrefix(vuln.ID, "UBUNTU-CVE-") &&
+			(severity.Type == osvschema.SeverityUbuntu || severity.Type == "") {
 			return severity.Score == "negligible"
 		}
 	}

--- a/pkg/osvscanner/vulnerability_result.go
+++ b/pkg/osvscanner/vulnerability_result.go
@@ -185,7 +185,7 @@ func buildVulnerabilityResults(
 // within their respective groups' experimental analysis.
 func setUnimportant(pkg *models.PackageVulns) {
 	for _, vuln := range pkg.Vulnerabilities {
-		if !isUnimportant(vuln.Affected) {
+		if !isUnimportant(vuln) {
 			continue
 		}
 		for i, group := range pkg.Groups {
@@ -211,11 +211,18 @@ func setUnimportant(pkg *models.PackageVulns) {
 // isUnimportant checks if a Debian-based vulnerability is tagged as unimportant
 // Debian: https://security-team.debian.org/security_tracker.html#severity-levels
 // Ubuntu: https://ubuntu.com/security/cves/about#priority
-func isUnimportant(affectedPackages []osvschema.Affected) bool {
-	for _, affected := range affectedPackages {
+func isUnimportant(vuln osvschema.Vulnerability) bool {
+	for _, severity := range vuln.Severity {
+		if strings.HasPrefix(vuln.ID, "UBUNTU-CVE-") && severity.Type == osvschema.SeverityUbuntu {
+			return severity.Score == "negligible"
+		}
+	}
+
+	for _, affected := range vuln.Affected {
 		if affected.EcosystemSpecific["urgency"] == "unimportant" {
 			return true
 		}
+		// TODO (gongh@): Remove this once Ubuntu has fully moved all priority tags into the severity field.
 		if affected.EcosystemSpecific["ubuntu_priority"] == "negligible" {
 			return true
 		}


### PR DESCRIPTION
Resolves https://github.com/google/osv-scanner/issues/1964

Note: some Ubuntu records have moved their priority tags from ecosystem-specific to severity fields, but osv.dev has failed to provide a correct severity type. For now, we check both empty severity tags and Ubuntu severity tags to see if a vulnerability has been marked as ineligible