### PR TITLE
Fix lookup of golang packages with major versions

### DIFF
--- a/internal/clients/clientimpl/osvmatcher/osvmatcher.go
+++ b/internal/clients/clientimpl/osvmatcher/osvmatcher.go
@@ -113,10 +113,8 @@ func pkgToQuery(pkg imodels.PackageInfo) *osvdev.Query {
 	if pkg.Name() != "" && !pkg.Ecosystem().IsEmpty() && pkg.Version() != "" {
 		return &osvdev.Query{
 			Package: osvdev.Package{
-				Name:      pkg.Name(),
-				Ecosystem: pkg.Ecosystem().String(),
+				PURL: pkg.PURL().String(),
 			},
-			Version: pkg.Version(),
 		}
 	}
 


### PR DESCRIPTION
Fix a bug causing to false positives for all golang packages with a
major version.

The bug is caused by the name of golang packages not including the major
version. This leads the osv query to look up vulnerabilities to look up
the right version, but for the wrong major. E.g. go-jose@v4.0.1 instead
of go-jose/v4@v4.0.1.

Solve this issue by using the PURL to all requests to osv.dev, which
correctly seems to resolve such versions.
