### PR TITLE
chore: adjust pseudo constraint for `osv-scalibr`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/go-git/go-billy/v5 v5.6.2
 	github.com/go-git/go-git/v5 v5.16.2
 	github.com/google/go-cmp v0.7.0
-	github.com/google/osv-scalibr v0.0.0-20250717211210-5a6c9471ffc4
+	github.com/google/osv-scalibr v0.3.2-0.20250717211210-5a6c9471ffc4
 	github.com/ianlancetaylor/demangle v0.0.0-20250628045327-2d64ad6b7ec5
 	github.com/jedib0t/go-pretty/v6 v6.6.7
 	github.com/muesli/reflow v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -215,8 +215,8 @@ github.com/google/go-containerregistry v0.20.6 h1:cvWX87UxxLgaH76b4hIvya6Dzz9qHB
 github.com/google/go-containerregistry v0.20.6/go.mod h1:T0x8MuoAoKX/873bkeSfLD2FAkwCDf9/HZgsFJ02E2Y=
 github.com/google/go-cpy v0.0.0-20211218193943-a9c933c06932 h1:5/4TSDzpDnHQ8rKEEQBjRlYx77mHOvXu08oGchxej7o=
 github.com/google/go-cpy v0.0.0-20211218193943-a9c933c06932/go.mod h1:cC6EdPbj/17GFCPDK39NRarlMI+kt+O60S12cNB5J9Y=
-github.com/google/osv-scalibr v0.0.0-20250717211210-5a6c9471ffc4 h1:781qxy0Baq69HJTdYoULKE6PBYQAL4mlRKaoZS8kKyw=
-github.com/google/osv-scalibr v0.0.0-20250717211210-5a6c9471ffc4/go.mod h1:fh2hHWWZDjTD3ILZMg/8DCZS8ubaUEnc0ThyzPoR/Xc=
+github.com/google/osv-scalibr v0.3.2-0.20250717211210-5a6c9471ffc4 h1:u3hmKVjwfrMKvPsr70V2C3mtG1dB8uMMDlk/L5H1OVk=
+github.com/google/osv-scalibr v0.3.2-0.20250717211210-5a6c9471ffc4/go.mod h1:fh2hHWWZDjTD3ILZMg/8DCZS8ubaUEnc0ThyzPoR/Xc=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=


### PR DESCRIPTION
It seems if you use 0.0.0 for a pseudo version, then renovate will want to upgrade to the latest tagged version rather than the latest digest, and that there's generally no explicit way to force renovate to only use digests.

I expect this means we'll need to adjust this again once the next version of osv-scalibr is tagged, but for now we can just set the version back to v0.3.2 🤷