### PR TITLE
fix: store absolute paths when scanning containers

### DIFF
--- a/cmd/osv-scanner/scan/image/__snapshots__/command_test.snap
+++ b/cmd/osv-scanner/scan/image/__snapshots__/command_test.snap
@@ -37,7 +37,7 @@ Total 2 packages affected by 3 known vulnerabilities (0 Critical, 0 High, 0 Medi
 
 Alpine:v3.18
 +------------------------------------------------------------------------------------------------------------------------------+
-| Source:os:lib/apk/db/installed                                                                                               |
+| Source:os:/lib/apk/db/installed                                                                                              |
 +----------------+-------------------+---------------+------------+-------------------------+------------------+---------------+
 | SOURCE PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | BINARY PACKAGES (COUNT) | INTRODUCED LAYER | IN BASE IMAGE |
 +----------------+-------------------+---------------+------------+-------------------------+------------------+---------------+
@@ -152,7 +152,7 @@ Total 2 packages affected by 41 known vulnerabilities (2 Critical, 18 High, 14 M
 
 Alpine:v3.18
 +------------------------------------------------------------------------------------------------------------------------------+
-| Source:os:lib/apk/db/installed                                                                                               |
+| Source:os:/lib/apk/db/installed                                                                                              |
 +----------------+-------------------+---------------+------------+-------------------------+------------------+---------------+
 | SOURCE PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | BINARY PACKAGES (COUNT) | INTRODUCED LAYER | IN BASE IMAGE |
 +----------------+-------------------+---------------+------------+-------------------------+------------------+---------------+
@@ -279,7 +279,7 @@ Total 19 packages affected by 37 known vulnerabilities (2 Critical, 9 High, 20 M
 
 Ubuntu:22.04
 +---------------------------------------------------------------------------------------------------------------------------------------------------+
-| Source:os:var/lib/dpkg/status                                                                                                                     |
+| Source:os:/var/lib/dpkg/status                                                                                                                    |
 +----------------+------------------------------+-------------------------+------------+-------------------------+------------------+---------------+
 | SOURCE PACKAGE | INSTALLED VERSION            | FIX AVAILABLE           | VULN COUNT | BINARY PACKAGES (COUNT) | INTRODUCED LAYER | IN BASE IMAGE |
 +----------------+------------------------------+-------------------------+------------+-------------------------+------------------+---------------+
@@ -324,7 +324,7 @@ Total 19 packages affected by 37 known vulnerabilities (2 Critical, 9 High, 20 M
 
 Ubuntu:22.04
 +---------------------------------------------------------------------------------------------------------------------------------------------------+
-| Source:os:var/lib/dpkg/status                                                                                                                     |
+| Source:os:/var/lib/dpkg/status                                                                                                                    |
 +----------------+------------------------------+-------------------------+------------+-------------------------+------------------+---------------+
 | SOURCE PACKAGE | INSTALLED VERSION            | FIX AVAILABLE           | VULN COUNT | BINARY PACKAGES (COUNT) | INTRODUCED LAYER | IN BASE IMAGE |
 +----------------+------------------------------+-------------------------+------------+-------------------------+------------------+---------------+
@@ -388,7 +388,7 @@ Total 18 packages affected by 26 known vulnerabilities (2 Critical, 8 High, 11 M
 
 Maven
 +-------------------------------------------------------------------------------------------------------------------------------+
-| Source:artifact:app/target.jar                                                                                                |
+| Source:artifact:/app/target.jar                                                                                               |
 +-------------------------------------------+-------------------+---------------+------------+------------------+---------------+
 | PACKAGE                                   | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
 +-------------------------------------------+-------------------+---------------+------------+------------------+---------------+
@@ -408,7 +408,7 @@ Maven
 +-------------------------------------------+-------------------+---------------+------------+------------------+---------------+
 Alpine:v3.21
 +-----------------------------------------------------------------------------------------------------------------------------------+
-| Source:os:lib/apk/db/installed                                                                                                    |
+| Source:os:/lib/apk/db/installed                                                                                                   |
 +----------------+-------------------+---------------+------------+----------------------------+------------------+-----------------+
 | SOURCE PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | BINARY PACKAGES (COUNT)    | INTRODUCED LAYER | IN BASE IMAGE   |
 +----------------+-------------------+---------------+------------+----------------------------+------------------+-----------------+
@@ -438,28 +438,28 @@ Total 14 packages affected by 22 known vulnerabilities (0 Critical, 6 High, 2 Me
 
 PyPI
 +---------------------------------------------------------------------------------------------+
-| Source:artifact:usr/local/lib/python3.9/ensurepip/_bundled/pip-23.0.1-py3-none-any.whl      |
+| Source:artifact:/usr/local/lib/python3.9/ensurepip/_bundled/pip-23.0.1-py3-none-any.whl     |
 +---------+-------------------+---------------+------------+------------------+---------------+
 | PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
 +---------+-------------------+---------------+------------+------------------+---------------+
 | pip     | 23.0.1            | Fix Available |          1 | # 7 Layer        | python        |
 +---------+-------------------+---------------+------------+------------------+---------------+
 +------------------------------------------------------------------------------------------------+
-| Source:artifact:usr/local/lib/python3.9/ensurepip/_bundled/setuptools-58.1.0-py3-none-any.whl  |
+| Source:artifact:/usr/local/lib/python3.9/ensurepip/_bundled/setuptools-58.1.0-py3-none-any.whl |
 +------------+-------------------+---------------+------------+------------------+---------------+
 | PACKAGE    | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
 +------------+-------------------+---------------+------------+------------------+---------------+
 | setuptools | 58.1.0            | Fix Available |          3 | # 7 Layer        | python        |
 +------------+-------------------+---------------+------------+------------------+---------------+
 +---------------------------------------------------------------------------------------------+
-| Source:artifact:usr/local/lib/python3.9/site-packages/pip-23.0.1.dist-info/METADATA         |
+| Source:artifact:/usr/local/lib/python3.9/site-packages/pip-23.0.1.dist-info/METADATA        |
 +---------+-------------------+---------------+------------+------------------+---------------+
 | PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
 +---------+-------------------+---------------+------------+------------------+---------------+
 | pip     | 23.0.1            | Fix Available |          1 | # 13 Layer       | python        |
 +---------+-------------------+---------------+------------+------------------+---------------+
 +------------------------------------------------------------------------------------------------+
-| Source:artifact:usr/local/lib/python3.9/site-packages/setuptools-58.1.0.dist-info/METADATA     |
+| Source:artifact:/usr/local/lib/python3.9/site-packages/setuptools-58.1.0.dist-info/METADATA    |
 +------------+-------------------+---------------+------------+------------------+---------------+
 | PACKAGE    | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
 +------------+-------------------+---------------+------------+------------------+---------------+
@@ -467,7 +467,7 @@ PyPI
 +------------+-------------------+---------------+------------+------------------+---------------+
 Debian:10
 +-----------------------------------------------------------------------------------------------------------------------------------------------+
-| Source:os:var/lib/dpkg/status                                                                                                                 |
+| Source:os:/var/lib/dpkg/status                                                                                                                |
 +------------------------+------------------------+---------------+------------+-----------------------------+------------------+---------------+
 | SOURCE PACKAGE         | INSTALLED VERSION      | FIX AVAILABLE | VULN COUNT | BINARY PACKAGES (COUNT)     | INTRODUCED LAYER | IN BASE IMAGE |
 +------------------------+------------------------+---------------+------------+-----------------------------+------------------+---------------+
@@ -502,63 +502,63 @@ Total 19 packages affected by 39 known vulnerabilities (0 Critical, 12 High, 12 
 
 PyPI
 +---------------------------------------------------------------------------------------------+
-| Source:artifact:usr/local/lib/python3.9/ensurepip/_bundled/pip-23.0.1-py3-none-any.whl      |
+| Source:artifact:/usr/local/lib/python3.9/ensurepip/_bundled/pip-23.0.1-py3-none-any.whl     |
 +---------+-------------------+---------------+------------+------------------+---------------+
 | PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
 +---------+-------------------+---------------+------------+------------------+---------------+
 | pip     | 23.0.1            | Fix Available |          1 | # 7 Layer        | python        |
 +---------+-------------------+---------------+------------+------------------+---------------+
 +------------------------------------------------------------------------------------------------+
-| Source:artifact:usr/local/lib/python3.9/ensurepip/_bundled/setuptools-58.1.0-py3-none-any.whl  |
+| Source:artifact:/usr/local/lib/python3.9/ensurepip/_bundled/setuptools-58.1.0-py3-none-any.whl |
 +------------+-------------------+---------------+------------+------------------+---------------+
 | PACKAGE    | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
 +------------+-------------------+---------------+------------+------------------+---------------+
 | setuptools | 58.1.0            | Fix Available |          3 | # 7 Layer        | python        |
 +------------+-------------------+---------------+------------+------------------+---------------+
 +---------------------------------------------------------------------------------------------+
-| Source:artifact:usr/local/lib/python3.9/site-packages/Django-1.11.29.dist-info/METADATA     |
+| Source:artifact:/usr/local/lib/python3.9/site-packages/Django-1.11.29.dist-info/METADATA    |
 +---------+-------------------+---------------+------------+------------------+---------------+
 | PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
 +---------+-------------------+---------------+------------+------------------+---------------+
 | django  | 1.11.29           | Fix Available |          4 | # 17 Layer       | --            |
 +---------+-------------------+---------------+------------+------------------+---------------+
 +---------------------------------------------------------------------------------------------+
-| Source:artifact:usr/local/lib/python3.9/site-packages/Flask-0.12.2.dist-info/METADATA       |
+| Source:artifact:/usr/local/lib/python3.9/site-packages/Flask-0.12.2.dist-info/METADATA      |
 +---------+-------------------+---------------+------------+------------------+---------------+
 | PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
 +---------+-------------------+---------------+------------+------------------+---------------+
 | flask   | 0.12.2            | Fix Available |          3 | # 17 Layer       | --            |
 +---------+-------------------+---------------+------------+------------------+---------------+
 +---------------------------------------------------------------------------------------------+
-| Source:artifact:usr/local/lib/python3.9/site-packages/idna-2.7.dist-info/METADATA           |
+| Source:artifact:/usr/local/lib/python3.9/site-packages/idna-2.7.dist-info/METADATA          |
 +---------+-------------------+---------------+------------+------------------+---------------+
 | PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
 +---------+-------------------+---------------+------------+------------------+---------------+
 | idna    | 2.7               | Fix Available |          1 | # 17 Layer       | --            |
 +---------+-------------------+---------------+------------+------------------+---------------+
 +---------------------------------------------------------------------------------------------+
-| Source:artifact:usr/local/lib/python3.9/site-packages/pip-23.0.1.dist-info/METADATA         |
+| Source:artifact:/usr/local/lib/python3.9/site-packages/pip-23.0.1.dist-info/METADATA        |
 +---------+-------------------+---------------+------------+------------------+---------------+
 | PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
 +---------+-------------------+---------------+------------+------------------+---------------+
 | pip     | 23.0.1            | Fix Available |          1 | # 13 Layer       | python        |
 +---------+-------------------+---------------+------------+------------------+---------------+
 +----------------------------------------------------------------------------------------------+
-| Source:artifact:usr/local/lib/python3.9/site-packages/requests-2.20.0.dist-info/METADATA     |
+| Source:artifact:/usr/local/lib/python3.9/site-packages/requests-2.20.0.dist-info/METADATA    |
 +----------+-------------------+---------------+------------+------------------+---------------+
 | PACKAGE  | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
 +----------+-------------------+---------------+------------+------------------+---------------+
 | requests | 2.20.0            | Fix Available |          3 | # 17 Layer       | --            |
 +----------+-------------------+---------------+------------+------------------+---------------+
 +------------------------------------------------------------------------------------------------+
-| Source:artifact:usr/local/lib/python3.9/site-packages/setuptools-58.1.0.dist-info/METADATA     |
+| Source:artifact:/usr/local/lib/python3.9/site-packages/setuptools-58.1.0.dist-info/METADATA    |
 +------------+-------------------+---------------+------------+------------------+---------------+
 | PACKAGE    | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
 +------------+-------------------+---------------+------------+------------------+---------------+
 | setuptools | 58.1.0            | Fix Available |          3 | # 13 Layer       | python        |
 +------------+-------------------+---------------+------------+------------------+---------------+
 +---------------------------------------------------------------------------------------------+
-| Source:artifact:usr/local/lib/python3.9/site-packages/urllib3-1.24.3.dist-info/METADATA     |
+| Source:artifact:/usr/local/lib/python3.9/site-packages/urllib3-1.24.3.dist-info/METADATA    |
 +---------+-------------------+---------------+------------+------------------+---------------+
 | PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
 +---------+-------------------+---------------+------------+------------------+---------------+
@@ -566,7 +566,7 @@ PyPI
 +---------+-------------------+---------------+------------+------------------+---------------+
 Debian:10
 +-----------------------------------------------------------------------------------------------------------------------------------------------+
-| Source:os:var/lib/dpkg/status                                                                                                                 |
+| Source:os:/var/lib/dpkg/status                                                                                                                |
 +------------------------+------------------------+---------------+------------+-----------------------------+------------------+---------------+
 | SOURCE PACKAGE         | INSTALLED VERSION      | FIX AVAILABLE | VULN COUNT | BINARY PACKAGES (COUNT)     | INTRODUCED LAYER | IN BASE IMAGE |
 +------------------------+------------------------+---------------+------------+-----------------------------+------------------+---------------+
@@ -601,42 +601,42 @@ Total 8 packages affected by 66 known vulnerabilities (0 Critical, 1 High, 0 Med
 
 Go
 +---------------------------------------------------------------------------------------------+
-| Source:artifact:go/bin/more-vuln-overwrite-less-vuln                                        |
+| Source:artifact:/go/bin/more-vuln-overwrite-less-vuln                                       |
 +---------+-------------------+---------------+------------+------------------+---------------+
 | PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
 +---------+-------------------+---------------+------------+------------------+---------------+
 | stdlib  | 1.22.4            | Fix Available |         10 | # 9 Layer        | --            |
 +---------+-------------------+---------------+------------+------------------+---------------+
 +---------------------------------------------------------------------------------------------+
-| Source:artifact:go/bin/ptf-1.2.0                                                            |
+| Source:artifact:/go/bin/ptf-1.2.0                                                           |
 +---------+-------------------+---------------+------------+------------------+---------------+
 | PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
 +---------+-------------------+---------------+------------+------------------+---------------+
 | stdlib  | 1.22.4            | Fix Available |         10 | # 2 Layer        | --            |
 +---------+-------------------+---------------+------------+------------------+---------------+
 +---------------------------------------------------------------------------------------------+
-| Source:artifact:go/bin/ptf-1.3.0                                                            |
+| Source:artifact:/go/bin/ptf-1.3.0                                                           |
 +---------+-------------------+---------------+------------+------------------+---------------+
 | PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
 +---------+-------------------+---------------+------------+------------------+---------------+
 | stdlib  | 1.22.4            | Fix Available |         10 | # 4 Layer        | --            |
 +---------+-------------------+---------------+------------+------------------+---------------+
 +---------------------------------------------------------------------------------------------+
-| Source:artifact:go/bin/ptf-1.3.0-moved                                                      |
+| Source:artifact:/go/bin/ptf-1.3.0-moved                                                     |
 +---------+-------------------+---------------+------------+------------------+---------------+
 | PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
 +---------+-------------------+---------------+------------+------------------+---------------+
 | stdlib  | 1.22.4            | Fix Available |         10 | # 3 Layer        | --            |
 +---------+-------------------+---------------+------------+------------------+---------------+
 +---------------------------------------------------------------------------------------------+
-| Source:artifact:go/bin/ptf-1.4.0                                                            |
+| Source:artifact:/go/bin/ptf-1.4.0                                                           |
 +---------+-------------------+---------------+------------+------------------+---------------+
 | PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
 +---------+-------------------+---------------+------------+------------------+---------------+
 | stdlib  | 1.22.4            | Fix Available |         10 | # 2 Layer        | --            |
 +---------+-------------------+---------------+------------+------------------+---------------+
 +---------------------------------------------------------------------------------------------+
-| Source:artifact:go/bin/ptf-vulnerable                                                       |
+| Source:artifact:/go/bin/ptf-vulnerable                                                      |
 +---------+-------------------+---------------+------------+------------------+---------------+
 | PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
 +---------+-------------------+---------------+------------+------------------+---------------+
@@ -644,7 +644,7 @@ Go
 +---------+-------------------+---------------+------------+------------------+---------------+
 Alpine:v3.20
 +------------------------------------------------------------------------------------------------------------------------------+
-| Source:os:lib/apk/db/installed                                                                                               |
+| Source:os:/lib/apk/db/installed                                                                                              |
 +----------------+-------------------+---------------+------------+-------------------------+------------------+---------------+
 | SOURCE PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | BINARY PACKAGES (COUNT) | INTRODUCED LAYER | IN BASE IMAGE |
 +----------------+-------------------+---------------+------------+-------------------------+------------------+---------------+
@@ -671,7 +671,7 @@ Total 1 package affected by 1 known vulnerability (1 Critical, 0 High, 0 Medium,
 
 Alpine:v3.10
 +------------------------------------------------------------------------------------------------------------------------------+
-| Source:os:lib/apk/db/installed                                                                                               |
+| Source:os:/lib/apk/db/installed                                                                                              |
 +----------------+-------------------+---------------+------------+-------------------------+------------------+---------------+
 | SOURCE PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | BINARY PACKAGES (COUNT) | INTRODUCED LAYER | IN BASE IMAGE |
 +----------------+-------------------+---------------+------------+-------------------------+------------------+---------------+
@@ -697,7 +697,7 @@ Total 1 package affected by 1 known vulnerability (1 Critical, 0 High, 0 Medium,
 
 Alpine:v3.10
 +------------------------------------------------------------------------------------------------------------------------------+
-| Source:os:lib/apk/db/installed                                                                                               |
+| Source:os:/lib/apk/db/installed                                                                                              |
 +----------------+-------------------+---------------+------------+-------------------------+------------------+---------------+
 | SOURCE PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | BINARY PACKAGES (COUNT) | INTRODUCED LAYER | IN BASE IMAGE |
 +----------------+-------------------+---------------+------------+-------------------------+------------------+---------------+
@@ -723,7 +723,7 @@ Total 1 package affected by 1 known vulnerability (1 Critical, 0 High, 0 Medium,
 
 Alpine:v3.10
 +------------------------------------------------------------------------------------------------------------------------------+
-| Source:os:lib/apk/db/installed                                                                                               |
+| Source:os:/lib/apk/db/installed                                                                                              |
 +----------------+-------------------+---------------+------------+-------------------------+------------------+---------------+
 | SOURCE PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | BINARY PACKAGES (COUNT) | INTRODUCED LAYER | IN BASE IMAGE |
 +----------------+-------------------+---------------+------------+-------------------------+------------------+---------------+
@@ -749,7 +749,7 @@ Total 1 package affected by 1 known vulnerability (1 Critical, 0 High, 0 Medium,
 
 Alpine:v3.10
 +------------------------------------------------------------------------------------------------------------------------------+
-| Source:os:lib/apk/db/installed                                                                                               |
+| Source:os:/lib/apk/db/installed                                                                                              |
 +----------------+-------------------+---------------+------------+-------------------------+------------------+---------------+
 | SOURCE PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | BINARY PACKAGES (COUNT) | INTRODUCED LAYER | IN BASE IMAGE |
 +----------------+-------------------+---------------+------------+-------------------------+------------------+---------------+
@@ -775,7 +775,7 @@ Total 2 packages affected by 11 known vulnerabilities (0 Critical, 1 High, 4 Med
 
 Alpine:v3.19
 +------------------------------------------------------------------------------------------------------------------------------+
-| Source:os:lib/apk/db/installed                                                                                               |
+| Source:os:/lib/apk/db/installed                                                                                              |
 +----------------+-------------------+---------------+------------+-------------------------+------------------+---------------+
 | SOURCE PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | BINARY PACKAGES (COUNT) | INTRODUCED LAYER | IN BASE IMAGE |
 +----------------+-------------------+---------------+------------+-------------------------+------------------+---------------+
@@ -802,7 +802,7 @@ Total 4 packages affected by 14 known vulnerabilities (2 Critical, 1 High, 5 Med
 
 npm
 +-------------------------------------------------------------------------------------------------+
-| Source:artifact:prod/app/node_modules/.package-lock.json                                        |
+| Source:artifact:/prod/app/node_modules/.package-lock.json                                       |
 +----------+-------------------+------------------+------------+------------------+---------------+
 | PACKAGE  | INSTALLED VERSION | FIX AVAILABLE    | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
 +----------+-------------------+------------------+------------+------------------+---------------+
@@ -811,7 +811,7 @@ npm
 +----------+-------------------+------------------+------------+------------------+---------------+
 Alpine:v3.19
 +------------------------------------------------------------------------------------------------------------------------------+
-| Source:os:lib/apk/db/installed                                                                                               |
+| Source:os:/lib/apk/db/installed                                                                                              |
 +----------------+-------------------+---------------+------------+-------------------------+------------------+---------------+
 | SOURCE PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | BINARY PACKAGES (COUNT) | INTRODUCED LAYER | IN BASE IMAGE |
 +----------------+-------------------+---------------+------------+-------------------------+------------------+---------------+
@@ -838,7 +838,7 @@ Total 2 packages affected by 11 known vulnerabilities (0 Critical, 1 High, 4 Med
 
 Alpine:v3.19
 +------------------------------------------------------------------------------------------------------------------------------+
-| Source:os:lib/apk/db/installed                                                                                               |
+| Source:os:/lib/apk/db/installed                                                                                              |
 +----------------+-------------------+---------------+------------+-------------------------+------------------+---------------+
 | SOURCE PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | BINARY PACKAGES (COUNT) | INTRODUCED LAYER | IN BASE IMAGE |
 +----------------+-------------------+---------------+------------+-------------------------+------------------+---------------+
@@ -865,7 +865,7 @@ Total 2 packages affected by 11 known vulnerabilities (0 Critical, 1 High, 4 Med
 
 Alpine:v3.19
 +------------------------------------------------------------------------------------------------------------------------------+
-| Source:os:lib/apk/db/installed                                                                                               |
+| Source:os:/lib/apk/db/installed                                                                                              |
 +----------------+-------------------+---------------+------------+-------------------------+------------------+---------------+
 | SOURCE PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | BINARY PACKAGES (COUNT) | INTRODUCED LAYER | IN BASE IMAGE |
 +----------------+-------------------+---------------+------------+-------------------------+------------------+---------------+
@@ -892,7 +892,7 @@ Total 2 packages affected by 11 known vulnerabilities (0 Critical, 1 High, 4 Med
 
 Alpine:v3.19
 +------------------------------------------------------------------------------------------------------------------------------+
-| Source:os:lib/apk/db/installed                                                                                               |
+| Source:os:/lib/apk/db/installed                                                                                              |
 +----------------+-------------------+---------------+------------+-------------------------+------------------+---------------+
 | SOURCE PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | BINARY PACKAGES (COUNT) | INTRODUCED LAYER | IN BASE IMAGE |
 +----------------+-------------------+---------------+------------+-------------------------+------------------+---------------+
@@ -919,7 +919,7 @@ Total 2 packages affected by 11 known vulnerabilities (0 Critical, 1 High, 4 Med
 
 Alpine:v3.19
 +------------------------------------------------------------------------------------------------------------------------------+
-| Source:os:lib/apk/db/installed                                                                                               |
+| Source:os:/lib/apk/db/installed                                                                                              |
 +----------------+-------------------+---------------+------------+-------------------------+------------------+---------------+
 | SOURCE PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | BINARY PACKAGES (COUNT) | INTRODUCED LAYER | IN BASE IMAGE |
 +----------------+-------------------+---------------+------------+-------------------------+------------------+---------------+
@@ -941,7 +941,7 @@ You can also view the full vulnerability list in your terminal with: `osv-scanne
   "results": [
     {
       "source": {
-        "path": "usr/local/lib/python3.9/ensurepip/_bundled/pip-23.0.1-py3-none-any.whl",
+        "path": "/usr/local/lib/python3.9/ensurepip/_bundled/pip-23.0.1-py3-none-any.whl",
         "type": "artifact"
       },
       "packages": [
@@ -964,7 +964,7 @@ You can also view the full vulnerability list in your terminal with: `osv-scanne
     },
     {
       "source": {
-        "path": "usr/local/lib/python3.9/ensurepip/_bundled/setuptools-58.1.0-py3-none-any.whl",
+        "path": "/usr/local/lib/python3.9/ensurepip/_bundled/setuptools-58.1.0-py3-none-any.whl",
         "type": "artifact"
       },
       "packages": [
@@ -990,7 +990,7 @@ You can also view the full vulnerability list in your terminal with: `osv-scanne
     },
     {
       "source": {
-        "path": "usr/local/lib/python3.9/site-packages/Django-1.11.29.dist-info/METADATA",
+        "path": "/usr/local/lib/python3.9/site-packages/Django-1.11.29.dist-info/METADATA",
         "type": "artifact"
       },
       "packages": [
@@ -1016,7 +1016,7 @@ You can also view the full vulnerability list in your terminal with: `osv-scanne
     },
     {
       "source": {
-        "path": "usr/local/lib/python3.9/site-packages/Flask-0.12.2.dist-info/METADATA",
+        "path": "/usr/local/lib/python3.9/site-packages/Flask-0.12.2.dist-info/METADATA",
         "type": "artifact"
       },
       "packages": [
@@ -1043,7 +1043,7 @@ You can also view the full vulnerability list in your terminal with: `osv-scanne
     },
     {
       "source": {
-        "path": "usr/local/lib/python3.9/site-packages/idna-2.7.dist-info/METADATA",
+        "path": "/usr/local/lib/python3.9/site-packages/idna-2.7.dist-info/METADATA",
         "type": "artifact"
       },
       "packages": [
@@ -1066,7 +1066,7 @@ You can also view the full vulnerability list in your terminal with: `osv-scanne
     },
     {
       "source": {
-        "path": "usr/local/lib/python3.9/site-packages/pip-23.0.1.dist-info/METADATA",
+        "path": "/usr/local/lib/python3.9/site-packages/pip-23.0.1.dist-info/METADATA",
         "type": "artifact"
       },
       "packages": [
@@ -1089,7 +1089,7 @@ You can also view the full vulnerability list in your terminal with: `osv-scanne
     },
     {
       "source": {
-        "path": "usr/local/lib/python3.9/site-packages/requests-2.20.0.dist-info/METADATA",
+        "path": "/usr/local/lib/python3.9/site-packages/requests-2.20.0.dist-info/METADATA",
         "type": "artifact"
       },
       "packages": [
@@ -1114,7 +1114,7 @@ You can also view the full vulnerability list in your terminal with: `osv-scanne
     },
     {
       "source": {
-        "path": "usr/local/lib/python3.9/site-packages/setuptools-58.1.0.dist-info/METADATA",
+        "path": "/usr/local/lib/python3.9/site-packages/setuptools-58.1.0.dist-info/METADATA",
         "type": "artifact"
       },
       "packages": [
@@ -1140,7 +1140,7 @@ You can also view the full vulnerability list in your terminal with: `osv-scanne
     },
     {
       "source": {
-        "path": "usr/local/lib/python3.9/site-packages/urllib3-1.24.3.dist-info/METADATA",
+        "path": "/usr/local/lib/python3.9/site-packages/urllib3-1.24.3.dist-info/METADATA",
         "type": "artifact"
       },
       "packages": [
@@ -1170,7 +1170,7 @@ You can also view the full vulnerability list in your terminal with: `osv-scanne
     },
     {
       "source": {
-        "path": "var/lib/dpkg/status",
+        "path": "/var/lib/dpkg/status",
         "type": "os"
       },
       "packages": [
@@ -1682,7 +1682,7 @@ Scanning local image tarball "../../../../internal/image/fixtures/test-python-fu
   "results": [
     {
       "source": {
-        "path": "go/bin/ptf-1.4.0",
+        "path": "/go/bin/ptf-1.4.0",
         "type": "artifact"
       },
       "packages": [
@@ -1737,7 +1737,7 @@ Scanning local image tarball "../../../../internal/image/fixtures/test-python-fu
     },
     {
       "source": {
-        "path": "lib/apk/db/installed",
+        "path": "/lib/apk/db/installed",
         "type": "os"
       },
       "packages": [
@@ -2010,7 +2010,7 @@ Scanning local image tarball "../../../../internal/image/fixtures/test-go-binary
   "results": [
     {
       "source": {
-        "path": "lib/apk/db/installed",
+        "path": "/lib/apk/db/installed",
         "type": "os"
       },
       "packages": [
@@ -2110,7 +2110,7 @@ Scanning local image tarball "../../../../internal/image/fixtures/test-alpine-et
   "results": [
     {
       "source": {
-        "path": "lib/apk/db/installed",
+        "path": "/lib/apk/db/installed",
         "type": "os"
       },
       "packages": [
@@ -2210,7 +2210,7 @@ Scanning local image tarball "../../../../internal/image/fixtures/test-alpine-et
   "results": [
     {
       "source": {
-        "path": "lib/apk/db/installed",
+        "path": "/lib/apk/db/installed",
         "type": "os"
       },
       "packages": [
@@ -2319,7 +2319,7 @@ Scanning local image tarball "../../../../internal/image/fixtures/test-alpine-et
     },
     {
       "source": {
-        "path": "prod/app/node_modules/.package-lock.json",
+        "path": "/prod/app/node_modules/.package-lock.json",
         "type": "artifact"
       },
       "packages": [
@@ -2495,7 +2495,7 @@ Scanning local image tarball "../../../../internal/image/fixtures/test-node_modu
   "results": [
     {
       "source": {
-        "path": "var/lib/dpkg/status",
+        "path": "/var/lib/dpkg/status",
         "type": "os"
       },
       "packages": [

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -359,8 +359,9 @@ func DoContainerScan(actions ScannerActions) (models.VulnerabilityResults, error
 	// --- Do Scalibr Scan ---
 	scanner := scalibr.New()
 	scalibrSR, err := scanner.ScanContainer(context.Background(), img, &scalibr.ScanConfig{
-		Plugins:      plugins,
-		Capabilities: capabilities,
+		Plugins:           plugins,
+		Capabilities:      capabilities,
+		StoreAbsolutePath: true,
 	})
 	if err != nil {
 		return models.VulnerabilityResults{}, fmt.Errorf("failed to scan container image: %w", err)


### PR DESCRIPTION
Turns out container scanning is not using absolute paths in its results, which isn't breaking anything but is an assumption of our `output` package