### PR TITLE
fix: Add `--ignore-scripts` flag to npm lockfile generation

### DIFF
--- a/cmd/osv-scanner/fix/regen_lockfile.go
+++ b/cmd/osv-scanner/fix/regen_lockfile.go
@@ -19,7 +19,7 @@ func regenerateLockfileCmd(ctx context.Context, opts osvFixOptions) (*exec.Cmd, 
 	}
 	// TODO: need to also remove node_modules/ in workspace packages
 
-	c := exec.CommandContext(ctx, "npm", "install", "--package-lock-only")
+	c := exec.CommandContext(ctx, "npm", "install", "--package-lock-only", "--ignore-scripts")
 	c.Dir = dir
 
 	return c, nil


### PR DESCRIPTION
This change adds the `--ignore-scripts` flag to `npm install` command in the guided remediation process. This is to prevent the execution of potentially malicious npm scripts when regenerating the `package-lock.json` file.
