### PR TITLE
feat: support license checks for RubyGems

### DIFF
--- a/cmd/osv-scanner/scan/source/__snapshots__/command_test.snap
+++ b/cmd/osv-scanner/scan/source/__snapshots__/command_test.snap
@@ -458,7 +458,7 @@ overriding license for package Packagist/sentry/sdk/2.0.4 with 0BSD
 overriding license for package Alpine/ssl_client/1.36.1-r27 with MIT
 overriding license for package Packagist/theseer/tokenizer/1.1.3 with 0BSD
 overriding license for package Alpine/zlib/1.2.13-r0 with MIT
-Total 3 packages affected by 3 known vulnerabilities (2 Critical, 1 High, 0 Medium, 0 Low, 0 Unknown) from 5 ecosystems.
+Total 3 packages affected by 3 known vulnerabilities (2 Critical, 1 High, 0 Medium, 0 Low, 0 Unknown) from 4 ecosystems.
 2 vulnerabilities can be fixed.
 
 
@@ -472,9 +472,9 @@ Total 3 packages affected by 3 known vulnerabilities (2 Critical, 1 High, 0 Medi
 +---------+-------------------------+
 | LICENSE | NO. OF PACKAGE VERSIONS |
 +---------+-------------------------+
-| MIT     |                      14 |
+| MIT     |                      15 |
 | 0BSD    |                       7 |
-| UNKNOWN |                       6 |
+| UNKNOWN |                       5 |
 +---------+-------------------------+
 +-------------------+-----------+------------------------------------------------+--------------+-------------------------------------------------------+
 | LICENSE VIOLATION | ECOSYSTEM | PACKAGE                                        | VERSION      | SOURCE                                                |
@@ -485,7 +485,6 @@ Total 3 packages affected by 3 known vulnerabilities (2 Critical, 1 High, 0 Medi
 | UNKNOWN           |           | https://chromium.googlesource.com/chromium/src |              | testdata/locks-insecure/osv-scanner-flutter-deps.json |
 | UNKNOWN           |           | https://github.com/brendan-duncan/archive.git  |              | testdata/locks-insecure/osv-scanner-flutter-deps.json |
 | UNKNOWN           |           | https://github.com/flutter/buildroot.git       |              | testdata/locks-insecure/osv-scanner-flutter-deps.json |
-| UNKNOWN           | RubyGems  | ast                                            | 2.4.2        | testdata/locks-many-with-insecure/Gemfile.lock        |
 | 0BSD              | Packagist | drupal/core                                    | 10.4.5       | testdata/locks-many-with-insecure/composer.lock       |
 | 0BSD              | Packagist | drupal/simple_sitemap                          | 4.2.2        | testdata/locks-many-with-insecure/composer.lock       |
 | 0BSD              | Packagist | drupal/tfa                                     | 2.0.0-alpha4 | testdata/locks-many-with-insecure/composer.lock       |
@@ -3242,9 +3241,9 @@ Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medi
 +------------+-------------------------+
 | LICENSE    | NO. OF PACKAGE VERSIONS |
 +------------+-------------------------+
+| MIT        |                       2 |
 | Apache-2.0 |                       1 |
-| MIT        |                       1 |
-| UNKNOWN    |                       2 |
+| UNKNOWN    |                       1 |
 +------------+-------------------------+
 
 ---
@@ -3266,9 +3265,9 @@ Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medi
 
 | License | No. of package versions |
 | --- | ---:|
+| MIT | 2 |
 | Apache-2.0 | 1 |
-| MIT | 1 |
-| UNKNOWN | 2 |
+| UNKNOWN | 1 |
 
 ---
 
@@ -3375,7 +3374,7 @@ Package npm/wrappy/1.0.2 has been filtered out because: (no reason given)
 Filtered 4 ignored package/s from the scan.
 overriding license for package Packagist/league/flysystem/1.0.8 with 0BSD
 overriding license for package Packagist/sentry/sdk/2.0.4 with 0BSD
-Total 1 package affected by 1 known vulnerability (1 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 3 ecosystems.
+Total 1 package affected by 1 known vulnerability (1 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 2 ecosystems.
 1 vulnerability can be fixed.
 
 
@@ -3388,7 +3387,8 @@ Total 1 package affected by 1 known vulnerability (1 Critical, 0 High, 0 Medium,
 | LICENSE | NO. OF PACKAGE VERSIONS |
 +---------+-------------------------+
 | 0BSD    |                       2 |
-| UNKNOWN |                       3 |
+| MIT     |                       1 |
+| UNKNOWN |                       2 |
 +---------+-------------------------+
 +-------------------+-----------+------------------+---------+-------------------------------------------------+
 | LICENSE VIOLATION | ECOSYSTEM | PACKAGE          | VERSION | SOURCE                                          |
@@ -3396,7 +3396,6 @@ Total 1 package affected by 1 known vulnerability (1 Critical, 0 High, 0 Medium,
 | 0BSD              | Packagist | league/flysystem | 1.0.8   | testdata/locks-insecure/composer.lock           |
 | UNKNOWN           | Go        | stdlib           | 1.99.9  | testdata/locks-insecure/osv-scanner-custom.json |
 | UNKNOWN           | Go        | toolchain        | 1.99.9  | testdata/locks-insecure/osv-scanner-custom.json |
-| UNKNOWN           | RubyGems  | ast              | 2.4.2   | testdata/locks-many/Gemfile.lock                |
 | 0BSD              | Packagist | sentry/sdk       | 2.0.4   | testdata/locks-many/composer.lock               |
 +-------------------+-----------+------------------+---------+-------------------------------------------------+
 

--- a/internal/depsdev/depsdev.go
+++ b/internal/depsdev/depsdev.go
@@ -19,4 +19,5 @@ var System = map[osvschema.Ecosystem]depsdevpb.System{
 	osvschema.EcosystemGo:       depsdevpb.System_GO,
 	osvschema.EcosystemMaven:    depsdevpb.System_MAVEN,
 	osvschema.EcosystemPyPI:     depsdevpb.System_PYPI,
+	osvschema.EcosystemRubyGems: depsdevpb.System_RUBYGEMS,
 }


### PR DESCRIPTION
Per https://github.com/google/osv-scalibr/issues/1511 and https://blog.deps.dev/rubygems/ we can now do license scanning for RubyGems