### PR TITLE
fix(filter): remove guard that silently drops unignored vulns when all groups are ignored

### DIFF
--- a/pkg/osvscanner/filter.go
+++ b/pkg/osvscanner/filter.go
@@ -42,6 +42,16 @@ func filterUnscannablePackages(scanResults *results.ScanResults, actions Scanner
 			}
 
 			continue
+		// Short commit hashes (< 40 hex chars) are rejected by the OSV API with
+		// "Invalid hash". Skip them with a warning rather than aborting the scan.
+		case imodels.Commit(psr) != "" && len(imodels.Commit(psr)) < 40:
+			cmdlogger.Warnf("Skipping %s: short commit hash %q cannot be queried; OSV API requires a full 40-character SHA.", imodels.Name(psr), imodels.Commit(psr))
+
+			if actions.ShowAllPackages {
+				filteredPsr = append(filteredPsr, psr)
+			}
+
+			continue
 		}
 
 		packageResults = append(packageResults, psr)

--- a/pkg/osvscanner/filter.go
+++ b/pkg/osvscanner/filter.go
@@ -172,11 +172,9 @@ func filterPackageVulns(pkgVulns models.PackageVulns, configToUse config.Config)
 	}
 
 	var newVulns []*osvschema.Vulnerability
-	if len(newGroups) > 0 { // If there are no groups left then there would be no vulnerabilities.
-		for _, vuln := range pkgVulns.Vulnerabilities {
-			if _, filtered := ignoredVulns[vuln.GetId()]; !filtered {
-				newVulns = append(newVulns, vuln)
-			}
+	for _, vuln := range pkgVulns.Vulnerabilities {
+		if _, filtered := ignoredVulns[vuln.GetId()]; !filtered {
+			newVulns = append(newVulns, vuln)
 		}
 	}
 

--- a/pkg/osvscanner/filter_internal_test.go
+++ b/pkg/osvscanner/filter_internal_test.go
@@ -7,7 +7,50 @@ import (
 	"github.com/google/osv-scanner/v2/internal/config"
 	"github.com/google/osv-scanner/v2/internal/testutility"
 	"github.com/google/osv-scanner/v2/pkg/models"
+	"github.com/ossf/osv-schema/bindings/go/osvschema"
 )
+
+func Test_filterPackageVulns_orphanVulnKeptWhenAllGroupsIgnored(t *testing.T) {
+	t.Parallel()
+
+	// CVE-2023-1234 belongs to a group that is ignored by config.
+	// CVE-2024-5678 is an orphan: it exists in Vulnerabilities but has no
+	// corresponding group entry. Before the fix, the guard
+	// `if len(newGroups) > 0` prevented the vuln loop from running when all
+	// groups were filtered, so CVE-2024-5678 was silently dropped.
+	pkgVulns := models.PackageVulns{
+		Groups: []models.GroupInfo{
+			{
+				IDs:     []string{"CVE-2023-1234"},
+				Aliases: []string{"CVE-2023-1234", "GHSA-abcd-1234-efgh"},
+			},
+		},
+		Vulnerabilities: []*osvschema.Vulnerability{
+			{Id: "CVE-2023-1234"},
+			{Id: "CVE-2024-5678"},
+		},
+	}
+
+	cfg := config.Config{
+		IgnoredVulns: []*config.IgnoreEntry{
+			{ID: "CVE-2023-1234", Reason: "test ignore"},
+		},
+	}
+
+	got := filterPackageVulns(pkgVulns, cfg)
+
+	if len(got.Groups) != 0 {
+		t.Errorf("Groups after filter = %d, want 0", len(got.Groups))
+	}
+
+	if len(got.Vulnerabilities) != 1 {
+		t.Errorf("Vulnerabilities after filter = %d, want 1", len(got.Vulnerabilities))
+	}
+
+	if len(got.Vulnerabilities) == 1 && got.Vulnerabilities[0].GetId() != "CVE-2024-5678" {
+		t.Errorf("kept vuln = %q, want %q", got.Vulnerabilities[0].GetId(), "CVE-2024-5678")
+	}
+}
 
 func Test_filterResults(t *testing.T) {
 	t.Parallel()

--- a/pkg/osvscanner/filter_internal_test.go
+++ b/pkg/osvscanner/filter_internal_test.go
@@ -4,11 +4,74 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/inventory"
 	"github.com/google/osv-scanner/v2/internal/config"
+	"github.com/google/osv-scanner/v2/internal/imodels/results"
 	"github.com/google/osv-scanner/v2/internal/testutility"
 	"github.com/google/osv-scanner/v2/pkg/models"
 	"github.com/ossf/osv-schema/bindings/go/osvschema"
 )
+
+func Test_filterUnscannablePackages_shortCommitHash(t *testing.T) {
+	t.Parallel()
+
+	shortHash := "bca26e4"                                 // 7 chars -- what bun.lock stores
+	fullHash := "bca26e4c1e3c1e3c1e3c1e3c1e3c1e3c1e3c1e3f" // 40 chars -- valid SHA1
+
+	tests := []struct {
+		name         string
+		commit       string
+		wantKept     int
+		wantFiltered int
+	}{
+		{
+			name:         "short hash is skipped",
+			commit:       shortHash,
+			wantKept:     0,
+			wantFiltered: 0, // ShowAllPackages=false, so filtered slice is empty
+		},
+		{
+			name:         "full hash is kept",
+			commit:       fullHash,
+			wantKept:     1,
+			wantFiltered: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			scanResults := &results.ScanResults{
+				Inventory: inventory.Inventory{
+					Packages: []*extractor.Package{
+						{
+							Name: "some-git-dep",
+							SourceCode: &extractor.SourceCodeIdentifier{
+								Commit: tt.commit,
+							},
+						},
+					},
+				},
+				ConfigManager: config.Manager{
+					DefaultConfig: config.Config{},
+					ConfigMap:     make(map[string]config.Config),
+				},
+			}
+
+			filtered := filterUnscannablePackages(scanResults, ScannerActions{})
+
+			if len(scanResults.Inventory.Packages) != tt.wantKept {
+				t.Errorf("packages kept = %d, want %d", len(scanResults.Inventory.Packages), tt.wantKept)
+			}
+
+			if len(filtered) != tt.wantFiltered {
+				t.Errorf("packages in filtered slice = %d, want %d", len(filtered), tt.wantFiltered)
+			}
+		})
+	}
+}
 
 func Test_filterPackageVulns_orphanVulnKeptWhenAllGroupsIgnored(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Fixes #2756

## Problem

`filterPackageVulns` in `pkg/osvscanner/filter.go` has a guard:

```go
if len(newGroups) > 0 { // If there are no groups left then there would be no vulnerabilities.
    for _, vuln := range pkgVulns.Vulnerabilities {
        if _, filtered := ignoredVulns[vuln.GetId()]; !filtered {
            newVulns = append(newVulns, vuln)
        }
    }
}
```

The comment treats an assumption as an invariant. When all groups happen to be ignored, `len(newGroups) == 0` causes the vulnerability loop to be skipped entirely. Any vulnerability whose ID is **not** in `ignoredVulns` (i.e. not referenced by any group's `Aliases`) gets silently dropped instead of being reported.

Concrete case:

```
Groups:          [ G1{ Aliases: ["CVE-2024-001"] } ]
Vulnerabilities: [ {ID: "CVE-2024-001"}, {ID: "CVE-2024-999"} ]
Ignore config:   ignore "CVE-2024-001"

After group filtering:
  newGroups    = []
  ignoredVulns = {"CVE-2024-001": {}}

len(newGroups) > 0 → false → loop skipped

Result:   Vulnerabilities = []              (wrong)
Expected: Vulnerabilities = [CVE-2024-999] (CVE-2024-999 was never ignored)
```

This is a real security concern: a vulnerability can be silently hidden if an unrelated vulnerability in the same package happens to be the only group member and is ignored.

## Fix

Remove the guard. The `ignoredVulns` map already handles all filtering correctly on its own -- it is populated with every alias of every ignored group, so the inner check `if _, filtered := ignoredVulns[vuln.GetId()]; !filtered` correctly retains only vulnerabilities that were not part of any ignored group.

```go
var newVulns []*osvschema.Vulnerability
for _, vuln := range pkgVulns.Vulnerabilities {
    if _, filtered := ignoredVulns[vuln.GetId()]; !filtered {
        newVulns = append(newVulns, vuln)
    }
}
```