### PR TITLE
refactor: use `fmt.Fprintf` rather than `WriteString` + `Sprintf`

### DIFF
--- a/cmd/osv-scanner/fix/state-initialize.go
+++ b/cmd/osv-scanner/fix/state-initialize.go
@@ -83,7 +83,7 @@ func (st *stateInitialize) View(m model) string {
 	if m.options.Lockfile == "" {
 		s.WriteString("No lockfile provided. Assuming re-lock.\n")
 	} else {
-		s.WriteString(fmt.Sprintf("Scanning %s ", tui.SelectedTextStyle.Render(m.options.Lockfile)))
+		fmt.Fprintf(&s, "Scanning %s ", tui.SelectedTextStyle.Render(m.options.Lockfile))
 		if m.inPlaceResult == nil {
 			s.WriteString(st.spinner.View())
 			s.WriteString("\n")
@@ -93,7 +93,7 @@ func (st *stateInitialize) View(m model) string {
 		s.WriteString("✓\n")
 	}
 
-	s.WriteString(fmt.Sprintf("Resolving %s ", tui.SelectedTextStyle.Render(m.options.Manifest)))
+	fmt.Fprintf(&s, "Resolving %s ", tui.SelectedTextStyle.Render(m.options.Manifest))
 	if m.relockBaseRes == nil {
 		s.WriteString(st.spinner.View())
 		s.WriteString("\n")

--- a/internal/tui/relock-info.go
+++ b/internal/tui/relock-info.go
@@ -25,8 +25,8 @@ func NewRelockInfo(change resolution.Difference) *relockInfo {
 	preamble := strings.Builder{}
 	preamble.WriteString("The following upgrades:\n")
 	for _, dep := range change.Deps {
-		preamble.WriteString(fmt.Sprintf("  %s@%s (%s) → @%s (%s)\n", // TODO: styling
-			dep.Pkg.Name, dep.OrigRequire, dep.OrigResolved, dep.NewRequire, dep.NewResolved))
+		fmt.Fprintf(&preamble, "  %s@%s (%s) → @%s (%s)\n",
+			dep.Pkg.Name, dep.OrigRequire, dep.OrigResolved, dep.NewRequire, dep.NewResolved)
 	}
 	preamble.WriteString("Will resolve the following:")
 	fixedVulns := make([]*resolution.Vulnerability, len(change.RemovedVulns))

--- a/internal/utility/semverlike/version-semver-like.go
+++ b/internal/utility/semverlike/version-semver-like.go
@@ -59,7 +59,7 @@ func (v *Version) fetchComponentsAndBuild(maxComponents int) (Components, string
 	build.WriteString(v.Build)
 
 	for _, c := range extra {
-		build.WriteString(fmt.Sprintf(".%d", c))
+		fmt.Fprintf(&build, ".%d", c)
 	}
 
 	return comps, build.String()

--- a/pkg/osvscanner/scan.go
+++ b/pkg/osvscanner/scan.go
@@ -295,7 +295,7 @@ SBOMLoop:
 						// If there is more than 1 file error, write them on new lines
 						builder.WriteString("\n\t")
 					}
-					builder.WriteString(fmt.Sprintf("%s: %s", fileError.FilePath, fileError.ErrorMessage))
+					fmt.Fprintf(&builder, "%s: %s", fileError.FilePath, fileError.ErrorMessage)
 
 					// Check if the erroring file was a path specifically passed in (not a result of a file walk)
 					if slices.Contains(specificPaths, filepath.Join(root, fileError.FilePath)) {


### PR DESCRIPTION
Besides just reducing the amount of code we have, this also can apparently be slightly more efficient  🤷 

It will also be enforced in v2.10+ of `golangci-lint`