### PR TITLE
test: add "ignore all" configs for fixtures

### DIFF
--- a/cmd/osv-scanner/scan/image/testdata/lockfile-fixture/osv-scanner.toml
+++ b/cmd/osv-scanner/scan/image/testdata/lockfile-fixture/osv-scanner.toml
@@ -1,0 +1,2 @@
+[[PackageOverrides]]
+ignore = true

--- a/cmd/osv-scanner/scan/image/testdata/package-tracing-fixture/osv-scanner.toml
+++ b/cmd/osv-scanner/scan/image/testdata/package-tracing-fixture/osv-scanner.toml
@@ -1,0 +1,2 @@
+[[PackageOverrides]]
+ignore = true

--- a/cmd/osv-scanner/scan/source/testdata/exp-plugins-pkgdeprecate/osv-scanner.toml
+++ b/cmd/osv-scanner/scan/source/testdata/exp-plugins-pkgdeprecate/osv-scanner.toml
@@ -1,0 +1,2 @@
+[[PackageOverrides]]
+ignore = true


### PR DESCRIPTION
We are getting marked down by scorecard as we don't have official "ignore everything" configs for these test fixtures