### PR TITLE
chore: add gemini config.yaml file

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,11 @@
+have_fun: false
+code_review:
+  disable: false
+  comment_severity_threshold: MEDIUM
+  max_review_comments: -1
+  pull_request_opened:
+    help: false
+    summary: false
+    code_review: false
+    include_drafts: true
+ignore_patterns: []


### PR DESCRIPTION
I believe Gemini was also recently enabled on this repo. The default settings has it automatically do a PR summary and code review, which we probably don't want.
https://developers.google.com/gemini-code-assist/docs/customize-gemini-behavior-github#add_configuration_files