### PR TITLE
fix(local): log and preserve package count before continuing on db error

### DIFF
--- a/internal/clients/clientimpl/localmatcher/localmatcher.go
+++ b/internal/clients/clientimpl/localmatcher/localmatcher.go
@@ -72,6 +72,9 @@ func (matcher *LocalMatcher) MatchVulnerabilities(ctx context.Context, invs []*e
 		db, err := matcher.loadDBFromCache(ctx, pkg.Ecosystem())
 
 		if err != nil {
+			// no logging here as the loader will have already done that
+			results = append(results, []*osvschema.Vulnerability{})
+
 			continue
 		}
 


### PR DESCRIPTION
The results from `MatchVulnerabilities` is expected to have the same items as packages that were provided but currently if the database cannot be loaded (such as because we're using an ecosystem that does not have a database available) we just "continue" resulting in off-by-n errors further down the line