### PR TITLE
chore: Specify ruby version in docs gemfile

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,3 +1,5 @@
+ruby "~> 3"
+
 source "https://rubygems.org"
 # Hello! This is where you manage which Jekyll version is used to run.
 # When you want to use a different version, change it below, save the

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -282,5 +282,8 @@ DEPENDENCIES
   wdm (~> 0.2.0)
   webrick (~> 1.7)
 
+RUBY VERSION
+   ruby 3.4.8p72
+
 BUNDLED WITH
    2.5.11


### PR DESCRIPTION
This PR sets the ruby version of the docs gemfile to ~> 3, this fixes an issue where the renovate bot cannot maintain dependencies because it is trying to use the latest version of ruby (4.0.1) which is not currently supported by this app.