### PR TITLE
test(mcp): waiting 15 seconds before timing out

### DIFF
--- a/cmd/osv-scanner/mcp/integration_test.go
+++ b/cmd/osv-scanner/mcp/integration_test.go
@@ -195,7 +195,7 @@ func connectMCPClient(t *testing.T, ctx context.Context, baseURL string) *mcp.Cl
 
 func waitForServer(t *testing.T, url string) {
 	t.Helper()
-	deadline := time.Now().Add(10 * time.Second)
+	deadline := time.Now().Add(15 * time.Second)
 	for time.Now().Before(deadline) {
 		//nolint:gosec,noctx // This is a test with a local URL
 		resp, err := http.Get(url)


### PR DESCRIPTION
I've seen a couple of timeout failures on Windows that are hopefully because we need to wait just a little longer on 🤞 