### PR TITLE
fix: only get and configure extractors once

### DIFF
--- a/cmd/osv-scanner/scan/source/__snapshots__/command_test.snap
+++ b/cmd/osv-scanner/scan/source/__snapshots__/command_test.snap
@@ -1464,7 +1464,6 @@ Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medi
 
 [TestCommand_ExplicitExtractors/scanning_directory_with_an_extractor_that_does_not_exist - 2]
 unknown extractor "custom/extractor"
-unknown extractor "custom/extractor"
 
 ---
 


### PR DESCRIPTION
This should help make things easier to maintain as it pushes us a little further towards having a single blob of extractors/plugins rather than needing to manage multiple conditions based on what (sub)type of scanning we're doing.

Right now this code path only comes into play when using the scanner package directly without passing any extractors, but once #2100 is landed (which pulls the extractor building into the scanner package itself) we'll be using this path more