### PR TITLE
chore: update formatting for Prettier

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -72,6 +72,7 @@ nav_external_links:
     url: https://ossf.github.io/osv-schema/
     hide_icon: false # set to true to hide the external link icon - defaults to false
 
+
 # Exclude from processing.
 # The following items will not be processed, by default.
 # Any item listed under the `exclude:` key here will be automatically added to


### PR DESCRIPTION
Prettier v3.7.1 likes there to be two newlines before the comment at the end of the file now