### PR TITLE
ci: allow dependencies workflow to record new cassette interactions

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -37,6 +37,7 @@ jobs:
       - run: go test ./cmd/osv-scanner/ -run 'Test_run$' || true
         env:
           TEST_ACCEPTANCE: true
+          TEST_VCR_MODE: replaywithnewepisodes
           UPDATE_SNAPS: always
       - uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:


### PR DESCRIPTION
I think it makes sense to do this for the same reason it made sense for the snapshots workflow, even though it is probably far less likely to be needed