### PR TITLE
ci: rename "pr title check" workflow and job

### DIFF
--- a/.github/workflows/title.yml
+++ b/.github/workflows/title.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: OSV PR format check
+name: Title
 
 on:
   # `pull_request_target` is only required when editing PRs from forks.
@@ -27,7 +27,6 @@ permissions:
 
 jobs:
   check:
-    name: Validate PR title
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1


### PR DESCRIPTION
Maybe it's just me but I always get this workflow file confused with the `checks` one. I've also adjusted the names so that they (imo) present a bit clearer - they should show up as "Title / check" rather than "OSV PR format check / Validate PR title"