### PR TITLE
ci: exclude `osv-scalibr` from the minor golang deps group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,7 @@
     },
     {
       "matchCategories": ["golang"],
+      "matchPackageNames": ["!osv-scalibr"],
       "groupName": "osv-scanner minor"
     },
     {


### PR DESCRIPTION
This should hopefully be the last thing we need 🤞 