### PR TITLE
Bump osv-scalibr to include CleanStart ecosystem support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/gobwas/glob v0.2.3
 	github.com/goccy/go-yaml v1.19.2
 	github.com/google/go-cmp v0.7.0
-	github.com/google/osv-scalibr v0.4.5-0.20260306165454-c7f2e9b7def6
+	github.com/google/osv-scalibr v0.4.5
 	github.com/ianlancetaylor/demangle v0.0.0-20251118225945-96ee0021ea0f
 	github.com/jedib0t/go-pretty/v6 v6.7.8
 	github.com/modelcontextprotocol/go-sdk v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -266,8 +266,8 @@ github.com/google/go-cpy v0.0.0-20211218193943-a9c933c06932 h1:5/4TSDzpDnHQ8rKEE
 github.com/google/go-cpy v0.0.0-20211218193943-a9c933c06932/go.mod h1:cC6EdPbj/17GFCPDK39NRarlMI+kt+O60S12cNB5J9Y=
 github.com/google/jsonschema-go v0.4.2 h1:tmrUohrwoLZZS/P3x7ex0WAVknEkBZM46iALbcqoRA8=
 github.com/google/jsonschema-go v0.4.2/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
-github.com/google/osv-scalibr v0.4.5-0.20260306165454-c7f2e9b7def6 h1:RTPwT3tKKskNVRexMULZw/pHEtW+qMnb40FYRKlQWew=
-github.com/google/osv-scalibr v0.4.5-0.20260306165454-c7f2e9b7def6/go.mod h1:cNGl//rZ1OcOiFkLXY5DNrhFN7JKMGf4ieQrENUfEZw=
+github.com/google/osv-scalibr v0.4.5 h1:fiJWZg0jXKzFmJiYKs/BhIzUMYUGs0HT2oUZOoKSL+Q=
+github.com/google/osv-scalibr v0.4.5/go.mod h1:cNGl//rZ1OcOiFkLXY5DNrhFN7JKMGf4ieQrENUfEZw=
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 h1:BHT72Gu3keYf3ZEu2J0b1vyeLSOYI8bm5wbJM/8yDe8=
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=


### PR DESCRIPTION
CleanStart OS is a Linux distribution using the APK package format with security advisories published on osv.dev under the CleanStart ecosystem.

This PR bumps the osv-scalibr dependency to include CleanStart ecosystem recognition (merged in [OSV Scalibr PR](https://github.com/google/osv-scalibr/pull/1855)), enabling osv-scanner to correctly detect and match vulnerabilities in CleanStart container images.