### PR TITLE
refactor: use `ScanResults.Inventory.Packages` directly

### DIFF
--- a/internal/imodels/results/scanresults.go
+++ b/internal/imodels/results/scanresults.go
@@ -3,7 +3,6 @@ package results
 
 import (
 	spb "github.com/google/osv-scalibr/binary/proto/scan_result_go_proto"
-	"github.com/google/osv-scalibr/extractor"
 	"github.com/google/osv-scalibr/inventory"
 	"github.com/google/osv-scanner/v2/internal/config"
 )
@@ -12,8 +11,6 @@ import (
 // This includes information that affect multiple packages.
 type ScanResults struct {
 	Inventory inventory.Inventory
-
-	PackageScanResults []*extractor.Package
 
 	// TODO(v2): Temporarily commented out until ScanParameters is moved
 	// to a shared package to avoid cyclic dependencies

--- a/pkg/osvscanner/filter.go
+++ b/pkg/osvscanner/filter.go
@@ -18,9 +18,9 @@ import (
 // are not a supported ecosystem, and returns the list of removed packages (if --all-packages flag is passed in)
 // e,g, local packages that specified by path
 func filterUnscannablePackages(scanResults *results.ScanResults, actions ScannerActions) []*extractor.Package {
-	packageResults := make([]*extractor.Package, 0, len(scanResults.PackageScanResults))
-	filteredPsr := make([]*extractor.Package, 0, len(scanResults.PackageScanResults))
-	for _, psr := range scanResults.PackageScanResults {
+	packageResults := make([]*extractor.Package, 0, len(scanResults.Inventory.Packages))
+	filteredPsr := make([]*extractor.Package, 0, len(scanResults.Inventory.Packages))
+	for _, psr := range scanResults.Inventory.Packages {
 		switch {
 		// If **none** of the cases match, skip this package since it's not scannable
 		case !imodels.Ecosystem(psr).IsEmpty() && imodels.Name(psr) != "" && imodels.Version(psr) != "":
@@ -47,19 +47,19 @@ func filterUnscannablePackages(scanResults *results.ScanResults, actions Scanner
 		packageResults = append(packageResults, psr)
 	}
 
-	if len(packageResults) != len(scanResults.PackageScanResults) {
-		cmdlogger.Infof("Filtered %d local/unscannable package/s from the scan.", len(scanResults.PackageScanResults)-len(packageResults))
+	if len(packageResults) != len(scanResults.Inventory.Packages) {
+		cmdlogger.Infof("Filtered %d local/unscannable package/s from the scan.", len(scanResults.Inventory.Packages)-len(packageResults))
 	}
 
-	scanResults.PackageScanResults = packageResults
+	scanResults.Inventory.Packages = packageResults
 
 	return filteredPsr
 }
 
 // filterNonContainerRelevantPackages removes packages that are not relevant when doing container scanning
 func filterNonContainerRelevantPackages(scanResults *results.ScanResults) {
-	packageResults := make([]*extractor.Package, 0, len(scanResults.PackageScanResults))
-	for _, psr := range scanResults.PackageScanResults {
+	packageResults := make([]*extractor.Package, 0, len(scanResults.Inventory.Packages))
+	for _, psr := range scanResults.Inventory.Packages {
 		// Almost all packages with linux as a SourceName are kernel packages
 		// which does not apply within a container, as containers use the host's kernel
 		if imodels.Name(psr) == "linux" {
@@ -69,19 +69,19 @@ func filterNonContainerRelevantPackages(scanResults *results.ScanResults) {
 		packageResults = append(packageResults, psr)
 	}
 
-	if len(packageResults) != len(scanResults.PackageScanResults) {
-		cmdlogger.Infof("Filtered %d non container relevant package/s from the scan.", len(scanResults.PackageScanResults)-len(packageResults))
+	if len(packageResults) != len(scanResults.Inventory.Packages) {
+		cmdlogger.Infof("Filtered %d non container relevant package/s from the scan.", len(scanResults.Inventory.Packages)-len(packageResults))
 	}
 
-	scanResults.PackageScanResults = packageResults
+	scanResults.Inventory.Packages = packageResults
 }
 
 // filterIgnoredPackages removes ignore scanned packages according to config. Returns filtered scanned packages.
 func filterIgnoredPackages(scanResults *results.ScanResults) {
 	configManager := &scanResults.ConfigManager
 
-	out := make([]*extractor.Package, 0, len(scanResults.PackageScanResults))
-	for _, psr := range scanResults.PackageScanResults {
+	out := make([]*extractor.Package, 0, len(scanResults.Inventory.Packages))
+	for _, psr := range scanResults.Inventory.Packages {
 		configToUse := configManager.Get(imodels.Location(psr))
 
 		if ignore, ignoreLine := configToUse.ShouldIgnorePackage(psr); ignore {
@@ -98,11 +98,11 @@ func filterIgnoredPackages(scanResults *results.ScanResults) {
 		out = append(out, psr)
 	}
 
-	if len(out) != len(scanResults.PackageScanResults) {
-		cmdlogger.Infof("Filtered %d ignored package/s from the scan.", len(scanResults.PackageScanResults)-len(out))
+	if len(out) != len(scanResults.Inventory.Packages) {
+		cmdlogger.Infof("Filtered %d ignored package/s from the scan.", len(scanResults.Inventory.Packages)-len(out))
 	}
 
-	scanResults.PackageScanResults = out
+	scanResults.Inventory.Packages = out
 }
 
 // Filters results according to config, preserving order. Returns total number of vulnerabilities removed.

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -16,7 +16,6 @@ import (
 	"github.com/google/osv-scalibr/artifact/image/layerscanning/image"
 	"github.com/google/osv-scalibr/binary/proto"
 	"github.com/google/osv-scalibr/clients/datasource"
-	"github.com/google/osv-scalibr/extractor"
 	"github.com/google/osv-scalibr/inventory"
 	scalibrlog "github.com/google/osv-scalibr/log"
 	"github.com/google/osv-scalibr/plugin"
@@ -175,7 +174,7 @@ func DoScan(actions ScannerActions) (models.VulnerabilityResults, error) {
 		return models.VulnerabilityResults{}, errors.New("databases can only be downloaded when running in offline mode")
 	}
 
-	scanResult := results.ScanResults{
+	scanResults := results.ScanResults{
 		ConfigManager: config.Manager{
 			DefaultConfig: config.Config{},
 			ConfigMap:     make(map[string]config.Config),
@@ -184,7 +183,7 @@ func DoScan(actions ScannerActions) (models.VulnerabilityResults, error) {
 
 	// --- Setup Config ---
 	if actions.ConfigOverridePath != "" {
-		err := scanResult.ConfigManager.UseOverride(actions.ConfigOverridePath)
+		err := scanResults.ConfigManager.UseOverride(actions.ConfigOverridePath)
 		if err != nil {
 			cmdlogger.Errorf("Failed to read config file: %s", err)
 			return models.VulnerabilityResults{}, err
@@ -203,19 +202,18 @@ func DoScan(actions ScannerActions) (models.VulnerabilityResults, error) {
 		return models.VulnerabilityResults{}, err
 	}
 
-	scanResult.PackageScanResults = packagesAndFindings.Packages
-	scanResult.Inventory = *packagesAndFindings
+	scanResults.Inventory = *packagesAndFindings
 
 	// ----- Filtering -----
-	unscannablePackages := filterUnscannablePackages(&scanResult, actions)
-	filterIgnoredPackages(&scanResult)
+	unscannablePackages := filterUnscannablePackages(&scanResults, actions)
+	filterIgnoredPackages(&scanResults)
 
 	// ----- Custom Overrides -----
-	overrideGoVersion(&scanResult)
+	overrideGoVersion(&scanResults)
 
 	// --- Make Vulnerability Requests ---
 	if accessors.VulnMatcher != nil {
-		err = makeVulnRequestWithMatcher(&scanResult, accessors.VulnMatcher)
+		err = makeVulnRequestWithMatcher(&scanResults, accessors.VulnMatcher)
 		if err != nil {
 			return models.VulnerabilityResults{}, err
 		}
@@ -223,21 +221,22 @@ func DoScan(actions ScannerActions) (models.VulnerabilityResults, error) {
 
 	// --- Make License Requests ---
 	if accessors.LicenseMatcher != nil {
-		err = accessors.LicenseMatcher.MatchLicenses(context.Background(), scanResult.PackageScanResults)
+		err = accessors.LicenseMatcher.MatchLicenses(context.Background(), scanResults.Inventory.Packages)
 		if err != nil {
 			return models.VulnerabilityResults{}, err
 		}
 	}
 
+	// todo: this previously wasn't being applied to Inventory - did we have a bug...?
 	if len(unscannablePackages) > 0 {
-		scanResult.PackageScanResults = slices.Concat(scanResult.PackageScanResults, unscannablePackages)
+		scanResults.Inventory.Packages = slices.Concat(scanResults.Inventory.Packages, unscannablePackages)
 	}
 
-	return finalizeScanResult(scanResult, actions)
+	return finalizeScanResult(scanResults, actions)
 }
 
 func DoContainerScan(actions ScannerActions) (models.VulnerabilityResults, error) {
-	scanResult := results.ScanResults{
+	scanResults := results.ScanResults{
 		ConfigManager: config.Manager{
 			DefaultConfig: config.Config{},
 			ConfigMap:     make(map[string]config.Config),
@@ -245,7 +244,7 @@ func DoContainerScan(actions ScannerActions) (models.VulnerabilityResults, error
 	}
 
 	if actions.ConfigOverridePath != "" {
-		err := scanResult.ConfigManager.UseOverride(actions.ConfigOverridePath)
+		err := scanResults.ConfigManager.UseOverride(actions.ConfigOverridePath)
 		if err != nil {
 			cmdlogger.Errorf("Failed to read config file: %s", err)
 			return models.VulnerabilityResults{}, err
@@ -332,11 +331,7 @@ func DoContainerScan(actions ScannerActions) (models.VulnerabilityResults, error
 	}
 
 	// --- Save Scalibr Scan Results ---
-	scanResult.PackageScanResults = make([]*extractor.Package, len(scalibrSR.Inventory.Packages))
-	for i, pkgs := range scalibrSR.Inventory.Packages {
-		scanResult.PackageScanResults[i] = pkgs
-		scanResult.PackageScanResults[i].ExploitabilitySignals = pkgs.ExploitabilitySignals
-	}
+	scanResults.Inventory = scalibrSR.Inventory
 
 	// --- Fill Image Metadata ---
 	pssr, err := proto.ScanResultToProto(scalibrSR)
@@ -345,22 +340,20 @@ func DoContainerScan(actions ScannerActions) (models.VulnerabilityResults, error
 	}
 
 	if len(pssr.GetInventory().GetContainerImageMetadata()) > 0 {
-		scanResult.ImageMetadata = pssr.GetInventory().GetContainerImageMetadata()[0]
+		scanResults.ImageMetadata = pssr.GetInventory().GetContainerImageMetadata()[0]
 	} else {
 		cmdlogger.Warnf("No container image metadata found in scan results")
 	}
 
-	scanResult.Inventory = scalibrSR.Inventory
-
 	// ----- Filtering -----
-	unscannablePackages := filterUnscannablePackages(&scanResult, actions)
-	filterIgnoredPackages(&scanResult)
+	unscannablePackages := filterUnscannablePackages(&scanResults, actions)
+	filterIgnoredPackages(&scanResults)
 
-	filterNonContainerRelevantPackages(&scanResult)
+	filterNonContainerRelevantPackages(&scanResults)
 
 	// --- Make Vulnerability Requests ---
 	if accessors.VulnMatcher != nil {
-		err = makeVulnRequestWithMatcher(&scanResult, accessors.VulnMatcher)
+		err = makeVulnRequestWithMatcher(&scanResults, accessors.VulnMatcher)
 		if err != nil {
 			return models.VulnerabilityResults{}, err
 		}
@@ -368,17 +361,18 @@ func DoContainerScan(actions ScannerActions) (models.VulnerabilityResults, error
 
 	// --- Make License Requests ---
 	if accessors.LicenseMatcher != nil {
-		err = accessors.LicenseMatcher.MatchLicenses(context.Background(), scanResult.PackageScanResults)
+		err = accessors.LicenseMatcher.MatchLicenses(context.Background(), scanResults.Inventory.Packages)
 		if err != nil {
 			return models.VulnerabilityResults{}, err
 		}
 	}
 
+	// todo: this previously wasn't being applied to Inventory - did we have a bug...?
 	if len(unscannablePackages) > 0 {
-		scanResult.PackageScanResults = slices.Concat(scanResult.PackageScanResults, unscannablePackages)
+		scanResults.Inventory.Packages = slices.Concat(scanResults.Inventory.Packages, unscannablePackages)
 	}
 
-	return finalizeScanResult(scanResult, actions)
+	return finalizeScanResult(scanResults, actions)
 }
 
 func finalizeScanResult(scanResult results.ScanResults, actions ScannerActions) (models.VulnerabilityResults, error) {
@@ -413,11 +407,11 @@ func finalizeScanResult(scanResult results.ScanResults, actions ScannerActions) 
 	return vulnerabilityResults, determineReturnErr(vulnerabilityResults, actions.ShowAllVulns)
 }
 
-func buildLicenseSummary(scanResult *results.ScanResults) []models.LicenseCount {
+func buildLicenseSummary(scanResults *results.ScanResults) []models.LicenseCount {
 	var licenseSummary []models.LicenseCount
 
 	counts := make(map[string]int)
-	for _, pkg := range scanResult.PackageScanResults {
+	for _, pkg := range scanResults.Inventory.Packages {
 		for _, l := range pkg.Licenses {
 			counts[l] += 1
 		}
@@ -503,7 +497,7 @@ func makeVulnRequestWithMatcher(
 	scanResults *results.ScanResults,
 	matcher clientinterfaces.VulnerabilityMatcher,
 ) error {
-	res, err := matcher.MatchVulnerabilities(context.Background(), scanResults.PackageScanResults)
+	res, err := matcher.MatchVulnerabilities(context.Background(), scanResults.Inventory.Packages)
 	if err != nil {
 		cmdlogger.Errorf("error when retrieving vulns: %v", err)
 		if res == nil {
@@ -515,7 +509,7 @@ func makeVulnRequestWithMatcher(
 		for _, vuln := range vulns {
 			scanResults.Inventory.PackageVulns = append(scanResults.Inventory.PackageVulns, &inventory.PackageVuln{
 				Vulnerability: vuln,
-				Package:       scanResults.PackageScanResults[i],
+				Package:       scanResults.Inventory.Packages[i],
 			})
 		}
 	}
@@ -525,11 +519,11 @@ func makeVulnRequestWithMatcher(
 
 // Overrides Go version using osv-scanner.toml
 func overrideGoVersion(scanResults *results.ScanResults) {
-	for i, pkg := range scanResults.PackageScanResults {
+	for i, pkg := range scanResults.Inventory.Packages {
 		if imodels.Name(pkg) == "stdlib" && imodels.Ecosystem(pkg).Ecosystem == osvconstants.EcosystemGo {
 			configToUse := scanResults.ConfigManager.Get(imodels.Location(pkg))
 			if configToUse.GoVersionOverride != "" {
-				scanResults.PackageScanResults[i].Version = configToUse.GoVersionOverride
+				scanResults.Inventory.Packages[i].Version = configToUse.GoVersionOverride
 			}
 
 			continue

--- a/pkg/osvscanner/vulnerability_result.go
+++ b/pkg/osvscanner/vulnerability_result.go
@@ -43,7 +43,7 @@ func buildVulnerabilityResults(
 
 	groupedBySource := map[models.SourceInfo]*packageVulnsGroup{}
 
-	for i, p := range scanResults.PackageScanResults {
+	for i, p := range scanResults.Inventory.Packages {
 		includePackage := actions.ShowAllPackages
 		var pkg models.PackageVulns
 
@@ -143,7 +143,7 @@ func buildVulnerabilityResults(
 			}
 
 			// Make sure licenses are overridden in the scan results.
-			scanResults.PackageScanResults[i] = p
+			scanResults.Inventory.Packages[i] = p
 		}
 		if includePackage {
 			source := models.SourceInfo{

--- a/pkg/osvscanner/vulnerability_result_internal_test.go
+++ b/pkg/osvscanner/vulnerability_result_internal_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/google/osv-scanner/v2/internal/config"
 	"github.com/google/osv-scanner/v2/internal/imodels/results"
 	"github.com/google/osv-scanner/v2/internal/testutility"
-	"github.com/google/osv-scanner/v2/pkg/models"
 	"github.com/ossf/osv-schema/bindings/go/osvschema"
 )
 
@@ -63,16 +62,6 @@ func makeScanResults() *results.ScanResults {
 			Vulnerability: &osvschema.Vulnerability{Id: "GHSA-456"},
 			Package:       scanResults.Inventory.Packages[2],
 		},
-	}
-
-	// add the package scan results, with pointer references to their underlying packages
-	for _, pkg := range scanResults.Inventory.Packages {
-		licenses := make([]models.License, len(pkg.Licenses))
-		for i, lic := range pkg.Licenses {
-			licenses[i] = models.License(lic)
-		}
-
-		scanResults.PackageScanResults = append(scanResults.PackageScanResults, pkg)
 	}
 
 	return scanResults


### PR DESCRIPTION
... and finally we come to the end (sort of): now that `PackageScanResults` holds `*extractor.Package`, we can just switch to using `Inventory.Packages` directly 🎉 