### PR TITLE
style(docs): Improve theme styling for Jekyll highlight blocks

### DIFF
--- a/docs/_sass/color_schemes/_variables.scss
+++ b/docs/_sass/color_schemes/_variables.scss
@@ -21,7 +21,8 @@ $green-000: #41d693 !default;
 $green-100: #11b584 !default;
 $green-200: #009c7b !default;
 $green-300: #026e57 !default;
-$yellow-000: #ffeb82 !default;
+// Override the default yellow 000 for better visibility
+$yellow-000: #5f4f00;
 $yellow-100: #fadf50 !default;
 $yellow-200: #f7d12e !default;
 $yellow-300: #e7af06 !default;

--- a/docs/_sass/color_schemes/custom_dark.scss
+++ b/docs/_sass/color_schemes/custom_dark.scss
@@ -14,7 +14,7 @@ $sidebar-color: $new-body-background-color; //Replacing default $grey-dk-300
 $base-button-color: $grey-dk-250;
 $btn-primary-color: $blue-200;
 $code-background-color: #202020; // Important to match with .highlight background and .highlight.err background-color
-$code-linenumber-color: #447fcf; // Important to match with .highlight.nf color
+$code-linenumber-color: #f5f6fa; // Important to match with .highlight.nf color
 $feedback-color: darken($sidebar-color, 3%);
 $table-background-color: lighten(
   $new-body-background-color,

--- a/docs/_sass/highlight/native.scss
+++ b/docs/_sass/highlight/native.scss
@@ -143,7 +143,7 @@ pre.highlight,
   }
 
   .nc {
-    color: #447fcf;
+    color: #f5f6fa;
     text-decoration: underline;
   }
 
@@ -164,7 +164,7 @@ pre.highlight,
   }
 
   .nf {
-    color: #447fcf;
+    color: #f5f6fa;
   }
 
   .nl {
@@ -172,7 +172,7 @@ pre.highlight,
   }
 
   .nn {
-    color: #447fcf;
+    color: #f5f6fa;
     text-decoration: underline;
   }
 


### PR DESCRIPTION
This PR adjusts the Callout block colors for better visibility, most notably affecting the highlight callouts on the [guided remediation page](https://google.github.io/osv-scanner/experimental/guided-remediation/)

Resolves #1291 