### PR TITLE
fix: increase color contrast of vulnerability stats

### DIFF
--- a/internal/output/html/style.css
+++ b/internal/output/html/style.css
@@ -412,6 +412,7 @@ header {
   overflow: hidden;
   white-space: nowrap;
   user-select: none;
+  font-weight: bold;
 }
 
 .severity-long p {
@@ -427,6 +428,7 @@ header {
 
 .high {
   background-color: #ffa500;
+  color: #292929;
 }
 
 .medium {
@@ -441,6 +443,7 @@ header {
 
 .unknown {
   background-color: #80868b;
+  color: #000;
 }
 
 .severity-count-summary {
@@ -450,6 +453,7 @@ header {
 .severity-short {
   width: 40px;
   user-select: none;
+  font-weight: bold;
 }
 
 .severity-short p {
@@ -533,6 +537,7 @@ header {
   text-decoration: underline;
   text-decoration-style: dotted;
   text-underline-offset: 3px;
+  font-weight: 100;
 }
 
 .tooltip.no-underline {


### PR DESCRIPTION
The vulnerability stats were a bit hard to read as they didn't meet WCAG 2 AA contrast guidelines. To fix this, those fonts has been made bold, and the color contrast has been increased for the harder to read colors.

### Before

<img width="554" height="705" alt="image" src="https://github.com/user-attachments/assets/aae7a023-e719-4c7d-b115-3580e91c6753" />

### After

<img width="544" height="698" alt="image" src="https://github.com/user-attachments/assets/4ffa12df-a3d4-478d-a918-ca2b35cca953" />
