### PR TITLE
chore: downgrade ruby to 4.0.2 for github pages

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@7372622e62b60b3cb750dcd2b9e32c247ffec26a # v1.302.0
         with:
-          ruby-version: "4.0.3" # Not needed with a .ruby-version file
+          ruby-version: "4.0.2" # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
       - name: Setup Pages

--- a/cmd/osv-scanner/scan/source/__snapshots__/command_test.snap
+++ b/cmd/osv-scanner/scan/source/__snapshots__/command_test.snap
@@ -890,7 +890,7 @@ Scanned <rootdir>/testdata/sbom-insecure/postgres-stretch.cdx.xml file and found
 Scanned <rootdir>/testdata/sbom-insecure/with-duplicates.cdx.xml file and found 17 packages
 Filtered 10 local/unscannable package/s from the scan.
 
-Total 27 packages affected by 200 known vulnerabilities (22 Critical, 86 High, 64 Medium, 5 Low, 23 Unknown) from 4 ecosystems.
+Total 27 packages affected by 200 known vulnerabilities (22 Critical, 86 High, 65 Medium, 4 Low, 23 Unknown) from 4 ecosystems.
 11 vulnerabilities can be fixed.
 
 +---------------------------------------+------+-----------+--------------------------------+------------------------------------+-----------------------------------+---------------------------------------------------------------------+
