### PR TITLE
fix: Include unscannable packages with --all-packages flag (#2157)

### DIFF
--- a/pkg/osvscanner/filter.go
+++ b/pkg/osvscanner/filter.go
@@ -15,7 +15,11 @@ import (
 // filterUnscannablePackages removes packages that don't have enough information to be scanned or
 // are not a supported ecosystem
 // e,g, local packages that specified by path
-func filterUnscannablePackages(scanResults *results.ScanResults) {
+func filterUnscannablePackages(scanResults *results.ScanResults, showAllPackages bool) {
+	if showAllPackages {
+		cmdlogger.Infof("Skipping filtering of unscannable packages as --all-packages is set.")
+		return
+	}
 	packageResults := make([]imodels.PackageScanResult, 0, len(scanResults.PackageScanResults))
 	for _, psr := range scanResults.PackageScanResults {
 		p := psr.PackageInfo

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -234,7 +234,8 @@ func DoScan(actions ScannerActions) (models.VulnerabilityResults, error) {
 	scanResult.GenericFindings = packagesAndFindings.GenericFindings
 
 	// ----- Filtering -----
-	filterUnscannablePackages(&scanResult)
+	filterUnscannablePackages(&scanResult, actions.ShowAllPackages)
+
 	filterIgnoredPackages(&scanResult)
 
 	// ----- Custom Overrides -----
@@ -369,7 +370,7 @@ func DoContainerScan(actions ScannerActions) (models.VulnerabilityResults, error
 	}
 
 	// ----- Filtering -----
-	filterUnscannablePackages(&scanResult)
+	filterUnscannablePackages(&scanResult, actions.ShowAllPackages)
 	filterIgnoredPackages(&scanResult)
 
 	filterNonContainerRelevantPackages(&scanResult)


### PR DESCRIPTION
The `--all-packages` flag previously excluded packages that couldn’t be scanned (unscannable packages). This fix updates the `filterUnscannablePackages` function in `pkg/osvscanner/filter.go` to respect the `showAllPackages` flag, ensuring these packages are included in the output and providing a more complete package list.

A simple conditional check was added to skip filtering unscannable packages when `--all-packages` is set.

The tests fail initially because a new log message,
"Skipping filtering of unscannable packages as --all-packages is set."
was added. This causes snapshot mismatches. Updating the snapshots will resolve the test failures.