### PR TITLE
refactor: migrate private extractors to use `cpb.PluginConfig` and return an error

### DIFF
--- a/internal/scalibrextract/filesystem/vendored/vendored.go
+++ b/internal/scalibrextract/filesystem/vendored/vendored.go
@@ -15,6 +15,7 @@ import (
 	"slices"
 	"strings"
 
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
 	"github.com/google/osv-scalibr/extractor"
 	"github.com/google/osv-scalibr/extractor/filesystem"
 	scalibrfs "github.com/google/osv-scalibr/fs"
@@ -76,8 +77,8 @@ type Extractor struct {
 }
 
 // New returns a new instance of the extractor.
-func New() filesystem.Extractor {
-	return &Extractor{}
+func New(_ *cpb.PluginConfig) (filesystem.Extractor, error) {
+	return &Extractor{}, nil
 }
 
 // Name of the extractor.

--- a/internal/scalibrextract/language/javascript/nodemodules/extractor.go
+++ b/internal/scalibrextract/language/javascript/nodemodules/extractor.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"path/filepath"
 
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
 	"github.com/google/osv-scalibr/extractor/filesystem"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/javascript/packagelockjson"
 	"github.com/google/osv-scalibr/inventory"
@@ -21,8 +22,8 @@ type Extractor struct {
 }
 
 // New returns a new instance of the extractor.
-func New() filesystem.Extractor {
-	return &Extractor{}
+func New(_ *cpb.PluginConfig) (filesystem.Extractor, error) {
+	return &Extractor{}, nil
 }
 
 // Name of the extractor.

--- a/internal/scalibrextract/language/osv/osvscannerjson/extractor.go
+++ b/internal/scalibrextract/language/osv/osvscannerjson/extractor.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
 	"github.com/google/osv-scalibr/extractor"
 	"github.com/google/osv-scalibr/extractor/filesystem"
 	"github.com/google/osv-scalibr/inventory"
@@ -33,8 +34,8 @@ func (e Extractor) Requirements() *plugin.Capabilities {
 	return &plugin.Capabilities{}
 }
 
-func New() filesystem.Extractor {
-	return Extractor{}
+func New(_ *cpb.PluginConfig) (filesystem.Extractor, error) {
+	return Extractor{}, nil
 }
 
 // FileRequired returns true only for osv-scanner-custom.json files,

--- a/internal/scalibrextract/vcs/gitrepo/extractor.go
+++ b/internal/scalibrextract/vcs/gitrepo/extractor.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/go-git/go-git/v5"
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
 	"github.com/google/osv-scalibr/extractor"
 	"github.com/google/osv-scalibr/extractor/filesystem"
 	"github.com/google/osv-scalibr/inventory"
@@ -62,8 +63,8 @@ func createCommitQueryInventory(commit string, location string) *extractor.Packa
 }
 
 // New returns a new instance of the extractor.
-func New() filesystem.Extractor {
-	return &Extractor{}
+func New(_ *cpb.PluginConfig) (filesystem.Extractor, error) {
+	return &Extractor{}, nil
 }
 
 // Name of the extractor.

--- a/internal/scalibrplugin/presets.go
+++ b/internal/scalibrplugin/presets.go
@@ -120,7 +120,7 @@ var ExtractorPresets = map[string]extractors.InitMap{
 		cabal.Name:     {noCFG(cabal.NewDefault)},
 		stacklock.Name: {noCFG(stacklock.NewDefault)},
 
-		osvscannerjson.Name: {noCFG(osvscannerjson.New)},
+		osvscannerjson.Name: {osvscannerjson.New},
 
 		// --- OS "lockfiles" ---
 		// These have very strict FileRequired paths, so we can safely enable them for source scanning as well.
@@ -130,8 +130,8 @@ var ExtractorPresets = map[string]extractors.InitMap{
 		dpkg.Name: {dpkg.New},
 	},
 	"directory": {
-		gitrepo.Name:  {noCFG(gitrepo.New)},
-		vendored.Name: {noCFG(vendored.New)},
+		gitrepo.Name:  {gitrepo.New},
+		vendored.Name: {vendored.New},
 	},
 	"artifact": {
 		// --- Project artifacts ---
@@ -142,7 +142,7 @@ var ExtractorPresets = map[string]extractors.InitMap{
 		// Go
 		gobinary.Name: {gobinary.New},
 		// Javascript
-		nodemodules.Name: {noCFG(nodemodules.New)},
+		nodemodules.Name: {nodemodules.New},
 		// Rust
 		cargoauditable.Name: {noCFG(cargoauditable.NewDefault)},
 

--- a/internal/scalibrplugin/resolve.go
+++ b/internal/scalibrplugin/resolve.go
@@ -28,14 +28,14 @@ func resolveFromName(name string) (plugin.Plugin, error) {
 		return pomxmlenhanceable.New(&cpb.PluginConfig{})
 	// Javascript
 	case nodemodules.Name:
-		return nodemodules.New(), nil
+		return nodemodules.New(&cpb.PluginConfig{})
 	// Directories
 	case vendored.Name:
-		return vendored.New(), nil
+		return vendored.New(&cpb.PluginConfig{})
 	case gitrepo.Name:
-		return gitrepo.New(), nil
+		return gitrepo.New(&cpb.PluginConfig{})
 	case osvscannerjson.Name:
-		return osvscannerjson.New(), nil
+		return osvscannerjson.New(&cpb.PluginConfig{})
 	default:
 		return nil, fmt.Errorf("not an exact name for a plugin: %q", name)
 	}


### PR DESCRIPTION
Relates to https://github.com/google/osv-scanner/pull/2478#issuecomment-3780743998