### PR TITLE
test: use a cassette for unused ignores in config cases

### DIFF
--- a/cmd/osv-scanner/scan/source/command_test.go
+++ b/cmd/osv-scanner/scan/source/command_test.go
@@ -348,6 +348,8 @@ func TestCommand(t *testing.T) {
 func TestCommand_Config_UnusedIgnores(t *testing.T) {
 	t.Parallel()
 
+	client := testcmd.InsertCassette(t)
+
 	tests := []testcmd.Case{
 		{
 			Name: "unused_ignores_are_reported_with_specific_config_and_file",
@@ -368,6 +370,9 @@ func TestCommand_Config_UnusedIgnores(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
+
+			tt.HTTPClient = testcmd.WithTestNameHeader(t, *client)
+
 			testcmd.RunAndMatchSnapshots(t, tt)
 		})
 	}

--- a/cmd/osv-scanner/scan/source/testdata/cassettes/TestCommand_Config_UnusedIgnores.yaml
+++ b/cmd/osv-scanner/scan/source/testdata/cassettes/TestCommand_Config_UnusedIgnores.yaml
@@ -1,0 +1,2868 @@
+---
+version: 2
+interactions:
+  - id: 0
+    request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
+      content_length: 1101
+      host: api.osv.dev
+      body: '{"queries":[{"package":{"ecosystem":"Alpine","name":"alpine-baselayout"},"version":"3.4.0-r0"},{"package":{"ecosystem":"Alpine","name":"alpine-baselayout-data"},"version":"3.4.0-r0"},{"package":{"ecosystem":"Alpine","name":"alpine-keys"},"version":"2.4-r1"},{"package":{"ecosystem":"Alpine","name":"apk-tools"},"version":"2.12.10-r1"},{"package":{"ecosystem":"Alpine","name":"busybox-binsh"},"version":"1.36.1-r27"},{"package":{"ecosystem":"Alpine","name":"ca-certificates-bundle"},"version":"20220614-r4"},{"package":{"ecosystem":"Alpine","name":"libc-utils"},"version":"0.7.2-r3"},{"package":{"ecosystem":"Alpine","name":"libcrypto3"},"version":"3.0.8-r0"},{"package":{"ecosystem":"Alpine","name":"libssl3"},"version":"3.0.8-r0"},{"package":{"ecosystem":"Alpine","name":"musl"},"version":"1.2.3-r4"},{"package":{"ecosystem":"Alpine","name":"musl-utils"},"version":"1.2.3-r4"},{"package":{"ecosystem":"Alpine","name":"scanelf"},"version":"1.3.5-r1"},{"package":{"ecosystem":"Alpine","name":"ssl_client"},"version":"1.36.1-r27"},{"package":{"ecosystem":"Alpine","name":"zlib"},"version":"1.2.10-r0"}]}'
+      headers:
+        Content-Type:
+          - application/json
+        X-Test-Name:
+          - TestCommand_Config_UnusedIgnores/unused_ignores_are_reported_with_specific_config_and_file
+      url: https://api.osv.dev/v1/querybatch
+      method: POST
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      content_length: 289
+      body: |
+        {
+          "results": [
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "ALPINE-CVE-2025-26519",
+                  "modified": "2025-11-19T06:21:21.194626Z"
+                }
+              ]
+            },
+            {},
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "ALPINE-CVE-2018-25032",
+                  "modified": "2025-12-03T22:47:03.844688Z"
+                },
+                {
+                  "id": "ALPINE-CVE-2022-37434",
+                  "modified": "2025-12-03T22:50:43.469206Z"
+                }
+              ]
+            }
+          ]
+        }
+      headers:
+        Content-Length:
+          - "289"
+        Content-Type:
+          - application/json
+      status: 200 OK
+      code: 200
+      duration: 0s
+  - id: 1
+    request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
+      content_length: 13920
+      host: api.osv.dev
+      body: '{"queries":[{"package":{"ecosystem":"Alpine","name":"zlib"},"version":"1.2.12-r1"},{"package":{"ecosystem":"Alpine","name":"alpine-baselayout"},"version":"3.4.0-r0"},{"package":{"ecosystem":"Alpine","name":"alpine-baselayout-data"},"version":"3.4.0-r0"},{"package":{"ecosystem":"Alpine","name":"alpine-keys"},"version":"2.4-r1"},{"package":{"ecosystem":"Alpine","name":"apk-tools"},"version":"2.12.10-r1"},{"package":{"ecosystem":"Alpine","name":"busybox-binsh"},"version":"1.36.1-r27"},{"package":{"ecosystem":"Alpine","name":"ca-certificates-bundle"},"version":"20220614-r4"},{"package":{"ecosystem":"Alpine","name":"libc-utils"},"version":"0.7.2-r3"},{"package":{"ecosystem":"Alpine","name":"libcrypto3"},"version":"3.0.8-r0"},{"package":{"ecosystem":"Alpine","name":"libssl3"},"version":"3.0.8-r0"},{"package":{"ecosystem":"Alpine","name":"musl"},"version":"1.2.3-r4"},{"package":{"ecosystem":"Alpine","name":"musl-utils"},"version":"1.2.3-r4"},{"package":{"ecosystem":"Alpine","name":"scanelf"},"version":"1.3.5-r1"},{"package":{"ecosystem":"Alpine","name":"ssl_client"},"version":"1.36.1-r27"},{"package":{"ecosystem":"Alpine","name":"zlib"},"version":"1.2.10-r0"},{"package":{"ecosystem":"Alpine","name":"alpine-baselayout"},"version":"3.4.0-r0"},{"package":{"ecosystem":"Alpine","name":"alpine-baselayout-data"},"version":"3.4.0-r0"},{"package":{"ecosystem":"Alpine","name":"apk-tools"},"version":"2.12.10-r1"},{"package":{"ecosystem":"Alpine","name":"busybox-binsh"},"version":"1.36.1-r27"},{"package":{"ecosystem":"Alpine","name":"libcrypto3"},"version":"3.0.8-r0"},{"package":{"ecosystem":"Alpine","name":"libssl3"},"version":"3.0.8-r0"},{"package":{"ecosystem":"Alpine","name":"musl-utils"},"version":"1.2.3-r4"},{"package":{"ecosystem":"Alpine","name":"scanelf"},"version":"1.3.5-r1"},{"package":{"ecosystem":"Ubuntu","name":"pcre3"},"version":"2:8.39-12ubuntu0.1"},{"package":{"ecosystem":"Debian","name":"adduser"},"version":"3.115"},{"package":{"ecosystem":"Debian","name":"apt"},"version":"1.4.11"},{"package":{"ecosystem":"Debian","name":"base-files"},"version":"9.9+deb9u13"},{"package":{"ecosystem":"Debian","name":"base-passwd"},"version":"3.5.43"},{"package":{"ecosystem":"Debian","name":"bash"},"version":"4.4-5"},{"package":{"ecosystem":"Debian","name":"bsdutils"},"version":"1:2.29.2-1+deb9u1"},{"package":{"ecosystem":"Debian","name":"coreutils"},"version":"8.26-3"},{"package":{"ecosystem":"Debian","name":"dash"},"version":"0.5.8-2.4"},{"package":{"ecosystem":"Debian","name":"debconf"},"version":"1.5.61"},{"package":{"ecosystem":"Debian","name":"debian-archive-keyring"},"version":"2017.5+deb9u2"},{"package":{"ecosystem":"Debian","name":"debianutils"},"version":"4.8.1.1"},{"package":{"ecosystem":"Debian","name":"diffutils"},"version":"1:3.5-3"},{"package":{"ecosystem":"Debian","name":"dirmngr"},"version":"2.1.18-8~deb9u4"},{"package":{"ecosystem":"Debian","name":"dpkg"},"version":"1.18.25"},{"package":{"ecosystem":"Debian","name":"e2fslibs"},"version":"1.43.4-2+deb9u2"},{"package":{"ecosystem":"Debian","name":"e2fsprogs"},"version":"1.43.4-2+deb9u2"},{"package":{"ecosystem":"Debian","name":"findutils"},"version":"4.6.0+git+20161106-2"},{"package":{"ecosystem":"Debian","name":"gcc-6-base"},"version":"6.3.0-18+deb9u1"},{"package":{"ecosystem":"Go","name":"github.com/opencontainers/runc"},"version":"v1.0.1"},{"package":{"ecosystem":"Go","name":"github.com/tianon/gosu"},"version":"(devel)"},{"package":{"ecosystem":"Debian","name":"gnupg"},"version":"2.1.18-8~deb9u4"},{"package":{"ecosystem":"Debian","name":"gnupg-agent"},"version":"2.1.18-8~deb9u4"},{"package":{"ecosystem":"Go","name":"golang.org/x/sys"},"version":"v0.0.0-20210817142637-7d9622a276b7"},{"package":{"ecosystem":"Debian","name":"gpgv"},"version":"2.1.18-8~deb9u4"},{"package":{"ecosystem":"Debian","name":"grep"},"version":"2.27-2"},{"package":{"ecosystem":"Debian","name":"gzip"},"version":"1.6-5+deb9u1"},{"package":{"ecosystem":"Debian","name":"hostname"},"version":"3.18+b1"},{"package":{"ecosystem":"Debian","name":"init-system-helpers"},"version":"1.48"},{"package":{"ecosystem":"Debian","name":"libacl1"},"version":"2.2.52-3+b1"},{"package":{"ecosystem":"Debian","name":"libapt-pkg5.0"},"version":"1.4.11"},{"package":{"ecosystem":"Debian","name":"libassuan0"},"version":"2.4.3-2"},{"package":{"ecosystem":"Debian","name":"libattr1"},"version":"1:2.4.47-2+b2"},{"package":{"ecosystem":"Debian","name":"libaudit-common"},"version":"1:2.6.7-2"},{"package":{"ecosystem":"Debian","name":"libaudit1"},"version":"1:2.6.7-2"},{"package":{"ecosystem":"Debian","name":"libblkid1"},"version":"2.29.2-1+deb9u1"},{"package":{"ecosystem":"Debian","name":"libbsd0"},"version":"0.8.3-1+deb9u1"},{"package":{"ecosystem":"Debian","name":"libbz2-1.0"},"version":"1.0.6-8.1"},{"package":{"ecosystem":"Debian","name":"libc-bin"},"version":"2.24-11+deb9u4"},{"package":{"ecosystem":"Debian","name":"libc-l10n"},"version":"2.24-11+deb9u4"},{"package":{"ecosystem":"Debian","name":"libc6"},"version":"2.24-11+deb9u4"},{"package":{"ecosystem":"Debian","name":"libcap-ng0"},"version":"0.7.7-3+b1"},{"package":{"ecosystem":"Debian","name":"libcomerr2"},"version":"1.43.4-2+deb9u2"},{"package":{"ecosystem":"Debian","name":"libdb5.3"},"version":"5.3.28-12+deb9u1"},{"package":{"ecosystem":"Debian","name":"libdebconfclient0"},"version":"0.227"},{"package":{"ecosystem":"Debian","name":"libedit2"},"version":"3.1-20160903-3"},{"package":{"ecosystem":"Debian","name":"libfdisk1"},"version":"2.29.2-1+deb9u1"},{"package":{"ecosystem":"Debian","name":"libffi6"},"version":"3.2.1-6"},{"package":{"ecosystem":"Debian","name":"libgcc1"},"version":"1:6.3.0-18+deb9u1"},{"package":{"ecosystem":"Debian","name":"libgcrypt20"},"version":"1.7.6-2+deb9u4"},{"package":{"ecosystem":"Debian","name":"libgdbm3"},"version":"1.8.3-14"},{"package":{"ecosystem":"Debian","name":"libgmp10"},"version":"2:6.1.2+dfsg-1+deb9u1"},{"package":{"ecosystem":"Debian","name":"libgnutls30"},"version":"3.5.8-5+deb9u6"},{"package":{"ecosystem":"Debian","name":"libgpg-error0"},"version":"1.26-2"},{"package":{"ecosystem":"Debian","name":"libgssapi-krb5-2"},"version":"1.15-1+deb9u3"},{"package":{"ecosystem":"Debian","name":"libhogweed4"},"version":"3.3-1+deb9u1"},{"package":{"ecosystem":"Debian","name":"libicu57"},"version":"57.1-6+deb9u5"},{"package":{"ecosystem":"Debian","name":"libidn11"},"version":"1.33-1+deb9u1"},{"package":{"ecosystem":"Debian","name":"libjson-perl"},"version":"2.90-1"},{"package":{"ecosystem":"Debian","name":"libk5crypto3"},"version":"1.15-1+deb9u3"},{"package":{"ecosystem":"Debian","name":"libkeyutils1"},"version":"1.5.9-9"},{"package":{"ecosystem":"Debian","name":"libkrb5-3"},"version":"1.15-1+deb9u3"},{"package":{"ecosystem":"Debian","name":"libkrb5support0"},"version":"1.15-1+deb9u3"},{"package":{"ecosystem":"Debian","name":"libksba8"},"version":"1.3.5-2"},{"package":{"ecosystem":"Debian","name":"libldap-2.4-2"},"version":"2.4.44+dfsg-5+deb9u8"},{"package":{"ecosystem":"Debian","name":"libldap-common"},"version":"2.4.44+dfsg-5+deb9u8"},{"package":{"ecosystem":"Debian","name":"libllvm6.0"},"version":"1:6.0-1~bpo9+1"},{"package":{"ecosystem":"Debian","name":"liblz4-1"},"version":"0.0~r131-2+deb9u1"},{"package":{"ecosystem":"Debian","name":"liblzma5"},"version":"5.2.2-1.2+deb9u1"},{"package":{"ecosystem":"Debian","name":"libmount1"},"version":"2.29.2-1+deb9u1"},{"package":{"ecosystem":"Debian","name":"libncurses5"},"version":"6.0+20161126-1+deb9u2"},{"package":{"ecosystem":"Debian","name":"libncursesw5"},"version":"6.0+20161126-1+deb9u2"},{"package":{"ecosystem":"Debian","name":"libnettle6"},"version":"3.3-1+deb9u1"},{"package":{"ecosystem":"Debian","name":"libnpth0"},"version":"1.3-1"},{"package":{"ecosystem":"Debian","name":"libnss-wrapper"},"version":"1.1.3-1"},{"package":{"ecosystem":"Debian","name":"libp11-kit0"},"version":"0.23.3-2+deb9u1"},{"package":{"ecosystem":"Debian","name":"libpam-modules"},"version":"1.1.8-3.6"},{"package":{"ecosystem":"Debian","name":"libpam-modules-bin"},"version":"1.1.8-3.6"},{"package":{"ecosystem":"Debian","name":"libpam-runtime"},"version":"1.1.8-3.6"},{"package":{"ecosystem":"Debian","name":"libpam0g"},"version":"1.1.8-3.6"},{"package":{"ecosystem":"Debian","name":"libpcre3"},"version":"2:8.39-3"},{"package":{"ecosystem":"Debian","name":"libperl5.24"},"version":"5.24.1-3+deb9u7"},{"package":{"ecosystem":"Debian","name":"libpq5"},"version":"14.2-1.pgdg90+1"},{"package":{"ecosystem":"Debian","name":"libreadline7"},"version":"7.0-3"},{"package":{"ecosystem":"Debian","name":"libsasl2-2"},"version":"2.1.27~101-g0780600+dfsg-3+deb9u2"},{"package":{"ecosystem":"Debian","name":"libsasl2-modules-db"},"version":"2.1.27~101-g0780600+dfsg-3+deb9u2"},{"package":{"ecosystem":"Debian","name":"libselinux1"},"version":"2.6-3+b3"},{"package":{"ecosystem":"Debian","name":"libsemanage-common"},"version":"2.6-2"},{"package":{"ecosystem":"Debian","name":"libsemanage1"},"version":"2.6-2"},{"package":{"ecosystem":"Debian","name":"libsepol1"},"version":"2.6-2"},{"package":{"ecosystem":"Debian","name":"libsmartcols1"},"version":"2.29.2-1+deb9u1"},{"package":{"ecosystem":"Debian","name":"libsqlite3-0"},"version":"3.16.2-5+deb9u3"},{"package":{"ecosystem":"Debian","name":"libss2"},"version":"1.43.4-2+deb9u2"},{"package":{"ecosystem":"Debian","name":"libssl1.1"},"version":"1.1.0l-1~deb9u5"},{"package":{"ecosystem":"Debian","name":"libstdc++6"},"version":"6.3.0-18+deb9u1"},{"package":{"ecosystem":"Debian","name":"libsystemd0"},"version":"232-25+deb9u13"},{"package":{"ecosystem":"Debian","name":"libtasn1-6"},"version":"4.10-1.1+deb9u1"},{"package":{"ecosystem":"Debian","name":"libtinfo5"},"version":"6.0+20161126-1+deb9u2"},{"package":{"ecosystem":"Debian","name":"libudev1"},"version":"232-25+deb9u13"},{"package":{"ecosystem":"Debian","name":"libustr-1.0-1"},"version":"1.0.4-6"},{"package":{"ecosystem":"Debian","name":"libuuid1"},"version":"2.29.2-1+deb9u1"},{"package":{"ecosystem":"Debian","name":"libxml2"},"version":"2.9.4+dfsg1-2.2+deb9u6"},{"package":{"ecosystem":"Debian","name":"libxslt1.1"},"version":"1.1.29-2.1+deb9u2"},{"package":{"ecosystem":"Debian","name":"libzstd1"},"version":"1.1.2-1+deb9u1"},{"package":{"ecosystem":"Debian","name":"locales"},"version":"2.24-11+deb9u4"},{"package":{"ecosystem":"Debian","name":"login"},"version":"1:4.4-4.1+deb9u1"},{"package":{"ecosystem":"Debian","name":"lsb-base"},"version":"9.20161125"},{"package":{"ecosystem":"Debian","name":"mawk"},"version":"1.3.3-17+b3"},{"package":{"ecosystem":"Debian","name":"mount"},"version":"2.29.2-1+deb9u1"},{"package":{"ecosystem":"Debian","name":"multiarch-support"},"version":"2.24-11+deb9u4"},{"package":{"ecosystem":"Debian","name":"ncurses-base"},"version":"6.0+20161126-1+deb9u2"},{"package":{"ecosystem":"Debian","name":"ncurses-bin"},"version":"6.0+20161126-1+deb9u2"},{"package":{"ecosystem":"Debian","name":"netbase"},"version":"5.4"},{"package":{"ecosystem":"Debian","name":"openssl"},"version":"1.1.0l-1~deb9u5"},{"package":{"ecosystem":"Debian","name":"passwd"},"version":"1:4.4-4.1+deb9u1"},{"package":{"ecosystem":"Debian","name":"perl"},"version":"5.24.1-3+deb9u7"},{"package":{"ecosystem":"Debian","name":"perl-base"},"version":"5.24.1-3+deb9u7"},{"package":{"ecosystem":"Debian","name":"perl-modules-5.24"},"version":"5.24.1-3+deb9u7"},{"package":{"ecosystem":"Debian","name":"pgdg-keyring"},"version":"2018.2"},{"package":{"ecosystem":"Debian","name":"pinentry-curses"},"version":"1.0.0-2"},{"package":{"ecosystem":"OSS-Fuzz","name":"postgresql"},"version":"11.15"},{"package":{"ecosystem":"Debian","name":"postgresql-11"},"version":"11.15-1.pgdg90+1"},{"package":{"ecosystem":"Debian","name":"postgresql-client-11"},"version":"11.15-1.pgdg90+1"},{"package":{"ecosystem":"Debian","name":"postgresql-client-common"},"version":"238.pgdg90+1"},{"package":{"ecosystem":"Debian","name":"postgresql-common"},"version":"238.pgdg90+1"},{"package":{"ecosystem":"Debian","name":"readline-common"},"version":"7.0-3"},{"package":{"ecosystem":"Debian","name":"sed"},"version":"4.4-1"},{"package":{"ecosystem":"Debian","name":"sensible-utils"},"version":"0.0.9+deb9u1"},{"package":{"ecosystem":"Debian","name":"ssl-cert"},"version":"1.0.39"},{"package":{"ecosystem":"Debian","name":"sysvinit-utils"},"version":"2.88dsf-59.9"},{"package":{"ecosystem":"Debian","name":"tar"},"version":"1.29b-1.1+deb9u1"},{"package":{"ecosystem":"Debian","name":"tzdata"},"version":"2021a-0+deb9u3"},{"package":{"ecosystem":"Debian","name":"ucf"},"version":"3.0036"},{"package":{"ecosystem":"Debian","name":"util-linux"},"version":"2.29.2-1+deb9u1"},{"package":{"ecosystem":"Debian","name":"xz-utils"},"version":"5.2.2-1.2+deb9u1"},{"package":{"ecosystem":"Debian","name":"zlib1g"},"version":"1:1.2.8.dfsg-5+deb9u1"},{"package":{"ecosystem":"Debian","name":"zstd"},"version":"1.1.2-1+deb9u1"},{"package":{"ecosystem":"Alpine","name":"alpine-baselayout"},"version":"3.4.0-r0"},{"package":{"ecosystem":"Alpine","name":"alpine-baselayout-data"},"version":"3.4.0-r0"},{"package":{"ecosystem":"Alpine","name":"alpine-keys"},"version":"2.4-r1"},{"package":{"ecosystem":"Alpine","name":"apk-tools"},"version":"2.12.10-r1"},{"package":{"ecosystem":"Alpine","name":"busybox-binsh"},"version":"1.36.1-r27"},{"package":{"ecosystem":"Alpine","name":"ca-certificates-bundle"},"version":"20220614-r4"},{"package":{"ecosystem":"Alpine","name":"libc-utils"},"version":"0.7.2-r3"},{"package":{"ecosystem":"Alpine","name":"libcrypto3"},"version":"3.0.8-r0"},{"package":{"ecosystem":"Alpine","name":"libssl3"},"version":"3.0.8-r0"},{"package":{"ecosystem":"Alpine","name":"musl"},"version":"1.2.3-r4"},{"package":{"ecosystem":"Alpine","name":"musl-utils"},"version":"1.2.3-r4"},{"package":{"ecosystem":"Alpine","name":"scanelf"},"version":"1.3.5-r1"},{"package":{"ecosystem":"Alpine","name":"ssl_client"},"version":"1.36.1-r27"},{"package":{"ecosystem":"Alpine","name":"zlib"},"version":"1.2.10-r0"}]}'
+      headers:
+        Content-Type:
+          - application/json
+        X-Test-Name:
+          - TestCommand_Config_UnusedIgnores/unused_ignores_are_reported_with_specific_config_and_file#01
+      url: https://api.osv.dev/v1/querybatch
+      method: POST
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      content_length: 20127
+      body: |
+        {
+          "results": [
+            {
+              "vulns": [
+                {
+                  "id": "ALPINE-CVE-2022-37434",
+                  "modified": "2025-12-03T22:50:43.469206Z"
+                }
+              ]
+            },
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "ALPINE-CVE-2025-26519",
+                  "modified": "2025-11-19T06:21:21.194626Z"
+                }
+              ]
+            },
+            {},
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "ALPINE-CVE-2018-25032",
+                  "modified": "2025-12-03T22:47:03.844688Z"
+                },
+                {
+                  "id": "ALPINE-CVE-2022-37434",
+                  "modified": "2025-12-03T22:50:43.469206Z"
+                }
+              ]
+            },
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "UBUNTU-CVE-2017-11164",
+                  "modified": "2025-10-24T04:46:24Z"
+                }
+              ]
+            },
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "DEBIAN-CVE-2011-3374",
+                  "modified": "2025-11-20T10:07:04.572010Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2018-0501",
+                  "modified": "2025-11-19T02:04:24.786271Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2019-3462",
+                  "modified": "2025-11-19T02:02:50.288367Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2020-27350",
+                  "modified": "2025-11-19T01:06:21.507844Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2020-3810",
+                  "modified": "2025-11-19T01:08:53.168851Z"
+                },
+                {
+                  "id": "DSA-4685-1",
+                  "modified": "2025-05-26T07:21:59.359875Z"
+                },
+                {
+                  "id": "DSA-4808-1",
+                  "modified": "2025-05-26T07:21:52.187597Z"
+                }
+              ]
+            },
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "DEBIAN-CVE-2019-18276",
+                  "modified": "2025-11-19T01:19:06.470662Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-3715",
+                  "modified": "2025-11-20T10:15:59.798571Z"
+                }
+              ]
+            },
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "DEBIAN-CVE-2016-2781",
+                  "modified": "2025-11-20T10:12:10.315580Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2017-18018",
+                  "modified": "2025-11-20T10:13:03.410084Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2024-0684",
+                  "modified": "2025-11-19T01:02:00.374806Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2025-5278",
+                  "modified": "2025-11-20T10:18:24.026350Z"
+                }
+              ]
+            },
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "DLA-3482-1",
+                  "modified": "2025-05-26T07:01:25.263124Z"
+                }
+              ]
+            },
+            {},
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "DEBIAN-CVE-2022-1664",
+                  "modified": "2025-11-20T10:15:48.083782Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2025-6297",
+                  "modified": "2025-11-20T10:18:27.456848Z"
+                },
+                {
+                  "id": "DLA-3022-1",
+                  "modified": "2025-05-26T07:22:47.007443Z"
+                },
+                {
+                  "id": "DSA-5147-1",
+                  "modified": "2025-05-26T07:22:47.069263Z"
+                }
+              ]
+            },
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "DEBIAN-CVE-2019-5094",
+                  "modified": "2025-11-19T02:02:52.019166Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2019-5188",
+                  "modified": "2025-11-19T01:01:51.904490Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-1304",
+                  "modified": "2025-11-20T10:15:47.847878Z"
+                },
+                {
+                  "id": "DLA-3910-1",
+                  "modified": "2025-05-26T07:22:45.827447Z"
+                },
+                {
+                  "id": "DSA-4535-1",
+                  "modified": "2025-05-26T07:21:16.735871Z"
+                }
+              ]
+            },
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "GHSA-9493-h29p-rfm2",
+                  "modified": "2025-11-18T18:36:38Z"
+                },
+                {
+                  "id": "GHSA-cgrx-mc8f-2prm",
+                  "modified": "2025-11-18T18:38:01Z"
+                },
+                {
+                  "id": "GHSA-f3fp-gc8g-vw66",
+                  "modified": "2024-08-21T15:26:57.192290Z"
+                },
+                {
+                  "id": "GHSA-g2j6-57v7-gm8c",
+                  "modified": "2024-12-06T15:31:17Z"
+                },
+                {
+                  "id": "GHSA-jfvp-7x6p-h2pv",
+                  "modified": "2025-02-21T21:03:04Z"
+                },
+                {
+                  "id": "GHSA-m8cg-xc2p-r3fc",
+                  "modified": "2024-08-20T20:58:42.328556Z"
+                },
+                {
+                  "id": "GHSA-qw9x-cqr3-wc7r",
+                  "modified": "2025-11-18T18:37:10Z"
+                },
+                {
+                  "id": "GHSA-v95c-p5hm-xq8f",
+                  "modified": "2024-05-31T17:47:57Z"
+                },
+                {
+                  "id": "GHSA-vpvm-3wq2-2wvm",
+                  "modified": "2024-12-06T15:31:17Z"
+                },
+                {
+                  "id": "GHSA-xr7r-f8xq-vfvv",
+                  "modified": "2024-07-05T21:38:20Z"
+                },
+                {
+                  "id": "GO-2022-0274",
+                  "modified": "2024-05-20T16:03:47Z"
+                },
+                {
+                  "id": "GO-2022-0452",
+                  "modified": "2025-08-05T19:57:40Z"
+                },
+                {
+                  "id": "GO-2023-1627",
+                  "modified": "2025-08-05T19:57:40Z"
+                },
+                {
+                  "id": "GO-2023-1682",
+                  "modified": "2025-08-05T19:57:40Z"
+                },
+                {
+                  "id": "GO-2023-1683",
+                  "modified": "2025-08-05T19:57:40Z"
+                },
+                {
+                  "id": "GO-2024-2491",
+                  "modified": "2024-07-01T21:50:42Z"
+                },
+                {
+                  "id": "GO-2024-3110",
+                  "modified": "2025-08-05T19:57:40Z"
+                },
+                {
+                  "id": "GO-2025-4096",
+                  "modified": "2025-11-18T16:13:48.753195Z"
+                },
+                {
+                  "id": "GO-2025-4097",
+                  "modified": "2025-11-18T16:14:16.667487Z"
+                },
+                {
+                  "id": "GO-2025-4098",
+                  "modified": "2025-11-18T16:13:50.829446Z"
+                }
+              ]
+            },
+            {},
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "GHSA-p782-xgp4-8hr8",
+                  "modified": "2024-05-20T21:27:32Z"
+                },
+                {
+                  "id": "GO-2022-0493",
+                  "modified": "2024-05-20T16:03:47Z"
+                }
+              ]
+            },
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "DEBIAN-CVE-2022-1271",
+                  "modified": "2025-11-20T10:15:47.940295Z"
+                },
+                {
+                  "id": "DSA-5122-1",
+                  "modified": "2025-05-26T07:22:45.579215Z"
+                }
+              ]
+            },
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "DEBIAN-CVE-2017-0379",
+                  "modified": "2025-11-19T01:06:25.120079Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2017-7526",
+                  "modified": "2025-11-19T02:04:40.318681Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2018-0495",
+                  "modified": "2025-11-19T02:04:27.207183Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2018-6829",
+                  "modified": "2025-11-20T10:13:52.315674Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2019-13627",
+                  "modified": "2025-11-19T01:12:35.581705Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2021-33560",
+                  "modified": "2025-11-20T10:15:42.132245Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2021-40528",
+                  "modified": "2025-11-19T01:01:59.995618Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2024-2236",
+                  "modified": "2025-11-20T10:17:03.685651Z"
+                }
+              ]
+            },
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "DEBIAN-CVE-2017-10790",
+                  "modified": "2025-11-19T01:01:57.855157Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2018-1000654",
+                  "modified": "2025-11-19T02:02:40.642360Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2018-6003",
+                  "modified": "2025-11-19T01:06:22.990063Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2021-46848",
+                  "modified": "2025-11-20T10:15:14.681077Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2024-12133",
+                  "modified": "2025-11-20T10:17:02.620233Z"
+                },
+                {
+                  "id": "DLA-3263-1",
+                  "modified": "2025-05-26T07:22:42.617563Z"
+                },
+                {
+                  "id": "DLA-4061-1",
+                  "modified": "2025-05-26T07:23:58.435350Z"
+                },
+                {
+                  "id": "DSA-5863-1",
+                  "modified": "2025-05-26T07:23:58.495667Z"
+                }
+              ]
+            },
+            {},
+            {},
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "DEBIAN-CVE-2016-3709",
+                  "modified": "2025-11-20T10:12:11.931996Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2016-9318",
+                  "modified": "2025-11-19T02:02:45.582059Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2017-0663",
+                  "modified": "2025-11-19T02:02:52.056836Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2017-15412",
+                  "modified": "2025-11-19T01:08:49.499099Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2017-16931",
+                  "modified": "2025-11-19T02:04:25.542166Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2017-16932",
+                  "modified": "2025-11-19T01:04:39.458229Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2017-18258",
+                  "modified": "2025-11-19T01:08:48.927062Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2017-5130",
+                  "modified": "2025-11-19T01:03:12.822124Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2017-5969",
+                  "modified": "2025-11-19T01:08:52.062516Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2017-7375",
+                  "modified": "2025-11-19T02:02:48.011785Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2017-7376",
+                  "modified": "2025-11-19T02:01:17.016443Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2017-8872",
+                  "modified": "2025-11-19T02:04:31.920669Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2017-9047",
+                  "modified": "2025-11-19T02:04:30.335407Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2017-9048",
+                  "modified": "2025-11-19T01:19:09.303210Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2017-9049",
+                  "modified": "2025-11-19T01:03:12.259406Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2017-9050",
+                  "modified": "2025-11-19T01:08:53.069573Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2018-14404",
+                  "modified": "2025-11-19T01:12:32.274520Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2018-14567",
+                  "modified": "2025-11-19T01:08:49.660035Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2019-19956",
+                  "modified": "2025-11-19T02:01:17.970372Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2019-20388",
+                  "modified": "2025-11-19T02:04:37.363509Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2020-24977",
+                  "modified": "2025-11-19T02:04:41.266003Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2020-7595",
+                  "modified": "2025-11-19T02:04:29.271836Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2021-3516",
+                  "modified": "2025-11-19T02:01:14.946107Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2021-3517",
+                  "modified": "2025-11-19T01:12:34.981900Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2021-3518",
+                  "modified": "2025-11-19T01:19:08.645337Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2021-3537",
+                  "modified": "2025-11-19T02:04:30.248276Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2021-3541",
+                  "modified": "2025-11-19T02:04:36.614917Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-2309",
+                  "modified": "2025-11-20T10:15:28.694644Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-23308",
+                  "modified": "2025-11-20T10:15:29.029152Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-29824",
+                  "modified": "2025-11-20T10:15:52.814213Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-40303",
+                  "modified": "2025-11-20T10:16:01.982632Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-40304",
+                  "modified": "2025-11-20T10:16:01.918054Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-49043",
+                  "modified": "2025-11-20T10:16:12.358770Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-28484",
+                  "modified": "2025-11-20T10:16:35.199991Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-29469",
+                  "modified": "2025-11-20T10:17:34.943682Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-39615",
+                  "modified": "2025-11-20T10:16:41.593841Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-45322",
+                  "modified": "2025-11-20T10:16:44.891362Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2024-25062",
+                  "modified": "2025-11-20T10:17:04.986212Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2024-34459",
+                  "modified": "2025-11-20T10:17:41.570595Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2024-56171",
+                  "modified": "2025-11-20T10:17:48.605695Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2025-12863",
+                  "modified": "2025-11-20T14:28:24.129936Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2025-24928",
+                  "modified": "2025-11-20T10:18:05.778161Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2025-27113",
+                  "modified": "2025-11-20T10:18:06.358243Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2025-32414",
+                  "modified": "2025-11-20T10:18:08.076077Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2025-32415",
+                  "modified": "2025-11-20T10:18:08.251077Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2025-49794",
+                  "modified": "2025-11-20T10:18:23.322205Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2025-49796",
+                  "modified": "2025-11-20T10:18:23.585429Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2025-6021",
+                  "modified": "2025-11-20T10:18:26.314947Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2025-6170",
+                  "modified": "2025-11-20T10:18:26.670728Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2025-8732",
+                  "modified": "2025-11-20T10:18:28.450401Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2025-9714",
+                  "modified": "2025-11-20T10:18:28.938756Z"
+                },
+                {
+                  "id": "DLA-3012-1",
+                  "modified": "2025-05-26T07:23:01.266561Z"
+                },
+                {
+                  "id": "DLA-3172-1",
+                  "modified": "2025-05-26T07:23:10.448009Z"
+                },
+                {
+                  "id": "DLA-3405-1",
+                  "modified": "2025-05-26T07:23:30.714665Z"
+                },
+                {
+                  "id": "DLA-3878-1",
+                  "modified": "2025-05-26T07:18:39.626843Z"
+                },
+                {
+                  "id": "DLA-4064-1",
+                  "modified": "2025-05-26T07:23:19.568188Z"
+                },
+                {
+                  "id": "DLA-4146-1",
+                  "modified": "2025-05-26T06:58:47.071983Z"
+                },
+                {
+                  "id": "DLA-4251-1",
+                  "modified": "2025-07-26T19:45:29.054316Z"
+                },
+                {
+                  "id": "DLA-4319-1",
+                  "modified": "2025-09-30T22:17:08.381361Z"
+                },
+                {
+                  "id": "DSA-5142-1",
+                  "modified": "2025-05-26T07:23:01.328825Z"
+                },
+                {
+                  "id": "DSA-5271-1",
+                  "modified": "2025-05-26T07:23:10.510965Z"
+                },
+                {
+                  "id": "DSA-5391-1",
+                  "modified": "2025-05-26T07:23:30.774960Z"
+                },
+                {
+                  "id": "DSA-5949-1",
+                  "modified": "2025-06-25T19:16:29.342484Z"
+                },
+                {
+                  "id": "DSA-5990-1",
+                  "modified": "2025-08-29T13:01:48.117026Z"
+                }
+              ]
+            },
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "DEBIAN-CVE-2018-0732",
+                  "modified": "2025-11-19T02:02:54.249966Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2018-0734",
+                  "modified": "2025-11-19T02:02:43.768735Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2018-0735",
+                  "modified": "2025-11-19T01:19:04.251217Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2018-5407",
+                  "modified": "2025-11-19T01:02:00.203143Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2019-1543",
+                  "modified": "2025-11-19T01:12:34.981629Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2019-1547",
+                  "modified": "2025-11-19T01:12:35.687253Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2019-1549",
+                  "modified": "2025-11-19T01:04:40.924710Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2019-1551",
+                  "modified": "2025-11-19T01:19:08.067279Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2019-1563",
+                  "modified": "2025-11-19T02:04:34.392400Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2020-1967",
+                  "modified": "2025-11-19T02:04:38.886020Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2020-1971",
+                  "modified": "2025-11-19T02:04:28.520483Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2021-23840",
+                  "modified": "2025-11-19T01:03:14.356310Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2021-23841",
+                  "modified": "2025-11-19T02:02:54.160482Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2021-3449",
+                  "modified": "2025-11-19T01:04:41.495834Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2021-3450",
+                  "modified": "2025-11-19T02:01:16.123253Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2021-3711",
+                  "modified": "2025-11-20T10:15:44.121033Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2021-3712",
+                  "modified": "2025-11-20T10:15:44.130193Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2021-4160",
+                  "modified": "2025-11-20T10:15:10.185497Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-0778",
+                  "modified": "2025-11-20T10:15:47.332694Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-1292",
+                  "modified": "2025-11-20T10:15:25.471825Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-2068",
+                  "modified": "2025-11-20T10:15:27.022420Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-2097",
+                  "modified": "2025-11-20T10:15:27.065089Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-2274",
+                  "modified": "2025-11-19T02:02:45.418259Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-3358",
+                  "modified": "2025-11-19T01:06:25.721124Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-3602",
+                  "modified": "2025-11-19T01:12:35.687556Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-3786",
+                  "modified": "2025-11-19T01:19:02.748977Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-3996",
+                  "modified": "2025-11-19T02:01:16.596616Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-4203",
+                  "modified": "2025-11-19T02:01:16.313531Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-4304",
+                  "modified": "2025-11-20T10:16:04.313466Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-4450",
+                  "modified": "2025-11-20T10:16:05.367442Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-0215",
+                  "modified": "2025-11-20T10:16:27.838296Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-0216",
+                  "modified": "2025-11-19T02:04:35.947667Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-0217",
+                  "modified": "2025-11-19T01:12:37.272749Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-0286",
+                  "modified": "2025-11-20T10:16:27.985311Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-0401",
+                  "modified": "2025-11-19T01:12:36.298552Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-0464",
+                  "modified": "2025-11-20T10:16:28.057931Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-0465",
+                  "modified": "2025-11-20T10:16:28.143046Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-0466",
+                  "modified": "2025-11-20T10:16:28.053837Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-1255",
+                  "modified": "2025-11-19T01:08:49.387669Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-2650",
+                  "modified": "2025-11-20T10:17:34.439123Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-2975",
+                  "modified": "2025-11-20T10:16:36.112183Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-3446",
+                  "modified": "2025-11-20T10:16:38.860251Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-3817",
+                  "modified": "2025-11-20T10:17:35.737266Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-5363",
+                  "modified": "2025-11-20T10:16:59.430619Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-5678",
+                  "modified": "2025-11-20T10:17:38.719690Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-6129",
+                  "modified": "2025-11-20T10:17:39.029757Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-6237",
+                  "modified": "2025-11-20T10:17:39.218097Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2024-0727",
+                  "modified": "2025-11-20T10:17:01.258658Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2024-12797",
+                  "modified": "2025-11-19T02:04:36.131726Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2024-13176",
+                  "modified": "2025-11-20T10:17:03.124812Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2024-2511",
+                  "modified": "2025-11-20T10:17:05.139581Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2024-4603",
+                  "modified": "2025-11-20T10:17:43.955114Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2024-4741",
+                  "modified": "2025-11-20T10:17:26.990307Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2024-5535",
+                  "modified": "2025-11-20T10:17:48.194687Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2024-6119",
+                  "modified": "2025-11-20T10:17:53.824117Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2024-9143",
+                  "modified": "2025-11-20T10:17:55.864918Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2025-27587",
+                  "modified": "2025-11-20T10:18:06.745292Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2025-4575",
+                  "modified": "2025-11-19T02:02:43.971243Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2025-9230",
+                  "modified": "2025-11-20T10:18:28.690398Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2025-9231",
+                  "modified": "2025-11-20T10:18:28.713979Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2025-9232",
+                  "modified": "2025-11-20T10:18:28.748819Z"
+                },
+                {
+                  "id": "DLA-3008-1",
+                  "modified": "2025-05-26T07:22:45.706031Z"
+                },
+                {
+                  "id": "DLA-3325-1",
+                  "modified": "2025-05-26T07:22:47.806974Z"
+                },
+                {
+                  "id": "DLA-3449-1",
+                  "modified": "2025-05-26T07:23:20.191820Z"
+                },
+                {
+                  "id": "DLA-3530-1",
+                  "modified": "2025-05-26T07:23:36.219658Z"
+                },
+                {
+                  "id": "DLA-3942-1",
+                  "modified": "2025-05-26T07:23:52.994725Z"
+                },
+                {
+                  "id": "DLA-3942-2",
+                  "modified": "2025-05-26T07:23:53.056205Z"
+                },
+                {
+                  "id": "DLA-4176-1",
+                  "modified": "2025-05-26T07:02:17.127596Z"
+                },
+                {
+                  "id": "DLA-4321-1",
+                  "modified": "2025-10-03T16:33:24.717173Z"
+                },
+                {
+                  "id": "DSA-4539-1",
+                  "modified": "2025-05-26T07:20:57.698150Z"
+                },
+                {
+                  "id": "DSA-4539-3",
+                  "modified": "2025-05-26T07:05:14.261652Z"
+                },
+                {
+                  "id": "DSA-4661-1",
+                  "modified": "2025-05-26T07:21:44.983880Z"
+                },
+                {
+                  "id": "DSA-4807-1",
+                  "modified": "2025-05-26T07:21:45.227381Z"
+                },
+                {
+                  "id": "DSA-4855-1",
+                  "modified": "2025-05-26T07:20:57.944135Z"
+                },
+                {
+                  "id": "DSA-4875-1",
+                  "modified": "2025-05-26T07:22:25.295971Z"
+                },
+                {
+                  "id": "DSA-4963-1",
+                  "modified": "2025-05-26T07:22:29.610492Z"
+                },
+                {
+                  "id": "DSA-5103-1",
+                  "modified": "2025-05-26T07:22:36.298650Z"
+                },
+                {
+                  "id": "DSA-5139-1",
+                  "modified": "2025-05-26T07:22:45.765450Z"
+                },
+                {
+                  "id": "DSA-5169-1",
+                  "modified": "2025-05-26T07:22:47.687377Z"
+                },
+                {
+                  "id": "DSA-5343-1",
+                  "modified": "2025-05-26T07:22:47.870882Z"
+                },
+                {
+                  "id": "DSA-5417-1",
+                  "modified": "2025-05-26T07:23:20.254324Z"
+                },
+                {
+                  "id": "DSA-5532-1",
+                  "modified": "2025-05-26T07:23:52.176093Z"
+                },
+                {
+                  "id": "DSA-5764-1",
+                  "modified": "2025-05-26T07:24:15.576601Z"
+                },
+                {
+                  "id": "DSA-6015-1",
+                  "modified": "2025-10-01T13:32:01.848986Z"
+                }
+              ]
+            },
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "DEBIAN-CVE-2011-4116",
+                  "modified": "2025-11-20T10:10:50.058601Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2017-12837",
+                  "modified": "2025-11-19T01:03:14.361068Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2017-12883",
+                  "modified": "2025-11-19T01:12:38.323688Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2018-12015",
+                  "modified": "2025-11-19T02:02:49.033339Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2018-18311",
+                  "modified": "2025-11-19T01:12:36.918544Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2018-18312",
+                  "modified": "2025-11-19T02:04:33.584277Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2018-18313",
+                  "modified": "2025-11-19T01:06:24.154928Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2018-18314",
+                  "modified": "2025-11-19T01:12:35.416886Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2018-6797",
+                  "modified": "2025-11-19T02:04:23.831823Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2018-6798",
+                  "modified": "2025-11-19T02:02:49.628171Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2018-6913",
+                  "modified": "2025-11-19T02:02:50.593437Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2020-10543",
+                  "modified": "2025-11-19T01:04:39.904198Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2020-10878",
+                  "modified": "2025-11-19T01:12:35.457057Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2020-12723",
+                  "modified": "2025-11-19T02:02:47.094787Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2020-16156",
+                  "modified": "2025-11-20T10:14:36.701112Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2021-36770",
+                  "modified": "2025-11-20T10:15:44.080114Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-48522",
+                  "modified": "2025-11-19T01:08:52.915564Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-31484",
+                  "modified": "2025-11-20T10:17:35.627220Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-31486",
+                  "modified": "2025-11-20T10:17:36.081192Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-47038",
+                  "modified": "2025-11-20T10:16:46.343364Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2024-56406",
+                  "modified": "2025-11-20T10:17:48.686371Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2025-40909",
+                  "modified": "2025-11-20T10:18:21.143971Z"
+                },
+                {
+                  "id": "DLA-3926-1",
+                  "modified": "2025-05-26T07:21:42.385892Z"
+                },
+                {
+                  "id": "DSA-5902-1",
+                  "modified": "2025-05-26T07:24:14.898997Z"
+                }
+              ]
+            },
+            {},
+            {},
+            {},
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "DLA-3072-1",
+                  "modified": "2025-05-26T07:22:56.848703Z"
+                },
+                {
+                  "id": "DLA-3189-1",
+                  "modified": "2025-05-26T07:01:07.887113Z"
+                },
+                {
+                  "id": "DLA-3316-1",
+                  "modified": "2025-05-26T07:01:13.127412Z"
+                },
+                {
+                  "id": "DLA-3422-1",
+                  "modified": "2025-05-26T07:23:26.375715Z"
+                },
+                {
+                  "id": "DLA-3600-1",
+                  "modified": "2025-05-26T07:23:40.030714Z"
+                },
+                {
+                  "id": "DLA-3651-1",
+                  "modified": "2025-05-26T07:23:53.368012Z"
+                },
+                {
+                  "id": "DLA-3764-1",
+                  "modified": "2025-05-26T07:23:55.849014Z"
+                },
+                {
+                  "id": "DSA-5135-1",
+                  "modified": "2025-05-26T07:22:46.760638Z"
+                }
+              ]
+            },
+            {},
+            {},
+            {},
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "DEBIAN-CVE-2017-17512",
+                  "modified": "2025-11-19T02:04:30.656495Z"
+                }
+              ]
+            },
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "DEBIAN-CVE-2005-2541",
+                  "modified": "2025-11-20T10:09:01.923782Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2018-20482",
+                  "modified": "2025-11-19T02:02:47.070832Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2019-9923",
+                  "modified": "2025-11-19T02:02:53.559001Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2021-20193",
+                  "modified": "2025-11-19T01:01:55.139356Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-48303",
+                  "modified": "2025-11-20T10:16:07.552593Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-39804",
+                  "modified": "2025-11-20T10:16:41.587973Z"
+                },
+                {
+                  "id": "DLA-3755-1",
+                  "modified": "2025-05-26T07:23:40.399798Z"
+                }
+              ]
+            },
+            {
+              "vulns": [
+                {
+                  "id": "DLA-3051-1",
+                  "modified": "2025-05-26T07:01:56.257796Z"
+                },
+                {
+                  "id": "DLA-3134-1",
+                  "modified": "2025-05-26T07:01:01.500124Z"
+                },
+                {
+                  "id": "DLA-3161-1",
+                  "modified": "2025-05-26T07:01:03.882213Z"
+                },
+                {
+                  "id": "DLA-3366-1",
+                  "modified": "2025-05-26T07:01:17.027142Z"
+                },
+                {
+                  "id": "DLA-3412-1",
+                  "modified": "2025-05-26T07:01:20.109212Z"
+                },
+                {
+                  "id": "DLA-3684-1",
+                  "modified": "2025-05-26T07:01:38.953691Z"
+                },
+                {
+                  "id": "DLA-3788-1",
+                  "modified": "2025-05-26T07:01:46.700929Z"
+                },
+                {
+                  "id": "DLA-3972-1",
+                  "modified": "2025-05-26T07:02:05.284676Z"
+                },
+                {
+                  "id": "DLA-4085-1",
+                  "modified": "2025-05-26T07:02:10.958749Z"
+                },
+                {
+                  "id": "DLA-4105-1",
+                  "modified": "2025-05-26T07:02:13.921097Z"
+                }
+              ]
+            },
+            {
+              "vulns": [
+                {
+                  "id": "DLA-4016-1",
+                  "modified": "2025-05-26T07:02:06.504254Z"
+                }
+              ]
+            },
+            {
+              "vulns": [
+                {
+                  "id": "DEBIAN-CVE-2016-2779",
+                  "modified": "2025-11-19T01:12:38.591462Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2018-7738",
+                  "modified": "2025-11-20T10:13:54.493707Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2021-37600",
+                  "modified": "2025-11-19T02:02:43.997954Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2021-3995",
+                  "modified": "2025-11-20T10:15:45.587792Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2021-3996",
+                  "modified": "2025-11-20T10:15:45.602424Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-0563",
+                  "modified": "2025-11-20T10:15:24.228408Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2024-28085",
+                  "modified": "2025-11-20T10:17:41.612682Z"
+                },
+                {
+                  "id": "DLA-3782-1",
+                  "modified": "2025-05-26T07:22:30.567107Z"
+                },
+                {
+                  "id": "DSA-5055-1",
+                  "modified": "2025-05-26T07:22:33.646795Z"
+                },
+                {
+                  "id": "DSA-5650-1",
+                  "modified": "2025-05-26T07:24:03.887524Z"
+                }
+              ]
+            },
+            {
+              "vulns": [
+                {
+                  "id": "DEBIAN-CVE-2022-1271",
+                  "modified": "2025-11-20T10:15:47.940295Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2024-3094",
+                  "modified": "2025-11-19T01:12:34.542011Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2025-31115",
+                  "modified": "2025-11-20T10:18:07.484724Z"
+                },
+                {
+                  "id": "DSA-5123-1",
+                  "modified": "2025-05-26T07:22:45.643786Z"
+                },
+                {
+                  "id": "DSA-5895-1",
+                  "modified": "2025-05-26T07:24:22.556406Z"
+                }
+              ]
+            },
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "ALPINE-CVE-2025-26519",
+                  "modified": "2025-11-19T06:21:21.194626Z"
+                }
+              ]
+            },
+            {},
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "ALPINE-CVE-2018-25032",
+                  "modified": "2025-12-03T22:47:03.844688Z"
+                },
+                {
+                  "id": "ALPINE-CVE-2022-37434",
+                  "modified": "2025-12-03T22:50:43.469206Z"
+                }
+              ]
+            }
+          ]
+        }
+      headers:
+        Content-Length:
+          - "20127"
+        Content-Type:
+          - application/json
+      status: 200 OK
+      code: 200
+      duration: 0s
+  - id: 2
+    request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
+      content_length: 12053
+      host: api.osv.dev
+      body: '{"queries":[{"package":{"ecosystem":"Alpine","name":"alpine-baselayout"},"version":"3.4.0-r0"},{"package":{"ecosystem":"Alpine","name":"alpine-baselayout-data"},"version":"3.4.0-r0"},{"package":{"ecosystem":"Alpine","name":"alpine-keys"},"version":"2.4-r1"},{"package":{"ecosystem":"Alpine","name":"apk-tools"},"version":"2.12.10-r1"},{"package":{"ecosystem":"Alpine","name":"busybox-binsh"},"version":"1.36.1-r27"},{"package":{"ecosystem":"Alpine","name":"ca-certificates-bundle"},"version":"20220614-r4"},{"package":{"ecosystem":"Alpine","name":"libc-utils"},"version":"0.7.2-r3"},{"package":{"ecosystem":"Alpine","name":"libcrypto3"},"version":"3.0.8-r0"},{"package":{"ecosystem":"Alpine","name":"libssl3"},"version":"3.0.8-r0"},{"package":{"ecosystem":"Alpine","name":"musl"},"version":"1.2.3-r4"},{"package":{"ecosystem":"Alpine","name":"musl-utils"},"version":"1.2.3-r4"},{"package":{"ecosystem":"Alpine","name":"scanelf"},"version":"1.3.5-r1"},{"package":{"ecosystem":"Alpine","name":"ssl_client"},"version":"1.36.1-r27"},{"package":{"ecosystem":"Alpine","name":"zlib"},"version":"1.2.10-r0"},{"package":{"ecosystem":"Debian","name":"adduser"},"version":"3.115"},{"package":{"ecosystem":"Debian","name":"apt"},"version":"1.4.11"},{"package":{"ecosystem":"Debian","name":"base-files"},"version":"9.9+deb9u13"},{"package":{"ecosystem":"Debian","name":"base-passwd"},"version":"3.5.43"},{"package":{"ecosystem":"Debian","name":"bash"},"version":"4.4-5"},{"package":{"ecosystem":"Debian","name":"bsdutils"},"version":"1:2.29.2-1+deb9u1"},{"package":{"ecosystem":"Debian","name":"coreutils"},"version":"8.26-3"},{"package":{"ecosystem":"Debian","name":"dash"},"version":"0.5.8-2.4"},{"package":{"ecosystem":"Debian","name":"debconf"},"version":"1.5.61"},{"package":{"ecosystem":"Debian","name":"debian-archive-keyring"},"version":"2017.5+deb9u2"},{"package":{"ecosystem":"Debian","name":"debianutils"},"version":"4.8.1.1"},{"package":{"ecosystem":"Debian","name":"diffutils"},"version":"1:3.5-3"},{"package":{"ecosystem":"Debian","name":"dirmngr"},"version":"2.1.18-8~deb9u4"},{"package":{"ecosystem":"Debian","name":"dpkg"},"version":"1.18.25"},{"package":{"ecosystem":"Debian","name":"e2fslibs"},"version":"1.43.4-2+deb9u2"},{"package":{"ecosystem":"Debian","name":"e2fsprogs"},"version":"1.43.4-2+deb9u2"},{"package":{"ecosystem":"Debian","name":"findutils"},"version":"4.6.0+git+20161106-2"},{"package":{"ecosystem":"Debian","name":"gcc-6-base"},"version":"6.3.0-18+deb9u1"},{"package":{"ecosystem":"Go","name":"github.com/opencontainers/runc"},"version":"v1.0.1"},{"package":{"ecosystem":"Go","name":"github.com/tianon/gosu"},"version":"(devel)"},{"package":{"ecosystem":"Debian","name":"gnupg"},"version":"2.1.18-8~deb9u4"},{"package":{"ecosystem":"Debian","name":"gnupg-agent"},"version":"2.1.18-8~deb9u4"},{"package":{"ecosystem":"Go","name":"golang.org/x/sys"},"version":"v0.0.0-20210817142637-7d9622a276b7"},{"package":{"ecosystem":"Debian","name":"gpgv"},"version":"2.1.18-8~deb9u4"},{"package":{"ecosystem":"Debian","name":"grep"},"version":"2.27-2"},{"package":{"ecosystem":"Debian","name":"gzip"},"version":"1.6-5+deb9u1"},{"package":{"ecosystem":"Debian","name":"hostname"},"version":"3.18+b1"},{"package":{"ecosystem":"Debian","name":"init-system-helpers"},"version":"1.48"},{"package":{"ecosystem":"Debian","name":"libacl1"},"version":"2.2.52-3+b1"},{"package":{"ecosystem":"Debian","name":"libapt-pkg5.0"},"version":"1.4.11"},{"package":{"ecosystem":"Debian","name":"libassuan0"},"version":"2.4.3-2"},{"package":{"ecosystem":"Debian","name":"libattr1"},"version":"1:2.4.47-2+b2"},{"package":{"ecosystem":"Debian","name":"libaudit-common"},"version":"1:2.6.7-2"},{"package":{"ecosystem":"Debian","name":"libaudit1"},"version":"1:2.6.7-2"},{"package":{"ecosystem":"Debian","name":"libblkid1"},"version":"2.29.2-1+deb9u1"},{"package":{"ecosystem":"Debian","name":"libbsd0"},"version":"0.8.3-1+deb9u1"},{"package":{"ecosystem":"Debian","name":"libbz2-1.0"},"version":"1.0.6-8.1"},{"package":{"ecosystem":"Debian","name":"libc-bin"},"version":"2.24-11+deb9u4"},{"package":{"ecosystem":"Debian","name":"libc-l10n"},"version":"2.24-11+deb9u4"},{"package":{"ecosystem":"Debian","name":"libc6"},"version":"2.24-11+deb9u4"},{"package":{"ecosystem":"Debian","name":"libcap-ng0"},"version":"0.7.7-3+b1"},{"package":{"ecosystem":"Debian","name":"libcomerr2"},"version":"1.43.4-2+deb9u2"},{"package":{"ecosystem":"Debian","name":"libdb5.3"},"version":"5.3.28-12+deb9u1"},{"package":{"ecosystem":"Debian","name":"libdebconfclient0"},"version":"0.227"},{"package":{"ecosystem":"Debian","name":"libedit2"},"version":"3.1-20160903-3"},{"package":{"ecosystem":"Debian","name":"libfdisk1"},"version":"2.29.2-1+deb9u1"},{"package":{"ecosystem":"Debian","name":"libffi6"},"version":"3.2.1-6"},{"package":{"ecosystem":"Debian","name":"libgcc1"},"version":"1:6.3.0-18+deb9u1"},{"package":{"ecosystem":"Debian","name":"libgcrypt20"},"version":"1.7.6-2+deb9u4"},{"package":{"ecosystem":"Debian","name":"libgdbm3"},"version":"1.8.3-14"},{"package":{"ecosystem":"Debian","name":"libgmp10"},"version":"2:6.1.2+dfsg-1+deb9u1"},{"package":{"ecosystem":"Debian","name":"libgnutls30"},"version":"3.5.8-5+deb9u6"},{"package":{"ecosystem":"Debian","name":"libgpg-error0"},"version":"1.26-2"},{"package":{"ecosystem":"Debian","name":"libgssapi-krb5-2"},"version":"1.15-1+deb9u3"},{"package":{"ecosystem":"Debian","name":"libhogweed4"},"version":"3.3-1+deb9u1"},{"package":{"ecosystem":"Debian","name":"libicu57"},"version":"57.1-6+deb9u5"},{"package":{"ecosystem":"Debian","name":"libidn11"},"version":"1.33-1+deb9u1"},{"package":{"ecosystem":"Debian","name":"libjson-perl"},"version":"2.90-1"},{"package":{"ecosystem":"Debian","name":"libk5crypto3"},"version":"1.15-1+deb9u3"},{"package":{"ecosystem":"Debian","name":"libkeyutils1"},"version":"1.5.9-9"},{"package":{"ecosystem":"Debian","name":"libkrb5-3"},"version":"1.15-1+deb9u3"},{"package":{"ecosystem":"Debian","name":"libkrb5support0"},"version":"1.15-1+deb9u3"},{"package":{"ecosystem":"Debian","name":"libksba8"},"version":"1.3.5-2"},{"package":{"ecosystem":"Debian","name":"libldap-2.4-2"},"version":"2.4.44+dfsg-5+deb9u8"},{"package":{"ecosystem":"Debian","name":"libldap-common"},"version":"2.4.44+dfsg-5+deb9u8"},{"package":{"ecosystem":"Debian","name":"libllvm6.0"},"version":"1:6.0-1~bpo9+1"},{"package":{"ecosystem":"Debian","name":"liblz4-1"},"version":"0.0~r131-2+deb9u1"},{"package":{"ecosystem":"Debian","name":"liblzma5"},"version":"5.2.2-1.2+deb9u1"},{"package":{"ecosystem":"Debian","name":"libmount1"},"version":"2.29.2-1+deb9u1"},{"package":{"ecosystem":"Debian","name":"libncurses5"},"version":"6.0+20161126-1+deb9u2"},{"package":{"ecosystem":"Debian","name":"libncursesw5"},"version":"6.0+20161126-1+deb9u2"},{"package":{"ecosystem":"Debian","name":"libnettle6"},"version":"3.3-1+deb9u1"},{"package":{"ecosystem":"Debian","name":"libnpth0"},"version":"1.3-1"},{"package":{"ecosystem":"Debian","name":"libnss-wrapper"},"version":"1.1.3-1"},{"package":{"ecosystem":"Debian","name":"libp11-kit0"},"version":"0.23.3-2+deb9u1"},{"package":{"ecosystem":"Debian","name":"libpam-modules"},"version":"1.1.8-3.6"},{"package":{"ecosystem":"Debian","name":"libpam-modules-bin"},"version":"1.1.8-3.6"},{"package":{"ecosystem":"Debian","name":"libpam-runtime"},"version":"1.1.8-3.6"},{"package":{"ecosystem":"Debian","name":"libpam0g"},"version":"1.1.8-3.6"},{"package":{"ecosystem":"Debian","name":"libpcre3"},"version":"2:8.39-3"},{"package":{"ecosystem":"Debian","name":"libperl5.24"},"version":"5.24.1-3+deb9u7"},{"package":{"ecosystem":"Debian","name":"libpq5"},"version":"14.2-1.pgdg90+1"},{"package":{"ecosystem":"Debian","name":"libreadline7"},"version":"7.0-3"},{"package":{"ecosystem":"Debian","name":"libsasl2-2"},"version":"2.1.27~101-g0780600+dfsg-3+deb9u2"},{"package":{"ecosystem":"Debian","name":"libsasl2-modules-db"},"version":"2.1.27~101-g0780600+dfsg-3+deb9u2"},{"package":{"ecosystem":"Debian","name":"libselinux1"},"version":"2.6-3+b3"},{"package":{"ecosystem":"Debian","name":"libsemanage-common"},"version":"2.6-2"},{"package":{"ecosystem":"Debian","name":"libsemanage1"},"version":"2.6-2"},{"package":{"ecosystem":"Debian","name":"libsepol1"},"version":"2.6-2"},{"package":{"ecosystem":"Debian","name":"libsmartcols1"},"version":"2.29.2-1+deb9u1"},{"package":{"ecosystem":"Debian","name":"libsqlite3-0"},"version":"3.16.2-5+deb9u3"},{"package":{"ecosystem":"Debian","name":"libss2"},"version":"1.43.4-2+deb9u2"},{"package":{"ecosystem":"Debian","name":"libssl1.1"},"version":"1.1.0l-1~deb9u5"},{"package":{"ecosystem":"Debian","name":"libstdc++6"},"version":"6.3.0-18+deb9u1"},{"package":{"ecosystem":"Debian","name":"libsystemd0"},"version":"232-25+deb9u13"},{"package":{"ecosystem":"Debian","name":"libtasn1-6"},"version":"4.10-1.1+deb9u1"},{"package":{"ecosystem":"Debian","name":"libtinfo5"},"version":"6.0+20161126-1+deb9u2"},{"package":{"ecosystem":"Debian","name":"libudev1"},"version":"232-25+deb9u13"},{"package":{"ecosystem":"Debian","name":"libustr-1.0-1"},"version":"1.0.4-6"},{"package":{"ecosystem":"Debian","name":"libuuid1"},"version":"2.29.2-1+deb9u1"},{"package":{"ecosystem":"Debian","name":"libxml2"},"version":"2.9.4+dfsg1-2.2+deb9u6"},{"package":{"ecosystem":"Debian","name":"libxslt1.1"},"version":"1.1.29-2.1+deb9u2"},{"package":{"ecosystem":"Debian","name":"libzstd1"},"version":"1.1.2-1+deb9u1"},{"package":{"ecosystem":"Debian","name":"locales"},"version":"2.24-11+deb9u4"},{"package":{"ecosystem":"Debian","name":"login"},"version":"1:4.4-4.1+deb9u1"},{"package":{"ecosystem":"Debian","name":"lsb-base"},"version":"9.20161125"},{"package":{"ecosystem":"Debian","name":"mawk"},"version":"1.3.3-17+b3"},{"package":{"ecosystem":"Debian","name":"mount"},"version":"2.29.2-1+deb9u1"},{"package":{"ecosystem":"Debian","name":"multiarch-support"},"version":"2.24-11+deb9u4"},{"package":{"ecosystem":"Debian","name":"ncurses-base"},"version":"6.0+20161126-1+deb9u2"},{"package":{"ecosystem":"Debian","name":"ncurses-bin"},"version":"6.0+20161126-1+deb9u2"},{"package":{"ecosystem":"Debian","name":"netbase"},"version":"5.4"},{"package":{"ecosystem":"Debian","name":"openssl"},"version":"1.1.0l-1~deb9u5"},{"package":{"ecosystem":"Debian","name":"passwd"},"version":"1:4.4-4.1+deb9u1"},{"package":{"ecosystem":"Debian","name":"perl"},"version":"5.24.1-3+deb9u7"},{"package":{"ecosystem":"Debian","name":"perl-base"},"version":"5.24.1-3+deb9u7"},{"package":{"ecosystem":"Debian","name":"perl-modules-5.24"},"version":"5.24.1-3+deb9u7"},{"package":{"ecosystem":"Debian","name":"pgdg-keyring"},"version":"2018.2"},{"package":{"ecosystem":"Debian","name":"pinentry-curses"},"version":"1.0.0-2"},{"package":{"ecosystem":"OSS-Fuzz","name":"postgresql"},"version":"11.15"},{"package":{"ecosystem":"Debian","name":"postgresql-11"},"version":"11.15-1.pgdg90+1"},{"package":{"ecosystem":"Debian","name":"postgresql-client-11"},"version":"11.15-1.pgdg90+1"},{"package":{"ecosystem":"Debian","name":"postgresql-client-common"},"version":"238.pgdg90+1"},{"package":{"ecosystem":"Debian","name":"postgresql-common"},"version":"238.pgdg90+1"},{"package":{"ecosystem":"Debian","name":"readline-common"},"version":"7.0-3"},{"package":{"ecosystem":"Debian","name":"sed"},"version":"4.4-1"},{"package":{"ecosystem":"Debian","name":"sensible-utils"},"version":"0.0.9+deb9u1"},{"package":{"ecosystem":"Debian","name":"ssl-cert"},"version":"1.0.39"},{"package":{"ecosystem":"Debian","name":"sysvinit-utils"},"version":"2.88dsf-59.9"},{"package":{"ecosystem":"Debian","name":"tar"},"version":"1.29b-1.1+deb9u1"},{"package":{"ecosystem":"Debian","name":"tzdata"},"version":"2021a-0+deb9u3"},{"package":{"ecosystem":"Debian","name":"ucf"},"version":"3.0036"},{"package":{"ecosystem":"Debian","name":"util-linux"},"version":"2.29.2-1+deb9u1"},{"package":{"ecosystem":"Debian","name":"xz-utils"},"version":"5.2.2-1.2+deb9u1"},{"package":{"ecosystem":"Debian","name":"zlib1g"},"version":"1:1.2.8.dfsg-5+deb9u1"},{"package":{"ecosystem":"Debian","name":"zstd"},"version":"1.1.2-1+deb9u1"}]}'
+      headers:
+        Content-Type:
+          - application/json
+        X-Test-Name:
+          - TestCommand_Config_UnusedIgnores/unused_ignores_are_reported_with_specific_config_and_multiple_files
+      url: https://api.osv.dev/v1/querybatch
+      method: POST
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      content_length: 19666
+      body: |
+        {
+          "results": [
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "ALPINE-CVE-2025-26519",
+                  "modified": "2025-11-19T06:21:21.194626Z"
+                }
+              ]
+            },
+            {},
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "ALPINE-CVE-2018-25032",
+                  "modified": "2025-12-03T22:47:03.844688Z"
+                },
+                {
+                  "id": "ALPINE-CVE-2022-37434",
+                  "modified": "2025-12-03T22:50:43.469206Z"
+                }
+              ]
+            },
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "DEBIAN-CVE-2011-3374",
+                  "modified": "2025-11-20T10:07:04.572010Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2018-0501",
+                  "modified": "2025-11-19T02:04:24.786271Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2019-3462",
+                  "modified": "2025-11-19T02:02:50.288367Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2020-27350",
+                  "modified": "2025-11-19T01:06:21.507844Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2020-3810",
+                  "modified": "2025-11-19T01:08:53.168851Z"
+                },
+                {
+                  "id": "DSA-4685-1",
+                  "modified": "2025-05-26T07:21:59.359875Z"
+                },
+                {
+                  "id": "DSA-4808-1",
+                  "modified": "2025-05-26T07:21:52.187597Z"
+                }
+              ]
+            },
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "DEBIAN-CVE-2019-18276",
+                  "modified": "2025-11-19T01:19:06.470662Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-3715",
+                  "modified": "2025-11-20T10:15:59.798571Z"
+                }
+              ]
+            },
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "DEBIAN-CVE-2016-2781",
+                  "modified": "2025-11-20T10:12:10.315580Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2017-18018",
+                  "modified": "2025-11-20T10:13:03.410084Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2024-0684",
+                  "modified": "2025-11-19T01:02:00.374806Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2025-5278",
+                  "modified": "2025-11-20T10:18:24.026350Z"
+                }
+              ]
+            },
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "DLA-3482-1",
+                  "modified": "2025-05-26T07:01:25.263124Z"
+                }
+              ]
+            },
+            {},
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "DEBIAN-CVE-2022-1664",
+                  "modified": "2025-11-20T10:15:48.083782Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2025-6297",
+                  "modified": "2025-11-20T10:18:27.456848Z"
+                },
+                {
+                  "id": "DLA-3022-1",
+                  "modified": "2025-05-26T07:22:47.007443Z"
+                },
+                {
+                  "id": "DSA-5147-1",
+                  "modified": "2025-05-26T07:22:47.069263Z"
+                }
+              ]
+            },
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "DEBIAN-CVE-2019-5094",
+                  "modified": "2025-11-19T02:02:52.019166Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2019-5188",
+                  "modified": "2025-11-19T01:01:51.904490Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-1304",
+                  "modified": "2025-11-20T10:15:47.847878Z"
+                },
+                {
+                  "id": "DLA-3910-1",
+                  "modified": "2025-05-26T07:22:45.827447Z"
+                },
+                {
+                  "id": "DSA-4535-1",
+                  "modified": "2025-05-26T07:21:16.735871Z"
+                }
+              ]
+            },
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "GHSA-9493-h29p-rfm2",
+                  "modified": "2025-11-18T18:36:38Z"
+                },
+                {
+                  "id": "GHSA-cgrx-mc8f-2prm",
+                  "modified": "2025-11-18T18:38:01Z"
+                },
+                {
+                  "id": "GHSA-f3fp-gc8g-vw66",
+                  "modified": "2024-08-21T15:26:57.192290Z"
+                },
+                {
+                  "id": "GHSA-g2j6-57v7-gm8c",
+                  "modified": "2024-12-06T15:31:17Z"
+                },
+                {
+                  "id": "GHSA-jfvp-7x6p-h2pv",
+                  "modified": "2025-02-21T21:03:04Z"
+                },
+                {
+                  "id": "GHSA-m8cg-xc2p-r3fc",
+                  "modified": "2024-08-20T20:58:42.328556Z"
+                },
+                {
+                  "id": "GHSA-qw9x-cqr3-wc7r",
+                  "modified": "2025-11-18T18:37:10Z"
+                },
+                {
+                  "id": "GHSA-v95c-p5hm-xq8f",
+                  "modified": "2024-05-31T17:47:57Z"
+                },
+                {
+                  "id": "GHSA-vpvm-3wq2-2wvm",
+                  "modified": "2024-12-06T15:31:17Z"
+                },
+                {
+                  "id": "GHSA-xr7r-f8xq-vfvv",
+                  "modified": "2024-07-05T21:38:20Z"
+                },
+                {
+                  "id": "GO-2022-0274",
+                  "modified": "2024-05-20T16:03:47Z"
+                },
+                {
+                  "id": "GO-2022-0452",
+                  "modified": "2025-08-05T19:57:40Z"
+                },
+                {
+                  "id": "GO-2023-1627",
+                  "modified": "2025-08-05T19:57:40Z"
+                },
+                {
+                  "id": "GO-2023-1682",
+                  "modified": "2025-08-05T19:57:40Z"
+                },
+                {
+                  "id": "GO-2023-1683",
+                  "modified": "2025-08-05T19:57:40Z"
+                },
+                {
+                  "id": "GO-2024-2491",
+                  "modified": "2024-07-01T21:50:42Z"
+                },
+                {
+                  "id": "GO-2024-3110",
+                  "modified": "2025-08-05T19:57:40Z"
+                },
+                {
+                  "id": "GO-2025-4096",
+                  "modified": "2025-11-18T16:13:48.753195Z"
+                },
+                {
+                  "id": "GO-2025-4097",
+                  "modified": "2025-11-18T16:14:16.667487Z"
+                },
+                {
+                  "id": "GO-2025-4098",
+                  "modified": "2025-11-18T16:13:50.829446Z"
+                }
+              ]
+            },
+            {},
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "GHSA-p782-xgp4-8hr8",
+                  "modified": "2024-05-20T21:27:32Z"
+                },
+                {
+                  "id": "GO-2022-0493",
+                  "modified": "2024-05-20T16:03:47Z"
+                }
+              ]
+            },
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "DEBIAN-CVE-2022-1271",
+                  "modified": "2025-11-20T10:15:47.940295Z"
+                },
+                {
+                  "id": "DSA-5122-1",
+                  "modified": "2025-05-26T07:22:45.579215Z"
+                }
+              ]
+            },
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "DEBIAN-CVE-2017-0379",
+                  "modified": "2025-11-19T01:06:25.120079Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2017-7526",
+                  "modified": "2025-11-19T02:04:40.318681Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2018-0495",
+                  "modified": "2025-11-19T02:04:27.207183Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2018-6829",
+                  "modified": "2025-11-20T10:13:52.315674Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2019-13627",
+                  "modified": "2025-11-19T01:12:35.581705Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2021-33560",
+                  "modified": "2025-11-20T10:15:42.132245Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2021-40528",
+                  "modified": "2025-11-19T01:01:59.995618Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2024-2236",
+                  "modified": "2025-11-20T10:17:03.685651Z"
+                }
+              ]
+            },
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "DEBIAN-CVE-2017-10790",
+                  "modified": "2025-11-19T01:01:57.855157Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2018-1000654",
+                  "modified": "2025-11-19T02:02:40.642360Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2018-6003",
+                  "modified": "2025-11-19T01:06:22.990063Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2021-46848",
+                  "modified": "2025-11-20T10:15:14.681077Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2024-12133",
+                  "modified": "2025-11-20T10:17:02.620233Z"
+                },
+                {
+                  "id": "DLA-3263-1",
+                  "modified": "2025-05-26T07:22:42.617563Z"
+                },
+                {
+                  "id": "DLA-4061-1",
+                  "modified": "2025-05-26T07:23:58.435350Z"
+                },
+                {
+                  "id": "DSA-5863-1",
+                  "modified": "2025-05-26T07:23:58.495667Z"
+                }
+              ]
+            },
+            {},
+            {},
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "DEBIAN-CVE-2016-3709",
+                  "modified": "2025-11-20T10:12:11.931996Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2016-9318",
+                  "modified": "2025-11-19T02:02:45.582059Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2017-0663",
+                  "modified": "2025-11-19T02:02:52.056836Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2017-15412",
+                  "modified": "2025-11-19T01:08:49.499099Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2017-16931",
+                  "modified": "2025-11-19T02:04:25.542166Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2017-16932",
+                  "modified": "2025-11-19T01:04:39.458229Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2017-18258",
+                  "modified": "2025-11-19T01:08:48.927062Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2017-5130",
+                  "modified": "2025-11-19T01:03:12.822124Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2017-5969",
+                  "modified": "2025-11-19T01:08:52.062516Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2017-7375",
+                  "modified": "2025-11-19T02:02:48.011785Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2017-7376",
+                  "modified": "2025-11-19T02:01:17.016443Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2017-8872",
+                  "modified": "2025-11-19T02:04:31.920669Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2017-9047",
+                  "modified": "2025-11-19T02:04:30.335407Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2017-9048",
+                  "modified": "2025-11-19T01:19:09.303210Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2017-9049",
+                  "modified": "2025-11-19T01:03:12.259406Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2017-9050",
+                  "modified": "2025-11-19T01:08:53.069573Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2018-14404",
+                  "modified": "2025-11-19T01:12:32.274520Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2018-14567",
+                  "modified": "2025-11-19T01:08:49.660035Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2019-19956",
+                  "modified": "2025-11-19T02:01:17.970372Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2019-20388",
+                  "modified": "2025-11-19T02:04:37.363509Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2020-24977",
+                  "modified": "2025-11-19T02:04:41.266003Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2020-7595",
+                  "modified": "2025-11-19T02:04:29.271836Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2021-3516",
+                  "modified": "2025-11-19T02:01:14.946107Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2021-3517",
+                  "modified": "2025-11-19T01:12:34.981900Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2021-3518",
+                  "modified": "2025-11-19T01:19:08.645337Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2021-3537",
+                  "modified": "2025-11-19T02:04:30.248276Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2021-3541",
+                  "modified": "2025-11-19T02:04:36.614917Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-2309",
+                  "modified": "2025-11-20T10:15:28.694644Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-23308",
+                  "modified": "2025-11-20T10:15:29.029152Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-29824",
+                  "modified": "2025-11-20T10:15:52.814213Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-40303",
+                  "modified": "2025-11-20T10:16:01.982632Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-40304",
+                  "modified": "2025-11-20T10:16:01.918054Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-49043",
+                  "modified": "2025-11-20T10:16:12.358770Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-28484",
+                  "modified": "2025-11-20T10:16:35.199991Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-29469",
+                  "modified": "2025-11-20T10:17:34.943682Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-39615",
+                  "modified": "2025-11-20T10:16:41.593841Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-45322",
+                  "modified": "2025-11-20T10:16:44.891362Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2024-25062",
+                  "modified": "2025-11-20T10:17:04.986212Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2024-34459",
+                  "modified": "2025-11-20T10:17:41.570595Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2024-56171",
+                  "modified": "2025-11-20T10:17:48.605695Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2025-12863",
+                  "modified": "2025-11-20T14:28:24.129936Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2025-24928",
+                  "modified": "2025-11-20T10:18:05.778161Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2025-27113",
+                  "modified": "2025-11-20T10:18:06.358243Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2025-32414",
+                  "modified": "2025-11-20T10:18:08.076077Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2025-32415",
+                  "modified": "2025-11-20T10:18:08.251077Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2025-49794",
+                  "modified": "2025-11-20T10:18:23.322205Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2025-49796",
+                  "modified": "2025-11-20T10:18:23.585429Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2025-6021",
+                  "modified": "2025-11-20T10:18:26.314947Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2025-6170",
+                  "modified": "2025-11-20T10:18:26.670728Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2025-8732",
+                  "modified": "2025-11-20T10:18:28.450401Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2025-9714",
+                  "modified": "2025-11-20T10:18:28.938756Z"
+                },
+                {
+                  "id": "DLA-3012-1",
+                  "modified": "2025-05-26T07:23:01.266561Z"
+                },
+                {
+                  "id": "DLA-3172-1",
+                  "modified": "2025-05-26T07:23:10.448009Z"
+                },
+                {
+                  "id": "DLA-3405-1",
+                  "modified": "2025-05-26T07:23:30.714665Z"
+                },
+                {
+                  "id": "DLA-3878-1",
+                  "modified": "2025-05-26T07:18:39.626843Z"
+                },
+                {
+                  "id": "DLA-4064-1",
+                  "modified": "2025-05-26T07:23:19.568188Z"
+                },
+                {
+                  "id": "DLA-4146-1",
+                  "modified": "2025-05-26T06:58:47.071983Z"
+                },
+                {
+                  "id": "DLA-4251-1",
+                  "modified": "2025-07-26T19:45:29.054316Z"
+                },
+                {
+                  "id": "DLA-4319-1",
+                  "modified": "2025-09-30T22:17:08.381361Z"
+                },
+                {
+                  "id": "DSA-5142-1",
+                  "modified": "2025-05-26T07:23:01.328825Z"
+                },
+                {
+                  "id": "DSA-5271-1",
+                  "modified": "2025-05-26T07:23:10.510965Z"
+                },
+                {
+                  "id": "DSA-5391-1",
+                  "modified": "2025-05-26T07:23:30.774960Z"
+                },
+                {
+                  "id": "DSA-5949-1",
+                  "modified": "2025-06-25T19:16:29.342484Z"
+                },
+                {
+                  "id": "DSA-5990-1",
+                  "modified": "2025-08-29T13:01:48.117026Z"
+                }
+              ]
+            },
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "DEBIAN-CVE-2018-0732",
+                  "modified": "2025-11-19T02:02:54.249966Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2018-0734",
+                  "modified": "2025-11-19T02:02:43.768735Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2018-0735",
+                  "modified": "2025-11-19T01:19:04.251217Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2018-5407",
+                  "modified": "2025-11-19T01:02:00.203143Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2019-1543",
+                  "modified": "2025-11-19T01:12:34.981629Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2019-1547",
+                  "modified": "2025-11-19T01:12:35.687253Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2019-1549",
+                  "modified": "2025-11-19T01:04:40.924710Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2019-1551",
+                  "modified": "2025-11-19T01:19:08.067279Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2019-1563",
+                  "modified": "2025-11-19T02:04:34.392400Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2020-1967",
+                  "modified": "2025-11-19T02:04:38.886020Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2020-1971",
+                  "modified": "2025-11-19T02:04:28.520483Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2021-23840",
+                  "modified": "2025-11-19T01:03:14.356310Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2021-23841",
+                  "modified": "2025-11-19T02:02:54.160482Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2021-3449",
+                  "modified": "2025-11-19T01:04:41.495834Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2021-3450",
+                  "modified": "2025-11-19T02:01:16.123253Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2021-3711",
+                  "modified": "2025-11-20T10:15:44.121033Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2021-3712",
+                  "modified": "2025-11-20T10:15:44.130193Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2021-4160",
+                  "modified": "2025-11-20T10:15:10.185497Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-0778",
+                  "modified": "2025-11-20T10:15:47.332694Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-1292",
+                  "modified": "2025-11-20T10:15:25.471825Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-2068",
+                  "modified": "2025-11-20T10:15:27.022420Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-2097",
+                  "modified": "2025-11-20T10:15:27.065089Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-2274",
+                  "modified": "2025-11-19T02:02:45.418259Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-3358",
+                  "modified": "2025-11-19T01:06:25.721124Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-3602",
+                  "modified": "2025-11-19T01:12:35.687556Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-3786",
+                  "modified": "2025-11-19T01:19:02.748977Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-3996",
+                  "modified": "2025-11-19T02:01:16.596616Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-4203",
+                  "modified": "2025-11-19T02:01:16.313531Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-4304",
+                  "modified": "2025-11-20T10:16:04.313466Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-4450",
+                  "modified": "2025-11-20T10:16:05.367442Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-0215",
+                  "modified": "2025-11-20T10:16:27.838296Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-0216",
+                  "modified": "2025-11-19T02:04:35.947667Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-0217",
+                  "modified": "2025-11-19T01:12:37.272749Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-0286",
+                  "modified": "2025-11-20T10:16:27.985311Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-0401",
+                  "modified": "2025-11-19T01:12:36.298552Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-0464",
+                  "modified": "2025-11-20T10:16:28.057931Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-0465",
+                  "modified": "2025-11-20T10:16:28.143046Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-0466",
+                  "modified": "2025-11-20T10:16:28.053837Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-1255",
+                  "modified": "2025-11-19T01:08:49.387669Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-2650",
+                  "modified": "2025-11-20T10:17:34.439123Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-2975",
+                  "modified": "2025-11-20T10:16:36.112183Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-3446",
+                  "modified": "2025-11-20T10:16:38.860251Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-3817",
+                  "modified": "2025-11-20T10:17:35.737266Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-5363",
+                  "modified": "2025-11-20T10:16:59.430619Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-5678",
+                  "modified": "2025-11-20T10:17:38.719690Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-6129",
+                  "modified": "2025-11-20T10:17:39.029757Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-6237",
+                  "modified": "2025-11-20T10:17:39.218097Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2024-0727",
+                  "modified": "2025-11-20T10:17:01.258658Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2024-12797",
+                  "modified": "2025-11-19T02:04:36.131726Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2024-13176",
+                  "modified": "2025-11-20T10:17:03.124812Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2024-2511",
+                  "modified": "2025-11-20T10:17:05.139581Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2024-4603",
+                  "modified": "2025-11-20T10:17:43.955114Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2024-4741",
+                  "modified": "2025-11-20T10:17:26.990307Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2024-5535",
+                  "modified": "2025-11-20T10:17:48.194687Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2024-6119",
+                  "modified": "2025-11-20T10:17:53.824117Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2024-9143",
+                  "modified": "2025-11-20T10:17:55.864918Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2025-27587",
+                  "modified": "2025-11-20T10:18:06.745292Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2025-4575",
+                  "modified": "2025-11-19T02:02:43.971243Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2025-9230",
+                  "modified": "2025-11-20T10:18:28.690398Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2025-9231",
+                  "modified": "2025-11-20T10:18:28.713979Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2025-9232",
+                  "modified": "2025-11-20T10:18:28.748819Z"
+                },
+                {
+                  "id": "DLA-3008-1",
+                  "modified": "2025-05-26T07:22:45.706031Z"
+                },
+                {
+                  "id": "DLA-3325-1",
+                  "modified": "2025-05-26T07:22:47.806974Z"
+                },
+                {
+                  "id": "DLA-3449-1",
+                  "modified": "2025-05-26T07:23:20.191820Z"
+                },
+                {
+                  "id": "DLA-3530-1",
+                  "modified": "2025-05-26T07:23:36.219658Z"
+                },
+                {
+                  "id": "DLA-3942-1",
+                  "modified": "2025-05-26T07:23:52.994725Z"
+                },
+                {
+                  "id": "DLA-3942-2",
+                  "modified": "2025-05-26T07:23:53.056205Z"
+                },
+                {
+                  "id": "DLA-4176-1",
+                  "modified": "2025-05-26T07:02:17.127596Z"
+                },
+                {
+                  "id": "DLA-4321-1",
+                  "modified": "2025-10-03T16:33:24.717173Z"
+                },
+                {
+                  "id": "DSA-4539-1",
+                  "modified": "2025-05-26T07:20:57.698150Z"
+                },
+                {
+                  "id": "DSA-4539-3",
+                  "modified": "2025-05-26T07:05:14.261652Z"
+                },
+                {
+                  "id": "DSA-4661-1",
+                  "modified": "2025-05-26T07:21:44.983880Z"
+                },
+                {
+                  "id": "DSA-4807-1",
+                  "modified": "2025-05-26T07:21:45.227381Z"
+                },
+                {
+                  "id": "DSA-4855-1",
+                  "modified": "2025-05-26T07:20:57.944135Z"
+                },
+                {
+                  "id": "DSA-4875-1",
+                  "modified": "2025-05-26T07:22:25.295971Z"
+                },
+                {
+                  "id": "DSA-4963-1",
+                  "modified": "2025-05-26T07:22:29.610492Z"
+                },
+                {
+                  "id": "DSA-5103-1",
+                  "modified": "2025-05-26T07:22:36.298650Z"
+                },
+                {
+                  "id": "DSA-5139-1",
+                  "modified": "2025-05-26T07:22:45.765450Z"
+                },
+                {
+                  "id": "DSA-5169-1",
+                  "modified": "2025-05-26T07:22:47.687377Z"
+                },
+                {
+                  "id": "DSA-5343-1",
+                  "modified": "2025-05-26T07:22:47.870882Z"
+                },
+                {
+                  "id": "DSA-5417-1",
+                  "modified": "2025-05-26T07:23:20.254324Z"
+                },
+                {
+                  "id": "DSA-5532-1",
+                  "modified": "2025-05-26T07:23:52.176093Z"
+                },
+                {
+                  "id": "DSA-5764-1",
+                  "modified": "2025-05-26T07:24:15.576601Z"
+                },
+                {
+                  "id": "DSA-6015-1",
+                  "modified": "2025-10-01T13:32:01.848986Z"
+                }
+              ]
+            },
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "DEBIAN-CVE-2011-4116",
+                  "modified": "2025-11-20T10:10:50.058601Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2017-12837",
+                  "modified": "2025-11-19T01:03:14.361068Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2017-12883",
+                  "modified": "2025-11-19T01:12:38.323688Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2018-12015",
+                  "modified": "2025-11-19T02:02:49.033339Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2018-18311",
+                  "modified": "2025-11-19T01:12:36.918544Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2018-18312",
+                  "modified": "2025-11-19T02:04:33.584277Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2018-18313",
+                  "modified": "2025-11-19T01:06:24.154928Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2018-18314",
+                  "modified": "2025-11-19T01:12:35.416886Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2018-6797",
+                  "modified": "2025-11-19T02:04:23.831823Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2018-6798",
+                  "modified": "2025-11-19T02:02:49.628171Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2018-6913",
+                  "modified": "2025-11-19T02:02:50.593437Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2020-10543",
+                  "modified": "2025-11-19T01:04:39.904198Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2020-10878",
+                  "modified": "2025-11-19T01:12:35.457057Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2020-12723",
+                  "modified": "2025-11-19T02:02:47.094787Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2020-16156",
+                  "modified": "2025-11-20T10:14:36.701112Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2021-36770",
+                  "modified": "2025-11-20T10:15:44.080114Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-48522",
+                  "modified": "2025-11-19T01:08:52.915564Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-31484",
+                  "modified": "2025-11-20T10:17:35.627220Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-31486",
+                  "modified": "2025-11-20T10:17:36.081192Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-47038",
+                  "modified": "2025-11-20T10:16:46.343364Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2024-56406",
+                  "modified": "2025-11-20T10:17:48.686371Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2025-40909",
+                  "modified": "2025-11-20T10:18:21.143971Z"
+                },
+                {
+                  "id": "DLA-3926-1",
+                  "modified": "2025-05-26T07:21:42.385892Z"
+                },
+                {
+                  "id": "DSA-5902-1",
+                  "modified": "2025-05-26T07:24:14.898997Z"
+                }
+              ]
+            },
+            {},
+            {},
+            {},
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "DLA-3072-1",
+                  "modified": "2025-05-26T07:22:56.848703Z"
+                },
+                {
+                  "id": "DLA-3189-1",
+                  "modified": "2025-05-26T07:01:07.887113Z"
+                },
+                {
+                  "id": "DLA-3316-1",
+                  "modified": "2025-05-26T07:01:13.127412Z"
+                },
+                {
+                  "id": "DLA-3422-1",
+                  "modified": "2025-05-26T07:23:26.375715Z"
+                },
+                {
+                  "id": "DLA-3600-1",
+                  "modified": "2025-05-26T07:23:40.030714Z"
+                },
+                {
+                  "id": "DLA-3651-1",
+                  "modified": "2025-05-26T07:23:53.368012Z"
+                },
+                {
+                  "id": "DLA-3764-1",
+                  "modified": "2025-05-26T07:23:55.849014Z"
+                },
+                {
+                  "id": "DSA-5135-1",
+                  "modified": "2025-05-26T07:22:46.760638Z"
+                }
+              ]
+            },
+            {},
+            {},
+            {},
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "DEBIAN-CVE-2017-17512",
+                  "modified": "2025-11-19T02:04:30.656495Z"
+                }
+              ]
+            },
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "DEBIAN-CVE-2005-2541",
+                  "modified": "2025-11-20T10:09:01.923782Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2018-20482",
+                  "modified": "2025-11-19T02:02:47.070832Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2019-9923",
+                  "modified": "2025-11-19T02:02:53.559001Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2021-20193",
+                  "modified": "2025-11-19T01:01:55.139356Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-48303",
+                  "modified": "2025-11-20T10:16:07.552593Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2023-39804",
+                  "modified": "2025-11-20T10:16:41.587973Z"
+                },
+                {
+                  "id": "DLA-3755-1",
+                  "modified": "2025-05-26T07:23:40.399798Z"
+                }
+              ]
+            },
+            {
+              "vulns": [
+                {
+                  "id": "DLA-3051-1",
+                  "modified": "2025-05-26T07:01:56.257796Z"
+                },
+                {
+                  "id": "DLA-3134-1",
+                  "modified": "2025-05-26T07:01:01.500124Z"
+                },
+                {
+                  "id": "DLA-3161-1",
+                  "modified": "2025-05-26T07:01:03.882213Z"
+                },
+                {
+                  "id": "DLA-3366-1",
+                  "modified": "2025-05-26T07:01:17.027142Z"
+                },
+                {
+                  "id": "DLA-3412-1",
+                  "modified": "2025-05-26T07:01:20.109212Z"
+                },
+                {
+                  "id": "DLA-3684-1",
+                  "modified": "2025-05-26T07:01:38.953691Z"
+                },
+                {
+                  "id": "DLA-3788-1",
+                  "modified": "2025-05-26T07:01:46.700929Z"
+                },
+                {
+                  "id": "DLA-3972-1",
+                  "modified": "2025-05-26T07:02:05.284676Z"
+                },
+                {
+                  "id": "DLA-4085-1",
+                  "modified": "2025-05-26T07:02:10.958749Z"
+                },
+                {
+                  "id": "DLA-4105-1",
+                  "modified": "2025-05-26T07:02:13.921097Z"
+                }
+              ]
+            },
+            {
+              "vulns": [
+                {
+                  "id": "DLA-4016-1",
+                  "modified": "2025-05-26T07:02:06.504254Z"
+                }
+              ]
+            },
+            {
+              "vulns": [
+                {
+                  "id": "DEBIAN-CVE-2016-2779",
+                  "modified": "2025-11-19T01:12:38.591462Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2018-7738",
+                  "modified": "2025-11-20T10:13:54.493707Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2021-37600",
+                  "modified": "2025-11-19T02:02:43.997954Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2021-3995",
+                  "modified": "2025-11-20T10:15:45.587792Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2021-3996",
+                  "modified": "2025-11-20T10:15:45.602424Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2022-0563",
+                  "modified": "2025-11-20T10:15:24.228408Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2024-28085",
+                  "modified": "2025-11-20T10:17:41.612682Z"
+                },
+                {
+                  "id": "DLA-3782-1",
+                  "modified": "2025-05-26T07:22:30.567107Z"
+                },
+                {
+                  "id": "DSA-5055-1",
+                  "modified": "2025-05-26T07:22:33.646795Z"
+                },
+                {
+                  "id": "DSA-5650-1",
+                  "modified": "2025-05-26T07:24:03.887524Z"
+                }
+              ]
+            },
+            {
+              "vulns": [
+                {
+                  "id": "DEBIAN-CVE-2022-1271",
+                  "modified": "2025-11-20T10:15:47.940295Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2024-3094",
+                  "modified": "2025-11-19T01:12:34.542011Z"
+                },
+                {
+                  "id": "DEBIAN-CVE-2025-31115",
+                  "modified": "2025-11-20T10:18:07.484724Z"
+                },
+                {
+                  "id": "DSA-5123-1",
+                  "modified": "2025-05-26T07:22:45.643786Z"
+                },
+                {
+                  "id": "DSA-5895-1",
+                  "modified": "2025-05-26T07:24:22.556406Z"
+                }
+              ]
+            },
+            {},
+            {}
+          ]
+        }
+      headers:
+        Content-Length:
+          - "19666"
+        Content-Type:
+          - application/json
+      status: 200 OK
+      code: 200
+      duration: 0s


### PR DESCRIPTION
I cannot recall any particular reason why I didn't have these use a cassette, and now they're failing because something external changed 🤷 