### PR TITLE
feat: switch to the commit version of `osv-scalibr`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/go-git/go-billy/v5 v5.6.2
 	github.com/go-git/go-git/v5 v5.16.2
 	github.com/google/go-cmp v0.7.0
-	github.com/google/osv-scalibr v0.3.1
+	github.com/google/osv-scalibr v0.3.2-0.20250710172718-d8537726da6b
 	github.com/ianlancetaylor/demangle v0.0.0-20250628045327-2d64ad6b7ec5
 	github.com/jedib0t/go-pretty/v6 v6.6.7
 	github.com/muesli/reflow v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -213,8 +213,8 @@ github.com/google/go-containerregistry v0.20.6 h1:cvWX87UxxLgaH76b4hIvya6Dzz9qHB
 github.com/google/go-containerregistry v0.20.6/go.mod h1:T0x8MuoAoKX/873bkeSfLD2FAkwCDf9/HZgsFJ02E2Y=
 github.com/google/go-cpy v0.0.0-20211218193943-a9c933c06932 h1:5/4TSDzpDnHQ8rKEEQBjRlYx77mHOvXu08oGchxej7o=
 github.com/google/go-cpy v0.0.0-20211218193943-a9c933c06932/go.mod h1:cC6EdPbj/17GFCPDK39NRarlMI+kt+O60S12cNB5J9Y=
-github.com/google/osv-scalibr v0.3.1 h1:bXSaKfhlh7Q4ysLLjfFRJ1HONFsLyYvPOXD9v94yi0M=
-github.com/google/osv-scalibr v0.3.1/go.mod h1:dUF/iQx3OboIV/z1N1S2Bji1esSvAj/sWlLzQ7BXhmo=
+github.com/google/osv-scalibr v0.3.2-0.20250710172718-d8537726da6b h1:ZdtTQPKfG5s40L1kgsG7EardLYKkc7BeqRRn9AVmKwc=
+github.com/google/osv-scalibr v0.3.2-0.20250710172718-d8537726da6b/go.mod h1:dUF/iQx3OboIV/z1N1S2Bji1esSvAj/sWlLzQ7BXhmo=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=


### PR DESCRIPTION
This should enable Renovate to automatically update us to the latest version of `osv-scalibr` on `main` - the actual commit I've used is for the one immediately after v0.3.1 as I couldn't get Go to use that exact commit (it seems to check for tags against the commit, and prefer those instead)