### PR TITLE
refactor: remove unneeded adjustment of subcommand help text

### DIFF
--- a/cmd/osv-scanner/internal/cmd/run.go
+++ b/cmd/osv-scanner/internal/cmd/run.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"io"
 	"log/slog"
-	"strings"
 	"testing"
 
 	scalibr "github.com/google/osv-scalibr/version"
@@ -24,16 +23,6 @@ var (
 type CommandBuilder = func(stdout, stderr io.Writer) *cli.Command
 
 func Run(args []string, stdout, stderr io.Writer, commands []CommandBuilder) int {
-	// get rid of the extraneous space in the subcommand help template, as otherwise
-	// our snapshots will fail because it will be trailing and removed by editors
-	//
-	// todo: remove this once https://github.com/urfave/cli/pull/2140 has been released
-	cli.SubcommandHelpTemplate = strings.ReplaceAll(
-		cli.SubcommandHelpTemplate,
-		"{{if .VisibleCommands}} [command [command options]] {{end}}",
-		"{{if .VisibleCommands}} [command [command options]]{{end}}",
-	)
-
 	// --- Setup Logger ---
 	logHandler := cmdlogger.New(stdout, stderr)
 


### PR DESCRIPTION
The fix for this was released months ago, so we can safely remove the workaround 🎉 