@@ -1120,7 +1120,7 @@ Total 27 packages affected by 200 known vulnerabilities (22 Critical, 86 High, 6
 | https://osv.dev/DSA-5650-1            | 5.5  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml                     |
 | https://osv.dev/DEBIAN-CVE-2016-2779  | 7.8  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml                     |
 | https://osv.dev/DEBIAN-CVE-2026-27456 | 4.7  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml                     |
-| https://osv.dev/DEBIAN-CVE-2026-3184  | 3.7  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml                     |
+| https://osv.dev/DEBIAN-CVE-2026-3184  | 5.3  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml                     |
 | https://osv.dev/DSA-5123-1            | 8.8  | Debian    | xz-utils                       | 5.2.2-1.2+deb9u1                   | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml                     |
 | https://osv.dev/DSA-5895-1            | 8.7  | Debian    | xz-utils                       | 5.2.2-1.2+deb9u1                   | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml                     |
 | https://osv.dev/DEBIAN-CVE-2024-3094  | 10.0 | Debian    | xz-utils                       | 5.2.2-1.2+deb9u1                   | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml                     |
@@ -2136,7 +2136,7 @@ Filtered 8 vulnerabilities from output
 testdata/osv-scanner-partial-ignores-config.toml has unused ignores:
  - CVE-2019-5188
 
-Total 27 packages affected by 194 known vulnerabilities (22 Critical, 81 High, 63 Medium, 5 Low, 23 Unknown) from 4 ecosystems.
+Total 27 packages affected by 194 known vulnerabilities (22 Critical, 81 High, 64 Medium, 4 Low, 23 Unknown) from 4 ecosystems.
 10 vulnerabilities can be fixed.
 
 +---------------------------------------+------+-----------+--------------------------------+------------------------------------+-----------------------------------+---------------------------------------------------------------------+
@@ -2358,7 +2358,7 @@ Total 27 packages affected by 194 known vulnerabilities (22 Critical, 81 High, 6
 | https://osv.dev/DSA-5650-1            | 5.5  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml                     |
 | https://osv.dev/DEBIAN-CVE-2016-2779  | 7.8  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml                     |
 | https://osv.dev/DEBIAN-CVE-2026-27456 | 4.7  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml                     |
-| https://osv.dev/DEBIAN-CVE-2026-3184  | 3.7  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml                     |
+| https://osv.dev/DEBIAN-CVE-2026-3184  | 5.3  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml                     |
 | https://osv.dev/DSA-5123-1            | 8.8  | Debian    | xz-utils                       | 5.2.2-1.2+deb9u1                   | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml                     |
 | https://osv.dev/DSA-5895-1            | 8.7  | Debian    | xz-utils                       | 5.2.2-1.2+deb9u1                   | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml                     |
 | https://osv.dev/DEBIAN-CVE-2024-3094  | 10.0 | Debian    | xz-utils                       | 5.2.2-1.2+deb9u1                   | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml                     |
@@ -2385,7 +2385,7 @@ Filtered 6 vulnerabilities from output
 testdata/osv-scanner-partial-ignores-config.toml has unused ignores:
  - CVE-2019-5188
 
-Total 24 packages affected by 186 known vulnerabilities (20 Critical, 78 High, 60 Medium, 5 Low, 23 Unknown) from 3 ecosystems.
+Total 24 packages affected by 186 known vulnerabilities (20 Critical, 78 High, 61 Medium, 4 Low, 23 Unknown) from 3 ecosystems.
 10 vulnerabilities can be fixed.
 
 +---------------------------------------+------+-----------+--------------------------------+------------------------------------+-----------------------------------+-------------------------------------------------+
@@ -2599,7 +2599,7 @@ Total 24 packages affected by 186 known vulnerabilities (20 Critical, 78 High, 6
 | https://osv.dev/DSA-5650-1            | 5.5  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DEBIAN-CVE-2016-2779  | 7.8  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DEBIAN-CVE-2026-27456 | 4.7  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DEBIAN-CVE-2026-3184  | 3.7  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
+| https://osv.dev/DEBIAN-CVE-2026-3184  | 5.3  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DSA-5123-1            | 8.8  | Debian    | xz-utils                       | 5.2.2-1.2+deb9u1                   | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DSA-5895-1            | 8.7  | Debian    | xz-utils                       | 5.2.2-1.2+deb9u1                   | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DEBIAN-CVE-2024-3094  | 10.0 | Debian    | xz-utils                       | 5.2.2-1.2+deb9u1                   | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
@@ -4658,7 +4658,7 @@ Filtered 1 local/unscannable package/s from the scan.
 Loaded Debian local db from <tempdir>/osv-scanner/Debian/all.zip
 Loaded Go local db from <tempdir>/osv-scanner/Go/all.zip
 
-Total 22 packages affected by 183 known vulnerabilities (19 Critical, 77 High, 59 Medium, 5 Low, 23 Unknown) from 2 ecosystems.
+Total 22 packages affected by 183 known vulnerabilities (19 Critical, 77 High, 60 Medium, 4 Low, 23 Unknown) from 2 ecosystems.
 11 vulnerabilities can be fixed.
 
 +---------------------------------------+------+-----------+--------------------------------+------------------------------------+-----------------------------------+-------------------------------------------------+
@@ -4871,7 +4871,7 @@ Total 22 packages affected by 183 known vulnerabilities (19 Critical, 77 High, 5
 | https://osv.dev/DSA-5650-1            | 5.5  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DEBIAN-CVE-2016-2779  | 7.8  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DEBIAN-CVE-2026-27456 | 4.7  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DEBIAN-CVE-2026-3184  | 3.7  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
+| https://osv.dev/DEBIAN-CVE-2026-3184  | 5.3  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DSA-5123-1            | 8.8  | Debian    | xz-utils                       | 5.2.2-1.2+deb9u1                   | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DSA-5895-1            | 8.7  | Debian    | xz-utils                       | 5.2.2-1.2+deb9u1                   | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DEBIAN-CVE-2024-3094  | 10.0 | Debian    | xz-utils                       | 5.2.2-1.2+deb9u1                   | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
@@ -4891,7 +4891,7 @@ Filtered 1 local/unscannable package/s from the scan.
 Loaded Debian local db from <tempdir>/osv-scanner/Debian/all.zip
 Loaded Go local db from <tempdir>/osv-scanner/Go/all.zip
 
-Total 22 packages affected by 183 known vulnerabilities (19 Critical, 77 High, 59 Medium, 5 Low, 23 Unknown) from 2 ecosystems.
+Total 22 packages affected by 183 known vulnerabilities (19 Critical, 77 High, 60 Medium, 4 Low, 23 Unknown) from 2 ecosystems.
 11 vulnerabilities can be fixed.
 
 +---------------------------------------+------+-----------+--------------------------------+------------------------------------+-----------------------------------+-------------------------------------------------+
@@ -5104,7 +5104,7 @@ Total 22 packages affected by 183 known vulnerabilities (19 Critical, 77 High, 5
 | https://osv.dev/DSA-5650-1            | 5.5  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DEBIAN-CVE-2016-2779  | 7.8  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DEBIAN-CVE-2026-27456 | 4.7  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
-| https://osv.dev/DEBIAN-CVE-2026-3184  | 3.7  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
+| https://osv.dev/DEBIAN-CVE-2026-3184  | 5.3  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DSA-5123-1            | 8.8  | Debian    | xz-utils                       | 5.2.2-1.2+deb9u1                   | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DSA-5895-1            | 8.7  | Debian    | xz-utils                       | 5.2.2-1.2+deb9u1                   | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DEBIAN-CVE-2024-3094  | 10.0 | Debian    | xz-utils                       | 5.2.2-1.2+deb9u1                   | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |

--- a/cmd/osv-scanner/scan/source/testdata/cassettes/TestCommand_Transitive.yaml
+++ b/cmd/osv-scanner/scan/source/testdata/cassettes/TestCommand_Transitive.yaml
@@ -1985,6 +1985,281 @@ interactions:
                 "ecosystem": "PyPI",
                 "name": "flask"
               },
+              "version": "1.0.0"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "idna"
+              },
+              "version": "2.7.0"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "itsdangerous"
+              },
+              "version": "2.2.0"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "jinja2"
+              },
+              "version": "3.1.6"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "markupsafe"
+              },
+              "version": "3.0.3"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "pytz"
+              },
+              "version": "2026.2.0"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "requests"
+              },
+              "version": "2.20.0"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "urllib3"
+              },
+              "version": "1.24.3"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "werkzeug"
+              },
+              "version": "3.1.8"
+            }
+          ]
+        }
+      headers:
+        Content-Type:
+          - application/json
+        X-Test-Name:
+          - TestCommand_Transitive/requirements.txt_transitive_default
+      url: https://api.osv.dev/v1/querybatch
+      method: POST
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      content_length: 2153
+      body: |
+        {
+          "results": [
+            {},
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "GHSA-68w8-qjq3-2gfm",
+                  "modified": "2024-09-20T15:46:52.557962Z"
+                },
+                {
+                  "id": "GHSA-6w2r-r2m5-xq5w",
+                  "modified": "2026-04-21T08:11:06.082206Z"
+                },
+                {
+                  "id": "GHSA-7xr5-9hcq-chf9",
+                  "modified": "2026-02-04T03:48:05.224740Z"
+                },
+                {
+                  "id": "GHSA-8x94-hmjh-97hq",
+                  "modified": "2026-02-04T02:45:55.690257Z"
+                },
+                {
+                  "id": "GHSA-frmv-pr5f-9mcr",
+                  "modified": "2026-04-21T08:11:22.119438Z"
+                },
+                {
+                  "id": "GHSA-qw25-v68c-qjf3",
+                  "modified": "2026-04-21T08:11:06.009868Z"
+                },
+                {
+                  "id": "GHSA-rrqc-c2jx-6jgv",
+                  "modified": "2024-10-30T19:23:59.139649Z"
+                },
+                {
+                  "id": "PYSEC-2021-98",
+                  "modified": "2023-12-06T01:01:16.755410Z"
+                }
+              ]
+            },
+            {
+              "vulns": [
+                {
+                  "id": "GHSA-68rp-wp8r-4726",
+                  "modified": "2026-02-23T23:43:45.778179Z"
+                },
+                {
+                  "id": "GHSA-m2qf-hxjv-5gpq",
+                  "modified": "2025-02-21T05:42:17.337040Z"
+                },
+                {
+                  "id": "PYSEC-2023-62",
+                  "modified": "2023-11-08T04:12:28.231927Z"
+                }
+              ]
+            },
+            {
+              "vulns": [
+                {
+                  "id": "GHSA-jjg7-2v4v-x38h",
+                  "modified": "2026-02-04T03:49:45.087439Z"
+                },
+                {
+                  "id": "PYSEC-2024-60",
+                  "modified": "2024-07-11T17:42:33.704488Z"
+                }
+              ]
+            },
+            {},
+            {},
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "GHSA-9hjg-9r4m-mvj7",
+                  "modified": "2026-02-04T03:44:00.676479Z"
+                },
+                {
+                  "id": "GHSA-9wx4-h78v-vm56",
+                  "modified": "2026-02-04T02:43:42.271895Z"
+                },
+                {
+                  "id": "GHSA-gc5v-m9x4-r6x2",
+                  "modified": "2026-03-27T22:17:33.595885Z"
+                },
+                {
+                  "id": "GHSA-j8r2-6x86-q33q",
+                  "modified": "2026-02-04T03:34:13.807518Z"
+                },
+                {
+                  "id": "PYSEC-2023-74",
+                  "modified": "2023-11-08T04:12:35.436175Z"
+                }
+              ]
+            },
+            {
+              "vulns": [
+                {
+                  "id": "GHSA-2xpw-w6gg-jr37",
+                  "modified": "2026-02-04T02:36:12.983430Z"
+                },
+                {
+                  "id": "GHSA-34jh-p97f-mpxf",
+                  "modified": "2026-02-04T03:37:44.850742Z"
+                },
+                {
+                  "id": "GHSA-38jv-5279-wg99",
+                  "modified": "2026-02-04T03:51:36.162029Z"
+                },
+                {
+                  "id": "GHSA-g4mx-q9vg-27p4",
+                  "modified": "2026-02-04T03:30:16.767903Z"
+                },
+                {
+                  "id": "GHSA-gm62-xv2j-4w53",
+                  "modified": "2026-02-04T03:37:15.919661Z"
+                },
+                {
+                  "id": "GHSA-pq67-6m6q-mj2v",
+                  "modified": "2026-02-04T04:38:01.163387Z"
+                },
+                {
+                  "id": "GHSA-v845-jxx5-vc9f",
+                  "modified": "2026-02-04T02:58:30.152562Z"
+                },
+                {
+                  "id": "GHSA-wqvq-5m8c-6g24",
+                  "modified": "2024-11-18T22:47:07.792720Z"
+                },
+                {
+                  "id": "PYSEC-2020-148",
+                  "modified": "2023-11-08T04:03:14.251187Z"
+                },
+                {
+                  "id": "PYSEC-2021-108",
+                  "modified": "2023-11-08T04:06:04.829992Z"
+                },
+                {
+                  "id": "PYSEC-2023-192",
+                  "modified": "2023-11-08T04:13:33.452167Z"
+                },
+                {
+                  "id": "PYSEC-2023-212",
+                  "modified": "2023-11-08T04:13:39.165450Z"
+                }
+              ]
+            },
+            {}
+          ]
+        }
+      headers:
+        Content-Length:
+          - "2153"
+        Content-Type:
+          - application/json
+      status: 200 OK
+      code: 200
+      duration: 0s
+  - request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
+      content_length: 1604
+      host: api.osv.dev
+      body: |
+        {
+          "queries": [
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "certifi"
+              },
+              "version": "2026.4.22"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "chardet"
+              },
+              "version": "3.0.4"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "click"
+              },
+              "version": "8.3.3"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "django"
+              },
+              "version": "1.11.29"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "flask"
+              },
               "version": "1.0"
             },
             {
@@ -2021,6 +2296,281 @@ interactions:
                 "name": "pytz"
               },
               "version": "2026.1.post1"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "requests"
