### PR TITLE
fix: load java extractor plugin for call analysis with the same config as other plugins

### DIFF
--- a/cmd/osv-scanner/scan/source/__snapshots__/command_test.snap
+++ b/cmd/osv-scanner/scan/source/__snapshots__/command_test.snap
@@ -3363,6 +3363,84 @@ Total 4 packages affected by 53 known vulnerabilities (18 Critical, 29 High, 5 M
 
 ---
 
+[TestCommand_JavareachArchive/jars_can_be_scanned_with_call_analysis_and_disabled_enricher - 1]
+Scanning dir ./testdata/artifact/javareach_test.jar
+Scanned <rootdir>/testdata/artifact/javareach_test.jar file and found 21 packages
+
+Total 8 packages affected by 60 known vulnerabilities (18 Critical, 32 High, 8 Medium, 2 Low, 0 Unknown) from 1 ecosystem.
+59 vulnerabilities can be fixed.
+
++-------------------------------------+------+-----------+---------------------------------------------+------------------+---------------+--------------------------------------+
+| OSV URL                             | CVSS | ECOSYSTEM | PACKAGE                                     | VERSION          | FIXED VERSION | SOURCE                               |
++-------------------------------------+------+-----------+---------------------------------------------+------------------+---------------+--------------------------------------+
+| https://osv.dev/GHSA-c28r-hw5m-5gv3 | 7.9  | Maven     | com.amazonaws:aws-java-sdk-s3               | 1.11.327         | 1.12.261      | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-72hv-8253-57qq | 8.7  | Maven     | com.fasterxml.jackson.core:jackson-core     | 2.14.0           | 2.18.6        | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-h46c-h94j-95f3 | 8.7  | Maven     | com.fasterxml.jackson.core:jackson-core     | 2.14.0           | 2.15.0        | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-288c-cq4h-88gq | 7.5  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.6.7.4       | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-4gq5-ch57-c2mg | 9.8  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.7.9.5       | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-4w82-r329-3q67 | 9.8  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.6.7.4       | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-57j2-w4cx-62h2 | 7.5  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.12.6.1      | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-5949-rw7g-wx7w | 8.1  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.6.7.5       | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-5r5r-6hpj-8gg9 | 8.1  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.9.10.8      | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-5ww9-j83m-q7qx | 7.5  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.6.7.3       | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-645p-88qh-w398 | 9.8  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.6.7.3       | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-6fpp-rgj9-8rwc | 9.8  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.7.9.6       | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-85cw-hj65-qqv9 | 9.8  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.6.7.3       | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-89qr-369f-5m5x | 8.1  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.6.7.5       | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-8c4j-34r4-xr8g | 8.1  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.6.7.5       | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-8w26-6f25-cm9x | 8.1  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.9.10.8      | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-9gph-22xh-8x98 | 8.1  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.6.7.5       | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-9m6f-7xcq-8vf8 | 8.1  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.6.7.5       | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-c8hm-7hpq-7jhg | 9.8  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.6.7.3       | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-cf6r-3wgc-h863 | 7.5  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.6.7.3       | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-cggj-fvv3-cqwv | 9.8  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.6.7.5       | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-cjjf-94ff-43w7 | 7.5  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.7.9.4       | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-cmfg-87vq-g5g4 | 5.9  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.6.7.3       | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-cvm9-fjm9-3572 | 8.1  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.6.7.5       | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-f3j5-rmmp-3fc5 | 9.8  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.8.11.5      | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-f9xh-2qgp-cq57 | 8.1  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.6.7.5       | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-fmmc-742q-jg75 | 9.8  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.6.7.3       | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-fqwf-pjwf-7vqv | 8.8  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.6.7.4       | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-gjmw-vf9h-g25v | 9.8  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.6.7.3       | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-gwp4-hfv6-p7hw | 7.5  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.6.7.3       | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-gww7-p5w4-wrfv | 9.8  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.6.7.4       | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-h3cw-g4mq-c5x2 | 8.1  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.9.10.6      | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-h592-38cm-4ggp | 9.8  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.6.7.3       | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-h822-r4r5-v8jg | 9.8  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.6.7.3       | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-jjjh-jjxp-wpff | 7.5  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.12.7.1      | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-m6x4-97wx-4q27 | 8.1  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.9.10.8      | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-mph4-vhrx-mv67 | 5.9  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.6.7.3       | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-mx7p-6679-8g3q | 9.8  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.6.7.3       | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-p43x-xfjf-5jhr | 9.8  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.7.9.7       | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-q93h-jc49-78gg | 9.8  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.7.9.7       | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-qjw2-hr98-qgfh | 8.1  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.6.7.5       | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-qr7j-h6gg-jmgc | 9.8  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.7.9.4       | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-r3gr-cxrf-hg25 | 8.1  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.9.10.8      | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-r695-7vr9-jgc2 | 8.1  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.9.10.8      | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-rfx6-vp9g-rh7v | 9.8  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.7.9.2       | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-rgv9-q543-rqg4 | 8.2  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.12.7.1      | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-rpr3-cw39-3pxh | 8.1  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.9.10.4      | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-v585-23hc-c647 | 8.1  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.9.10.8      | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-vfqx-33qm-g869 | 8.1  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.6.7.5       | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-w3f4-3q6j-rh82 | 8.1  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.7.9.5       | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-wh8g-3j2c-rqj5 | 8.1  | Maven     | com.fasterxml.jackson.core:jackson-databind | 2.6.7.1          | 2.9.10.8      | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-j288-q9x7-2f5v | 6.5  | Maven     | org.apache.commons:commons-lang3            | 3.12.0           | 3.18.0        | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-7r82-7xv7-xcpj | 5.3  | Maven     | org.apache.httpcomponents:httpclient        | 4.5.5            | 4.5.13        | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-cj7v-27pg-wf7q | 2.7  | Maven     | org.eclipse.jetty:jetty-http                | 9.4.40.v20210413 | 9.4.47        | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-hmr7-m48g-48f6 | 5.3  | Maven     | org.eclipse.jetty:jetty-http                | 9.4.40.v20210413 | 9.4.52        | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-qh8g-58pp-2wxh | 6.3  | Maven     | org.eclipse.jetty:jetty-http                | 9.4.40.v20210413 | 12.0.12       | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-3gh6-v5v9-6v9j | 3.5  | Maven     | org.eclipse.jetty:jetty-servlets            | 9.4.40.v20210413 | 9.4.52        | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-gwcr-j4wh-j3cq | 5.3  | Maven     | org.eclipse.jetty:jetty-servlets            | 9.4.40.v20210413 | 9.4.41        | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-j26w-f9rq-mr2q | 5.3  | Maven     | org.eclipse.jetty:jetty-servlets            | 9.4.40.v20210413 | 9.4.54        | testdata/artifact/javareach_test.jar |
+| https://osv.dev/GHSA-264p-99wq-f4j6 | 7.5  | Maven     | software.amazon.ion:ion-java                | 1.0.2            | --            | testdata/artifact/javareach_test.jar |
++-------------------------------------+------+-----------+---------------------------------------------+------------------+---------------+--------------------------------------+
+
+---
+
+[TestCommand_JavareachArchive/jars_can_be_scanned_with_call_analysis_and_disabled_enricher - 2]
+
+---
+
 [TestCommand_JavareachArchive/jars_can_be_scanned_without_call_analysis - 1]
 Scanning dir ./testdata/artifact/javareach_test.jar
 Scanned <rootdir>/testdata/artifact/javareach_test.jar file and found 21 packages

--- a/cmd/osv-scanner/scan/source/command_test.go
+++ b/cmd/osv-scanner/scan/source/command_test.go
@@ -433,6 +433,11 @@ func TestCommand_JavareachArchive(t *testing.T) {
 			Args: []string{"", "source", "--call-analysis=jar", "--all-vulns", "--experimental-plugins=artifact", "./testdata/artifact/javareach_test.jar"},
 			Exit: 1,
 		},
+		{
+			Name: "jars_can_be_scanned_with_call_analysis_and_disabled_enricher",
+			Args: []string{"", "source", "--call-analysis=jar", "--experimental-disable-plugins=reachability/java", "--all-vulns", "--experimental-plugins=artifact", "./testdata/artifact/javareach_test.jar"},
+			Exit: 1,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {

--- a/cmd/osv-scanner/scan/source/testdata/cassettes/TestCommand_JavareachArchive.yaml
+++ b/cmd/osv-scanner/scan/source/testdata/cassettes/TestCommand_JavareachArchive.yaml
@@ -629,6 +629,944 @@ interactions:
         Content-Type:
           - application/json
         X-Test-Name:
+          - TestCommand_JavareachArchive/jars_can_be_scanned_with_call_analysis_and_disabled_enricher
+      url: https://api.osv.dev/v1/querybatch
+      method: POST
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      content_length: 4348
+      body: |
+        {
+          "results": [
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "GHSA-c28r-hw5m-5gv3",
+                  "modified": "2023-11-08T04:09:28.159861Z"
+                }
+              ]
+            },
+            {},
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "GHSA-72hv-8253-57qq",
+                  "modified": "2026-03-04T15:06:51.908001Z"
+                },
+                {
+                  "id": "GHSA-h46c-h94j-95f3",
+                  "modified": "2026-02-04T03:44:39.385253Z"
+                }
+              ]
+            },
+            {
+              "vulns": [
+                {
+                  "id": "GHSA-288c-cq4h-88gq",
+                  "modified": "2026-02-04T04:33:29.159339Z"
+                },
+                {
+                  "id": "GHSA-4gq5-ch57-c2mg",
+                  "modified": "2024-03-15T05:20:21.411726Z"
+                },
+                {
+                  "id": "GHSA-4w82-r329-3q67",
+                  "modified": "2024-03-16T05:18:54.922179Z"
+                },
+                {
+                  "id": "GHSA-57j2-w4cx-62h2",
+                  "modified": "2026-02-04T04:26:14.546092Z"
+                },
+                {
+                  "id": "GHSA-5949-rw7g-wx7w",
+                  "modified": "2025-09-15T07:42:14.888352Z"
+                },
+                {
+                  "id": "GHSA-5r5r-6hpj-8gg9",
+                  "modified": "2024-02-18T05:42:28.539166Z"
+                },
+                {
+                  "id": "GHSA-5ww9-j83m-q7qx",
+                  "modified": "2024-03-15T01:17:50.016820Z"
+                },
+                {
+                  "id": "GHSA-645p-88qh-w398",
+                  "modified": "2024-03-16T05:19:17.936174Z"
+                },
+                {
+                  "id": "GHSA-6fpp-rgj9-8rwc",
+                  "modified": "2024-03-15T05:18:54.134884Z"
+                },
+                {
+                  "id": "GHSA-85cw-hj65-qqv9",
+                  "modified": "2024-03-15T05:20:15.574552Z"
+                },
+                {
+                  "id": "GHSA-89qr-369f-5m5x",
+                  "modified": "2024-02-18T05:37:27.581808Z"
+                },
+                {
+                  "id": "GHSA-8c4j-34r4-xr8g",
+                  "modified": "2024-02-18T05:31:52.762759Z"
+                },
+                {
+                  "id": "GHSA-8w26-6f25-cm9x",
+                  "modified": "2024-02-18T05:30:48.085017Z"
+                },
+                {
+                  "id": "GHSA-9gph-22xh-8x98",
+                  "modified": "2024-02-18T05:33:27.617261Z"
+                },
+                {
+                  "id": "GHSA-9m6f-7xcq-8vf8",
+                  "modified": "2024-02-18T05:32:25.400029Z"
+                },
+                {
+                  "id": "GHSA-c8hm-7hpq-7jhg",
+                  "modified": "2024-03-15T01:17:19.251183Z"
+                },
+                {
+                  "id": "GHSA-cf6r-3wgc-h863",
+                  "modified": "2024-02-18T05:32:56.325249Z"
+                },
+                {
+                  "id": "GHSA-cggj-fvv3-cqwv",
+                  "modified": "2024-03-15T01:18:46.938616Z"
+                },
+                {
+                  "id": "GHSA-cjjf-94ff-43w7",
+                  "modified": "2024-03-11T05:19:23.395848Z"
+                },
+                {
+                  "id": "GHSA-cmfg-87vq-g5g4",
+                  "modified": "2024-03-15T01:18:17.903231Z"
+                },
+                {
+                  "id": "GHSA-cvm9-fjm9-3572",
+                  "modified": "2024-02-18T05:25:36.165759Z"
+                },
+                {
+                  "id": "GHSA-f3j5-rmmp-3fc5",
+                  "modified": "2024-03-15T05:20:35.120151Z"
+                },
+                {
+                  "id": "GHSA-f9xh-2qgp-cq57",
+                  "modified": "2024-02-18T05:32:05.421673Z"
+                },
+                {
+                  "id": "GHSA-fmmc-742q-jg75",
+                  "modified": "2024-03-16T05:19:55.172981Z"
+                },
+                {
+                  "id": "GHSA-fqwf-pjwf-7vqv",
+                  "modified": "2024-07-03T21:22:37.578162Z"
+                },
+                {
+                  "id": "GHSA-gjmw-vf9h-g25v",
+                  "modified": "2024-03-16T05:19:37.211801Z"
+                },
+                {
+                  "id": "GHSA-gwp4-hfv6-p7hw",
+                  "modified": "2024-03-13T05:27:58.436849Z"
+                },
+                {
+                  "id": "GHSA-gww7-p5w4-wrfv",
+                  "modified": "2024-03-15T01:05:18.790961Z"
+                },
+                {
+                  "id": "GHSA-h3cw-g4mq-c5x2",
+                  "modified": "2024-02-18T05:30:45.329621Z"
+                },
+                {
+                  "id": "GHSA-h592-38cm-4ggp",
+                  "modified": "2024-03-15T01:16:50.905794Z"
+                },
+                {
+                  "id": "GHSA-h822-r4r5-v8jg",
+                  "modified": "2026-02-04T02:19:17.186100Z"
+                },
+                {
+                  "id": "GHSA-jjjh-jjxp-wpff",
+                  "modified": "2026-02-04T02:23:59.070528Z"
+                },
+                {
+                  "id": "GHSA-m6x4-97wx-4q27",
+                  "modified": "2024-02-18T05:21:54.725837Z"
+                },
+                {
+                  "id": "GHSA-mph4-vhrx-mv67",
+                  "modified": "2024-03-15T01:16:21.467932Z"
+                },
+                {
+                  "id": "GHSA-mx7p-6679-8g3q",
+                  "modified": "2024-03-15T01:01:46.432481Z"
+                },
+                {
+                  "id": "GHSA-p43x-xfjf-5jhr",
+                  "modified": "2024-03-15T00:33:14.700288Z"
+                },
+                {
+                  "id": "GHSA-q93h-jc49-78gg",
+                  "modified": "2024-03-16T05:19:47.711015Z"
+                },
+                {
+                  "id": "GHSA-qjw2-hr98-qgfh",
+                  "modified": "2024-02-18T05:20:56.894470Z"
+                },
+                {
+                  "id": "GHSA-qr7j-h6gg-jmgc",
+                  "modified": "2024-03-11T05:21:14.313980Z"
+                },
+                {
+                  "id": "GHSA-r3gr-cxrf-hg25",
+                  "modified": "2024-06-25T14:20:21.323050Z"
+                },
+                {
+                  "id": "GHSA-r695-7vr9-jgc2",
+                  "modified": "2024-02-18T05:30:45.856594Z"
+                },
+                {
+                  "id": "GHSA-rfx6-vp9g-rh7v",
+                  "modified": "2024-03-11T05:17:47.425595Z"
+                },
+                {
+                  "id": "GHSA-rgv9-q543-rqg4",
+                  "modified": "2026-02-04T02:40:22.352009Z"
+                },
+                {
+                  "id": "GHSA-rpr3-cw39-3pxh",
+                  "modified": "2026-02-04T04:07:52.719878Z"
+                },
+                {
+                  "id": "GHSA-v585-23hc-c647",
+                  "modified": "2024-02-18T05:22:38.024460Z"
+                },
+                {
+                  "id": "GHSA-vfqx-33qm-g869",
+                  "modified": "2024-02-18T05:24:26.785781Z"
+                },
+                {
+                  "id": "GHSA-w3f4-3q6j-rh82",
+                  "modified": "2024-03-11T05:18:22.727055Z"
+                },
+                {
+                  "id": "GHSA-wh8g-3j2c-rqj5",
+                  "modified": "2024-03-15T00:31:15.123603Z"
+                }
+              ]
+            },
+            {},
+            {},
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "GHSA-j288-q9x7-2f5v",
+                  "modified": "2026-02-04T03:18:02.851501Z"
+                }
+              ]
+            },
+            {
+              "vulns": [
+                {
+                  "id": "GHSA-7r82-7xv7-xcpj",
+                  "modified": "2026-02-04T02:20:49.137443Z"
+                }
+              ]
+            },
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "GHSA-cj7v-27pg-wf7q",
+                  "modified": "2026-02-04T02:37:14.415320Z"
+                },
+                {
+                  "id": "GHSA-hmr7-m48g-48f6",
+                  "modified": "2026-02-04T03:59:52.327364Z"
+                },
+                {
+                  "id": "GHSA-qh8g-58pp-2wxh",
+                  "modified": "2026-02-04T05:13:21.910792Z"
+                }
+              ]
+            },
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "GHSA-3gh6-v5v9-6v9j",
+                  "modified": "2026-02-04T03:12:16.534413Z"
+                },
+                {
+                  "id": "GHSA-gwcr-j4wh-j3cq",
+                  "modified": "2026-02-04T04:36:55.164608Z"
+                },
+                {
+                  "id": "GHSA-j26w-f9rq-mr2q",
+                  "modified": "2026-02-04T03:32:43.162423Z"
+                }
+              ]
+            },
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "GHSA-264p-99wq-f4j6",
+                  "modified": "2026-02-04T03:21:48.913313Z"
+                }
+              ]
+            }
+          ]
+        }
+      headers:
+        Content-Length:
+          - "4348"
+        Content-Type:
+          - application/json
+      status: 200 OK
+      code: 200
+      duration: 0s
+  - id: 2
+    request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
+      content_length: 3196
+      host: api.osv.dev
+      body: |
+        {
+          "queries": [
+            {
+              "package": {
+                "ecosystem": "Maven",
+                "name": "com.amazonaws:aws-java-sdk-core"
+              },
+              "version": "1.11.327"
+            },
+            {
+              "package": {
+                "ecosystem": "Maven",
+                "name": "com.amazonaws:aws-java-sdk-kms"
+              },
+              "version": "1.11.327"
+            },
+            {
+              "package": {
+                "ecosystem": "Maven",
+                "name": "com.amazonaws:aws-java-sdk-s3"
+              },
+              "version": "1.11.327"
+            },
+            {
+              "package": {
+                "ecosystem": "Maven",
+                "name": "com.amazonaws:jmespath-java"
+              },
+              "version": "1.11.327"
+            },
+            {
+              "package": {
+                "ecosystem": "Maven",
+                "name": "com.example:hello-tester"
+              },
+              "version": "1.0-SNAPSHOT"
+            },
+            {
+              "package": {
+                "ecosystem": "Maven",
+                "name": "com.fasterxml.jackson.core:jackson-annotations"
+              },
+              "version": "2.6.0"
+            },
+            {
+              "package": {
+                "ecosystem": "Maven",
+                "name": "com.fasterxml.jackson.core:jackson-core"
+              },
+              "version": "2.14.0"
+            },
+            {
+              "package": {
+                "ecosystem": "Maven",
+                "name": "com.fasterxml.jackson.core:jackson-databind"
+              },
+              "version": "2.6.7.1"
+            },
+            {
+              "package": {
+                "ecosystem": "Maven",
+                "name": "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor"
+              },
+              "version": "2.6.7"
+            },
+            {
+              "package": {
+                "ecosystem": "Maven",
+                "name": "commons-codec:commons-codec"
+              },
+              "version": "1.10"
+            },
+            {
+              "package": {
+                "ecosystem": "Maven",
+                "name": "commons-logging:commons-logging"
+              },
+              "version": "1.1.3"
+            },
+            {
+              "package": {
+                "ecosystem": "Maven",
+                "name": "joda-time:joda-time"
+              },
+              "version": "2.8.1"
+            },
+            {
+              "package": {
+                "ecosystem": "Maven",
+                "name": "org.apache.commons:commons-lang3"
+              },
+              "version": "3.12.0"
+            },
+            {
+              "package": {
+                "ecosystem": "Maven",
+                "name": "org.apache.httpcomponents:httpclient"
+              },
+              "version": "4.5.5"
+            },
+            {
+              "package": {
+                "ecosystem": "Maven",
+                "name": "org.apache.httpcomponents:httpcore"
+              },
+              "version": "4.4.9"
+            },
+            {
+              "package": {
+                "ecosystem": "Maven",
+                "name": "org.eclipse.jetty:jetty-continuation"
+              },
+              "version": "9.4.40.v20210413"
+            },
+            {
+              "package": {
+                "ecosystem": "Maven",
+                "name": "org.eclipse.jetty:jetty-http"
+              },
+              "version": "9.4.40.v20210413"
+            },
+            {
+              "package": {
+                "ecosystem": "Maven",
+                "name": "org.eclipse.jetty:jetty-io"
+              },
+              "version": "9.4.40.v20210413"
+            },
+            {
+              "package": {
+                "ecosystem": "Maven",
+                "name": "org.eclipse.jetty:jetty-servlets"
+              },
+              "version": "9.4.40.v20210413"
+            },
+            {
+              "package": {
+                "ecosystem": "Maven",
+                "name": "org.eclipse.jetty:jetty-util"
+              },
+              "version": "9.4.40.v20210413"
+            },
+            {
+              "package": {
+                "ecosystem": "Maven",
+                "name": "software.amazon.ion:ion-java"
+              },
+              "version": "1.0.2"
+            }
+          ]
+        }
+      headers:
+        Content-Type:
+          - application/json
+        X-Test-Name:
+          - TestCommand_JavareachArchive/jars_can_be_scanned_with_call_analysis_disabled
+      url: https://api.osv.dev/v1/querybatch
+      method: POST
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      content_length: 4348
+      body: |
+        {
+          "results": [
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "GHSA-c28r-hw5m-5gv3",
+                  "modified": "2023-11-08T04:09:28.159861Z"
+                }
+              ]
+            },
+            {},
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "GHSA-72hv-8253-57qq",
+                  "modified": "2026-03-04T15:06:51.908001Z"
+                },
+                {
+                  "id": "GHSA-h46c-h94j-95f3",
+                  "modified": "2026-02-04T03:44:39.385253Z"
+                }
+              ]
+            },
+            {
+              "vulns": [
+                {
+                  "id": "GHSA-288c-cq4h-88gq",
+                  "modified": "2026-02-04T04:33:29.159339Z"
+                },
+                {
+                  "id": "GHSA-4gq5-ch57-c2mg",
+                  "modified": "2024-03-15T05:20:21.411726Z"
+                },
+                {
+                  "id": "GHSA-4w82-r329-3q67",
+                  "modified": "2024-03-16T05:18:54.922179Z"
+                },
+                {
+                  "id": "GHSA-57j2-w4cx-62h2",
+                  "modified": "2026-02-04T04:26:14.546092Z"
+                },
+                {
+                  "id": "GHSA-5949-rw7g-wx7w",
+                  "modified": "2025-09-15T07:42:14.888352Z"
+                },
+                {
+                  "id": "GHSA-5r5r-6hpj-8gg9",
+                  "modified": "2024-02-18T05:42:28.539166Z"
+                },
+                {
+                  "id": "GHSA-5ww9-j83m-q7qx",
+                  "modified": "2024-03-15T01:17:50.016820Z"
+                },
+                {
+                  "id": "GHSA-645p-88qh-w398",
+                  "modified": "2024-03-16T05:19:17.936174Z"
+                },
+                {
+                  "id": "GHSA-6fpp-rgj9-8rwc",
+                  "modified": "2024-03-15T05:18:54.134884Z"
+                },
+                {
+                  "id": "GHSA-85cw-hj65-qqv9",
+                  "modified": "2024-03-15T05:20:15.574552Z"
+                },
+                {
+                  "id": "GHSA-89qr-369f-5m5x",
+                  "modified": "2024-02-18T05:37:27.581808Z"
+                },
+                {
+                  "id": "GHSA-8c4j-34r4-xr8g",
+                  "modified": "2024-02-18T05:31:52.762759Z"
+                },
+                {
+                  "id": "GHSA-8w26-6f25-cm9x",
+                  "modified": "2024-02-18T05:30:48.085017Z"
+                },
+                {
+                  "id": "GHSA-9gph-22xh-8x98",
+                  "modified": "2024-02-18T05:33:27.617261Z"
+                },
+                {
+                  "id": "GHSA-9m6f-7xcq-8vf8",
+                  "modified": "2024-02-18T05:32:25.400029Z"
+                },
+                {
+                  "id": "GHSA-c8hm-7hpq-7jhg",
+                  "modified": "2024-03-15T01:17:19.251183Z"
+                },
+                {
+                  "id": "GHSA-cf6r-3wgc-h863",
+                  "modified": "2024-02-18T05:32:56.325249Z"
+                },
+                {
+                  "id": "GHSA-cggj-fvv3-cqwv",
+                  "modified": "2024-03-15T01:18:46.938616Z"
+                },
+                {
+                  "id": "GHSA-cjjf-94ff-43w7",
+                  "modified": "2024-03-11T05:19:23.395848Z"
+                },
+                {
+                  "id": "GHSA-cmfg-87vq-g5g4",
+                  "modified": "2024-03-15T01:18:17.903231Z"
+                },
+                {
+                  "id": "GHSA-cvm9-fjm9-3572",
+                  "modified": "2024-02-18T05:25:36.165759Z"
+                },
+                {
+                  "id": "GHSA-f3j5-rmmp-3fc5",
+                  "modified": "2024-03-15T05:20:35.120151Z"
+                },
+                {
+                  "id": "GHSA-f9xh-2qgp-cq57",
+                  "modified": "2024-02-18T05:32:05.421673Z"
+                },
+                {
+                  "id": "GHSA-fmmc-742q-jg75",
+                  "modified": "2024-03-16T05:19:55.172981Z"
+                },
+                {
+                  "id": "GHSA-fqwf-pjwf-7vqv",
+                  "modified": "2024-07-03T21:22:37.578162Z"
+                },
+                {
+                  "id": "GHSA-gjmw-vf9h-g25v",
+                  "modified": "2024-03-16T05:19:37.211801Z"
+                },
+                {
+                  "id": "GHSA-gwp4-hfv6-p7hw",
+                  "modified": "2024-03-13T05:27:58.436849Z"
+                },
+                {
+                  "id": "GHSA-gww7-p5w4-wrfv",
+                  "modified": "2024-03-15T01:05:18.790961Z"
+                },
+                {
+                  "id": "GHSA-h3cw-g4mq-c5x2",
+                  "modified": "2024-02-18T05:30:45.329621Z"
+                },
+                {
+                  "id": "GHSA-h592-38cm-4ggp",
+                  "modified": "2024-03-15T01:16:50.905794Z"
+                },
+                {
+                  "id": "GHSA-h822-r4r5-v8jg",
+                  "modified": "2026-02-04T02:19:17.186100Z"
+                },
+                {
+                  "id": "GHSA-jjjh-jjxp-wpff",
+                  "modified": "2026-02-04T02:23:59.070528Z"
+                },
+                {
+                  "id": "GHSA-m6x4-97wx-4q27",
+                  "modified": "2024-02-18T05:21:54.725837Z"
+                },
+                {
+                  "id": "GHSA-mph4-vhrx-mv67",
+                  "modified": "2024-03-15T01:16:21.467932Z"
+                },
+                {
+                  "id": "GHSA-mx7p-6679-8g3q",
+                  "modified": "2024-03-15T01:01:46.432481Z"
+                },
+                {
+                  "id": "GHSA-p43x-xfjf-5jhr",
+                  "modified": "2024-03-15T00:33:14.700288Z"
+                },
+                {
+                  "id": "GHSA-q93h-jc49-78gg",
+                  "modified": "2024-03-16T05:19:47.711015Z"
+                },
+                {
+                  "id": "GHSA-qjw2-hr98-qgfh",
+                  "modified": "2024-02-18T05:20:56.894470Z"
+                },
+                {
+                  "id": "GHSA-qr7j-h6gg-jmgc",
+                  "modified": "2024-03-11T05:21:14.313980Z"
+                },
+                {
+                  "id": "GHSA-r3gr-cxrf-hg25",
+                  "modified": "2024-06-25T14:20:21.323050Z"
+                },
+                {
+                  "id": "GHSA-r695-7vr9-jgc2",
+                  "modified": "2024-02-18T05:30:45.856594Z"
+                },
+                {
+                  "id": "GHSA-rfx6-vp9g-rh7v",
+                  "modified": "2024-03-11T05:17:47.425595Z"
+                },
+                {
+                  "id": "GHSA-rgv9-q543-rqg4",
+                  "modified": "2026-02-04T02:40:22.352009Z"
+                },
+                {
+                  "id": "GHSA-rpr3-cw39-3pxh",
+                  "modified": "2026-02-04T04:07:52.719878Z"
+                },
+                {
+                  "id": "GHSA-v585-23hc-c647",
+                  "modified": "2024-02-18T05:22:38.024460Z"
+                },
+                {
+                  "id": "GHSA-vfqx-33qm-g869",
+                  "modified": "2024-02-18T05:24:26.785781Z"
+                },
+                {
+                  "id": "GHSA-w3f4-3q6j-rh82",
+                  "modified": "2024-03-11T05:18:22.727055Z"
+                },
+                {
+                  "id": "GHSA-wh8g-3j2c-rqj5",
+                  "modified": "2024-03-15T00:31:15.123603Z"
+                }
+              ]
+            },
+            {},
+            {},
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "GHSA-j288-q9x7-2f5v",
+                  "modified": "2026-02-04T03:18:02.851501Z"
+                }
+              ]
+            },
+            {
+              "vulns": [
+                {
+                  "id": "GHSA-7r82-7xv7-xcpj",
+                  "modified": "2026-02-04T02:20:49.137443Z"
+                }
+              ]
+            },
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "GHSA-cj7v-27pg-wf7q",
+                  "modified": "2026-02-04T02:37:14.415320Z"
+                },
+                {
+                  "id": "GHSA-hmr7-m48g-48f6",
+                  "modified": "2026-02-04T03:59:52.327364Z"
+                },
+                {
+                  "id": "GHSA-qh8g-58pp-2wxh",
+                  "modified": "2026-02-04T05:13:21.910792Z"
+                }
+              ]
+            },
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "GHSA-3gh6-v5v9-6v9j",
+                  "modified": "2026-02-04T03:12:16.534413Z"
+                },
+                {
+                  "id": "GHSA-gwcr-j4wh-j3cq",
+                  "modified": "2026-02-04T04:36:55.164608Z"
+                },
+                {
+                  "id": "GHSA-j26w-f9rq-mr2q",
+                  "modified": "2026-02-04T03:32:43.162423Z"
+                }
+              ]
+            },
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "GHSA-264p-99wq-f4j6",
+                  "modified": "2026-02-04T03:21:48.913313Z"
+                }
+              ]
+            }
+          ]
+        }
+      headers:
+        Content-Length:
+          - "4348"
+        Content-Type:
+          - application/json
+      status: 200 OK
+      code: 200
+      duration: 0s
+  - id: 3
+    request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
+      content_length: 3196
+      host: api.osv.dev
+      body: |
+        {
+          "queries": [
+            {
+              "package": {
+                "ecosystem": "Maven",
+                "name": "com.amazonaws:aws-java-sdk-core"
+              },
+              "version": "1.11.327"
+            },
+            {
+              "package": {
+                "ecosystem": "Maven",
+                "name": "com.amazonaws:aws-java-sdk-kms"
+              },
+              "version": "1.11.327"
+            },
+            {
+              "package": {
+                "ecosystem": "Maven",
+                "name": "com.amazonaws:aws-java-sdk-s3"
+              },
+              "version": "1.11.327"
+            },
+            {
+              "package": {
+                "ecosystem": "Maven",
+                "name": "com.amazonaws:jmespath-java"
+              },
+              "version": "1.11.327"
+            },
+            {
+              "package": {
+                "ecosystem": "Maven",
+                "name": "com.example:hello-tester"
+              },
+              "version": "1.0-SNAPSHOT"
+            },
+            {
+              "package": {
+                "ecosystem": "Maven",
+                "name": "com.fasterxml.jackson.core:jackson-annotations"
+              },
+              "version": "2.6.0"
+            },
+            {
+              "package": {
+                "ecosystem": "Maven",
+                "name": "com.fasterxml.jackson.core:jackson-core"
+              },
+              "version": "2.14.0"
+            },
+            {
+              "package": {
+                "ecosystem": "Maven",
+                "name": "com.fasterxml.jackson.core:jackson-databind"
+              },
+              "version": "2.6.7.1"
+            },
+            {
+              "package": {
+                "ecosystem": "Maven",
+                "name": "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor"
+              },
+              "version": "2.6.7"
+            },
+            {
+              "package": {
+                "ecosystem": "Maven",
+                "name": "commons-codec:commons-codec"
+              },
+              "version": "1.10"
+            },
+            {
+              "package": {
+                "ecosystem": "Maven",
+                "name": "commons-logging:commons-logging"
+              },
+              "version": "1.1.3"
+            },
+            {
+              "package": {
+                "ecosystem": "Maven",
+                "name": "joda-time:joda-time"
+              },
+              "version": "2.8.1"
+            },
+            {
+              "package": {
+                "ecosystem": "Maven",
+                "name": "org.apache.commons:commons-lang3"
+              },
+              "version": "3.12.0"
+            },
+            {
+              "package": {
+                "ecosystem": "Maven",
+                "name": "org.apache.httpcomponents:httpclient"
+              },
+              "version": "4.5.5"
+            },
+            {
+              "package": {
+                "ecosystem": "Maven",
+                "name": "org.apache.httpcomponents:httpcore"
+              },
+              "version": "4.4.9"
+            },
+            {
+              "package": {
+                "ecosystem": "Maven",
+                "name": "org.eclipse.jetty:jetty-continuation"
+              },
+              "version": "9.4.40.v20210413"
+            },
+            {
+              "package": {
+                "ecosystem": "Maven",
+                "name": "org.eclipse.jetty:jetty-http"
+              },
+              "version": "9.4.40.v20210413"
+            },
+            {
+              "package": {
+                "ecosystem": "Maven",
+                "name": "org.eclipse.jetty:jetty-io"
+              },
+              "version": "9.4.40.v20210413"
+            },
+            {
+              "package": {
+                "ecosystem": "Maven",
+                "name": "org.eclipse.jetty:jetty-servlets"
+              },
+              "version": "9.4.40.v20210413"
+            },
+            {
+              "package": {
+                "ecosystem": "Maven",
+                "name": "org.eclipse.jetty:jetty-util"
+              },
+              "version": "9.4.40.v20210413"
+            },
+            {
+              "package": {
+                "ecosystem": "Maven",
+                "name": "software.amazon.ion:ion-java"
+              },
+              "version": "1.0.2"
+            }
+          ]
+        }
+      headers:
+        Content-Type:
+          - application/json
+        X-Test-Name:
           - TestCommand_JavareachArchive/jars_can_be_scanned_without_call_analysis
       url: https://api.osv.dev/v1/querybatch
       method: POST

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -18,7 +18,6 @@ import (
 	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
 	"github.com/google/osv-scalibr/clients/datasource"
 	"github.com/google/osv-scalibr/enricher/packagedeprecation"
-	"github.com/google/osv-scalibr/enricher/reachability/java"
 	"github.com/google/osv-scalibr/extractor"
 	"github.com/google/osv-scalibr/inventory"
 	scalibrlog "github.com/google/osv-scalibr/log"
@@ -279,10 +278,6 @@ func DoContainerScan(actions ScannerActions) (models.VulnerabilityResults, error
 	// not mentioning them to avoid confusion since they're still in their infancy
 	if countNotEnrichers(plugins) == 0 {
 		return models.VulnerabilityResults{}, errors.New("at least one extractor must be enabled")
-	}
-
-	if actions.CallAnalysisStates["jar"] {
-		plugins = append(plugins, java.NewDefault())
 	}
 
 	if actions.FlagDeprecatedPackages {

--- a/pkg/osvscanner/scan.go
+++ b/pkg/osvscanner/scan.go
@@ -81,6 +81,10 @@ func getPlugins(defaultPlugins []string, accessors ExternalAccessors, actions Sc
 		actions.PluginsDisabled = append(actions.PluginsDisabled, vendored.Name)
 	}
 
+	if actions.CallAnalysisStates["jar"] {
+		actions.PluginsEnabled = append(actions.PluginsEnabled, java.Name)
+	}
+
 	plugins := scalibrplugin.Resolve(actions.PluginsEnabled, actions.PluginsDisabled, cfg)
 
 	configurePlugins(plugins, accessors, actions)
@@ -115,10 +119,6 @@ func scan(accessors ExternalAccessors, actions ScannerActions) (*inventory.Inven
 	// not mentioning them to avoid confusion since they're still in their infancy
 	if countNotEnrichers(plugins) == 0 {
 		return nil, errors.New("at least one extractor must be enabled")
-	}
-
-	if actions.CallAnalysisStates["jar"] {
-		plugins = append(plugins, java.NewDefault())
 	}
 
 	if actions.FlagDeprecatedPackages {


### PR DESCRIPTION
This technically means you can now disable the plugin, but I don't think that matters - I've added a test though to showcase how the scanner reacts