### PR TITLE
ci: have reusable workflows error

### DIFF
--- a/.github/workflows/osv-scanner-reusable-pr.yml
+++ b/.github/workflows/osv-scanner-reusable-pr.yml
@@ -50,65 +50,7 @@ jobs:
   scan-pr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          # Do persist credentials, as we need it for the git checkout later
-      - name: "Checkout target branch"
-        run: git checkout $GITHUB_BASE_REF
-      - name: "Run scanner on existing code"
-        uses: google/osv-scanner/actions/scanner@main
-        continue-on-error: true
-        with:
-          scan-args: |-
-            --format=json
-            --output=old-results.json
-            ${{ inputs.scan-args }}
-      - name: "Checkout current branch"
-        run: git checkout $GITHUB_SHA
-      - name: "Run scanner on new code"
-        uses: google/osv-scanner/actions/scanner@main
-        with:
-          scan-args: |-
-            --format=json
-            --output=new-results.json
-            ${{ inputs.scan-args }}
-        continue-on-error: true
-      - name: "Run osv-scanner-reporter"
-        uses: google/osv-scanner/actions/reporter@main
-        with:
-          scan-args: |-
-            --output=${{ inputs.results-file-name }}
-            --old=old-results.json
-            --new=new-results.json
-            --gh-annotations=true
-            --fail-on-vuln=${{ inputs.fail-on-vuln }}
-      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
-      # format to the repository Actions tab.
-      - name: "Upload artifact"
-        if: "!cancelled()"
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: SARIF file
-          path: ${{ inputs.results-file-name }}
-          retention-days: 5
-      - name: "Upload old scan json results"
-        if: "!cancelled()"
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: old-json-results
-          path: old-results.json
-          retention-days: 5
-      - name: "Upload new scan json results"
-        if: "!cancelled()"
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: new-json-results
-          path: new-results.json
-          retention-days: 5
-      # Upload the results to GitHub's code scanning dashboard.
-      - name: "Upload to code-scanning"
-        if: ${{ !cancelled() && inputs.upload-sarif == true }}
-        uses: github/codeql-action/upload-sarif@181d5eefc20863364f96762470ba6f862bdef56b # v3.29.2
-        with:
-          sarif_file: ${{ inputs.results-file-name }}
+      - run: |
+          echo "### This action is deprecated" >> $GITHUB_STEP_SUMMARY
+          echo "Please use https://github.com/google/osv-scanner-action instead" >> $GITHUB_STEP_SUMMARY
+          false

--- a/.github/workflows/osv-scanner-reusable.yml
+++ b/.github/workflows/osv-scanner-reusable.yml
@@ -55,43 +55,7 @@ jobs:
   osv-scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          persist-credentials: false
-      - name: "Download custom artifact if specified"
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        if: "${{ inputs.download-artifact != '' }}"
-        with:
-          name: "${{ inputs.download-artifact }}"
-          path: "./"
-      - name: "Run scanner"
-        uses: google/osv-scanner/actions/scanner@main
-        with:
-          scan-args: |-
-            --output=results.json
-            --format=json
-            ${{ inputs.scan-args }}
-        continue-on-error: true
-      - name: "Run osv-scanner-reporter"
-        uses: google/osv-scanner/actions/reporter@main
-        with:
-          scan-args: |-
-            --output=${{ inputs.results-file-name }}
-            --new=results.json
-            --gh-annotations=false
-            --fail-on-vuln=${{ inputs.fail-on-vuln }}
-      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
-      # format to the repository Actions tab.
-      - name: "Upload artifact"
-        if: "!cancelled()"
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: SARIF file
-          path: ${{ inputs.results-file-name }}
-          retention-days: 5
-      # Upload the results to GitHub's code scanning dashboard.
-      - name: "Upload to code-scanning"
-        if: "${{ !cancelled() && inputs.upload-sarif == true }}"
-        uses: github/codeql-action/upload-sarif@181d5eefc20863364f96762470ba6f862bdef56b # v3.29.2
-        with:
-          sarif_file: ${{ inputs.results-file-name }}
+      - run: |
+          echo "### This action is deprecated" >> $GITHUB_STEP_SUMMARY
+          echo "Please use https://github.com/google/osv-scanner-action instead" >> $GITHUB_STEP_SUMMARY
+          false


### PR DESCRIPTION
I realized that instead of emitting a warning we can just have the action error, and use [workflow summaries](https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#adding-a-job-summary) to show a nice message pointing at the replacement action 😄 