### PR TITLE
ci: use the latest image artifacts available

### DIFF
--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -2,8 +2,6 @@
 package main
 
 import (
-	"os"
-	"runtime"
 	"testing"
 
 	"github.com/google/osv-scanner/v2/cmd/osv-scanner/internal/testcmd"
@@ -11,10 +9,6 @@ import (
 
 //nolint:paralleltest
 func Test_run(t *testing.T) {
-	if runtime.GOOS == "linux" && os.Getenv("GITHUB_RUN_ATTEMPT") == "1" {
-		t.Fail()
-	}
-
 	tests := []testcmd.Case{
 		{
 			Name: "",


### PR DESCRIPTION
This should make it possible to re-run failed jobs specifically rather than needing to rerun the whole workflow - technically this makes it possible for outdated artifacts to be used, but in practice that shouldn't matter unless you're re-running the job days later, and ultimately you can still just re-run the whole workflow to get an update-to-date artifact