+              },
+              "version": "2.20.0"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "urllib3"
+              },
+              "version": "1.24.3"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "werkzeug"
+              },
+              "version": "3.1.8"
+            }
+          ]
+        }
+      headers:
+        Content-Type:
+          - application/json
+        X-Test-Name:
+          - TestCommand_Transitive/requirements.txt_transitive_native_source
+      url: https://api.osv.dev/v1/querybatch
+      method: POST
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      content_length: 2153
+      body: |
+        {
+          "results": [
+            {},
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "GHSA-68w8-qjq3-2gfm",
+                  "modified": "2024-09-20T15:46:52.557962Z"
+                },
+                {
+                  "id": "GHSA-6w2r-r2m5-xq5w",
+                  "modified": "2026-04-21T08:11:06.082206Z"
+                },
+                {
+                  "id": "GHSA-7xr5-9hcq-chf9",
+                  "modified": "2026-02-04T03:48:05.224740Z"
+                },
+                {
+                  "id": "GHSA-8x94-hmjh-97hq",
+                  "modified": "2026-02-04T02:45:55.690257Z"
+                },
+                {
+                  "id": "GHSA-frmv-pr5f-9mcr",
+                  "modified": "2026-04-21T08:11:22.119438Z"
+                },
+                {
+                  "id": "GHSA-qw25-v68c-qjf3",
+                  "modified": "2026-04-21T08:11:06.009868Z"
+                },
+                {
+                  "id": "GHSA-rrqc-c2jx-6jgv",
+                  "modified": "2024-10-30T19:23:59.139649Z"
+                },
+                {
+                  "id": "PYSEC-2021-98",
+                  "modified": "2023-12-06T01:01:16.755410Z"
+                }
+              ]
+            },
+            {
+              "vulns": [
+                {
+                  "id": "GHSA-68rp-wp8r-4726",
+                  "modified": "2026-02-23T23:43:45.778179Z"
+                },
+                {
+                  "id": "GHSA-m2qf-hxjv-5gpq",
+                  "modified": "2025-02-21T05:42:17.337040Z"
+                },
+                {
+                  "id": "PYSEC-2023-62",
+                  "modified": "2023-11-08T04:12:28.231927Z"
+                }
+              ]
+            },
+            {
+              "vulns": [
+                {
+                  "id": "GHSA-jjg7-2v4v-x38h",
+                  "modified": "2026-02-04T03:49:45.087439Z"
+                },
+                {
+                  "id": "PYSEC-2024-60",
+                  "modified": "2024-07-11T17:42:33.704488Z"
+                }
+              ]
+            },
+            {},
+            {},
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "GHSA-9hjg-9r4m-mvj7",
+                  "modified": "2026-02-04T03:44:00.676479Z"
+                },
+                {
+                  "id": "GHSA-9wx4-h78v-vm56",
+                  "modified": "2026-02-04T02:43:42.271895Z"
+                },
+                {
+                  "id": "GHSA-gc5v-m9x4-r6x2",
+                  "modified": "2026-03-27T22:17:33.595885Z"
+                },
+                {
+                  "id": "GHSA-j8r2-6x86-q33q",
+                  "modified": "2026-02-04T03:34:13.807518Z"
+                },
+                {
+                  "id": "PYSEC-2023-74",
+                  "modified": "2023-11-08T04:12:35.436175Z"
+                }
+              ]
+            },
+            {
+              "vulns": [
+                {
+                  "id": "GHSA-2xpw-w6gg-jr37",
+                  "modified": "2026-02-04T02:36:12.983430Z"
+                },
+                {
+                  "id": "GHSA-34jh-p97f-mpxf",
+                  "modified": "2026-02-04T03:37:44.850742Z"
+                },
+                {
+                  "id": "GHSA-38jv-5279-wg99",
+                  "modified": "2026-02-04T03:51:36.162029Z"
+                },
+                {
+                  "id": "GHSA-g4mx-q9vg-27p4",
+                  "modified": "2026-02-04T03:30:16.767903Z"
+                },
+                {
+                  "id": "GHSA-gm62-xv2j-4w53",
+                  "modified": "2026-02-04T03:37:15.919661Z"
+                },
+                {
+                  "id": "GHSA-pq67-6m6q-mj2v",
+                  "modified": "2026-02-04T04:38:01.163387Z"
+                },
+                {
+                  "id": "GHSA-v845-jxx5-vc9f",
+                  "modified": "2026-02-04T02:58:30.152562Z"
+                },
+                {
+                  "id": "GHSA-wqvq-5m8c-6g24",
+                  "modified": "2024-11-18T22:47:07.792720Z"
+                },
+                {
+                  "id": "PYSEC-2020-148",
+                  "modified": "2023-11-08T04:03:14.251187Z"
+                },
+                {
+                  "id": "PYSEC-2021-108",
+                  "modified": "2023-11-08T04:06:04.829992Z"
+                },
+                {
+                  "id": "PYSEC-2023-192",
+                  "modified": "2023-11-08T04:13:33.452167Z"
+                },
+                {
+                  "id": "PYSEC-2023-212",
+                  "modified": "2023-11-08T04:13:39.165450Z"
+                }
+              ]
+            },
+            {}
+          ]
+        }
+      headers:
+        Content-Length:
+          - "2153"
+        Content-Type:
+          - application/json
+      status: 200 OK
+      code: 200
+      duration: 0s
+  - request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
+      content_length: 1598
+      host: api.osv.dev
+      body: |
+        {
+          "queries": [
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "certifi"
+              },
+              "version": "2026.4.22"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "chardet"
+              },
+              "version": "3.0.4"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "click"
+              },
+              "version": "8.3.3"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "django"
+              },
+              "version": "1.11.29"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "flask"
+              },
+              "version": "1.0"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "idna"
+              },
+              "version": "2.7"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "itsdangerous"
+              },
+              "version": "2.2.0"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "jinja2"
+              },
+              "version": "3.1.6"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "markupsafe"
+              },
+              "version": "3.0.3"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "pytz"
+              },
+              "version": "2026.2"
             },
             {
               "package": {


### PR DESCRIPTION
Downgrade ruby in the github pages deployment down to 4.0.2 from 4.0.3, as 4.0.3 is not yet supported on setup-ruby action.

Also update snapshots

---
*PR created automatically by Jules for task [1277786316140062320](https://jules.google.com/task/1277786316140062320) started by @another-rex*