### PR TITLE
ci: fix zizmor github actions security warnings

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -167,8 +167,10 @@ jobs:
           distribution: goreleaser
           version: "~> v2"
           args: release --clean --snapshot
-      - run: |
-          echo '${{ steps.run-goreleaser.outputs.artifacts }}' > output.json
+      - env:
+          ARTIFACTS: ${{ steps.run-goreleaser.outputs.artifacts }}
+        run: |
+          echo "$ARTIFACTS" > output.json
           jq -r '.[] | select(
             .type == "Docker Image" and
             .goarch == "amd64" and

--- a/.github/workflows/goreleaser-nightly.yml
+++ b/.github/workflows/goreleaser-nightly.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: tcort/github-action-markdown-link-check@e7c7a18363c842693fadde5d41a3bd3573a7a225 # v1.1.2
         with:
           use-quiet-mode: "yes"

--- a/.github/workflows/prerelease-check.yml
+++ b/.github/workflows/prerelease-check.yml
@@ -35,6 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: tcort/github-action-markdown-link-check@e7c7a18363c842693fadde5d41a3bd3573a7a225 # v1.1.2
         with:
           use-quiet-mode: "yes"

--- a/.github/workflows/renovate-validator.yml
+++ b/.github/workflows/renovate-validator.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Nodes.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0


### PR DESCRIPTION
Fixes zizmor findings for credential persistence through GitHub Actions artifacts and code injection via template expansion.

Fixes include:
1. Adding `persist-credentials: false` to `actions/checkout` in `renovate-validator.yml`.
2. Adding `persist-credentials: false` to `actions/checkout` in `prerelease-check.yml`.
3. Adding `persist-credentials: false` to `actions/checkout` in `links.yml`.
4. Adding `persist-credentials: false` to `actions/checkout` in `goreleaser.yml`.
5. Adding `persist-credentials: false` to `actions/checkout` in `goreleaser-nightly.yml`.
6. Refactoring the template expansion for `${{ steps.run-goreleaser.outputs.artifacts }}` to use an `env` variable in `checks.yml` to prevent code injection.

---
*PR created automatically by Jules for task [1731879245063753428](https://jules.google.com/task/1731879245063753428) started by @another-rex*