### PR TITLE
fix: License scanning to match new deps.dev names

### DIFF
--- a/internal/clients/clientimpl/licensematcher/licensematcher.go
+++ b/internal/clients/clientimpl/licensematcher/licensematcher.go
@@ -97,6 +97,8 @@ func (matcher *DepsDevLicenseMatcher) makeVersionRequest(ctx context.Context, qu
 
 func versionQuery(system depsdevpb.System, name string, version string) *depsdevpb.GetVersionRequest {
 	if system == depsdevpb.System_GO {
+		// deps.dev uses native go versioning, which includes prepending v for package versions
+		// and go for stdlib
 		if name == "stdlib" {
 			version = "go" + version
 		} else {


### PR DESCRIPTION
They are also looking at implementing a translation layer to keep supporting the old version format (eta sometime next week) to make sure existing osv-scanner queries are not broken. 

Closes #2394