### PR TITLE
refactor: simplify internal plugin disabling and configuration

### DIFF
--- a/internal/scalibrextract/vcs/gitrepo/extractor.go
+++ b/internal/scalibrextract/vcs/gitrepo/extractor.go
@@ -21,14 +21,12 @@ const (
 
 type Config struct {
 	IncludeRootGit bool
-	Disabled       bool
 }
 
 // Extractor extracts git repository hashes including submodule hashes.
 // This extractor will not return an error, and will just return no results if we fail to extract
 type Extractor struct {
 	IncludeRootGit bool
-	Disabled       bool
 }
 
 func getCommitSHA(repo *git.Repository) (string, error) {
@@ -89,10 +87,6 @@ func (e *Extractor) Requirements() *plugin.Capabilities {
 
 // FileRequired returns true for git repositories .git dirs
 func (e *Extractor) FileRequired(fapi filesystem.FileAPI) bool {
-	if e.Disabled {
-		return false
-	}
-
 	if filepath.Base(fapi.Path()) != ".git" {
 		return false
 	}
@@ -108,11 +102,6 @@ func (e *Extractor) FileRequired(fapi filesystem.FileAPI) bool {
 
 // Extract extracts git commits from HEAD and from submodules
 func (e *Extractor) Extract(_ context.Context, input *filesystem.ScanInput) (inventory.Inventory, error) {
-	// todo: maybe we should return an error instead? need to double check we're always using FileRequired correctly first
-	if e.Disabled {
-		return inventory.Inventory{}, nil
-	}
-
 	// The input path is the .git directory, but git.PlainOpen expects the actual directory containing the .git dir.
 	// So call filepath.Dir to get the parent path
 	// Assume this is fully on a real filesystem
@@ -166,7 +155,6 @@ type configurable interface {
 
 func (e *Extractor) Configure(config Config) {
 	e.IncludeRootGit = config.IncludeRootGit
-	e.Disabled = config.Disabled
 }
 
 var _ configurable = &Extractor{}

--- a/internal/scalibrextract/vcs/gitrepo/extractor_test.go
+++ b/internal/scalibrextract/vcs/gitrepo/extractor_test.go
@@ -49,9 +49,7 @@ func TestExtractor_Extract(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
-			extr := gitrepo.Extractor{
-				IncludeRootGit: true,
-			}
+			extr := gitrepo.Extractor{}
 			parent := filepath.Dir(tt.InputConfig.Path)
 			err := os.Rename(path.Join(parent, "git-hidden"), path.Join(parent, ".git"))
 			if err != nil {

--- a/pkg/osvscanner/scan.go
+++ b/pkg/osvscanner/scan.go
@@ -46,12 +46,6 @@ func configurePlugins(plugins []plugin.Plugin, accessors ExternalAccessors, acti
 			})
 		}
 
-		// todo: the "disabled" aspect should probably be worked into the extractor being present in the first place
-		//  since "IncludeRootGit" is always true
-		gitrepo.Configure(plug, gitrepo.Config{
-			IncludeRootGit: actions.IncludeGitRoot,
-		})
-
 		vendored.Configure(plug, vendored.Config{
 			// Only attempt to vendor check git directories if we are not skipping scanning root git directories
 			ScanGitDir: !actions.IncludeGitRoot,

--- a/pkg/osvscanner/scan.go
+++ b/pkg/osvscanner/scan.go
@@ -50,14 +50,12 @@ func configurePlugins(plugins []plugin.Plugin, accessors ExternalAccessors, acti
 		//  since "IncludeRootGit" is always true
 		gitrepo.Configure(plug, gitrepo.Config{
 			IncludeRootGit: actions.IncludeGitRoot,
-			Disabled:       !actions.IncludeGitRoot,
 		})
 
 		vendored.Configure(plug, vendored.Config{
 			// Only attempt to vendor check git directories if we are not skipping scanning root git directories
 			ScanGitDir: !actions.IncludeGitRoot,
 			OSVClient:  accessors.OSVDevClient,
-			Disabled:   accessors.OSVDevClient == nil,
 		})
 	}
 }
@@ -65,6 +63,14 @@ func configurePlugins(plugins []plugin.Plugin, accessors ExternalAccessors, acti
 func getPlugins(defaultPlugins []string, accessors ExternalAccessors, actions ScannerActions) []plugin.Plugin {
 	if !actions.PluginsNoDefaults {
 		actions.PluginsEnabled = append(actions.PluginsEnabled, defaultPlugins...)
+	}
+
+	if !actions.IncludeGitRoot {
+		actions.PluginsDisabled = append(actions.PluginsDisabled, gitrepo.Name)
+	}
+
+	if accessors.OSVDevClient == nil {
+		actions.PluginsDisabled = append(actions.PluginsDisabled, vendored.Name)
 	}
 
 	plugins := scalibrplugin.Resolve(actions.PluginsEnabled, actions.PluginsDisabled)


### PR DESCRIPTION
Rather than configuring our internal plugins to be disabled, we can just explicitly add them to the disabled plugins list as part of fetching the plugins; we also don't need to support not including the git root in the `gitrepo` extractor since we always disable the plugin if that option is not enabled