### PR TITLE
fix: osv-scanner.json output should show GIT repo names correctly

### DIFF
--- a/internal/imodels/imodels.go
+++ b/internal/imodels/imodels.go
@@ -80,8 +80,8 @@ func (pkg *PackageInfo) Name() string {
 		}
 	}
 
-	if pkg.Ecosystem().String() == "GIT" && pkg.Package.SourceCode != nil && pkg.Package.SourceCode.Repo != "" {
-		return pkg.Package.SourceCode.Repo
+	if pkg.Ecosystem().String() == "GIT" && pkg.SourceCode != nil && pkg.SourceCode.Repo != "" {
+		return pkg.SourceCode.Repo
 	}
 
 	return pkg.Package.Name

--- a/internal/imodels/imodels_test.go
+++ b/internal/imodels/imodels_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestPackageInfo_Name(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		pkg  PackageInfo
@@ -56,6 +57,7 @@ func TestPackageInfo_Name(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if got := tt.pkg.Name(); got != tt.want {
 				t.Errorf("PackageInfo.Name() = %v, want %v", got, tt.want)
 			}


### PR DESCRIPTION
Related: https://github.com/google/osv-scalibr/issues/1619