### PR TITLE
fix: unimportant vulns returning 1 error code when not image scanning

### DIFF
--- a/cmd/osv-scanner/scan/source/__snapshots__/command_test.snap
+++ b/cmd/osv-scanner/scan/source/__snapshots__/command_test.snap
@@ -4323,3 +4323,38 @@ No issues found
 [TestCommand_WithDetector_OnLinux/ssh_version_is_before_first_vuln_version - 2]
 
 ---
+
+[TestCommand/folder_of_supported_sbom_with_only_unimportant - 1]
+Scanning dir ./testdata/sbom-insecure/only-unimportant.spdx.json
+Scanned <rootdir>/testdata/sbom-insecure/only-unimportant.spdx.json file and found 1 package
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+
+
+---
+
+[TestCommand/folder_of_supported_sbom_with_only_unimportant - 2]
+
+---
+
+[TestCommand/folder_of_supported_sbom_with_only_unimportant#01 - 1]
+Scanning dir ./testdata/sbom-insecure/only-unimportant.spdx.json
+Scanned <rootdir>/testdata/sbom-insecure/only-unimportant.spdx.json file and found 1 package
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+
++---------------------------------------+------+-----------+---------+--------------------+---------------+---------------------------------------------------+
+| OSV URL                               | CVSS | ECOSYSTEM | PACKAGE | VERSION            | FIXED VERSION | SOURCE                                            |
++---------------------------------------+------+-----------+---------+--------------------+---------------+---------------------------------------------------+
+| Unimportant vulnerabilities           |      |           |         |                    |               |                                                   |
++---------------------------------------+------+-----------+---------+--------------------+---------------+---------------------------------------------------+
+| https://osv.dev/UBUNTU-CVE-2017-11164 | 7.5  | Ubuntu    | pcre3   | 2:8.39-12ubuntu0.1 | --            | testdata/sbom-insecure/only-unimportant.spdx.json |
++---------------------------------------+------+-----------+---------+--------------------+---------------+---------------------------------------------------+
+
+---
+
+[TestCommand/folder_of_supported_sbom_with_only_unimportant#01 - 2]
+
+---

--- a/cmd/osv-scanner/scan/source/__snapshots__/command_test.snap
+++ b/cmd/osv-scanner/scan/source/__snapshots__/command_test.snap
@@ -708,15 +708,51 @@ Scanned <rootdir>/testdata/locks-insecure/osv-scanner-custom.json file and found
 
 ---
 
+[TestCommand/folder_of_supported_sbom_with_only_unimportant - 1]
+Scanning dir ./testdata/sbom-insecure/only-unimportant.spdx.json
+Scanned <rootdir>/testdata/sbom-insecure/only-unimportant.spdx.json file and found 1 package
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+
+
+---
+
+[TestCommand/folder_of_supported_sbom_with_only_unimportant - 2]
+
+---
+
+[TestCommand/folder_of_supported_sbom_with_only_unimportant#01 - 1]
+Scanning dir ./testdata/sbom-insecure/only-unimportant.spdx.json
+Scanned <rootdir>/testdata/sbom-insecure/only-unimportant.spdx.json file and found 1 package
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+
++---------------------------------------+------+-----------+---------+--------------------+---------------+---------------------------------------------------+
+| OSV URL                               | CVSS | ECOSYSTEM | PACKAGE | VERSION            | FIXED VERSION | SOURCE                                            |
++---------------------------------------+------+-----------+---------+--------------------+---------------+---------------------------------------------------+
+| Unimportant vulnerabilities           |      |           |         |                    |               |                                                   |
++---------------------------------------+------+-----------+---------+--------------------+---------------+---------------------------------------------------+
+| https://osv.dev/UBUNTU-CVE-2017-11164 | 7.5  | Ubuntu    | pcre3   | 2:8.39-12ubuntu0.1 | --            | testdata/sbom-insecure/only-unimportant.spdx.json |
++---------------------------------------+------+-----------+---------+--------------------+---------------+---------------------------------------------------+
+
+---
+
+[TestCommand/folder_of_supported_sbom_with_only_unimportant#01 - 2]
+
+---
+
 [TestCommand/folder_of_supported_sbom_with_vulns - 1]
 Scanning dir ./testdata/sbom-insecure/
 Scanned <rootdir>/testdata/sbom-insecure/alpine-zlib-16.cdx.json file and found 1 package
 Scanned <rootdir>/testdata/sbom-insecure/alpine.cdx.xml file and found 15 packages
 Scanned <rootdir>/testdata/sbom-insecure/bad-purls.cdx.xml file and found 15 packages
+Scanned <rootdir>/testdata/sbom-insecure/only-unimportant.spdx.json file and found 1 package
 Scanned <rootdir>/testdata/sbom-insecure/postgres-stretch.cdx.xml file and found 136 packages
 Scanned <rootdir>/testdata/sbom-insecure/with-duplicates.cdx.xml file and found 17 packages
 Filtered 9 local/unscannable package/s from the scan.
-Total 26 packages affected by 154 known vulnerabilities (20 Critical, 61 High, 37 Medium, 1 Low, 35 Unknown) from 3 ecosystems.
+Total 26 packages affected by 154 known vulnerabilities (20 Critical, 61 High, 37 Medium, 1 Low, 35 Unknown) from 4 ecosystems.
 8 vulnerabilities can be fixed.
 
 
@@ -902,27 +938,6 @@ Total 26 packages affected by 154 known vulnerabilities (20 Critical, 61 High, 3
 | https://osv.dev/DSA-5123-1          | 8.8  | Debian    | xz-utils                       | 5.2.2-1.2+deb9u1                   | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml                     |
 | https://osv.dev/DSA-5895-1          |      | Debian    | xz-utils                       | 5.2.2-1.2+deb9u1                   | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml                     |
 | https://osv.dev/CVE-2024-3094       | 10.0 | Debian    | xz-utils                       | 5.2.2-1.2+deb9u1                   | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml                     |
-+-------------------------------------+------+-----------+--------------------------------+------------------------------------+-----------------------------------+---------------------------------------------------------------------+
-| Unimportant vulnerabilities         |      |           |                                |                                    |                                   |                                                                     |
-+-------------------------------------+------+-----------+--------------------------------+------------------------------------+-----------------------------------+---------------------------------------------------------------------+
-| https://osv.dev/CVE-2011-3374       | 3.7  | Debian    | apt                            | 1.4.11                             | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml                     |
-| https://osv.dev/CVE-2019-18276      | 7.8  | Debian    | bash                           | 4.4-5                              | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml                     |
-| https://osv.dev/CVE-2017-18018      | 4.7  | Debian    | coreutils                      | 8.26-3                             | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml                     |
-| https://osv.dev/CVE-2025-5278       |      | Debian    | coreutils                      | 8.26-3                             | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml                     |
-| https://osv.dev/CVE-2018-6829       | 7.5  | Debian    | libgcrypt20                    | 1.7.6-2+deb9u4                     | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml                     |
-| https://osv.dev/CVE-2024-2236       |      | Debian    | libgcrypt20                    | 1.7.6-2+deb9u4                     | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml                     |
-| https://osv.dev/CVE-2018-1000654    | 5.5  | Debian    | libtasn1-6                     | 4.10-1.1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml                     |
-| https://osv.dev/DSA-5949-1          | 7.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml                     |
-| https://osv.dev/CVE-2020-24977      | 6.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml                     |
-| https://osv.dev/CVE-2011-4116       | 3.3  | Debian    | perl                           | 5.24.1-3+deb9u7                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml                     |
-| https://osv.dev/CVE-2022-48522      | 9.8  | Debian    | perl                           | 5.24.1-3+deb9u7                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml                     |
-| https://osv.dev/CVE-2023-31486      | 8.1  | Debian    | perl                           | 5.24.1-3+deb9u7                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml                     |
-| https://osv.dev/CVE-2005-2541       |      | Debian    | tar                            | 1.29b-1.1+deb9u1                   | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml                     |
-| https://osv.dev/CVE-2019-9923       | 7.5  | Debian    | tar                            | 1.29b-1.1+deb9u1                   | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml                     |
-| https://osv.dev/CVE-2021-20193      | 3.3  | Debian    | tar                            | 1.29b-1.1+deb9u1                   | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml                     |
-| https://osv.dev/CVE-2022-48303      | 5.5  | Debian    | tar                            | 1.29b-1.1+deb9u1                   | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml                     |
-| https://osv.dev/CVE-2018-7738       | 7.8  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml                     |
-| https://osv.dev/CVE-2022-0563       | 5.5  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml                     |
 +-------------------------------------+------+-----------+--------------------------------+------------------------------------+-----------------------------------+---------------------------------------------------------------------+
 
 ---
@@ -3249,27 +3264,6 @@ Total 21 packages affected by 147 known vulnerabilities (17 Critical, 59 High, 3
 | https://osv.dev/DSA-5895-1          |      | Debian    | xz-utils                       | 5.2.2-1.2+deb9u1                   | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/CVE-2024-3094       | 10.0 | Debian    | xz-utils                       | 5.2.2-1.2+deb9u1                   | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 +-------------------------------------+------+-----------+--------------------------------+------------------------------------+-----------------------------------+-------------------------------------------------+
-| Unimportant vulnerabilities         |      |           |                                |                                    |                                   |                                                 |
-+-------------------------------------+------+-----------+--------------------------------+------------------------------------+-----------------------------------+-------------------------------------------------+
-| https://osv.dev/CVE-2011-3374       | 3.7  | Debian    | apt                            | 1.4.11                             | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2019-18276      | 7.8  | Debian    | bash                           | 4.4-5                              | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-18018      | 4.7  | Debian    | coreutils                      | 8.26-3                             | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2025-5278       |      | Debian    | coreutils                      | 8.26-3                             | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-6829       | 7.5  | Debian    | libgcrypt20                    | 1.7.6-2+deb9u4                     | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2024-2236       |      | Debian    | libgcrypt20                    | 1.7.6-2+deb9u4                     | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-1000654    | 5.5  | Debian    | libtasn1-6                     | 4.10-1.1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5949-1          | 7.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2020-24977      | 6.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2011-4116       | 3.3  | Debian    | perl                           | 5.24.1-3+deb9u7                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-48522      | 9.8  | Debian    | perl                           | 5.24.1-3+deb9u7                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2023-31486      | 8.1  | Debian    | perl                           | 5.24.1-3+deb9u7                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2005-2541       |      | Debian    | tar                            | 1.29b-1.1+deb9u1                   | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2019-9923       | 7.5  | Debian    | tar                            | 1.29b-1.1+deb9u1                   | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2021-20193      | 3.3  | Debian    | tar                            | 1.29b-1.1+deb9u1                   | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-48303      | 5.5  | Debian    | tar                            | 1.29b-1.1+deb9u1                   | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-7738       | 7.8  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-0563       | 5.5  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
-+-------------------------------------+------+-----------+--------------------------------+------------------------------------+-----------------------------------+-------------------------------------------------+
 
 ---
 
@@ -3462,27 +3456,6 @@ Total 21 packages affected by 147 known vulnerabilities (17 Critical, 59 High, 3
 | https://osv.dev/DSA-5123-1          | 8.8  | Debian    | xz-utils                       | 5.2.2-1.2+deb9u1                   | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DSA-5895-1          |      | Debian    | xz-utils                       | 5.2.2-1.2+deb9u1                   | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/CVE-2024-3094       | 10.0 | Debian    | xz-utils                       | 5.2.2-1.2+deb9u1                   | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
-+-------------------------------------+------+-----------+--------------------------------+------------------------------------+-----------------------------------+-------------------------------------------------+
-| Unimportant vulnerabilities         |      |           |                                |                                    |                                   |                                                 |
-+-------------------------------------+------+-----------+--------------------------------+------------------------------------+-----------------------------------+-------------------------------------------------+
-| https://osv.dev/CVE-2011-3374       | 3.7  | Debian    | apt                            | 1.4.11                             | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2019-18276      | 7.8  | Debian    | bash                           | 4.4-5                              | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2017-18018      | 4.7  | Debian    | coreutils                      | 8.26-3                             | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2025-5278       |      | Debian    | coreutils                      | 8.26-3                             | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-6829       | 7.5  | Debian    | libgcrypt20                    | 1.7.6-2+deb9u4                     | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2024-2236       |      | Debian    | libgcrypt20                    | 1.7.6-2+deb9u4                     | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-1000654    | 5.5  | Debian    | libtasn1-6                     | 4.10-1.1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DSA-5949-1          | 7.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2020-24977      | 6.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2011-4116       | 3.3  | Debian    | perl                           | 5.24.1-3+deb9u7                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-48522      | 9.8  | Debian    | perl                           | 5.24.1-3+deb9u7                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2023-31486      | 8.1  | Debian    | perl                           | 5.24.1-3+deb9u7                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2005-2541       |      | Debian    | tar                            | 1.29b-1.1+deb9u1                   | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2019-9923       | 7.5  | Debian    | tar                            | 1.29b-1.1+deb9u1                   | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2021-20193      | 3.3  | Debian    | tar                            | 1.29b-1.1+deb9u1                   | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-48303      | 5.5  | Debian    | tar                            | 1.29b-1.1+deb9u1                   | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2018-7738       | 7.8  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/CVE-2022-0563       | 5.5  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 +-------------------------------------+------+-----------+--------------------------------+------------------------------------+-----------------------------------+-------------------------------------------------+
 
 ---
@@ -4321,40 +4294,5 @@ No issues found
 ---
 
 [TestCommand_WithDetector_OnLinux/ssh_version_is_before_first_vuln_version - 2]
-
----
-
-[TestCommand/folder_of_supported_sbom_with_only_unimportant - 1]
-Scanning dir ./testdata/sbom-insecure/only-unimportant.spdx.json
-Scanned <rootdir>/testdata/sbom-insecure/only-unimportant.spdx.json file and found 1 package
-Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
-0 vulnerabilities can be fixed.
-
-
-
----
-
-[TestCommand/folder_of_supported_sbom_with_only_unimportant - 2]
-
----
-
-[TestCommand/folder_of_supported_sbom_with_only_unimportant#01 - 1]
-Scanning dir ./testdata/sbom-insecure/only-unimportant.spdx.json
-Scanned <rootdir>/testdata/sbom-insecure/only-unimportant.spdx.json file and found 1 package
-Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
-0 vulnerabilities can be fixed.
-
-
-+---------------------------------------+------+-----------+---------+--------------------+---------------+---------------------------------------------------+
-| OSV URL                               | CVSS | ECOSYSTEM | PACKAGE | VERSION            | FIXED VERSION | SOURCE                                            |
-+---------------------------------------+------+-----------+---------+--------------------+---------------+---------------------------------------------------+
-| Unimportant vulnerabilities           |      |           |         |                    |               |                                                   |
-+---------------------------------------+------+-----------+---------+--------------------+---------------+---------------------------------------------------+
-| https://osv.dev/UBUNTU-CVE-2017-11164 | 7.5  | Ubuntu    | pcre3   | 2:8.39-12ubuntu0.1 | --            | testdata/sbom-insecure/only-unimportant.spdx.json |
-+---------------------------------------+------+-----------+---------+--------------------+---------------+---------------------------------------------------+
-
----
-
-[TestCommand/folder_of_supported_sbom_with_only_unimportant#01 - 2]
 
 ---

--- a/cmd/osv-scanner/scan/source/command_test.go
+++ b/cmd/osv-scanner/scan/source/command_test.go
@@ -32,6 +32,18 @@ func TestCommand(t *testing.T) {
 			Args: []string{"", "source", "--config=./testdata/osv-scanner-empty-config.toml", "./testdata/sbom-insecure/"},
 			Exit: 1,
 		},
+		// one specific supported sbom with only unimportant
+		{
+			Name: "folder of supported sbom with only unimportant",
+			Args: []string{"", "source", "--config=./testdata/osv-scanner-empty-config.toml", "./testdata/sbom-insecure/only-unimportant.spdx.json"},
+			Exit: 0,
+		},
+		// one specific supported sbom with only unimportant but with --all-vulns
+		{
+			Name: "folder of supported sbom with only unimportant",
+			Args: []string{"", "source", "--config=./testdata/osv-scanner-empty-config.toml", "--all-vulns", "./testdata/sbom-insecure/only-unimportant.spdx.json"},
+			Exit: 1,
+		},
 		// one specific supported sbom with vulns
 		{
 			Name: "one specific supported sbom with vulns",

--- a/cmd/osv-scanner/scan/source/testdata/sbom-insecure/only-unimportant.spdx.json
+++ b/cmd/osv-scanner/scan/source/testdata/sbom-insecure/only-unimportant.spdx.json
@@ -1,0 +1,34 @@
+{
+  "spdxVersion": "SPDX-2.3",
+  "dataLicense": "CC0-1.0",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "SCALIBR-generated SPDX",
+  "documentNamespace": "https://spdx.google/1989157b-1458-4e57-abcb-fbec4a542b9c",
+  "creationInfo": {
+    "creators": [
+      "Tool: SCALIBR"
+    ],
+    "created": "2025-08-26T01:01:15Z"
+  },
+  "packages": [
+    {
+      "name": "libpcre3",
+      "SPDXID": "SPDXRef-Package-libpcre3-9f1e7f2f-24ab-4eb2-8be4-7d3be9403a72",
+      "versionInfo": "2:8.39-12ubuntu0.1",
+      "supplier": "NOASSERTION",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "sourceInfo": "Identified by the os/dpkg extractor from var/lib/dpkg/status",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:deb/ubuntu/pcre3@2%3A8.39-12ubuntu0.1?arch=amd64\u0026distro=focal\u0026source=pcre3"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+
+  ]
+}

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -90,7 +90,7 @@ func tableBuilder(outputTable table.Writer, result Result, showAllVulns bool) ta
 	}
 
 	unimportantRows := tableBuilderInner(result, VulnTypeUnimportant)
-	if len(unimportantRows) != 0 {
+	if showAllVulns && len(unimportantRows) != 0 {
 		outputTable.AppendSeparator()
 		outputTable.AppendRow(table.Row{"Unimportant vulnerabilities"})
 		outputTable.AppendSeparator()

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -489,9 +489,7 @@ func determineReturnErr(vulnResults models.VulnerabilityResults, showAllVulns bo
 			if vf.Vulnerability.ID != "" {
 				vuln = true
 				// TODO(gongh): rewrite the logic once we support reachability analysis for container scanning.
-				if !isContainerScanning && vf.GroupInfo.IsCalled() {
-					onlyUnimportantVuln = false
-				} else if isContainerScanning && !vf.GroupInfo.IsGroupUnimportant() {
+				if vf.GroupInfo.IsCalled() && !vf.GroupInfo.IsGroupUnimportant() {
 					onlyUnimportantVuln = false
 				}
 			}

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -272,7 +272,7 @@ func DoScan(actions ScannerActions) (models.VulnerabilityResults, error) {
 		)
 	}
 
-	return vulnerabilityResults, determineReturnErr(vulnerabilityResults, actions.ShowAllVulns, false)
+	return vulnerabilityResults, determineReturnErr(vulnerabilityResults, actions.ShowAllVulns)
 }
 
 func DoContainerScan(actions ScannerActions) (models.VulnerabilityResults, error) {
@@ -433,7 +433,7 @@ func DoContainerScan(actions ScannerActions) (models.VulnerabilityResults, error
 		)
 	}
 
-	return vulnerabilityResults, determineReturnErr(vulnerabilityResults, actions.ShowAllVulns, true)
+	return vulnerabilityResults, determineReturnErr(vulnerabilityResults, actions.ShowAllVulns)
 }
 
 func buildLicenseSummary(scanResult *results.ScanResults) []models.LicenseCount {
@@ -480,7 +480,7 @@ func buildLicenseSummary(scanResult *results.ScanResults) []models.LicenseCount 
 
 // determineReturnErr determines whether we found a "vulnerability" or not,
 // and therefore whether we should return a ErrVulnerabilityFound error.
-func determineReturnErr(vulnResults models.VulnerabilityResults, showAllVulns bool, isContainerScanning bool) error {
+func determineReturnErr(vulnResults models.VulnerabilityResults, showAllVulns bool) error {
 	if len(vulnResults.Results) > 0 {
 		var vuln bool
 		onlyUnimportantVuln := true


### PR DESCRIPTION
Fixes #2201 
Fixes #1975

There's a bug with the original implementation of the --all-vulns flag, where when scanning OS packages in non container scanning mode, it would not correctly hide unimportant packages. This fixes that issue and adds some test cases to confirm the fix.
