### PR TITLE
fix: osv-scanner json scans not matching with correct ecosystem

### DIFF
--- a/cmd/osv-scanner/scan/source/__snapshots__/command_test.snap
+++ b/cmd/osv-scanner/scan/source/__snapshots__/command_test.snap
@@ -864,6 +864,24 @@ Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
 ::error file=fixtures/locks-many/package-lock.json::fixtures/locks-many/package-lock.json%0A+-----------+-------------------------------------+------+-----------------+---------------+%0A| PACKAGE   | VULNERABILITY ID                    | CVSS | CURRENT VERSION | FIXED VERSION |%0A+-----------+-------------------------------------+------+-----------------+---------------+%0A| ansi-html | https://osv.dev/GHSA-whgm-jr23-g3j9 | 7.5  | 0.0.1           | 0.0.8         |%0A+-----------+-------------------------------------+------+-----------------+---------------+
 ---
 
+[TestCommand/go_packages_in_osv-scanner.json_format - 1]
+Scanned <rootdir>/fixtures/locks-insecure/osv-scanner.json file as a osv-scanner and found 2 packages
+Total 1 package affected by 1 known vulnerability (0 Critical, 0 High, 0 Medium, 0 Low, 1 Unknown) from 1 ecosystem.
+1 vulnerability can be fixed.
+
+
++------------------------------+------+-----------+-----------+---------+---------------+------------------------------------------+
+| OSV URL                      | CVSS | ECOSYSTEM | PACKAGE   | VERSION | FIXED VERSION | SOURCE                                   |
++------------------------------+------+-----------+-----------+---------+---------------+------------------------------------------+
+| https://osv.dev/GO-2025-3828 |      | Go        | toolchain | 1.24.4  | 1.24.5        | fixtures/locks-insecure/osv-scanner.json |
++------------------------------+------+-----------+-----------+---------+---------------+------------------------------------------+
+
+---
+
+[TestCommand/go_packages_in_osv-scanner.json_format - 2]
+
+---
+
 [TestCommand/ignores_without_reason_should_be_explicitly_called_out - 1]
 Scanning dir ./fixtures/locks-many/package-lock.json
 Scanning dir ./fixtures/locks-many/composer.lock

--- a/cmd/osv-scanner/scan/source/command_test.go
+++ b/cmd/osv-scanner/scan/source/command_test.go
@@ -284,6 +284,11 @@ func TestCommand(t *testing.T) {
 			Args: []string{"", "source", "--config=./fixtures/osv-scanner-empty-config.toml", "./fixtures/locks-requirements"},
 			Exit: 1,
 		},
