### PR TITLE
test: fail if there are dirty snapshots or if there is an issue cleaning snapshots

### DIFF
--- a/cmd/osv-scanner/scan/source/testmain_test.go
+++ b/cmd/osv-scanner/scan/source/testmain_test.go
@@ -28,7 +28,7 @@ func TestMain(m *testing.M) {
 	testcmd.CommandsUnderTest = []cmd.CommandBuilder{source.Command}
 	m.Run()
 
-	testutility.CleanSnapshots(m)
-
 	os.RemoveAll("./fixtures/.git")
+
+	testutility.CleanSnapshots(m)
 }

--- a/cmd/osv-scanner/scan/testmain_test.go
+++ b/cmd/osv-scanner/scan/testmain_test.go
@@ -28,7 +28,7 @@ func TestMain(m *testing.M) {
 	testcmd.CommandsUnderTest = []cmd.CommandBuilder{scan.Command}
 	m.Run()
 
-	testutility.CleanSnapshots(m)
-
 	os.RemoveAll("./fixtures/.git")
+
+	testutility.CleanSnapshots(m)
 }

--- a/cmd/osv-scanner/testmain_test.go
+++ b/cmd/osv-scanner/testmain_test.go
@@ -34,7 +34,7 @@ func TestMain(m *testing.M) {
 	}
 	m.Run()
 
-	testutility.CleanSnapshots(m)
-
 	os.RemoveAll("./fixtures/.git")
+
+	testutility.CleanSnapshots(m)
 }

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.6
 	github.com/charmbracelet/glamour v0.10.0
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
-	github.com/gkampitakis/go-snaps v0.5.13
+	github.com/gkampitakis/go-snaps v0.5.14
 	github.com/go-git/go-git/v5 v5.16.2
 	github.com/google/go-cmp v0.7.0
 	github.com/google/osv-scalibr v0.3.2-0.20250730184944-a53bc1d5872b

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,8 @@ github.com/gkampitakis/ciinfo v0.3.2 h1:JcuOPk8ZU7nZQjdUhctuhQofk7BGHuIy0c9Ez8BN
 github.com/gkampitakis/ciinfo v0.3.2/go.mod h1:1NIwaOcFChN4fa/B0hEBdAb6npDlFL8Bwx4dfRLRqAo=
 github.com/gkampitakis/go-diff v1.3.2 h1:Qyn0J9XJSDTgnsgHRdz9Zp24RaJeKMUHg2+PDZZdC4M=
 github.com/gkampitakis/go-diff v1.3.2/go.mod h1:LLgOrpqleQe26cte8s36HTWcTmMEur6OPYerdAAS9tk=
-github.com/gkampitakis/go-snaps v0.5.13 h1:Hhjmvv1WboSCxkR9iU2mj5PQ8tsz/y8ECGrIbjjPF8Q=
-github.com/gkampitakis/go-snaps v0.5.13/go.mod h1:HNpx/9GoKisdhw9AFOBT1N7DBs9DiHo/hGheFGBZ+mc=
+github.com/gkampitakis/go-snaps v0.5.14 h1:3fAqdB6BCPKHDMHAKRwtPUwYexKtGrNuw8HX/T/4neo=
+github.com/gkampitakis/go-snaps v0.5.14/go.mod h1:HNpx/9GoKisdhw9AFOBT1N7DBs9DiHo/hGheFGBZ+mc=
 github.com/glebarez/go-sqlite v1.20.3 h1:89BkqGOXR9oRmG58ZrzgoY/Fhy5x0M+/WV48U5zVrZ4=
 github.com/glebarez/go-sqlite v1.20.3/go.mod h1:u3N6D/wftiAzIOJtZl6BmedqxmmkDfH3q+ihjqxC9u0=
 github.com/gliderlabs/ssh v0.3.8 h1:a4YXD1V7xMF9g5nTkdfnja3Sxy1PVDCj1Zg4Wb8vY6c=

--- a/internal/testutility/utility.go
+++ b/internal/testutility/utility.go
@@ -2,6 +2,7 @@ package testutility
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"runtime"
 	"strings"
@@ -36,7 +37,16 @@ func applyWindowsReplacements(content string, replacements map[string]string) st
 
 // CleanSnapshots ensures that snapshots are relevant and sorted for consistency
 func CleanSnapshots(m *testing.M) {
-	snaps.Clean(m, snaps.CleanOpts{Sort: true})
+	dirty, err := snaps.Clean(m, snaps.CleanOpts{Sort: true})
+
+	if err != nil {
+		fmt.Println("Error cleaning snaps:", err)
+		os.Exit(1)
+	}
+	if dirty {
+		fmt.Println("Some snapshots were outdated.")
+		os.Exit(1)
+	}
 }
 
 // Skip is equivalent to t.Log followed by t.SkipNow, but allows tracking of


### PR DESCRIPTION
[`go-snaps` have added support](https://github.com/gkampitakis/go-snaps/issues/130) for signaling if there are dirty snapshots or if there was an issue with cleaning snapshots, so now our snapshot clean utility function will fail the tests if that is the case.

It feels a little meh to be doing an `os.Exit` in a function like this but the alternative would be to do this in every `TestMain` that uses snapshots, and we only have three packages whose `TestMain` does something after cleaning snapshots so its probably fine (for now at least)