### PR TITLE
test: always use a unique directory for local advisory cases

### DIFF
--- a/cmd/osv-scanner/scan/source/command_test.go
+++ b/cmd/osv-scanner/scan/source/command_test.go
@@ -1027,12 +1027,11 @@ func TestCommand_LocalDatabases(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
-			if testutility.IsAcceptanceTesting() {
-				testDir := testutility.CreateTestDir(t)
-				old := tt.Args
-				tt.Args = []string{"", "source", "--local-db-path", testDir}
-				tt.Args = append(tt.Args, old[2:]...)
-			}
+
+			testDir := testutility.CreateTestDir(t)
+			old := tt.Args
+			tt.Args = []string{"", "source", "--local-db-path", testDir}
+			tt.Args = append(tt.Args, old[2:]...)
 
 			tt.HTTPClient = testcmd.WithTestNameHeader(t, *client)
 


### PR DESCRIPTION
Since #2445 has us stream bytes to and from disk rather than writing the entire contents in one go, it's no longer safe for tests to be using the databases in parallel so we always need to use a unique directory