### PR TITLE
ci: run `osv-scanner` on the whole codebase

### DIFF
--- a/.github/workflows/osv-scanner-unified-action.yml
+++ b/.github/workflows/osv-scanner-unified-action.yml
@@ -35,11 +35,6 @@ jobs:
     if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
     # If you want to copy this config, highly suggest pinning this to a release rather than tracking the nightly branch.
     uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@nightly"
-    with:
-      # Just scan the root directory and docs, since everything else is testdata
-      scan-args: |-
-        ./
-        ./docs/
   scan-pr:
     permissions:
       contents: read # to fetch code (actions/checkout)
@@ -48,8 +43,3 @@ jobs:
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
     # If you want to copy this config, highly suggest pinning this to a release rather than tracking the nightly branch.
     uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@nightly"
-    with:
-      # Just scan the root directory and docs, since everything else is testdata
-      scan-args: |-
-        ./
-        ./docs/


### PR DESCRIPTION
Our test suite has been using `osv-scanner-test.toml` for a while meaning we can (and should) be using `osv-scanner.toml`s to ignore any vulns in our testdata, so it should be fine to just scan the whole codebase

(and this'll hopefully catch when we forget to add the config)