### PR TITLE
refactor(output): remove unused `Ecosystem` field

### DIFF
--- a/internal/output/__snapshots__/output_result_test.snap
+++ b/internal/output/__snapshots__/output_result_test.snap
@@ -8,7 +8,6 @@
         {
           "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
-          "Ecosystem": "npm",
           "PackageTypeCount": {
             "Regular": 2,
             "Hidden": 0
@@ -240,7 +239,6 @@
         {
           "Name": "sbom:<rootdir>/path/to/my/second/lockfile",
           "Type": "sbom",
-          "Ecosystem": "npm",
           "PackageTypeCount": {
             "Regular": 2,
             "Hidden": 0
@@ -524,7 +522,6 @@
         {
           "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
-          "Ecosystem": "npm",
           "PackageTypeCount": {
             "Regular": 2,
             "Hidden": 0
@@ -756,7 +753,6 @@
         {
           "Name": "sbom:<rootdir>/path/to/my/second/lockfile",
           "Type": "sbom",
-          "Ecosystem": "npm",
           "PackageTypeCount": {
             "Regular": 2,
             "Hidden": 0
@@ -1040,7 +1036,6 @@
         {
           "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
-          "Ecosystem": "npm",
           "PackageTypeCount": {
             "Regular": 0,
             "Hidden": 0
@@ -1150,7 +1145,6 @@
         {
           "Name": "sbom:<rootdir>/path/to/my/second/lockfile",
           "Type": "sbom",
-          "Ecosystem": "npm",
           "PackageTypeCount": {
             "Regular": 0,
             "Hidden": 0
@@ -1341,7 +1335,6 @@
         {
           "Name": "unknown:<rootdir>/path/to/my/third/lockfile",
           "Type": "unknown",
-          "Ecosystem": "npm",
           "PackageTypeCount": {
             "Regular": 0,
             "Hidden": 0
@@ -1584,7 +1577,6 @@
         {
           "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
-          "Ecosystem": "npm",
           "PackageTypeCount": {
             "Regular": 1,
             "Hidden": 0
@@ -1708,7 +1700,6 @@
         {
           "Name": "sbom:<rootdir>/path/to/my/second/lockfile",
           "Type": "sbom",
-          "Ecosystem": "npm",
           "PackageTypeCount": {
             "Regular": 1,
             "Hidden": 0
@@ -1913,7 +1904,6 @@
         {
           "Name": "unknown:<rootdir>/path/to/my/third/lockfile",
           "Type": "unknown",
-          "Ecosystem": "npm",
           "PackageTypeCount": {
             "Regular": 1,
             "Hidden": 0
@@ -2170,7 +2160,6 @@
         {
           "Name": "sbom:<rootdir>/path/to/my/second/lockfile",
           "Type": "sbom",
-          "Ecosystem": "NuGet",
           "PackageTypeCount": {
             "Regular": 1,
             "Hidden": 0
@@ -2300,7 +2289,6 @@
         {
           "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
-          "Ecosystem": "Packagist",
           "PackageTypeCount": {
             "Regular": 1,
             "Hidden": 0
@@ -2437,7 +2425,6 @@
         {
           "Name": "sbom:<rootdir>/path/to/my/second/lockfile",
           "Type": "sbom",
-          "Ecosystem": "Packagist",
           "PackageTypeCount": {
             "Regular": 1,
             "Hidden": 0
@@ -2580,7 +2567,6 @@
         {
           "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
-          "Ecosystem": "npm",
           "PackageTypeCount": {
             "Regular": 1,
             "Hidden": 0
@@ -2756,7 +2742,6 @@
         {
           "Name": "sbom:<rootdir>/path/to/my/second/lockfile",
           "Type": "sbom",
-          "Ecosystem": "NuGet",
           "PackageTypeCount": {
             "Regular": 1,
             "Hidden": 0
@@ -2886,7 +2871,6 @@
         {
           "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
-          "Ecosystem": "Packagist",
           "PackageTypeCount": {
             "Regular": 1,
             "Hidden": 1
@@ -3024,7 +3008,6 @@
         {
           "Name": "sbom:<rootdir>/path/to/my/second/lockfile",
           "Type": "sbom",
-          "Ecosystem": "Packagist",
           "PackageTypeCount": {
             "Regular": 1,
             "Hidden": 0
@@ -3167,7 +3150,6 @@
         {
           "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
-          "Ecosystem": "npm",
           "PackageTypeCount": {
             "Regular": 1,
             "Hidden": 0
@@ -3343,7 +3325,6 @@
         {
           "Name": "sbom:<rootdir>/path/to/my/second/lockfile",
           "Type": "sbom",
-          "Ecosystem": "NuGet",
           "PackageTypeCount": {
             "Regular": 1,
             "Hidden": 0
@@ -3473,7 +3454,6 @@
         {
           "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
-          "Ecosystem": "Packagist",
           "PackageTypeCount": {
             "Regular": 1,
             "Hidden": 0
@@ -3610,7 +3590,6 @@
         {
           "Name": "sbom:<rootdir>/path/to/my/second/lockfile",
           "Type": "sbom",
-          "Ecosystem": "Packagist",
           "PackageTypeCount": {
             "Regular": 1,
             "Hidden": 0
@@ -3753,7 +3732,6 @@
         {
           "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
-          "Ecosystem": "npm",
           "PackageTypeCount": {
             "Regular": 1,
             "Hidden": 0
@@ -3929,7 +3907,6 @@
         {
           "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
-          "Ecosystem": "",
           "PackageTypeCount": {
             "Regular": 0,
             "Hidden": 0
@@ -3957,7 +3934,6 @@
         {
           "Name": "sbom:<rootdir>/path/to/my/second/lockfile",
           "Type": "sbom",
-          "Ecosystem": "",
           "PackageTypeCount": {
             "Regular": 0,
             "Hidden": 0
@@ -3985,7 +3961,6 @@
         {
           "Name": "unknown:<rootdir>/path/to/my/third/lockfile",
           "Type": "unknown",
-          "Ecosystem": "",
           "PackageTypeCount": {
             "Regular": 0,
             "Hidden": 0
@@ -4110,7 +4085,6 @@
         {
           "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
-          "Ecosystem": "",
           "PackageTypeCount": {
             "Regular": 0,
             "Hidden": 0
@@ -4190,7 +4164,6 @@
         {
           "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
-          "Ecosystem": "npm",
           "PackageTypeCount": {
             "Regular": 0,
             "Hidden": 0
@@ -4352,7 +4325,6 @@
         {
           "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
-          "Ecosystem": "npm",
           "PackageTypeCount": {
             "Regular": 1,
             "Hidden": 1
@@ -4542,7 +4514,6 @@
         {
           "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
-          "Ecosystem": "npm",
           "PackageTypeCount": {
             "Regular": 1,
             "Hidden": 0
@@ -4718,7 +4689,6 @@
         {
           "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
-          "Ecosystem": "npm",
           "PackageTypeCount": {
             "Regular": 0,
             "Hidden": 1
@@ -4894,7 +4864,6 @@
         {
           "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
-          "Ecosystem": "npm",
           "PackageTypeCount": {
             "Regular": 1,
             "Hidden": 0
@@ -5070,7 +5039,6 @@
         {
           "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
-          "Ecosystem": "npm",
           "PackageTypeCount": {
             "Regular": 1,
             "Hidden": 0
@@ -5246,7 +5214,6 @@
         {
           "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
-          "Ecosystem": "npm",
           "PackageTypeCount": {
             "Regular": 0,
             "Hidden": 1
@@ -5425,7 +5392,6 @@
         {
           "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
-          "Ecosystem": "npm",
           "PackageTypeCount": {
             "Regular": 1,
             "Hidden": 0
@@ -5604,7 +5570,6 @@
         {
           "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
-          "Ecosystem": "npm",
           "PackageTypeCount": {
             "Regular": 1,
             "Hidden": 0
@@ -5780,7 +5745,6 @@
         {
           "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
-          "Ecosystem": "npm",
           "PackageTypeCount": {
             "Regular": 1,
             "Hidden": 0
@@ -5956,7 +5920,6 @@
         {
           "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
-          "Ecosystem": "npm",
           "PackageTypeCount": {
             "Regular": 2,
             "Hidden": 0
@@ -6227,7 +6190,6 @@
         {
           "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
-          "Ecosystem": "npm",
           "PackageTypeCount": {
             "Regular": 1,
             "Hidden": 0
@@ -6351,7 +6313,6 @@
         {
           "Name": "sbom:<rootdir>/path/to/my/second/lockfile",
           "Type": "sbom",
-          "Ecosystem": "npm",
           "PackageTypeCount": {
             "Regular": 0,
             "Hidden": 0
@@ -6513,7 +6474,6 @@
         {
           "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
           "Type": "lockfile",
-          "Ecosystem": "npm",
           "PackageTypeCount": {
             "Regular": 1,
             "Hidden": 0
@@ -6637,7 +6597,6 @@
         {
           "Name": "sbom:<rootdir>/path/to/my/second/lockfile",
           "Type": "sbom",
-          "Ecosystem": "npm",
           "PackageTypeCount": {
             "Regular": 1,
             "Hidden": 0

--- a/internal/output/output_result.go
+++ b/internal/output/output_result.go
@@ -44,7 +44,6 @@ type EcosystemResult struct {
 type SourceResult struct {
 	Name                   string
 	Type                   models.SourceType
-	Ecosystem              string
 	PackageTypeCount       AnalysisCount
 	Packages               []PackageResult
 	VulnCount              VulnCount
@@ -372,10 +371,9 @@ func processSource(packageSource models.PackageSource) map[string]SourceResult {
 	// If no packages with issues are found, mark the ecosystem as empty.
 	if len(packageSource.Packages) == 0 {
 		sourceResults[""] = SourceResult{
-			Name:      packageSource.Source.String(),
-			Type:      packageSource.Source.Type,
-			Ecosystem: "",
-			Packages:  []PackageResult{},
+			Name:     packageSource.Source.String(),
+			Type:     packageSource.Source.Type,
+			Packages: []PackageResult{},
 		}
 
 		return sourceResults
@@ -384,9 +382,8 @@ func processSource(packageSource models.PackageSource) map[string]SourceResult {
 	for _, vulnPkg := range packageSource.Packages {
 		if _, exists := sourceResults[vulnPkg.Package.Ecosystem]; !exists {
 			sourceResults[vulnPkg.Package.Ecosystem] = SourceResult{
-				Name:      packageSource.Source.String(),
-				Type:      packageSource.Source.Type,
-				Ecosystem: vulnPkg.Package.Ecosystem,
+				Name: packageSource.Source.String(),
+				Type: packageSource.Source.Type,
 			}
 		}
 


### PR DESCRIPTION
This field is not used by anything and we already have the ecosystem available as the map key, so this is just wasting memory