### PR TITLE
ci: create pr for updating scalibr even if tests fail

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -34,7 +34,7 @@ jobs:
           go get github.com/google/osv-scalibr@"$latest_commit"
           echo "latest_scalibr_commit=$latest_commit" >> "$GITHUB_ENV"
           go mod tidy
-      - run: go test ./cmd/osv-scanner/ -run 'Test_run$'
+      - run: go test ./cmd/osv-scanner/ -run 'Test_run$' || true
         env:
           TEST_ACCEPTANCE: true
           UPDATE_SNAPS: always


### PR DESCRIPTION
As running the tests involves compiling Go, it'll error if a change in scalibr causes a compile-time error which is exactly why we're wanting this workflow in the first place so we should be continuing regardless of if the running-of-tests step is successful 😅 