### PR TITLE
ci: run `zizmor` on `main` and on pull requests that change workflows

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,6 +1,8 @@
 name: GitHub Actions Security Analysis with zizmor 🌈
 
 on:
+  pull_request:
+    paths: [".github/workflows/**"]
   push:
     branches: ["main"]
 


### PR DESCRIPTION
This repo uses `main` rather than `master` so right now `zizmor` isn't being run at all, ~but also I think really what we want is for it to be running whenever workflow files have or are being changed since it is only applying static analysis~ (I'm wrong, it is actually doing offline checks)