### PR TITLE
perf(local): exclude withdrawn advisories as part of checking if packages are affected

### DIFF
--- a/internal/clients/clientimpl/localmatcher/localmatcher.go
+++ b/internal/clients/clientimpl/localmatcher/localmatcher.go
@@ -78,7 +78,7 @@ func (matcher *LocalMatcher) MatchVulnerabilities(ctx context.Context, invs []*e
 			continue
 		}
 
-		results = append(results, VulnerabilitiesAffectingPackage(db.Vulnerabilities(false), pkg))
+		results = append(results, VulnerabilitiesAffectingPackage(db.vulnerabilities, pkg))
 	}
 
 	return results, nil

--- a/internal/clients/clientimpl/localmatcher/zip.go
+++ b/internal/clients/clientimpl/localmatcher/zip.go
@@ -219,28 +219,12 @@ func NewZippedDB(ctx context.Context, dbBasePath, name, url, userAgent string, o
 	return db, nil
 }
 
-func (db *ZipDB) Vulnerabilities(includeWithdrawn bool) []osvschema.Vulnerability {
-	if includeWithdrawn {
-		return db.vulnerabilities
-	}
-
-	var vulnerabilities []osvschema.Vulnerability
-
-	for _, vulnerability := range db.vulnerabilities {
-		if vulnerability.Withdrawn.IsZero() {
-			vulnerabilities = append(vulnerabilities, vulnerability)
-		}
-	}
-
-	return vulnerabilities
-}
-
 // TODO: Move this to another file.
 func VulnerabilitiesAffectingPackage(allVulns []osvschema.Vulnerability, pkg imodels.PackageInfo) []*osvschema.Vulnerability {
 	var vulnerabilities []*osvschema.Vulnerability
 
 	for _, vulnerability := range allVulns {
-		if vulns.IsAffected(vulnerability, pkg) && !vulns.Include(vulnerabilities, vulnerability) {
+		if vulnerability.Withdrawn.IsZero() && vulns.IsAffected(vulnerability, pkg) && !vulns.Include(vulnerabilities, vulnerability) {
 			vulnerabilities = append(vulnerabilities, &vulnerability)
 		}
 	}


### PR DESCRIPTION
Currently when doing local matching we remove withdrawn advisories before any further checks by building a dedicated new slice, which results in huge memory usage - see [this comment](https://github.com/google/osv-scanner/issues/2217#issuecomment-3255336143) for some profiles, but e.g. scanning our own `go.mod` takes up 1.5gb of memory.

I originally implemented it like this back in `osv-detector` as I found it interesting to include withdrawn advisories to review data quality and have their count in the output, but it's not worth this. I have actually since ended up optimizing this out of the detector anyway via https://github.com/G-Rath/osv-detector/pull/216 which switched to using a map for vulnerabilities meaning I calculated the count differently, but for now this just brings over the change for fixing the memory issue.

Resolves #2217