### PR TITLE
Sanitize GitHub Actions line terminators in human output

### DIFF
--- a/internal/cmdlogger/handler.go
+++ b/internal/cmdlogger/handler.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"log/slog"
 	"strings"
+
+	"github.com/google/osv-scanner/v2/internal/utility/terminal"
 )
 
 var (
@@ -76,7 +78,7 @@ func (c *Handler) Handle(ctx context.Context, record slog.Record) error {
 		return c.overrideHandler.Handle(ctx, record)
 	}
 
-	_, err := fmt.Fprint(c.writer(record.Level), record.Message+"\n")
+	_, err := fmt.Fprint(c.writer(record.Level), terminal.EscapeGitHubActionsCommandChars(record.Message)+"\n")
 
 	return err
 }

--- a/internal/cmdlogger/handler_test.go
+++ b/internal/cmdlogger/handler_test.go
@@ -1,0 +1,38 @@
+package cmdlogger
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHandlerEscapesGitHubActionsCommandChars(t *testing.T) {
+	t.Parallel()
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	handler := New(stdout, stderr)
+
+	err := handler.Handle(context.Background(), slog.NewRecord(
+		time.Time{},
+		slog.LevelInfo,
+		"Scanning dir safe\r::warning::pwn\nnext",
+		0,
+	))
+	if err != nil {
+		t.Fatalf("Handle() error = %v", err)
+	}
+
+	got := stdout.String()
+	if strings.ContainsAny(got, "\r") {
+		t.Fatalf("log output contains raw carriage return: %q", got)
+	}
+
+	want := "Scanning dir safe%0D::warning::pwn%0Anext\n"
+	if got != want {
+		t.Fatalf("log output = %q, want %q", got, want)
+	}
+}

--- a/internal/output/githubannotation.go
+++ b/internal/output/githubannotation.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/google/osv-scanner/v2/internal/utility/terminal"
 	"github.com/google/osv-scanner/v2/pkg/models"
 	"github.com/jedib0t/go-pretty/v6/table"
 )
