### PR TITLE
fix(rust): disable unsafe cargo build by default to prevent ACE

### DIFF
--- a/internal/sourceanalysis/rust.go
+++ b/internal/sourceanalysis/rust.go
@@ -267,6 +267,9 @@ func rustBuildSource(source models.SourceInfo) ([]string, error) {
 
 	resultBinaryPaths := []string{}
 	for _, de := range entries {
+		// We only want .d files, which is generated for each output binary from cargo
+		// These files contains a string to the full path of output binary/library file.
+		// This is a reasonably reliable way to identify the output in a cross-platform way.
 		if de.IsDir() || !strings.HasSuffix(de.Name(), ".d") {
 			continue
 		}


### PR DESCRIPTION
This PR mitigates a Critical Arbitrary Code Execution (ACE) vulnerability in the Rust source analysis pipeline.

**The Vulnerability**
Currently, `rustBuildSource` executes `cargo build` on the target repository. In the Rust ecosystem, `cargo build` executes `build.rs` scripts and procedural macros. If `osv-scanner` is run on an untrusted malicious repository, that repository can execute arbitrary code on the scanner's host.