### PR TITLE
ci: add minimum release age for non-security updates in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,7 @@
   "labels": ["dependencies"],
   "postUpdateOptions": ["gomodTidy"],
   "osvVulnerabilityAlerts": true,
+  "minimumReleaseAge": "7 days",
   "lockFileMaintenance": {
     "enabled": true
   },


### PR DESCRIPTION
Configures renovatebot to wait 7 days after a new release before creating a pull request for non-security updates. This ensures better stability by letting early adopters catch any issues before the update is automatically proposed.
Security vulnerability updates will bypass this delay and be created immediately due to renovate's default behavior for security alerts.

---
*PR created automatically by Jules for task [4240693944033737293](https://jules.google.com/task/4240693944033737293) started by @another-rex*