### PR TITLE
chore: don't crash for packages without test files

### DIFF
--- a/scripts/report_uncleaned_snapshots.py
+++ b/scripts/report_uncleaned_snapshots.py
@@ -27,7 +27,10 @@ def report_lack_of_snapshot_cleaning(directory):
     annotate_file(file, 'Make sure that `TestMain` is calling `testutility.CleanSnapshots(m)` after the tests have been run')
     print(f'{file} is not calling `testutility.CleanSnapshots(m)`')
   else:
-    file = list(glob.iglob(os.path.join(directory, '*_test.go')))[0]
+    try:
+      file = list(glob.iglob(os.path.join(directory, '*_test.go')))[0]
+    except IndexError:
+      file = directory
 
     annotate_file(file, 'Please add a `testmain_test.go` file with a `TestMain` function that calls `testutility.CleanSnapshots(m)` after the tests have been run')
     print(f'{directory} does not have a `testmain_test.go` file with a `TestMain` function that calls `testutility.CleanSnapshots(m)` after the tests have been run')


### PR DESCRIPTION
Currently if you have a directory with `__snapshots__` but no tests, our script will crash - while it shouldn't be possible for this to happen on `main`, I think its good for us to handle since it can happen locally especially if you're switching between branches that add and remove packages
