### PR TITLE
refactor(models): remove unneeded group IDs length check

### DIFF
--- a/pkg/models/results.go
+++ b/pkg/models/results.go
@@ -144,12 +144,6 @@ type GroupInfo struct {
 // IsCalled returns true if any analysis performed determines that the vulnerability is being called
 // Also returns true if no analysis is performed
 func (groupInfo *GroupInfo) IsCalled() bool {
-	if len(groupInfo.IDs) == 0 {
-		// This PackageVulns may be a license violation, not a
-		// vulnerability.
-		return false
-	}
-
 	if len(groupInfo.ExperimentalAnalysis) == 0 {
 		return true
 	}
@@ -164,10 +158,6 @@ func (groupInfo *GroupInfo) IsCalled() bool {
 }
 
 func (groupInfo *GroupInfo) IsGroupUnimportant() bool {
-	if len(groupInfo.IDs) == 0 {
-		return false
-	}
-
 	if len(groupInfo.ExperimentalAnalysis) == 0 {
 		return false
 	}


### PR DESCRIPTION
These branches are not covered by our test suite indicating we've either got some missing cases or they're not actually needed - I'm betting on it being the latter, and if I'm wrong then we'll have found a hole