### PR TITLE
feat: move resolving extractors from names into `osvscanner`

### DIFF
--- a/cmd/osv-scanner/internal/helper/getters.go
+++ b/cmd/osv-scanner/internal/helper/getters.go
@@ -48,10 +48,8 @@ func GetCommonScannerActions(cmd *cli.Command, scanLicensesAllowlist []string) o
 
 func GetExperimentalScannerActions(cmd *cli.Command) osvscanner.ExperimentalScannerActions {
 	return osvscanner.ExperimentalScannerActions{
-		Extractors: ResolveEnabledExtractors(
-			cmd.StringSlice("experimental-extractors"),
-			cmd.StringSlice("experimental-disable-extractors"),
-		),
+		ExtractorsEnabled:  cmd.StringSlice("experimental-extractors"),
+		ExtractorsDisabled: cmd.StringSlice("experimental-disable-extractors"),
 		Detectors: ResolveEnabledDetectors(
 			cmd.StringSlice("experimental-detectors"),
 			cmd.StringSlice("experimental-disable-detectors"),

--- a/cmd/osv-scanner/internal/helper/getters.go
+++ b/cmd/osv-scanner/internal/helper/getters.go
@@ -50,9 +50,8 @@ func GetExperimentalScannerActions(cmd *cli.Command) osvscanner.ExperimentalScan
 	return osvscanner.ExperimentalScannerActions{
 		ExtractorsEnabled:  cmd.StringSlice("experimental-extractors"),
 		ExtractorsDisabled: cmd.StringSlice("experimental-disable-extractors"),
-		Detectors: ResolveEnabledDetectors(
-			cmd.StringSlice("experimental-detectors"),
-			cmd.StringSlice("experimental-disable-detectors"),
-		),
+
+		DetectorsEnabled:  cmd.StringSlice("experimental-detectors"),
+		DetectorsDisabled: cmd.StringSlice("experimental-disable-detectors"),
 	}
 }

--- a/cmd/osv-scanner/scan/image/command.go
+++ b/cmd/osv-scanner/scan/image/command.go
@@ -76,9 +76,9 @@ func action(_ context.Context, cmd *cli.Command, stdout, stderr io.Writer) error
 	scannerAction.IsImageArchive = cmd.Bool("archive")
 	scannerAction.ExperimentalScannerActions = helper.GetExperimentalScannerActions(cmd)
 
-	if len(scannerAction.Extractors) == 0 {
-		return errors.New("at least one extractor must be enabled")
-	}
+	// if len(scannerAction.Extractors) == 0 {
+	// 	return errors.New("at least one extractor must be enabled")
+	// }
 
 	var vulnResult models.VulnerabilityResults
 	//nolint:contextcheck // passing the context in would be a breaking change

--- a/cmd/osv-scanner/scan/image/command.go
+++ b/cmd/osv-scanner/scan/image/command.go
@@ -76,10 +76,6 @@ func action(_ context.Context, cmd *cli.Command, stdout, stderr io.Writer) error
 	scannerAction.IsImageArchive = cmd.Bool("archive")
 	scannerAction.ExperimentalScannerActions = helper.GetExperimentalScannerActions(cmd)
 
-	// if len(scannerAction.Extractors) == 0 {
-	// 	return errors.New("at least one extractor must be enabled")
-	// }
-
 	var vulnResult models.VulnerabilityResults
 	//nolint:contextcheck // passing the context in would be a breaking change
 	vulnResult, err = osvscanner.DoContainerScan(scannerAction)

--- a/cmd/osv-scanner/scan/source/__snapshots__/command_test.snap
+++ b/cmd/osv-scanner/scan/source/__snapshots__/command_test.snap
@@ -1467,6 +1467,7 @@ Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medi
 
 [TestCommand_ExplicitExtractors/scanning_directory_with_an_extractor_that_does_not_exist - 2]
 unknown extractor "custom/extractor"
+unknown extractor "custom/extractor"
 
 ---
 

--- a/cmd/osv-scanner/scan/source/command.go
+++ b/cmd/osv-scanner/scan/source/command.go
@@ -134,10 +134,6 @@ func action(_ context.Context, cmd *cli.Command, stdout, stderr io.Writer) error
 	scannerAction.CallAnalysisStates = callAnalysisStates
 	scannerAction.ExperimentalScannerActions = experimentalScannerActions
 
-	// if len(experimentalScannerActions.Extractors) == 0 {
-	// 	return errors.New("at least one extractor must be enabled")
-	// }
-
 	var vulnResult models.VulnerabilityResults
 	//nolint:contextcheck // passing the context in would be a breaking change
 	vulnResult, err = osvscanner.DoScan(scannerAction)

--- a/cmd/osv-scanner/scan/source/command.go
+++ b/cmd/osv-scanner/scan/source/command.go
@@ -134,9 +134,9 @@ func action(_ context.Context, cmd *cli.Command, stdout, stderr io.Writer) error
 	scannerAction.CallAnalysisStates = callAnalysisStates
 	scannerAction.ExperimentalScannerActions = experimentalScannerActions
 
-	if len(experimentalScannerActions.Extractors) == 0 {
-		return errors.New("at least one extractor must be enabled")
-	}
+	// if len(experimentalScannerActions.Extractors) == 0 {
+	// 	return errors.New("at least one extractor must be enabled")
+	// }
 
 	var vulnResult models.VulnerabilityResults
 	//nolint:contextcheck // passing the context in would be a breaking change

--- a/internal/scalibrplugin/detectors_parser.go
+++ b/internal/scalibrplugin/detectors_parser.go
@@ -1,4 +1,4 @@
-package helper
+package scalibrplugin
 
 import (
 	"github.com/google/osv-scalibr/detector"

--- a/internal/scalibrplugin/detectors_parser_test.go
+++ b/internal/scalibrplugin/detectors_parser_test.go
@@ -1,4 +1,4 @@
-package helper
+package scalibrplugin
 
 import (
 	"slices"

--- a/internal/scalibrplugin/extractors_parser.go
+++ b/internal/scalibrplugin/extractors_parser.go
@@ -1,4 +1,5 @@
-package helper
+// Package scalibrplugin provides functions related to configuring scalibr plugins
+package scalibrplugin
 
 import (
 	"github.com/google/osv-scalibr/extractor/filesystem"

--- a/internal/scalibrplugin/extractors_parser_test.go
+++ b/internal/scalibrplugin/extractors_parser_test.go
@@ -1,4 +1,4 @@
-package helper
+package scalibrplugin
 
 import (
 	"slices"

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -19,7 +19,6 @@ import (
 	"github.com/google/osv-scalibr/clients/resolution"
 	"github.com/google/osv-scalibr/detector"
 	"github.com/google/osv-scalibr/extractor"
-	"github.com/google/osv-scalibr/extractor/filesystem"
 	"github.com/google/osv-scalibr/plugin"
 	"github.com/google/osv-scanner/v2/internal/clients/clientimpl/baseimagematcher"
 	"github.com/google/osv-scanner/v2/internal/clients/clientimpl/licensematcher"
@@ -72,8 +71,9 @@ type ScannerActions struct {
 type ExperimentalScannerActions struct {
 	TransitiveScanningActions
 
-	Extractors []filesystem.Extractor
-	Detectors  []detector.Detector
+	ExtractorsEnabled  []string
+	ExtractorsDisabled []string
+	Detectors          []detector.Detector
 }
 
 type TransitiveScanningActions struct {

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -298,6 +298,16 @@ func DoContainerScan(actions ScannerActions) (models.VulnerabilityResults, error
 		return models.VulnerabilityResults{}, fmt.Errorf("failed to initialize accessors: %w", err)
 	}
 
+	filesystemExtractors := getExtractors(
+		scalibrextract.ExtractorsArtifacts,
+		accessors,
+		actions,
+	)
+
+	if len(filesystemExtractors) == 0 {
+		return models.VulnerabilityResults{}, errors.New("at least one extractor must be enabled")
+	}
+
 	// --- Initialize Image To Scan ---'
 
 	var img *image.Image
@@ -324,12 +334,6 @@ func DoContainerScan(actions ScannerActions) (models.VulnerabilityResults, error
 			cmdlogger.Errorf("Failed to clean up image: %s", err)
 		}
 	}()
-
-	filesystemExtractors := getExtractors(
-		scalibrextract.ExtractorsArtifacts,
-		accessors,
-		actions,
-	)
 
 	plugins := make([]plugin.Plugin, len(filesystemExtractors)+len(actions.Detectors))
 	for i, ext := range filesystemExtractors {

--- a/pkg/osvscanner/scan.go
+++ b/pkg/osvscanner/scan.go
@@ -84,6 +84,11 @@ func scan(accessors ExternalAccessors, actions ScannerActions) (*imodels.ScanRes
 
 	// --- Lockfiles ---
 	lockfileExtractors := getExtractors(scalibrextract.ExtractorsLockfiles, accessors, actions)
+
+	if len(lockfileExtractors) == 0 {
+		return nil, errors.New("at least one extractor must be enabled")
+	}
+
 	for _, lockfileElem := range actions.LockfilePaths {
 		invs, err := scanners.ScanSingleFileWithMapping(lockfileElem, lockfileExtractors)
 		if err != nil {
@@ -128,6 +133,10 @@ func scan(accessors ExternalAccessors, actions ScannerActions) (*imodels.ScanRes
 		accessors,
 		actions,
 	)
+
+	if len(dirExtractors) == 0 {
+		return nil, errors.New("at least one extractor must be enabled")
+	}
 
 	scanner := scalibr.New()
 

--- a/pkg/osvscanner/scan.go
+++ b/pkg/osvscanner/scan.go
@@ -162,6 +162,8 @@ func scan(accessors ExternalAccessors, actions ScannerActions) (*imodels.ScanRes
 	testlogger.BeginDirScanMarker()
 	osCapability := determineOS()
 
+	detectors := scalibrplugin.ResolveEnabledDetectors(actions.DetectorsEnabled, actions.DetectorsDisabled)
+
 	// For each root, run scalibr's scan() once.
 	for root, paths := range rootMap {
 		capabilities := plugin.Capabilities{
@@ -175,12 +177,12 @@ func scan(accessors ExternalAccessors, actions ScannerActions) (*imodels.ScanRes
 			capabilities.Network = plugin.NetworkOffline
 		}
 
-		plugins := make([]plugin.Plugin, len(dirExtractors)+len(actions.Detectors))
+		plugins := make([]plugin.Plugin, len(dirExtractors)+len(detectors))
 		for i, ext := range dirExtractors {
 			plugins[i] = ext.(plugin.Plugin)
 		}
 
-		for i, det := range actions.Detectors {
+		for i, det := range detectors {
 			plugins[i+len(dirExtractors)] = det.(plugin.Plugin)
 		}
 

--- a/pkg/osvscanner/scan.go
+++ b/pkg/osvscanner/scan.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/osv-scanner/v2/internal/scalibrextract/language/java/pomxmlenhanceable"
 	"github.com/google/osv-scanner/v2/internal/scalibrextract/language/python/requirementsenhancable"
 	"github.com/google/osv-scanner/v2/internal/scalibrextract/vcs/gitrepo"
+	"github.com/google/osv-scanner/v2/internal/scalibrplugin"
 	"github.com/google/osv-scanner/v2/internal/testlogger"
 	"github.com/google/osv-scanner/v2/pkg/osvscanner/internal/scanners"
 	"github.com/ossf/osv-schema/bindings/go/osvschema"
@@ -64,11 +65,11 @@ func configureExtractors(extractors []filesystem.Extractor, accessors ExternalAc
 }
 
 func getExtractors(defaultExtractorNames []string, accessors ExternalAccessors, actions ScannerActions) []filesystem.Extractor {
-	extractors := actions.Extractors
-
-	if len(extractors) == 0 {
-		extractors = builders.BuildExtractors(defaultExtractorNames)
+	if len(actions.ExtractorsEnabled) == 0 {
+		actions.ExtractorsEnabled = defaultExtractorNames
 	}
+
+	extractors := scalibrplugin.ResolveEnabledExtractors(actions.ExtractorsEnabled, actions.ExtractorsDisabled)
 
 	configureExtractors(extractors, accessors, actions)
 


### PR DESCRIPTION
This puts the API of our CLI and public package back in sync and make it easier to build on since we should not have to do as much double-handling.

As this is expected to be one of a couple of changes to this aspect of the scanner, I've introduced the `scalibrplugin` package as part of this which I expect to eventually house stuff like our presets and builder related code