### PR TITLE
ci: allow snapshots workflow to record new cassette interactions

### DIFF
--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -31,6 +31,7 @@ jobs:
       - run: ./scripts/run_tests.sh || true
         env:
           TEST_ACCEPTANCE: true
+          TEST_VCR_MODE: replaywithnewepisodes
           UPDATE_SNAPS: always
       - uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v8.0.0
         with:


### PR DESCRIPTION
This should hopefully make it easier to land our snapshot updates when an external service change results in "new" interactions, while not changing existing interactions