### PR TITLE
fix: invalid ecosystem error

### DIFF
--- a/cmd/osv-scanner/scan/image/__snapshots__/command_test.snap
+++ b/cmd/osv-scanner/scan/image/__snapshots__/command_test.snap
@@ -595,8 +595,8 @@ You can also view the full vulnerability list in your terminal with: `osv-scanne
 Scanning local image tarball "../../../../internal/image/fixtures/test-package-tracing.tar"
 
 Container Scanning Result (Alpine Linux v3.20):
-Total 8 packages affected by 66 known vulnerabilities (0 Critical, 1 High, 0 Medium, 0 Low, 65 Unknown) from 2 ecosystems.
-66 vulnerabilities can be fixed.
+Total 8 packages affected by 72 known vulnerabilities (0 Critical, 1 High, 0 Medium, 0 Low, 71 Unknown) from 2 ecosystems.
+72 vulnerabilities can be fixed.
 
 
 Go
@@ -605,42 +605,42 @@ Go
 +---------+-------------------+---------------+------------+------------------+---------------+
 | PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
 +---------+-------------------+---------------+------------+------------------+---------------+
-| stdlib  | 1.22.4            | Fix Available |         10 | # 9 Layer        | --            |
+| stdlib  | 1.22.4            | Fix Available |         11 | # 9 Layer        | --            |
 +---------+-------------------+---------------+------------+------------------+---------------+
 +---------------------------------------------------------------------------------------------+
 | Source:artifact:/go/bin/ptf-1.2.0                                                           |
 +---------+-------------------+---------------+------------+------------------+---------------+
 | PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
 +---------+-------------------+---------------+------------+------------------+---------------+
-| stdlib  | 1.22.4            | Fix Available |         10 | # 2 Layer        | --            |
+| stdlib  | 1.22.4            | Fix Available |         11 | # 2 Layer        | --            |
 +---------+-------------------+---------------+------------+------------------+---------------+
 +---------------------------------------------------------------------------------------------+
 | Source:artifact:/go/bin/ptf-1.3.0                                                           |
 +---------+-------------------+---------------+------------+------------------+---------------+
 | PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
 +---------+-------------------+---------------+------------+------------------+---------------+
-| stdlib  | 1.22.4            | Fix Available |         10 | # 4 Layer        | --            |
+| stdlib  | 1.22.4            | Fix Available |         11 | # 4 Layer        | --            |
 +---------+-------------------+---------------+------------+------------------+---------------+
 +---------------------------------------------------------------------------------------------+
 | Source:artifact:/go/bin/ptf-1.3.0-moved                                                     |
 +---------+-------------------+---------------+------------+------------------+---------------+
 | PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
 +---------+-------------------+---------------+------------+------------------+---------------+
-| stdlib  | 1.22.4            | Fix Available |         10 | # 3 Layer        | --            |
+| stdlib  | 1.22.4            | Fix Available |         11 | # 3 Layer        | --            |
 +---------+-------------------+---------------+------------+------------------+---------------+
 +---------------------------------------------------------------------------------------------+
 | Source:artifact:/go/bin/ptf-1.4.0                                                           |
 +---------+-------------------+---------------+------------+------------------+---------------+
 | PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
 +---------+-------------------+---------------+------------+------------------+---------------+
-| stdlib  | 1.22.4            | Fix Available |         10 | # 2 Layer        | --            |
+| stdlib  | 1.22.4            | Fix Available |         11 | # 2 Layer        | --            |
 +---------+-------------------+---------------+------------+------------------+---------------+
 +---------------------------------------------------------------------------------------------+
 | Source:artifact:/go/bin/ptf-vulnerable                                                      |
 +---------+-------------------+---------------+------------+------------------+---------------+
 | PACKAGE | INSTALLED VERSION | FIX AVAILABLE | VULN COUNT | INTRODUCED LAYER | IN BASE IMAGE |
 +---------+-------------------+---------------+------------+------------------+---------------+
-| stdlib  | 1.22.4            | Fix Available |         10 | # 7 Layer        | --            |
+| stdlib  | 1.22.4            | Fix Available |         11 | # 7 Layer        | --            |
 +---------+-------------------+---------------+------------+------------------+---------------+
 Alpine:v3.20
 +------------------------------------------------------------------------------------------------------------------------------+
@@ -1717,9 +1717,10 @@ Scanning local image tarball "../../../../internal/image/fixtures/test-python-fu
             "GO-2025-3447",
             "GO-2025-3563",
             "GO-2025-3750",
-            "GO-2025-3751"
+            "GO-2025-3751",
+            "GO-2025-3849"
           ],
-          "groups": 10
+          "groups": 11
         },
         {
           "package": {

--- a/cmd/osv-scanner/scan/source/__snapshots__/command_test.snap
+++ b/cmd/osv-scanner/scan/source/__snapshots__/command_test.snap
@@ -866,13 +866,14 @@ Scanned <rootdir>/fixtures/locks-many/package-lock.json file and found 1 package
 
 [TestCommand/go_packages_in_osv-scanner.json_format - 1]
 Scanned <rootdir>/fixtures/locks-insecure/osv-scanner.json file as a osv-scanner and found 2 packages
-Total 1 package affected by 1 known vulnerability (0 Critical, 0 High, 0 Medium, 0 Low, 1 Unknown) from 1 ecosystem.
-1 vulnerability can be fixed.
+Total 2 packages affected by 2 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 2 Unknown) from 1 ecosystem.
+2 vulnerabilities can be fixed.
 
 
 +------------------------------+------+-----------+-----------+---------+---------------+------------------------------------------+
 | OSV URL                      | CVSS | ECOSYSTEM | PACKAGE   | VERSION | FIXED VERSION | SOURCE                                   |
 +------------------------------+------+-----------+-----------+---------+---------------+------------------------------------------+
+| https://osv.dev/GO-2025-3849 |      | Go        | stdlib    | 1.24.4  | 1.24.6        | fixtures/locks-insecure/osv-scanner.json |
 | https://osv.dev/GO-2025-3828 |      | Go        | toolchain | 1.24.4  | 1.24.5        | fixtures/locks-insecure/osv-scanner.json |
 +------------------------------+------+-----------+-----------+---------+---------------+------------------------------------------+
 
@@ -3411,6 +3412,24 @@ Total 2 packages affected by 2 known vulnerabilities (1 Critical, 1 High, 0 Medi
 ---
 
 [TestCommand_LockfileWithExplicitParseAs/when_an_explicit_parse-as_is_given,_it's_applied_to_that_file - 2]
+
+---
+
+[TestCommand_MoreLockfiles/Package.resolved_-_Unsupported_ecosystem,_should_not_be_scanned - 1]
+
+---
+
+[TestCommand_MoreLockfiles/Package.resolved_-_Unsupported_ecosystem,_should_not_be_scanned - 2]
+could not determine extractor suitable to this file
+
+---
+
+[TestCommand_MoreLockfiles/Podfile.lock_-_Unsupported_ecosystem,_should_not_be_scanned - 1]
+
+---
+
+[TestCommand_MoreLockfiles/Podfile.lock_-_Unsupported_ecosystem,_should_not_be_scanned - 2]
+could not determine extractor suitable to this file
 
 ---
 

--- a/cmd/osv-scanner/scan/source/command_test.go
+++ b/cmd/osv-scanner/scan/source/command_test.go
@@ -960,13 +960,16 @@ func TestCommand_MoreLockfiles(t *testing.T) {
 			Args: []string{"", "source", "-L", "./fixtures/locks-scalibr/gems.locked"},
 			Exit: 1,
 		},
-		/*
-			{
-				name: "Package.resolved",
-				args: []string{"", "source", "-L", "./fixtures/locks-scalibr/Package.resolved"},
-				exit: 0,
-			},
-		*/
+		{
+			Name: "Podfile.lock - Unsupported ecosystem, should not be scanned",
+			Args: []string{"", "source", "-L", "./fixtures/locks-scalibr/Podfile.lock"},
+			Exit: 127,
+		},
+		{
+			Name: "Package.resolved - Unsupported ecosystem, should not be scanned",
+			Args: []string{"", "source", "-L", "./fixtures/locks-scalibr/Package.resolved"},
+			Exit: 127,
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/osv-scanner/scan/source/fixtures/locks-scalibr/Podfile.lock
+++ b/cmd/osv-scanner/scan/source/fixtures/locks-scalibr/Podfile.lock
@@ -1,0 +1,42 @@
+PODS:
+  - GlossButtonNode (3.1.2):
+    - Texture/Core (~> 3)
+    - TextureSwiftSupport (>= 3.10.0)
+  - PINCache (3.0.3):
+    - PINCache/Arc-exception-safe (= 3.0.3)
+    - PINCache/Core (= 3.0.3)
+
+DEPENDENCIES:
+  - GlossButtonNode
+  - Reveal-SDK
+  - SwiftGen
+  - Texture
+  - TextureSwiftSupport
+  - TinyConstraints
+
+SPEC REPOS:
+  trunk:
+    - GlossButtonNode
+    - PINCache
+    - PINOperation
+    - PINRemoteImage
+    - Reveal-SDK
+    - SwiftGen
+    - Texture
+    - TextureSwiftSupport
+    - TinyConstraints
+
+SPEC CHECKSUMS:
+  GlossButtonNode: 4ea1197a744f2fb5fb875fe31caf17ded4762e8f
+  PINCache: 7a8fc1a691173d21dbddbf86cd515de6efa55086
+  PINOperation: 00c935935f1e8cf0d1e2d6b542e75b88fc3e5e20
+  PINRemoteImage: f1295b29f8c5e640e25335a1b2bd9d805171bd01
+  Reveal-SDK: effba1c940b8337195563c425a6b5862ec875caa
+  SwiftGen: a6d22010845f08fe18fbdf3a07a8e380fd22e0ea
+  Texture: 2e8ab2519452515f7f5a520f5a8f7e0a413abfa3
+  TextureSwiftSupport: c515c7927fab92d0d9485f49b885b8c5de34fbfb
+  TinyConstraints: 7b7ccc0c485bb3bb47082138ff28bc33cd49897f
+
+PODFILE CHECKSUM: 07aa55f54421f6e6d3a920c11716a89fc9243d1b
+
+COCOAPODS: 1.11.2

--- a/internal/imodels/ecosystem/ecosystem.go
+++ b/internal/imodels/ecosystem/ecosystem.go
@@ -91,6 +91,53 @@ func (p Parsed) String() string {
 	return str
 }
 
+func (p Parsed) IsValid() bool {
+	// Missing ecosystems here would be caught by the "exhaustive" linter
+	switch p.Ecosystem {
+	case osvschema.EcosystemAlmaLinux,
+		osvschema.EcosystemAlpaquita,
+		osvschema.EcosystemAlpine,
+		osvschema.EcosystemAndroid,
+		osvschema.EcosystemBellSoftHardenedContainers,
+		osvschema.EcosystemBioconductor,
+		osvschema.EcosystemBitnami,
+		osvschema.EcosystemChainguard,
+		osvschema.EcosystemConanCenter,
+		osvschema.EcosystemCRAN,
+		osvschema.EcosystemCratesIO,
+		osvschema.EcosystemDebian,
+		osvschema.EcosystemGHC,
+		osvschema.EcosystemGitHubActions,
+		osvschema.EcosystemGo,
+		osvschema.EcosystemHackage,
+		osvschema.EcosystemHex,
+		osvschema.EcosystemKubernetes,
+		osvschema.EcosystemLinux,
+		osvschema.EcosystemMageia,
+		osvschema.EcosystemMaven,
+		osvschema.EcosystemMinimOS,
+		osvschema.EcosystemNPM,
+		osvschema.EcosystemNuGet,
+		osvschema.EcosystemOpenEuler,
+		osvschema.EcosystemOpenSUSE,
+		osvschema.EcosystemOSSFuzz,
+		osvschema.EcosystemPackagist,
+		osvschema.EcosystemPhotonOS,
+		osvschema.EcosystemPub,
+		osvschema.EcosystemPyPI,
+		osvschema.EcosystemRedHat,
+		osvschema.EcosystemRockyLinux,
+		osvschema.EcosystemRubyGems,
+		osvschema.EcosystemSUSE,
+		osvschema.EcosystemSwiftURL,
+		osvschema.EcosystemUbuntu,
+		osvschema.EcosystemWolfi:
+		return true
+	}
+
+	return false
+}
+
 // MustParse parses a string into a constants.Ecosystem and an optional suffix specified with a ":"
 // Panics if there is an invalid ecosystem
 func MustParse(str string) Parsed {

--- a/internal/scalibrplugin/__snapshots__/resolve_test.snap
+++ b/internal/scalibrplugin/__snapshots__/resolve_test.snap
@@ -89,8 +89,6 @@ r/renvlock
 ruby/gemfilelock
 ruby/gemspec
 rust/cargolock
-swift/packageresolved
-swift/podfilelock
 ---
 
 [TestResolve_Extractors_Presets/sbom - 1]

--- a/internal/scalibrplugin/presets.go
+++ b/internal/scalibrplugin/presets.go
@@ -10,6 +10,8 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/requirements"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/python/requirementsnet"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/rust/cargotoml"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/swift/packageresolved"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/swift/podfilelock"
 	extractors "github.com/google/osv-scalibr/extractor/filesystem/list"
 	"github.com/google/osv-scalibr/extractor/filesystem/secrets"
 	"github.com/google/osv-scanner/v2/internal/scalibrextract/filesystem/vendored"
@@ -33,6 +35,9 @@ var ExtractorPresets = map[string]extractors.InitMap{
 			pomxml.Name, pomxmlnet.Name,
 			requirements.Name, requirementsnet.Name,
 			secrets.Name, cargotoml.Name,
+			// We don't support Cocoapods ecosystem
+			podfilelock.Name,
+			packageresolved.Name,
 		}),
 		extractors.InitMap{
 			pomxmlenhanceable.Name:      {pomxmlenhanceable.New},


### PR DESCRIPTION
Fixes: #2151

It looks like osv.dev will return invalid ecosystem for all queries in a batchquery if 1 query has an invalid ecosystem. This means we have to add a check in osv-scanner to prevent any invalid ecosystems from being sent. 

This does mean if we release osv-scanner with extractors to support future ecosystems that are currently invalid, people will have to update to get support for those ecosystems when supported in osv.dev in the future, instead of being able to use existing version of osv-scanner. I don't think this is a common case, so this is acceptable.

Changes in this PR:
- Added Podfile.lock to test cases, should return 127 if scanned alone
- Excude Podfile.lock and Package.resolved because we don't support the Swift Cocoapods ecosystem  (SwiftURL is for the Swift package manager, which is different from Cocapods?)
- Added a IsValid() check for ecosystems, which contains all the current ecosystems within osvschema. Missing ecosystems would be caught by the exhaustive linter in the future.
- Filter on IsValid ecosystems so we don't send queries with invalid ecosystems.
- Fix what seemed to be a bug with unknown Maven packages not being skipped.
