### PR TITLE
ci: update snapshots earlier in the AU/NZ morning

### DIFF
--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -2,7 +2,7 @@ name: Snapshots
 
 on:
   schedule:
-    - cron: "47 12 * * *"
+    - cron: "47 18 * * *"
   workflow_dispatch:
 concurrency:
   # Pushing new changes to a branch will cancel any in-progress CI runs


### PR DESCRIPTION
Since the team is based in AU & NZ, there's a good 4-6 hours min. before a snapshot update PR will get looked at let alone merged during which time further advisory changes might occur.

Having the workflow run later in the AU/NZ morning will hopefully reduce a few of the (re)runs