@@ -82,8 +83,7 @@ func PrintGHAnnotationReport(vulnResult *models.VulnerabilityResults, outputWrit
 		// Sanitize artifactPath to prevent GitHub Actions workflow command injection.
 		// \r and \n in the file= parameter can terminate the annotation early and inject
 		// arbitrary workflow commands (e.g. ::warning::, ::add-mask::) into the runner output.
-		artifactPath = strings.ReplaceAll(artifactPath, "\r", "%0D")
-		artifactPath = strings.ReplaceAll(artifactPath, "\n", "%0A")
+		artifactPath = terminal.EscapeGitHubActionsCommandChars(artifactPath)
 
 		remediationTable, hasVulnTable := createSourceRemediationTable(source, groupedFixedVersions)
 		if hasVulnTable {
@@ -92,7 +92,7 @@ func PrintGHAnnotationReport(vulnResult *models.VulnerabilityResults, outputWrit
 			// so we URL encode the new line character
 			renderedTable = strings.ReplaceAll(renderedTable, "\n", "%0A")
 			// Sanitize \r to prevent workflow command injection via carriage return in package names
-			renderedTable = strings.ReplaceAll(renderedTable, "\r", "%0D")
+			renderedTable = terminal.EscapeGitHubActionsCommandChars(renderedTable)
 
 			// Prepend the table with a new line to look nicer in the output
 			fmt.Fprintf(outputWriter, "::error file=%s::%s%s", artifactPath, artifactPath, "%0A"+renderedTable)
@@ -104,7 +104,7 @@ func PrintGHAnnotationReport(vulnResult *models.VulnerabilityResults, outputWrit
 			renderedDeprecationTable := deprecationTable.Render()
 			renderedDeprecationTable = strings.ReplaceAll(renderedDeprecationTable, "\n", "%0A")
 			// Sanitize \r to prevent workflow command injection via carriage return in package names
-			renderedDeprecationTable = strings.ReplaceAll(renderedDeprecationTable, "\r", "%0D")
+			renderedDeprecationTable = terminal.EscapeGitHubActionsCommandChars(renderedDeprecationTable)
 			fmt.Fprintf(outputWriter, "::error file=%s::%s%s", artifactPath, artifactPath, "%0A"+renderedDeprecationTable)
 		}
 	}

--- a/internal/output/sanitization_test.go
+++ b/internal/output/sanitization_test.go
@@ -1,0 +1,78 @@
+package output
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/google/osv-scanner/v2/pkg/models"
+	"github.com/jedib0t/go-pretty/v6/text"
+)
+
+func TestPrintVerticalHeaderEscapesGitHubActionsCommandChars(t *testing.T) {
+	t.Parallel()
+
+	out := &bytes.Buffer{}
+	printVerticalHeader(SourceResult{
+		Name:             "safe\r::warning::pwn\nnext",
+		PackageTypeCount: AnalysisCount{Regular: 1},
+	}, out)
+
+	got := text.StripEscape(out.String())
+	if strings.ContainsAny(got, "\r") {
+		t.Fatalf("vertical output contains raw carriage return: %q", got)
+	}
+
+	if !strings.Contains(got, "safe%0D::warning::pwn%0Anext") {
+		t.Fatalf("vertical output does not contain escaped source name: %q", got)
+	}
+}
+
+func TestTableBuilderInnerEscapesSourceColumnCommandChars(t *testing.T) {
+	t.Parallel()
+
+	rows := tableBuilderInner(Result{
+		Ecosystems: []EcosystemResult{
+			{
+				Name: "npm",
+				Sources: []SourceResult{
+					{
+						Name: "lockfiles\r::warning::pwn\nnext/package-lock.json",
+						Type: models.SourceTypeProjectPackage,
+						Packages: []PackageResult{
+							{
+								Name:             "lodash",
+								InstalledVersion: "4.17.20",
+								RegularVulns: []VulnResult{
+									{
+										GroupIDs:         []string{"GHSA-35jh-r3h4-6jhm"},
+										SeverityScore:    "7.2",
+										IsFixable:        false,
+										VulnAnalysisType: VulnTypeRegular,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, VulnTypeRegular)
+
+	if len(rows) != 1 {
+		t.Fatalf("tableBuilderInner returned %d rows, want 1", len(rows))
+	}
+
+	sourceColumn, ok := rows[0].row[len(rows[0].row)-1].(string)
+	if !ok {
+		t.Fatalf("source column has type %T, want string", rows[0].row[len(rows[0].row)-1])
+	}
+
+	if strings.ContainsAny(sourceColumn, "\r\n") {
+		t.Fatalf("source column contains raw line terminator: %q", sourceColumn)
+	}
+
+	if !strings.Contains(sourceColumn, "lockfiles%0D::warning::pwn%0Anext/package-lock.json") {
+		t.Fatalf("source column does not contain escaped source name: %q", sourceColumn)
+	}
+}

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -10,6 +10,7 @@ import (
 	depgroups "github.com/google/osv-scanner/v2/internal/utility/depgroup"
 	"github.com/google/osv-scanner/v2/internal/utility/results"
 	"github.com/google/osv-scanner/v2/internal/utility/severity"
+	"github.com/google/osv-scanner/v2/internal/utility/terminal"
 	"github.com/google/osv-scanner/v2/pkg/models"
 	"github.com/ossf/osv-schema/bindings/go/osvschema"
 
@@ -140,7 +141,7 @@ func printSummaryResult(result Result, outputWriter io.Writer, terminalWidth int
 				continue
 			}
 			outputTable := newTable(outputWriter, terminalWidth)
-			outputTable.SetTitle("Source:" + source.Name)
+			outputTable.SetTitle("Source:" + terminal.EscapeGitHubActionsCommandChars(source.Name))
 			sourcePackageHeader := "Package"
 			if isOSResult(source.Type) {
 				sourcePackageHeader = "Source Package"
@@ -349,7 +350,7 @@ func tableBuilderInner(result Result, vulnAnalysisType VulnAnalysisType) []tbInn
 					p = strings.TrimPrefix(p, filepath.ToSlash(workingDir))
 					p = strings.TrimPrefix(p, "/")
 
-					outputRow = append(outputRow, p)
+					outputRow = append(outputRow, terminal.EscapeGitHubActionsCommandChars(p))
 
 					allOutputRows = append(allOutputRows, tbInnerResponse{
 						row:         outputRow,

--- a/internal/output/vertical.go
+++ b/internal/output/vertical.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/google/osv-scanner/v2/internal/utility/terminal"
 	"github.com/google/osv-scanner/v2/pkg/models"
 	"github.com/jedib0t/go-pretty/v6/text"
 )
@@ -155,7 +156,7 @@ func printVerticalHeader(result SourceResult, out io.Writer) {
 	fmt.Fprintf(
 		out,
 		"%s: found %s %s with issues\n",
-		text.FgMagenta.Sprintf("%s", result.Name),
+		text.FgMagenta.Sprintf("%s", terminal.EscapeGitHubActionsCommandChars(result.Name)),
 		text.FgYellow.Sprintf("%d", result.PackageTypeCount.Regular),
 		Form(result.PackageTypeCount.Regular, "package", "packages"),
 	)

--- a/internal/utility/terminal/sanitize.go
+++ b/internal/utility/terminal/sanitize.go
@@ -1,0 +1,14 @@
+package terminal
+
+import "strings"
+
+var ghaCommandReplacer = strings.NewReplacer(
+	"\r", "%0D",
+	"\n", "%0A",
+)
+
+// EscapeGitHubActionsCommandChars escapes line terminators that GitHub Actions
+// treats as workflow command boundaries.
+func EscapeGitHubActionsCommandChars(s string) string {
+	return ghaCommandReplacer.Replace(s)
+}

--- a/internal/utility/terminal/sanitize_test.go
+++ b/internal/utility/terminal/sanitize_test.go
@@ -1,0 +1,14 @@
+package terminal
+
+import "testing"
+
+func TestEscapeGitHubActionsCommandChars(t *testing.T) {
+	t.Parallel()
+
+	got := EscapeGitHubActionsCommandChars("dir\r::warning::pwn\nnext")
+	want := "dir%0D::warning::pwn%0Anext"
+
+	if got != want {
+		t.Fatalf("EscapeGitHubActionsCommandChars() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- add a shared helper for escaping line terminators that GitHub Actions treats as workflow command boundaries
- sanitize cmdlogger messages before writing to stdout/stderr
- sanitize source names in table and vertical human output paths
- reuse the shared helper in GitHub annotation output and add regression coverage

Fixes #2749

## Testing
- GOCACHE=/tmp/go-build-small GOPATH=/tmp/go go test ./internal/utility/terminal ./internal/cmdlogger
- Attempted focused ./internal/output regression tests, but the local machine ran out of disk space while downloading/unzipping the package dependency graph.