### PR TITLE
fix: show plugin failure reason if there are no file errors

### DIFF
--- a/pkg/osvscanner/scan.go
+++ b/pkg/osvscanner/scan.go
@@ -302,7 +302,14 @@ SBOMLoop:
 						criticalError = true
 					}
 				}
-				cmdlogger.Errorf("Error during extraction: (extracting as %s) %s", status.Name, builder.String())
+
+				msg := status.Status.FailureReason
+
+				if len(status.Status.FileErrors) > 0 {
+					msg = builder.String()
+				}
+
+				cmdlogger.Errorf("Error during extraction: (extracting as %s) %s", status.Name, msg)
 				if criticalError {
 					return nil, errors.New("extraction failed on specified lockfile")
 				}


### PR DESCRIPTION
We currently assume that there are always file errors, but it seems that it not always the case - currently, the only example I have of this is with the `transitivedependency/pomxml` enricher which might be due to a bug, but ultimately I think we should have this logic to fallback as a just-in-case