### PR TITLE
ci: Nightly mainline docker builds

### DIFF
--- a/.goreleaser-nightly.yml
+++ b/.goreleaser-nightly.yml
@@ -5,6 +5,27 @@ before:
     - go mod tidy
 builds:
   - main: ./cmd/osv-scanner/
+    id: osv-scanner
+    binary: osv-scanner
+    env:
+      # goreleaser does not work with CGO, it could also complicate
+      # usage by users in CI/CD systems like Terraform Cloud where
+      # they are unable to install libraries.
+      - CGO_ENABLED=0
+      - GO111MODULE=on
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    flags:
+      - -trimpath
+    ldflags:
+      - "-s -w"
+      - "-X github.com/google/osv-scanner/v2/internal/version.OSVVersion={{.Version}}.nightly"
+      - "-X github.com/google/osv-scanner/v2/cmd/osv-scanner/internal/cmd.commit={{.Commit}}"
+      - "-X github.com/google/osv-scanner/v2/cmd/osv-scanner/internal/cmd.date={{.CommitDate}}"
+    goos:
+      - linux
+    goarch:
+      - amd64
+  - main: ./cmd/osv-scanner/
     id: osv-scanner-action
     binary: osv-scanner-action
     env:
@@ -18,7 +39,7 @@ builds:
       - -trimpath
     ldflags:
       - "-s -w"
-      - "-X github.com/google/osv-scanner/v2/internal/version.OSVVersion={{.Version}}_GHAction"
+      - "-X github.com/google/osv-scanner/v2/internal/version.OSVVersion={{.Version}}.nightly_GHAction"
       - "-X github.com/google/osv-scanner/v2/cmd/osv-scanner/internal/cmd.commit={{.Commit}}"
       - "-X github.com/google/osv-scanner/v2/cmd/osv-scanner/internal/cmd.date={{.CommitDate}}"
     goos:
@@ -45,6 +66,23 @@ builds:
       - amd64
 
 dockers:
+  # Main osv-scanner
+  - image_templates:
+      - "ghcr.io/google/osv-scanner:nightly"
+    dockerfile: goreleaser.dockerfile
+    use: buildx
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.title=osv-scanner"
+      - "--label=org.opencontainers.image.description=Vulnerability scanner written in Go which uses the data provided by https://osv.dev"
+      - "--label=org.opencontainers.image.licenses=Apache License 2.0"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.name={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
+      - "--label=org.opencontainers.image.url={{.GitURL}}"
+      - "--platform=linux/amd64"
   # Github Action
   - image_templates:
       - "ghcr.io/google/osv-scanner-action:nightly"


### PR DESCRIPTION
We only enabled osv-scanner-action nightly docker builds, but we should do the same for the main dockerfile as well.