### PR TITLE
test: simplify struct building for `assembleResult` cases

### DIFF
--- a/pkg/osvscanner/vulnerability_result_internal_test.go
+++ b/pkg/osvscanner/vulnerability_result_internal_test.go
@@ -14,71 +14,72 @@ import (
 	"github.com/ossf/osv-schema/bindings/go/osvschema"
 )
 
+// makeScanResults returns a unique instance of results.ScanResults for use in tests,
+// to avoid mutations impacting other test cases
+func makeScanResults() *results.ScanResults {
+	return &results.ScanResults{
+		PackageScanResults: []imodels.PackageScanResult{
+			{
+				PackageInfo: imodels.PackageInfo{
+					Package: &extractor.Package{
+						Name:      "pkg-1",
+						PURLType:  purl.TypeNPM,
+						Plugins:   []string{packagelockjson.Name},
+						Version:   "1.0.0",
+						Locations: []string{"dir/package-lock.json"},
+					},
+				},
+				Vulnerabilities: []*osvschema.Vulnerability{
+					{Id: "GHSA-123", Aliases: []string{"CVE-123"}},
+					{Id: "CVE-123"},
+				},
+				Licenses: []models.License{
+					"MIT", "0BSD",
+				},
+			},
+			{
+				PackageInfo: imodels.PackageInfo{
+					Package: &extractor.Package{
+						Name:      "pkg-2",
+						PURLType:  purl.TypeNPM,
+						Plugins:   []string{packagelockjson.Name},
+						Version:   "1.0.0",
+						Locations: []string{"dir/package-lock.json"},
+					},
+				},
+				Vulnerabilities: []*osvschema.Vulnerability{},
+				Licenses: []models.License{
+					"MIT",
+				},
+			},
+			{
+				PackageInfo: imodels.PackageInfo{
+					Package: &extractor.Package{
+						Name:      "pkg-3",
+						PURLType:  purl.TypeNPM,
+						Plugins:   []string{packagelockjson.Name},
+						Version:   "1.0.0",
+						Locations: []string{"other-dir/package-lock.json"},
+					},
+				},
+				Vulnerabilities: []*osvschema.Vulnerability{
+					{Id: "GHSA-456"},
+				},
+				Licenses: []models.License{
+					"UNKNOWN",
+				},
+			},
+		},
+		ConfigManager: config.Manager{},
+	}
+}
+
 func Test_assembleResult(t *testing.T) {
 	t.Parallel()
 	type args struct {
 		actions     ScannerActions
 		scanResults *results.ScanResults
 		config      config.Manager
-	}
-
-	// makeScanResults make a separate instance of ScanResults to avoid mutations changing other tests
-	makeScanResults := func() *results.ScanResults {
-		return &results.ScanResults{
-			PackageScanResults: []imodels.PackageScanResult{
-				{
-					PackageInfo: imodels.PackageInfo{
-						Package: &extractor.Package{
-							Name:      "pkg-1",
-							PURLType:  purl.TypeNPM,
-							Plugins:   []string{packagelockjson.Name},
-							Version:   "1.0.0",
-							Locations: []string{"dir/package-lock.json"},
-						},
-					},
-					Vulnerabilities: []*osvschema.Vulnerability{
-						{Id: "GHSA-123", Aliases: []string{"CVE-123"}},
-						{Id: "CVE-123"},
-					},
-					Licenses: []models.License{
-						"MIT", "0BSD",
-					},
-				},
-				{
-					PackageInfo: imodels.PackageInfo{
-						Package: &extractor.Package{
-							Name:      "pkg-2",
-							PURLType:  purl.TypeNPM,
-							Plugins:   []string{packagelockjson.Name},
-							Version:   "1.0.0",
-							Locations: []string{"dir/package-lock.json"},
-						},
-					},
-					Vulnerabilities: []*osvschema.Vulnerability{},
-					Licenses: []models.License{
-						"MIT",
-					},
-				},
-				{
-					PackageInfo: imodels.PackageInfo{
-						Package: &extractor.Package{
-							Name:      "pkg-3",
-							PURLType:  purl.TypeNPM,
-							Plugins:   []string{packagelockjson.Name},
-							Version:   "1.0.0",
-							Locations: []string{"other-dir/package-lock.json"},
-						},
-					},
-					Vulnerabilities: []*osvschema.Vulnerability{
-						{Id: "GHSA-456"},
-					},
-					Licenses: []models.License{
-						"UNKNOWN",
-					},
-				},
-			},
-			ConfigManager: config.Manager{},
-		}
 	}
 
 	callAnalysisStates := make(map[string]bool)


### PR DESCRIPTION
This should make my work on refactoring `ScanResults` a bit easier since I can just change the whole struct directly rather than having to figure out how to modify the loops and move data around to avoid mutations 😅 