### PR TITLE
chore: remove old public `reporter.Reporter` config

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -53,13 +53,6 @@ linters:
     gocritic:
       disabled-checks:
         - ifElseChain
-    govet:
-      settings:
-        printf:
-          funcs:
-            - (github.com/google/osv-scanner/v2/pkg/reporter.Reporter).Errorf
-            - (github.com/google/osv-scanner/v2/pkg/reporter.Reporter).Warnf
-            - (github.com/google/osv-scanner/v2/pkg/reporter.Reporter).Infof
     nlreturn:
       block-size: 2
     revive:


### PR DESCRIPTION
These functions have long since gone, and the package itself now is internal