### PR TITLE
refactor: use `cmdlogger` instead of `log`

### DIFF
--- a/internal/clients/clientimpl/localmatcher/localmatcher.go
+++ b/internal/clients/clientimpl/localmatcher/localmatcher.go
@@ -107,7 +107,6 @@ func (matcher *LocalMatcher) loadDBFromCache(ctx context.Context, eco ecosystem.
 		return nil, err
 	}
 
-	// TODO(v2 logging): Replace with slog / another logger
 	cmdlogger.Infof("Loaded %s local db from %s", db.Name, db.StoredAt)
 
 	matcher.dbs[eco.Ecosystem] = db

--- a/internal/clients/clientimpl/osvmatcher/osvmatcher.go
+++ b/internal/clients/clientimpl/osvmatcher/osvmatcher.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/google/osv-scalibr/extractor"
-	"github.com/google/osv-scalibr/log"
+	"github.com/google/osv-scanner/v2/internal/cmdlogger"
 	"github.com/google/osv-scanner/v2/internal/imodels"
 	"github.com/ossf/osv-schema/bindings/go/osvschema"
 	"golang.org/x/sync/errgroup"
@@ -127,7 +127,7 @@ func pkgToQuery(pkg imodels.PackageInfo) *osvdev.Query {
 	}
 
 	// This should have be filtered out before reaching this point
-	log.Errorf("invalid query element: %#v", pkg)
+	cmdlogger.Errorf("invalid query element: %#v", pkg)
 
 	return nil
 }

--- a/internal/imodels/imodels.go
+++ b/internal/imodels/imodels.go
@@ -3,7 +3,6 @@ package imodels
 
 import (
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/google/osv-scalibr/converter"
@@ -22,6 +21,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/sbom/spdx"
 	"github.com/google/osv-scalibr/inventory"
 	"github.com/google/osv-scanner/v2/internal/cachedregexp"
+	"github.com/google/osv-scanner/v2/internal/cmdlogger"
 	"github.com/google/osv-scanner/v2/internal/imodels/ecosystem"
 	"github.com/google/osv-scanner/v2/internal/scalibrextract/language/javascript/nodemodules"
 	"github.com/google/osv-scanner/v2/internal/scalibrextract/vcs/gitrepo"
@@ -124,8 +124,7 @@ func (pkg *PackageInfo) Ecosystem() ecosystem.Parsed {
 	eco, err := ecosystem.Parse(ecosystemStr)
 	if err != nil {
 		// Ignore this error for now as we can't do too much about an unknown ecosystem
-		// TODO(v2): Replace with slog
-		log.Printf("Warning: %s\n", err.Error())
+		cmdlogger.Warnf("Warning: %s", err.Error())
 	}
 
 	return eco

--- a/internal/remediation/override.go
+++ b/internal/remediation/override.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"slices"
 
 	"deps.dev/util/resolve"
 	"deps.dev/util/resolve/dep"
 	"deps.dev/util/semver"
+	"github.com/google/osv-scanner/v2/internal/cmdlogger"
 	"github.com/google/osv-scanner/v2/internal/remediation/upgrade"
 	"github.com/google/osv-scanner/v2/internal/resolution"
 	"github.com/google/osv-scanner/v2/internal/resolution/client"
@@ -262,7 +262,7 @@ func getVersionsGreater(ctx context.Context, cl client.DependencyClient, vk reso
 	for _, ver := range versions {
 		parsed, err := semver.Maven.Parse(ver.Version)
 		if err != nil {
-			log.Printf("parsing Maven version %s: %v", parsed, err)
+			cmdlogger.Warnf("parsing Maven version %s: %v", parsed, err)
 			continue
 		}
 		semvers[ver.VersionKey] = parsed

--- a/internal/remediation/suggest/maven.go
+++ b/internal/remediation/suggest/maven.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"slices"
 	"strings"
 
 	"deps.dev/util/resolve"
 	"deps.dev/util/semver"
+	"github.com/google/osv-scanner/v2/internal/cmdlogger"
 	"github.com/google/osv-scanner/v2/internal/remediation/upgrade"
 	"github.com/google/osv-scanner/v2/internal/resolution/manifest"
 	"github.com/google/osv-scanner/v2/internal/utility/maven"
@@ -81,7 +81,7 @@ func suggestMavenVersion(ctx context.Context, cl resolve.Client, req resolve.Req
 	for _, ver := range versions {
 		parsed, err := semver.Maven.Parse(ver.Version)
 		if err != nil {
-			log.Printf("parsing Maven version %s: %v", parsed, err)
+			cmdlogger.Warnf("parsing Maven version %s: %v", parsed, err)
 			continue
 		}
 		semvers = append(semvers, parsed)

--- a/internal/sourceanalysis/rust.go
+++ b/internal/sourceanalysis/rust.go
@@ -202,7 +202,7 @@ func extractRlibArchive(rlibPath string) (bytes.Buffer, error) {
 			// There should only be one file (since we set codegen-units=1)
 			if !strings.HasSuffix(filename, RustLibExtension) {
 				// TODO: Verify this, and return an error here instead.
-				log.Printf("rlib archive contents were unexpected: %s\n", filename)
+				cmdlogger.Warnf("rlib archive contents were unexpected: %s\n", filename)
 			}
 		}
 		// /0 indicates the first file mentioned in the "//" store


### PR DESCRIPTION
This gets rid of a couple of todos and overall makes things a bit more consistent - we still have uses of `log.Fatalf` and `log.Panicf` as we don't have `cmdlogger` versions of those, which might be worth doing just for further consistency