### PR TITLE
fix: correctly output packages from osv-scanner.json source in spdx format

### DIFF
--- a/internal/output/__snapshots__/spdx_test.snap
+++ b/internal/output/__snapshots__/spdx_test.snap
@@ -2423,6 +2423,182 @@
 
 ---
 
+[TestPrintSPDXResults_WithOSVScannerJSONSource/multiple_ecosystems_from_osv_scanner_json - 1]
+{
+  "spdxVersion": "SPDX-2.3",
+  "dataLicense": "CC0-1.0",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "SCALIBR-generated SPDX",
+  "documentNamespace": "https://spdx.google/<uuid>",
+  "creationInfo": {
+    "creators": [
+      "Tool: SCALIBR"
+    ],
+    "created": "<timestamp>"
+  },
+  "packages": [
+    {
+      "name": "main",
+      "SPDXID": "SPDXRef-Package-main-<uuid>",
+      "versionInfo": "0",
+      "supplier": "NOASSERTION",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false
+    },
+    {
+      "name": "requests",
+      "SPDXID": "SPDXRef-Package-requests-<uuid>",
+      "versionInfo": "2.25.1",
+      "supplier": "NOASSERTION",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:pypi/requests@2.25.1"
+        }
+      ]
+    },
+    {
+      "name": "mylib",
+      "SPDXID": "SPDXRef-Package-mylib-<uuid>",
+      "versionInfo": "1.0.0",
+      "supplier": "NOASSERTION",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:maven/com.example/mylib@1.0.0"
+        }
+      ]
+    },
+    {
+      "name": "bar",
+      "SPDXID": "SPDXRef-Package-bar-<uuid>",
+      "versionInfo": "v1.2.3",
+      "supplier": "NOASSERTION",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/github.com/foo/bar@v1.2.3"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relatedSpdxElement": "SPDXRef-Package-main-<uuid>",
+      "relationshipType": "DESCRIBES"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-main-<uuid>",
+      "relatedSpdxElement": "SPDXRef-Package-requests-<uuid>",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-requests-<uuid>",
+      "relatedSpdxElement": "NOASSERTION",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-main-<uuid>",
+      "relatedSpdxElement": "SPDXRef-Package-mylib-<uuid>",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-mylib-<uuid>",
+      "relatedSpdxElement": "NOASSERTION",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-main-<uuid>",
+      "relatedSpdxElement": "SPDXRef-Package-bar-<uuid>",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-bar-<uuid>",
+      "relatedSpdxElement": "NOASSERTION",
+      "relationshipType": "CONTAINS"
+    }
+  ]
+}
+
+---
+
+[TestPrintSPDXResults_WithOSVScannerJSONSource/npm_package_from_osv_scanner_json - 1]
+{
+  "spdxVersion": "SPDX-2.3",
+  "dataLicense": "CC0-1.0",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "SCALIBR-generated SPDX",
+  "documentNamespace": "https://spdx.google/<uuid>",
+  "creationInfo": {
+    "creators": [
+      "Tool: SCALIBR"
+    ],
+    "created": "<timestamp>"
+  },
+  "packages": [
+    {
+      "name": "main",
+      "SPDXID": "SPDXRef-Package-main-<uuid>",
+      "versionInfo": "0",
+      "supplier": "NOASSERTION",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false
+    },
+    {
+      "name": "lodash",
+      "SPDXID": "SPDXRef-Package-lodash-<uuid>",
+      "versionInfo": "4.17.11",
+      "supplier": "NOASSERTION",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lodash@4.17.11"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relatedSpdxElement": "SPDXRef-Package-main-<uuid>",
+      "relationshipType": "DESCRIBES"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-main-<uuid>",
+      "relatedSpdxElement": "SPDXRef-Package-lodash-<uuid>",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-lodash-<uuid>",
+      "relatedSpdxElement": "NOASSERTION",
+      "relationshipType": "CONTAINS"
+    }
+  ]
+}
+
+---
+
 [TestPrintSPDXResults_WithVulnerabilities/multiple_sources_with_a_mixed_count_of_grouped_packages,_and_multiple_vulnerabilities - 1]
 {
   "spdxVersion": "SPDX-2.3",

--- a/internal/output/spdx.go
+++ b/internal/output/spdx.go
@@ -3,9 +3,15 @@ package output
 import (
 	"encoding/json"
 	"io"
+	"strings"
 
 	scalibr "github.com/google/osv-scalibr"
 	"github.com/google/osv-scalibr/converter/spdx"
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/extractor/filesystem/language/java/javalockfile"
+	"github.com/google/osv-scalibr/inventory/osvecosystem"
+	scalibr_purl "github.com/google/osv-scalibr/purl"
+	purlutil "github.com/google/osv-scanner/v2/internal/utility/purl"
 	"github.com/google/osv-scanner/v2/pkg/models"
 )
 
@@ -15,7 +21,13 @@ func PrintSPDXResults(vulnResult *models.VulnerabilityResults, outputWriter io.W
 
 	for _, source := range vulnResult.Results {
 		for _, pkg := range source.Packages {
-			scanResult.Inventory.Packages = append(scanResult.Inventory.Packages, pkg.Package.Inventory)
+			inv := pkg.Package.Inventory
+			if inv == nil {
+				inv = inventoryFromPackageInfo(pkg.Package)
+			}
+			if inv != nil {
+				scanResult.Inventory.Packages = append(scanResult.Inventory.Packages, inv)
+			}
 		}
 	}
 
@@ -26,4 +38,39 @@ func PrintSPDXResults(vulnResult *models.VulnerabilityResults, outputWriter io.W
 	encoder.SetIndent("", "  ")
 
 	return encoder.Encode(doc)
+}
+
+// inventoryFromPackageInfo constructs a synthetic extractor.Package from a PackageInfo
+// for packages that don't have a populated Inventory field (e.g., loaded from osv-scanner.json).
+func inventoryFromPackageInfo(pkg models.PackageInfo) *extractor.Package {
+	eco, err := osvecosystem.Parse(pkg.Ecosystem)
+	if err != nil {
+		return nil
+	}
+
+	purlType, ok := purlutil.EcosystemToPURLMapper[eco.Ecosystem]
+	if !ok {
+		return nil
+	}
+
+	inv := &extractor.Package{
+		Name:     pkg.Name,
+		Version:  pkg.Version,
+		PURLType: purlType,
+	}
+
+	// Maven names in osv-scanner are "groupId:artifactId".
+	// The scalibr Maven PURL converter requires Metadata with GroupID/ArtifactID
+	// to produce the correct PURL (pkg:maven/groupId/artifactId@version).
+	if purlType == scalibr_purl.TypeMaven {
+		parts := strings.SplitN(pkg.Name, ":", 2)
+		if len(parts) == 2 {
+			inv.Metadata = &javalockfile.Metadata{
+				GroupID:    parts[0],
+				ArtifactID: parts[1],
+			}
+		}
+	}
+
+	return inv
 }

--- a/internal/output/spdx.go
+++ b/internal/output/spdx.go
@@ -2,6 +2,7 @@ package output
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"strings"
 
@@ -10,7 +11,7 @@ import (
 	"github.com/google/osv-scalibr/extractor"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/java/javalockfile"
 	"github.com/google/osv-scalibr/inventory/osvecosystem"
-	scalibr_purl "github.com/google/osv-scalibr/purl"
+	scalibrpurl "github.com/google/osv-scalibr/purl"
 	purlutil "github.com/google/osv-scanner/v2/internal/utility/purl"
 	"github.com/google/osv-scanner/v2/pkg/models"
 )
@@ -23,7 +24,11 @@ func PrintSPDXResults(vulnResult *models.VulnerabilityResults, outputWriter io.W
 		for _, pkg := range source.Packages {
 			inv := pkg.Package.Inventory
 			if inv == nil {
-				inv = inventoryFromPackageInfo(pkg.Package)
+				var err error
+				inv, err = inventoryFromPackageInfo(pkg.Package)
+				if err != nil {
+					return err
+				}
 			}
 			if inv != nil {
 				scanResult.Inventory.Packages = append(scanResult.Inventory.Packages, inv)
@@ -42,15 +47,15 @@ func PrintSPDXResults(vulnResult *models.VulnerabilityResults, outputWriter io.W
 
 // inventoryFromPackageInfo constructs a synthetic extractor.Package from a PackageInfo
 // for packages that don't have a populated Inventory field (e.g., loaded from osv-scanner.json).
-func inventoryFromPackageInfo(pkg models.PackageInfo) *extractor.Package {
+func inventoryFromPackageInfo(pkg models.PackageInfo) (*extractor.Package, error) {
 	eco, err := osvecosystem.Parse(pkg.Ecosystem)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 
 	purlType, ok := purlutil.EcosystemToPURLMapper[eco.Ecosystem]
 	if !ok {
-		return nil
+		return nil, fmt.Errorf("unsupported ecosystem: %s", pkg.Ecosystem)
 	}
 
 	inv := &extractor.Package{
@@ -62,7 +67,7 @@ func inventoryFromPackageInfo(pkg models.PackageInfo) *extractor.Package {
 	// Maven names in osv-scanner are "groupId:artifactId".
 	// The scalibr Maven PURL converter requires Metadata with GroupID/ArtifactID
 	// to produce the correct PURL (pkg:maven/groupId/artifactId@version).
-	if purlType == scalibr_purl.TypeMaven {
+	if purlType == scalibrpurl.TypeMaven {
 		parts := strings.SplitN(pkg.Name, ":", 2)
 		if len(parts) == 2 {
 			inv.Metadata = &javalockfile.Metadata{
@@ -72,5 +77,5 @@ func inventoryFromPackageInfo(pkg models.PackageInfo) *extractor.Package {
 		}
 	}
 
-	return inv
+	return inv, nil
 }

--- a/internal/output/spdx_test.go
+++ b/internal/output/spdx_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/osv-scanner/v2/internal/cachedregexp"
 	"github.com/google/osv-scanner/v2/internal/output"
 	"github.com/google/osv-scanner/v2/internal/testutility"
+	"github.com/google/osv-scanner/v2/pkg/models"
 	"github.com/jedib0t/go-pretty/v6/text"
 )
 
@@ -69,4 +70,85 @@ func TestPrintSPDXResults_WithMixedIssues(t *testing.T) {
 
 		testutility.NewSnapshot().MatchText(t, normalizeSPDXOutput(t, outputWriter.String()))
 	})
+}
+
+// TestPrintSPDXResults_WithOSVScannerJSONSource tests that packages loaded from an
+// osv-scanner.json results file (which have Inventory == nil) are correctly included
+// in the SPDX output with the right PURL types. This is a regression test for issue #2192.
+func TestPrintSPDXResults_WithOSVScannerJSONSource(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		vulnResult *models.VulnerabilityResults
+	}{
+		{
+			name: "npm_package_from_osv_scanner_json",
+			vulnResult: &models.VulnerabilityResults{
+				Results: []models.PackageSource{
+					{
+						Source: models.SourceInfo{Path: "/path/to/osv-scanner.json", Type: models.SourceTypeProjectPackage},
+						Packages: []models.PackageVulns{
+							{
+								// Inventory is nil, as it would be when loaded from osv-scanner.json
+								Package: models.PackageInfo{
+									Name:      "lodash",
+									Version:   "4.17.11",
+									Ecosystem: "npm",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple_ecosystems_from_osv_scanner_json",
+			vulnResult: &models.VulnerabilityResults{
+				Results: []models.PackageSource{
+					{
+						Source: models.SourceInfo{Path: "/path/to/osv-scanner.json", Type: models.SourceTypeProjectPackage},
+						Packages: []models.PackageVulns{
+							{
+								Package: models.PackageInfo{
+									Name:      "requests",
+									Version:   "2.25.1",
+									Ecosystem: "PyPI",
+								},
+							},
+							{
+								Package: models.PackageInfo{
+									Name:      "com.example:mylib",
+									Version:   "1.0.0",
+									Ecosystem: "Maven",
+								},
+							},
+							{
+								Package: models.PackageInfo{
+									Name:      "github.com/foo/bar",
+									Version:   "v1.2.3",
+									Ecosystem: "Go",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			outputWriter := &bytes.Buffer{}
+			err := output.PrintSPDXResults(tt.vulnResult, outputWriter)
+
+			if err != nil {
+				t.Errorf("%v", err)
+			}
+
+			testutility.NewSnapshot().MatchText(t, normalizeSPDXOutput(t, outputWriter.String()))
+		})
+	}
 }

--- a/internal/output/spdx_test.go
+++ b/internal/output/spdx_test.go
@@ -79,7 +79,7 @@ func TestPrintSPDXResults_WithOSVScannerJSONSource(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
+		name       string
 		vulnResult *models.VulnerabilityResults
 	}{
 		{


### PR DESCRIPTION
Fixes #2192

Packages loaded from an `osv-scanner.json` results file have `Inventory == nil`
because `PackageInfo.Inventory` is not populated during JSON deserialization.

`PrintSPDXResults` was blindly appending nil Inventory values, causing the
SPDX converter to silently skip all such packages.

This fix constructs a synthetic `extractor.Package` using the available
PackageInfo fields (name, version, ecosystem) when Inventory is nil.

Maven packages require special handling because their names are stored as
`groupId:artifactId` in osv-scanner. The scalibr PURL converter requires
`javalockfile.Metadata` with `GroupID` and `ArtifactID` to generate the correct
`pkg:maven/groupId/artifactId@version` PURL.

This ensures packages from osv-scanner.json sources appear correctly
in the generated SPDX SBOM output.