### PR TITLE
docs: fix broken anchors and missing word in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ OSV-Scanner supports 11+ language ecosystems and 19+ lockfile types. To check if
 
 ### [Container Scanning](https://google.github.io/osv-scanner/usage/scan-image)
 
-OSV-Scanner also supports comprehensive, layer-aware scanning for container images to detect vulnerabilities the following operating system packages and language-specific dependencies.
+OSV-Scanner also supports comprehensive, layer-aware scanning for container images to detect vulnerabilities in the following operating system packages and language-specific dependencies.
 
 | Distro Support | Language Artifacts Support |
 | -------------- | -------------------------- |
@@ -116,8 +116,8 @@ We currently support remediating vulnerabilities in the following files:
 
 | Ecosystem | File Format (Type)             | Supported Remediation Strategies                                                                                  |
 | :-------- | :----------------------------- | :---------------------------------------------------------------------------------------------------------------- |
-| npm       | `package-lock.json` (lockfile) | [`in-place`](https://google.github.io/osv-scanner/experimental/guided-remediation/#in-place-lockfile-remediation) |
-| npm       | `package.json` (manifest)      | [`relock`](https://google.github.io/osv-scanner/experimental/guided-remediation/#in-place-lockfile-remediation)   |
+| npm       | `package-lock.json` (lockfile) | [`in-place`](https://google.github.io/osv-scanner/experimental/guided-remediation/#in-place-lockfile-changes)        |
+| npm       | `package.json` (manifest)      | [`relock`](https://google.github.io/osv-scanner/experimental/guided-remediation/#relock-and-relax-direct-dependencies) |
 | Maven     | `pom.xml` (manifest)           | [`override`](https://google.github.io/osv-scanner/experimental/guided-remediation/#override-dependency-versions)  |
 
 This is available as a headless CLI command, as well as an interactive mode.


### PR DESCRIPTION
## Overview

Three small README fixes — all objectively wrong things, no judgment calls:

1. **Container Scanning paragraph** is missing the word "in":
   > "...detect vulnerabilities **in** the following operating system packages..."
2. **Guided remediation table — `in-place` link** points to `#in-place-lockfile-remediation`, which does not exist on the [docs page](https://google.github.io/osv-scanner/experimental/guided-remediation/). The actual H3 anchor is `#in-place-lockfile-changes`.
3. **Guided remediation table — `relock` link** reuses the same broken `#in-place-lockfile-remediation` anchor. The relock strategy lives at `#relock-and-relax-direct-dependencies` (also confirmed by inspecting the rendered docs page).

## Details

Verified each anchor by fetching https://google.github.io/osv-scanner/experimental/guided-remediation/ and listing the heading IDs. Only README.md is touched — six lines, three real fixes.

## Testing

- [x] Confirmed all three corrected anchors (`#in-place-lockfile-changes`, `#relock-and-relax-direct-dependencies`, `#override-dependency-versions`) resolve to the correct sections on the live docs site.
- [x] No code changes — linter/test suite unaffected.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/).
- [x] No code changes; lints/tests not applicable.
- [x] Conventional Commits title (`docs:` prefix).