### PR TITLE
ci: clean up renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,8 +12,7 @@
   "packageRules": [
     {
       "matchUpdateTypes": ["major"],
-      "groupName": "Major Updates",
-      "enabled": true
+      "groupName": "Major Updates"
     },
     {
       "matchCategories": ["golang"],
@@ -24,13 +23,8 @@
       "groupName": "workflows"
     },
     {
-      "matchDepTypes": ["golang"],
-      "enabled": false
-    },
-    {
       "matchPackageNames": ["github.com/google/osv-scalibr"],
-      "groupName": "osv-scalibr",
-      "enabled": true
+      "groupName": "osv-scalibr"
     }
   ],
   "ignorePaths": ["**/fixtures/**", "**/fixtures-go/**"],


### PR DESCRIPTION
Currently we have a rule that disables updated for the `golang` category which was added in an attempt to stop Renovate from updating the Go version in `go.mod`, but it's not clear if its doing anything and adds confusion so we're axing it