+		{
+			Name: "go_packages_in_osv-scanner.json_format",
+			Args: []string{"", "source", "--config=./fixtures/osv-scanner-empty-config.toml", "-L", "osv-scanner:./fixtures/locks-insecure/osv-scanner.json"},
+			Exit: 1,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {

--- a/cmd/osv-scanner/scan/source/fixtures/locks-insecure/osv-scanner.json
+++ b/cmd/osv-scanner/scan/source/fixtures/locks-insecure/osv-scanner.json
@@ -1,0 +1,28 @@
+{
+  "results": [
+    {
+      "source": {},
+      "packages": [
+        {
+          "package": {
+            "name": "stdlib",
+            "version": "1.24.4",
+            "ecosystem": "Go"
+          }
+        }
+      ]
+    },
+    {
+      "source": {},
+      "packages": [
+        {
+          "package": {
+            "name": "toolchain",
+            "version": "1.24.4",
+            "ecosystem": "Go"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/internal/imodels/imodels.go
+++ b/internal/imodels/imodels.go
@@ -17,7 +17,8 @@ import (
 	"github.com/google/osv-scalibr/inventory"
 	"github.com/google/osv-scanner/v2/internal/cachedregexp"
 	"github.com/google/osv-scanner/v2/internal/cmdlogger"
-	"github.com/google/osv-scanner/v2/internal/imodels/ecosystem"
+	"github.com/google/osv-scanner/v2/internal/imodels/ecosystem"	
+	"github.com/google/osv-scanner/v2/internal/scalibrextract/language/osv/osvscannerjson"
 	"github.com/google/osv-scanner/v2/internal/scalibrextract/vcs/gitrepo"
 	"github.com/google/osv-scanner/v2/internal/scalibrplugin"
 	"github.com/google/osv-scanner/v2/internal/utility/purl"
@@ -97,6 +98,10 @@ func (pkg *PackageInfo) Name() string {
 
 func (pkg *PackageInfo) Ecosystem() ecosystem.Parsed {
 	ecosystemStr := pkg.Package.Ecosystem()
+
+	if metadata, ok := pkg.Metadata.(*osvscannerjson.Metadata); ok {
+		ecosystemStr = metadata.Ecosystem
+	}
 
 	// TODO(v2): SBOM special case, to be removed after PURL to ESI conversion within each extractor is complete
 	if pkg.purlCache != nil {

--- a/internal/imodels/imodels.go
+++ b/internal/imodels/imodels.go
@@ -17,7 +17,7 @@ import (
 	"github.com/google/osv-scalibr/inventory"
 	"github.com/google/osv-scanner/v2/internal/cachedregexp"
 	"github.com/google/osv-scanner/v2/internal/cmdlogger"
-	"github.com/google/osv-scanner/v2/internal/imodels/ecosystem"	
+	"github.com/google/osv-scanner/v2/internal/imodels/ecosystem"
 	"github.com/google/osv-scanner/v2/internal/scalibrextract/language/osv/osvscannerjson"
 	"github.com/google/osv-scanner/v2/internal/scalibrextract/vcs/gitrepo"
 	"github.com/google/osv-scanner/v2/internal/scalibrplugin"

--- a/internal/scalibrextract/language/osv/osvscannerjson/extractor.go
+++ b/internal/scalibrextract/language/osv/osvscannerjson/extractor.go
@@ -10,7 +10,6 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem"
 	"github.com/google/osv-scalibr/inventory"
 	"github.com/google/osv-scalibr/plugin"
-	"github.com/google/osv-scalibr/purl"
 	"github.com/google/osv-scanner/v2/pkg/models"
 )
 
@@ -53,11 +52,12 @@ func (e Extractor) Extract(_ context.Context, input *filesystem.ScanInput) (inve
 			inv := extractor.Package{
 				Name:    pkg.Package.Name,
 				Version: pkg.Package.Version,
-				Metadata: Metadata{
+				Metadata: &Metadata{
 					Ecosystem:  pkg.Package.Ecosystem,
 					SourceInfo: res.Source,
 				},
 				Locations: []string{input.Path},
+				Plugins:   []string{"osv/osvscannerjson"},
 			}
 			if pkg.Package.Commit != "" {
 				inv.SourceCode = &extractor.SourceCodeIdentifier{
@@ -72,20 +72,6 @@ func (e Extractor) Extract(_ context.Context, input *filesystem.ScanInput) (inve
 	return inventory.Inventory{
 		Packages: packages,
 	}, nil
-}
-
-// ToPURL converts an inventory created by this extractor into a PURL.
-func (e Extractor) ToPURL(_ *extractor.Package) *purl.PackageURL {
-	// TODO: support purl conversion
-	return nil
-}
-
-// ToCPEs is not applicable as this extractor does not infer CPEs from the Package.
-func (e Extractor) ToCPEs(_ *extractor.Package) []string { return []string{} }
-
-// Ecosystem returns the OSV ecosystem ('npm') of the software extracted by this extractor.
-func (e Extractor) Ecosystem(i *extractor.Package) string {
-	return i.Metadata.(Metadata).Ecosystem
 }
 
 var _ filesystem.Extractor = Extractor{}

--- a/internal/scalibrextract/language/osv/osvscannerjson/extractor_test.go
+++ b/internal/scalibrextract/language/osv/osvscannerjson/extractor_test.go
@@ -39,7 +39,8 @@ func TestExtractor_Extract(t *testing.T) {
 					Name:      "activesupport",
 					Version:   "7.0.7",
 					Locations: []string{"testdata/one-package.json"},
-					Metadata: osvscannerjson.Metadata{
+					Plugins:   []string{"osv/osvscannerjson"},
+					Metadata: &osvscannerjson.Metadata{
 						Ecosystem: "RubyGems",
 						SourceInfo: models.SourceInfo{
 							Path: "/path/to/Gemfile.lock",
@@ -57,10 +58,11 @@ func TestExtractor_Extract(t *testing.T) {
 			WantPackages: []*extractor.Package{
 				{
 					Locations: []string{"testdata/one-package-commit.json"},
+					Plugins:   []string{"osv/osvscannerjson"},
 					SourceCode: &extractor.SourceCodeIdentifier{
 						Commit: "9a6bd55c9d0722cb101fe85a3b22d89e4ff4fe52",
 					},
-					Metadata: osvscannerjson.Metadata{
+					Metadata: &osvscannerjson.Metadata{
 						SourceInfo: models.SourceInfo{
 							Path: "/path/to/Gemfile.lock",
 							Type: "lockfile",
@@ -79,7 +81,8 @@ func TestExtractor_Extract(t *testing.T) {
 					Name:      "crossbeam-utils",
 					Version:   "0.6.6",
 					Locations: []string{"testdata/multiple-packages-with-vulns.json"},
-					Metadata: osvscannerjson.Metadata{
+					Plugins:   []string{"osv/osvscannerjson"},
+					Metadata: &osvscannerjson.Metadata{
 						Ecosystem: "crates.io",
 						SourceInfo: models.SourceInfo{
 							Path: "/path/to/Cargo.lock",
@@ -91,7 +94,8 @@ func TestExtractor_Extract(t *testing.T) {
 					Name:      "memoffset",
 					Version:   "0.5.6",
 					Locations: []string{"testdata/multiple-packages-with-vulns.json"},
-					Metadata: osvscannerjson.Metadata{
+					Plugins:   []string{"osv/osvscannerjson"},
+					Metadata: &osvscannerjson.Metadata{
 						Ecosystem: "crates.io",
 						SourceInfo: models.SourceInfo{
 							Path: "/path/to/Cargo.lock",
@@ -103,7 +107,8 @@ func TestExtractor_Extract(t *testing.T) {
 					Name:      "smallvec",
 					Version:   "1.6.0",
 					Locations: []string{"testdata/multiple-packages-with-vulns.json"},
-					Metadata: osvscannerjson.Metadata{
+					Plugins:   []string{"osv/osvscannerjson"},
+					Metadata: &osvscannerjson.Metadata{
 						Ecosystem: "crates.io",
 						SourceInfo: models.SourceInfo{
 							Path: "/path/to/Cargo.lock",


### PR DESCRIPTION
Fixes #2139 

Since osv-scalibr updated how Ecosystem is returned to be centralized, we need to add our own check in imodels to return the correct ecosystem.

Also:
- Removed extra functions in the extractor that's no longer needed
- Added a test for the regression.
 