### PR TITLE
fix: pass through plugin capabilities

### DIFF
--- a/cmd/osv-scanner/scan/source/__snapshots__/command_test.snap
+++ b/cmd/osv-scanner/scan/source/__snapshots__/command_test.snap
@@ -1935,6 +1935,30 @@ Scanned <rootdir>/fixtures/locks-licenses/package-lock.json file and found 4 pac
 
 ---
 
+[TestCommand_Licenses/No_vulnerabilities_but_license_violations_with_allowlist - 1]
+Scanning dir ./fixtures/locks-many/yarn.lock
+Scanned <rootdir>/fixtures/locks-many/yarn.lock file and found 1 package
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+
++---------+-------------------------+
+| LICENSE | NO. OF PACKAGE VERSIONS |
++---------+-------------------------+
+| MIT     |                       1 |
++---------+-------------------------+
++-------------------+-----------+----------------+---------+-------------------------------+
+| LICENSE VIOLATION | ECOSYSTEM | PACKAGE        | VERSION | SOURCE                        |
++-------------------+-----------+----------------+---------+-------------------------------+
+| MIT               | npm       | balanced-match | 1.0.2   | fixtures/locks-many/yarn.lock |
++-------------------+-----------+----------------+---------+-------------------------------+
+
+---
+
+[TestCommand_Licenses/No_vulnerabilities_but_license_violations_with_allowlist - 2]
+
+---
+
 [TestCommand_Licenses/No_vulnerabilities_with_license_summary - 1]
 Scanning dir ./fixtures/locks-many
 Scanned <rootdir>/fixtures/locks-many/Gemfile.lock file and found 1 package

--- a/cmd/osv-scanner/scan/source/command_test.go
+++ b/cmd/osv-scanner/scan/source/command_test.go
@@ -761,6 +761,11 @@ func TestCommand_Licenses(t *testing.T) {
 			Exit: 1,
 		},
 		{
+			Name: "No vulnerabilities but license violations with allowlist",
+			Args: []string{"", "source", "--licenses=Apache-2.0", "--config=./fixtures/osv-scanner-empty-config.toml", "./fixtures/locks-many/yarn.lock"},
+			Exit: 1,
+		},
+		{
 			Name: "Vulnerabilities and all license violations allowlisted",
 			Args: []string{"", "source", "--licenses=Apache-2.0", "--config=./fixtures/osv-scanner-empty-config.toml", "./fixtures/locks-many/package-lock.json"},
 			Exit: 1,

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -340,16 +340,18 @@ func DoContainerScan(actions ScannerActions) (models.VulnerabilityResults, error
 		plugins[i+len(filesystemExtractors)] = det.(plugin.Plugin)
 	}
 
-	plugins = plugin.FilterByCapabilities(plugins, &plugin.Capabilities{
+	capabilities := &plugin.Capabilities{
 		DirectFS:      true,
 		RunningSystem: false,
 		OS:            plugin.OSLinux,
-	})
+	}
+	plugins = plugin.FilterByCapabilities(plugins, capabilities)
 
 	// --- Do Scalibr Scan ---
 	scanner := scalibr.New()
 	scalibrSR, err := scanner.ScanContainer(context.Background(), img, &scalibr.ScanConfig{
-		Plugins: plugins,
+		Plugins:      plugins,
+		Capabilities: capabilities,
 	})
 	if err != nil {
 		return models.VulnerabilityResults{}, fmt.Errorf("failed to scan container image: %w", err)


### PR DESCRIPTION
Also added a test for No vulnerabilities but with license violations. (about #2093, it looks like this doesn't actually trigger the removed codepath either suprisingly)