### PR TITLE
fix: Secure file path handling with os.OpenRoot

### DIFF
--- a/internal/clients/clientimpl/localmatcher/localmatcher.go
+++ b/internal/clients/clientimpl/localmatcher/localmatcher.go
@@ -120,9 +120,15 @@ func (matcher *LocalMatcher) loadDBFromCache(ctx context.Context, eco osvconstan
 		return nil, matcher.failedDBs[eco]
 	}
 
+	dbRoot, err := os.OpenRoot(matcher.dbBasePath)
+	if err != nil {
+		return nil, fmt.Errorf("could not open db root: %w", err)
+	}
+	defer dbRoot.Close()
+
 	db, err := NewZippedDB(
 		ctx,
-		matcher.dbBasePath,
+		dbRoot,
 		string(eco),
 		fmt.Sprintf("%s/%s/all.zip", zippedDBRemoteHost, eco),
 		matcher.userAgent,
@@ -137,7 +143,7 @@ func (matcher *LocalMatcher) loadDBFromCache(ctx context.Context, eco osvconstan
 		return nil, err
 	}
 
-	cmdlogger.Infof("Loaded %s local db from %s", db.Name, db.StoredAt)
+	cmdlogger.Infof("Loaded %s local db from %s", db.Name, path.Join(matcher.dbBasePath, db.StoredAt))
 
 	matcher.dbs[eco] = db
 

--- a/internal/clients/clientimpl/localmatcher/localmatcher.go
+++ b/internal/clients/clientimpl/localmatcher/localmatcher.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/osv-scalibr/inventory/osvecosystem"
 	"github.com/google/osv-scanner/v2/internal/cmdlogger"
 	"github.com/google/osv-scanner/v2/internal/imodels"
+	"github.com/google/osv-scanner/v2/internal/utility/pathfilter"
 	"github.com/ossf/osv-schema/bindings/go/osvconstants"
 	"github.com/ossf/osv-schema/bindings/go/osvschema"
 )
@@ -126,11 +127,12 @@ func (matcher *LocalMatcher) loadDBFromCache(ctx context.Context, eco osvconstan
 	}
 	defer dbRoot.Close()
 
+	safeEco := pathfilter.FilterPath(string(eco))
 	db, err := NewZippedDB(
 		ctx,
 		dbRoot,
-		string(eco),
-		fmt.Sprintf("%s/%s/all.zip", zippedDBRemoteHost, eco),
+		safeEco,
+		fmt.Sprintf("%s/%s/all.zip", zippedDBRemoteHost, safeEco),
 		matcher.userAgent,
 		!matcher.downloadDB,
 		invs,

--- a/internal/clients/clientimpl/localmatcher/zip.go
+++ b/internal/clients/clientimpl/localmatcher/zip.go
@@ -31,7 +31,7 @@ type ZipDB struct {
 	ArchiveURL string
 	// whether this database should make any network requests
 	Offline bool
-	// the path to the zip archive on disk
+	// the path to the zip archive on disk (relative to dbRoot)
 	StoredAt string
 	// the vulnerabilities that are loaded into this database
 	Vulnerabilities []*osvschema.Vulnerability
@@ -41,6 +41,9 @@ type ZipDB struct {
 	// whether this database only has some of the advisories
 	// loaded from the underlying zip file
 	Partial bool
+
+	// root directory for safe filesystem operations
+	dbRoot *os.Root
 }
 
 var ErrOfflineDatabaseNotFound = errors.New("no offline version of the OSV database is available")
@@ -90,7 +93,7 @@ func fetchLocalArchiveCRC32CHash(f *os.File) (uint32, error) {
 }
 
 func (db *ZipDB) fetchZip(ctx context.Context) (*os.File, error) {
-	f, err := os.Open(db.StoredAt)
+	f, err := db.dbRoot.Open(db.StoredAt)
 
 	if db.Offline {
 		if err != nil {
@@ -139,13 +142,13 @@ func (db *ZipDB) fetchZip(ctx context.Context) (*os.File, error) {
 		return nil, fmt.Errorf("db host returned %s", resp.Status)
 	}
 
-	err = os.MkdirAll(path.Dir(db.StoredAt), 0750)
+	err = db.dbRoot.MkdirAll(path.Dir(db.StoredAt), 0750)
 
 	if err != nil {
 		return nil, fmt.Errorf("could not create cache directory: %w", err)
 	}
 
-	f, err = os.OpenFile(db.StoredAt, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+	f, err = db.dbRoot.OpenFile(db.StoredAt, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
 
 	if err != nil {
 		return nil, fmt.Errorf("could not create cache file: %w", err)
@@ -264,12 +267,13 @@ func (db *ZipDB) load(ctx context.Context, names []string) error {
 	return nil
 }
 
-func NewZippedDB(ctx context.Context, dbBasePath, name, url, userAgent string, offline bool, pkgs []*extractor.Package) (*ZipDB, error) {
+func NewZippedDB(ctx context.Context, dbRoot *os.Root, name, url, userAgent string, offline bool, pkgs []*extractor.Package) (*ZipDB, error) {
 	db := &ZipDB{
+		dbRoot:     dbRoot,
 		Name:       name,
 		ArchiveURL: url,
 		Offline:    offline,
-		StoredAt:   path.Join(dbBasePath, name, "all.zip"),
+		StoredAt:   path.Join(name, "all.zip"),
 		UserAgent:  userAgent,
 
 		// we only fully load the database if we're not provided a list of packages

--- a/internal/clients/clientimpl/localmatcher/zip_test.go
+++ b/internal/clients/clientimpl/localmatcher/zip_test.go
@@ -48,7 +48,8 @@ func expectDBToHaveOSVs(
 	}
 }
 
-func newZippedDB(t *testing.T, ctx context.Context, dbBasePath string, name, url, userAgent string, offline bool, pkgs []*extractor.Package) (*localmatcher.ZipDB, error) {
+//nolint:unparam // name always receives "my-db" in tests but keeping it for flexibility
+func newZippedDB(ctx context.Context, t *testing.T, dbBasePath string, name, url, userAgent string, offline bool, pkgs []*extractor.Package) (*localmatcher.ZipDB, error) {
 	t.Helper()
 	dbRoot, err := os.OpenRoot(dbBasePath)
 	if err != nil {
@@ -60,7 +61,6 @@ func newZippedDB(t *testing.T, ctx context.Context, dbBasePath string, name, url
 
 	return localmatcher.NewZippedDB(ctx, dbRoot, name, url, userAgent, offline, pkgs)
 }
-
 
 func cacheWrite(t *testing.T, storedAt string, cache []byte) {
 	t.Helper()
@@ -163,7 +163,7 @@ func TestNewZippedDB_Offline_WithoutCache(t *testing.T) {
 		t.Errorf("a server request was made when running offline")
 	})
 
-	_, err := newZippedDB(t, t.Context(), testDir, "my-db", ts.URL, userAgent, true, nil)
+	_, err := newZippedDB(t.Context(), t, testDir, "my-db", ts.URL, userAgent, true, nil)
 
 	if !errors.Is(err, localmatcher.ErrOfflineDatabaseNotFound) {
 		t.Errorf("expected \"%v\" error but got \"%v\"", localmatcher.ErrOfflineDatabaseNotFound, err)
@@ -195,7 +195,7 @@ func TestNewZippedDB_Offline_WithCache(t *testing.T) {
 		"GHSA-5.json": {Id: "GHSA-5"},
 	}))
 
-	db, err := newZippedDB(t, t.Context(), testDir, "my-db", ts.URL, userAgent, true, nil)
+	db, err := newZippedDB(t.Context(), t, testDir, "my-db", ts.URL, userAgent, true, nil)
 
 	if err != nil {
 		t.Fatalf("unexpected error \"%v\"", err)
@@ -216,7 +216,7 @@ func TestNewZippedDB_BadZip(t *testing.T) {
 		_, _ = w.Write([]byte("this is not a zip"))
 	})
 
-	_, err := newZippedDB(t, t.Context(), testDir, "my-db", ts.URL, userAgent, false, nil)
+	_, err := newZippedDB(t.Context(), t, testDir, "my-db", ts.URL, userAgent, false, nil)
 
 	if err == nil {
 		t.Errorf("expected an error but did not get one")
@@ -228,7 +228,7 @@ func TestNewZippedDB_UnsupportedProtocol(t *testing.T) {
 
 	testDir := testutility.CreateTestDir(t)
 
-	_, err := newZippedDB(t, t.Context(), testDir, "my-db", "file://hello-world", userAgent, false, nil)
+	_, err := newZippedDB(t.Context(), t, testDir, "my-db", "file://hello-world", userAgent, false, nil)
 
 	if err == nil {
 		t.Errorf("expected an error but did not get one")
@@ -258,7 +258,7 @@ func TestNewZippedDB_Online_WithoutCache(t *testing.T) {
 		})
 	})
 
-	db, err := newZippedDB(t, t.Context(), testDir, "my-db", ts.URL, userAgent, false, nil)
+	db, err := newZippedDB(t.Context(), t, testDir, "my-db", ts.URL, userAgent, false, nil)
 
 	if err != nil {
 		t.Fatalf("unexpected error \"%v\"", err)
@@ -293,7 +293,7 @@ func TestNewZippedDB_Online_WithoutCacheAndNoHashHeader(t *testing.T) {
 		}))
 	})
 
-	db, err := newZippedDB(t, t.Context(), testDir, "my-db", ts.URL, userAgent, false, nil)
+	db, err := newZippedDB(t.Context(), t, testDir, "my-db", ts.URL, userAgent, false, nil)
 
 	if err != nil {
 		t.Fatalf("unexpected error \"%v\"", err)
@@ -334,7 +334,7 @@ func TestNewZippedDB_Online_WithSameCache(t *testing.T) {
 
 	cacheWrite(t, determineStoredAtPath(testDir, "my-db"), cache)
 
-	db, err := newZippedDB(t, t.Context(), testDir, "my-db", ts.URL, userAgent, false, nil)
+	db, err := newZippedDB(t.Context(), t, testDir, "my-db", ts.URL, userAgent, false, nil)
 
 	if err != nil {
 		t.Fatalf("unexpected error \"%v\"", err)
@@ -375,7 +375,7 @@ func TestNewZippedDB_Online_WithDifferentCache(t *testing.T) {
 		"GHSA-3.json": {Id: "GHSA-3"},
 	}))
 
-	db, err := newZippedDB(t, t.Context(), testDir, "my-db", ts.URL, userAgent, false, nil)
+	db, err := newZippedDB(t.Context(), t, testDir, "my-db", ts.URL, userAgent, false, nil)
 
 	if err != nil {
 		t.Fatalf("unexpected error \"%v\"", err)
@@ -402,7 +402,7 @@ func TestNewZippedDB_Online_WithCacheButBadHeadResponse(t *testing.T) {
 		"GHSA-3.json": {Id: "GHSA-3"},
 	}))
 
-	_, err := newZippedDB(t, t.Context(), testDir, "my-db", ts.URL, userAgent, false, nil)
+	_, err := newZippedDB(t.Context(), t, testDir, "my-db", ts.URL, userAgent, false, nil)
 
 	if err == nil {
 		t.Errorf("expected an error but did not get one")
@@ -432,7 +432,7 @@ func TestNewZippedDB_Online_WithCacheButBadHashHeader(t *testing.T) {
 		"GHSA-3.json": {Id: "GHSA-3"},
 	}))
 
-	_, err := newZippedDB(t, t.Context(), testDir, "my-db", ts.URL, userAgent, false, nil)
+	_, err := newZippedDB(t.Context(), t, testDir, "my-db", ts.URL, userAgent, false, nil)
 
 	if err == nil {
 		t.Errorf("expected an error but did not get one")
@@ -460,7 +460,7 @@ func TestNewZippedDB_Online_WithCacheButNoHashHeader(t *testing.T) {
 		"GHSA-3.json": {Id: "GHSA-3"},
 	}))
 
-	_, err := newZippedDB(t, t.Context(), testDir, "my-db", ts.URL, userAgent, false, nil)
+	_, err := newZippedDB(t.Context(), t, testDir, "my-db", ts.URL, userAgent, false, nil)
 
 	if err == nil {
 		t.Errorf("expected an error but did not get one")
@@ -488,7 +488,7 @@ func TestNewZippedDB_Online_WithBadCache(t *testing.T) {
 
 	cacheWriteBad(t, determineStoredAtPath(testDir, "my-db"), "this is not json!")
 
-	db, err := newZippedDB(t, t.Context(), testDir, "my-db", ts.URL, userAgent, false, nil)
+	db, err := newZippedDB(t.Context(), t, testDir, "my-db", ts.URL, userAgent, false, nil)
 
 	if err != nil {
 		t.Fatalf("unexpected error \"%v\"", err)
@@ -515,7 +515,7 @@ func TestNewZippedDB_Online_WithBadGetResponse(t *testing.T) {
 		_, _ = writeOSVsZip(t, w, map[string]*osvschema.Vulnerability{})
 	})
 
-	_, err := newZippedDB(t, t.Context(), testDir, "my-db", ts.URL, userAgent, false, nil)
+	_, err := newZippedDB(t.Context(), t, testDir, "my-db", ts.URL, userAgent, false, nil)
 
 	if err == nil {
 		t.Errorf("expected an error but did not get one")
@@ -539,7 +539,7 @@ func TestNewZippedDB_FileChecks(t *testing.T) {
 		})
 	})
 
-	db, err := newZippedDB(t, t.Context(), testDir, "my-db", ts.URL, userAgent, false, nil)
+	db, err := newZippedDB(t.Context(), t, testDir, "my-db", ts.URL, userAgent, false, nil)
 
 	if err != nil {
 		t.Fatalf("unexpected error \"%v\"", err)
@@ -623,8 +623,8 @@ func TestNewZippedDB_WithSpecificPackages(t *testing.T) {
 	})
 
 	db, err := newZippedDB(
-		t,
 		t.Context(),
+		t,
 		testDir,
 		"my-db",
 		ts.URL,
@@ -711,4 +711,3 @@ func TestNewZippedDB_PathTraversal(t *testing.T) {
 	}
 	t.Logf("Got expected error: %v", err)
 }
-

--- a/internal/clients/clientimpl/localmatcher/zip_test.go
+++ b/internal/clients/clientimpl/localmatcher/zip_test.go
@@ -49,7 +49,7 @@ func expectDBToHaveOSVs(
 }
 
 //nolint:unparam // name always receives "my-db" in tests but keeping it for flexibility
-func newZippedDB(ctx context.Context, t *testing.T, dbBasePath string, name, url, userAgent string, offline bool, pkgs []*extractor.Package) (*localmatcher.ZipDB, error) {
+func newZippedDB(ctx context.Context, t *testing.T, dbBasePath, name, url, userAgent string, offline bool, pkgs []*extractor.Package) (*localmatcher.ZipDB, error) {
 	t.Helper()
 	dbRoot, err := os.OpenRoot(dbBasePath)
 	if err != nil {

--- a/internal/clients/clientimpl/localmatcher/zip_test.go
+++ b/internal/clients/clientimpl/localmatcher/zip_test.go
@@ -3,6 +3,7 @@ package localmatcher_test
 import (
 	"archive/zip"
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/binary"
 	"errors"
@@ -46,6 +47,20 @@ func expectDBToHaveOSVs(
 		t.Errorf("db is missing some vulnerabilities (-want +got):\n%s", diff)
 	}
 }
+
+func newZippedDB(t *testing.T, ctx context.Context, dbBasePath string, name, url, userAgent string, offline bool, pkgs []*extractor.Package) (*localmatcher.ZipDB, error) {
+	t.Helper()
+	dbRoot, err := os.OpenRoot(dbBasePath)
+	if err != nil {
+		return nil, err
+	}
+	t.Cleanup(func() {
+		dbRoot.Close()
+	})
+
+	return localmatcher.NewZippedDB(ctx, dbRoot, name, url, userAgent, offline, pkgs)
+}
+
 
 func cacheWrite(t *testing.T, storedAt string, cache []byte) {
 	t.Helper()
@@ -148,7 +163,7 @@ func TestNewZippedDB_Offline_WithoutCache(t *testing.T) {
 		t.Errorf("a server request was made when running offline")
 	})
 
-	_, err := localmatcher.NewZippedDB(t.Context(), testDir, "my-db", ts.URL, userAgent, true, nil)
+	_, err := newZippedDB(t, t.Context(), testDir, "my-db", ts.URL, userAgent, true, nil)
 
 	if !errors.Is(err, localmatcher.ErrOfflineDatabaseNotFound) {
 		t.Errorf("expected \"%v\" error but got \"%v\"", localmatcher.ErrOfflineDatabaseNotFound, err)
@@ -180,7 +195,7 @@ func TestNewZippedDB_Offline_WithCache(t *testing.T) {
 		"GHSA-5.json": {Id: "GHSA-5"},
 	}))
 
-	db, err := localmatcher.NewZippedDB(t.Context(), testDir, "my-db", ts.URL, userAgent, true, nil)
+	db, err := newZippedDB(t, t.Context(), testDir, "my-db", ts.URL, userAgent, true, nil)
 
 	if err != nil {
 		t.Fatalf("unexpected error \"%v\"", err)
@@ -201,7 +216,7 @@ func TestNewZippedDB_BadZip(t *testing.T) {
 		_, _ = w.Write([]byte("this is not a zip"))
 	})
 
-	_, err := localmatcher.NewZippedDB(t.Context(), testDir, "my-db", ts.URL, userAgent, false, nil)
+	_, err := newZippedDB(t, t.Context(), testDir, "my-db", ts.URL, userAgent, false, nil)
 
 	if err == nil {
 		t.Errorf("expected an error but did not get one")
@@ -213,7 +228,7 @@ func TestNewZippedDB_UnsupportedProtocol(t *testing.T) {
 
 	testDir := testutility.CreateTestDir(t)
 
-	_, err := localmatcher.NewZippedDB(t.Context(), testDir, "my-db", "file://hello-world", userAgent, false, nil)
+	_, err := newZippedDB(t, t.Context(), testDir, "my-db", "file://hello-world", userAgent, false, nil)
 
 	if err == nil {
 		t.Errorf("expected an error but did not get one")
@@ -243,7 +258,7 @@ func TestNewZippedDB_Online_WithoutCache(t *testing.T) {
 		})
 	})
 
-	db, err := localmatcher.NewZippedDB(t.Context(), testDir, "my-db", ts.URL, userAgent, false, nil)
+	db, err := newZippedDB(t, t.Context(), testDir, "my-db", ts.URL, userAgent, false, nil)
 
 	if err != nil {
 		t.Fatalf("unexpected error \"%v\"", err)
@@ -278,7 +293,7 @@ func TestNewZippedDB_Online_WithoutCacheAndNoHashHeader(t *testing.T) {
 		}))
 	})
 
-	db, err := localmatcher.NewZippedDB(t.Context(), testDir, "my-db", ts.URL, userAgent, false, nil)
+	db, err := newZippedDB(t, t.Context(), testDir, "my-db", ts.URL, userAgent, false, nil)
 
 	if err != nil {
 		t.Fatalf("unexpected error \"%v\"", err)
@@ -319,7 +334,7 @@ func TestNewZippedDB_Online_WithSameCache(t *testing.T) {
 
 	cacheWrite(t, determineStoredAtPath(testDir, "my-db"), cache)
 
-	db, err := localmatcher.NewZippedDB(t.Context(), testDir, "my-db", ts.URL, userAgent, false, nil)
+	db, err := newZippedDB(t, t.Context(), testDir, "my-db", ts.URL, userAgent, false, nil)
 
 	if err != nil {
 		t.Fatalf("unexpected error \"%v\"", err)
@@ -360,7 +375,7 @@ func TestNewZippedDB_Online_WithDifferentCache(t *testing.T) {
 		"GHSA-3.json": {Id: "GHSA-3"},
 	}))
 
-	db, err := localmatcher.NewZippedDB(t.Context(), testDir, "my-db", ts.URL, userAgent, false, nil)
+	db, err := newZippedDB(t, t.Context(), testDir, "my-db", ts.URL, userAgent, false, nil)
 
 	if err != nil {
 		t.Fatalf("unexpected error \"%v\"", err)
@@ -387,7 +402,7 @@ func TestNewZippedDB_Online_WithCacheButBadHeadResponse(t *testing.T) {
 		"GHSA-3.json": {Id: "GHSA-3"},
 	}))
 
-	_, err := localmatcher.NewZippedDB(t.Context(), testDir, "my-db", ts.URL, userAgent, false, nil)
+	_, err := newZippedDB(t, t.Context(), testDir, "my-db", ts.URL, userAgent, false, nil)
 
 	if err == nil {
 		t.Errorf("expected an error but did not get one")
@@ -417,7 +432,7 @@ func TestNewZippedDB_Online_WithCacheButBadHashHeader(t *testing.T) {
 		"GHSA-3.json": {Id: "GHSA-3"},
 	}))
 
-	_, err := localmatcher.NewZippedDB(t.Context(), testDir, "my-db", ts.URL, userAgent, false, nil)
+	_, err := newZippedDB(t, t.Context(), testDir, "my-db", ts.URL, userAgent, false, nil)
 
 	if err == nil {
 		t.Errorf("expected an error but did not get one")
@@ -445,7 +460,7 @@ func TestNewZippedDB_Online_WithCacheButNoHashHeader(t *testing.T) {
 		"GHSA-3.json": {Id: "GHSA-3"},
 	}))
 
-	_, err := localmatcher.NewZippedDB(t.Context(), testDir, "my-db", ts.URL, userAgent, false, nil)
+	_, err := newZippedDB(t, t.Context(), testDir, "my-db", ts.URL, userAgent, false, nil)
 
 	if err == nil {
 		t.Errorf("expected an error but did not get one")
@@ -473,7 +488,7 @@ func TestNewZippedDB_Online_WithBadCache(t *testing.T) {
 
 	cacheWriteBad(t, determineStoredAtPath(testDir, "my-db"), "this is not json!")
 
-	db, err := localmatcher.NewZippedDB(t.Context(), testDir, "my-db", ts.URL, userAgent, false, nil)
+	db, err := newZippedDB(t, t.Context(), testDir, "my-db", ts.URL, userAgent, false, nil)
 
 	if err != nil {
 		t.Fatalf("unexpected error \"%v\"", err)
@@ -500,7 +515,7 @@ func TestNewZippedDB_Online_WithBadGetResponse(t *testing.T) {
 		_, _ = writeOSVsZip(t, w, map[string]*osvschema.Vulnerability{})
 	})
 
-	_, err := localmatcher.NewZippedDB(t.Context(), testDir, "my-db", ts.URL, userAgent, false, nil)
+	_, err := newZippedDB(t, t.Context(), testDir, "my-db", ts.URL, userAgent, false, nil)
 
 	if err == nil {
 		t.Errorf("expected an error but did not get one")
@@ -524,7 +539,7 @@ func TestNewZippedDB_FileChecks(t *testing.T) {
 		})
 	})
 
-	db, err := localmatcher.NewZippedDB(t.Context(), testDir, "my-db", ts.URL, userAgent, false, nil)
+	db, err := newZippedDB(t, t.Context(), testDir, "my-db", ts.URL, userAgent, false, nil)
 
 	if err != nil {
 		t.Fatalf("unexpected error \"%v\"", err)
@@ -607,7 +622,8 @@ func TestNewZippedDB_WithSpecificPackages(t *testing.T) {
 		})
 	})
 
-	db, err := localmatcher.NewZippedDB(
+	db, err := newZippedDB(
+		t,
 		t.Context(),
 		testDir,
 		"my-db",
@@ -665,3 +681,34 @@ func TestNewZippedDB_WithSpecificPackages(t *testing.T) {
 		},
 	})
 }
+
+func TestNewZippedDB_PathTraversal(t *testing.T) {
+	t.Parallel()
+
+	testDir := testutility.CreateTestDir(t)
+	dbRoot, err := os.OpenRoot(testDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dbRoot.Close()
+
+	ts := createZipServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = writeOSVsZip(t, w, map[string]*osvschema.Vulnerability{})
+	})
+
+	_, err = localmatcher.NewZippedDB(
+		t.Context(),
+		dbRoot,
+		"../../escaped",
+		ts.URL,
+		userAgent,
+		false,
+		nil,
+	)
+
+	if err == nil {
+		t.Errorf("expected an error due to path traversal, but got nil")
+	}
+	t.Logf("Got expected error: %v", err)
+}
+

--- a/internal/sourceanalysis/go.go
+++ b/internal/sourceanalysis/go.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -165,7 +164,7 @@ func runGovulncheck(moddir string, vulns []*osvschema.Vulnerability, goVersion s
 		if err != nil {
 			return nil, err
 		}
-		if err := root.WriteFile(fmt.Sprintf("%s.json", pathfilter.FilterPath(vuln.GetId())), dat, 0600); err != nil {
+		if err := root.WriteFile(pathfilter.FilterPath(vuln.GetId())+".json", dat, 0600); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/sourceanalysis/go.go
+++ b/internal/sourceanalysis/go.go
@@ -153,12 +153,18 @@ func runGovulncheck(moddir string, vulns []*osvschema.Vulnerability, goVersion s
 		}
 	}()
 
+	root, err := os.OpenRoot(dbdir)
+	if err != nil {
+		return nil, err
+	}
+	defer root.Close()
+
 	for _, vuln := range vulns {
 		dat, err := protojson.Marshal(vuln)
 		if err != nil {
 			return nil, err
 		}
-		if err := os.WriteFile(fmt.Sprintf("%s/%s.json", dbdir, vuln.GetId()), dat, 0600); err != nil {
+		if err := root.WriteFile(fmt.Sprintf("%s.json", vuln.GetId()), dat, 0600); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/sourceanalysis/go.go
+++ b/internal/sourceanalysis/go.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/osv-scanner/v2/internal/cmdlogger"
 	"github.com/google/osv-scanner/v2/internal/sourceanalysis/govulncheck"
 	"github.com/google/osv-scanner/v2/internal/url"
+	"github.com/google/osv-scanner/v2/internal/utility/pathfilter"
 	"github.com/google/osv-scanner/v2/pkg/models"
 	"github.com/ossf/osv-schema/bindings/go/osvschema"
 	"golang.org/x/vuln/scan"
@@ -164,7 +165,7 @@ func runGovulncheck(moddir string, vulns []*osvschema.Vulnerability, goVersion s
 		if err != nil {
 			return nil, err
 		}
-		if err := root.WriteFile(fmt.Sprintf("%s.json", vuln.GetId()), dat, 0600); err != nil {
+		if err := root.WriteFile(fmt.Sprintf("%s.json", pathfilter.FilterPath(vuln.GetId())), dat, 0600); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/utility/pathfilter/pathfilter.go
+++ b/internal/utility/pathfilter/pathfilter.go
@@ -1,0 +1,37 @@
+package pathfilter
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// FilterPath removes any ".." components from the path to prevent path traversal.
+// It cleans the path first, then removes any ".." components.
+// If the path becomes empty or only contains "." after filtering, it returns ".".
+func FilterPath(p string) string {
+	if p == "" {
+		return ""
+	}
+
+	cleaned := filepath.Clean(p)
+
+	// Split into volume and path (for Windows compatibility)
+	vol := filepath.VolumeName(cleaned)
+	rel := cleaned[len(vol):]
+
+	components := strings.Split(rel, string(filepath.Separator))
+	var filtered []string
+	for _, c := range components {
+		if c == ".." || c == "." || c == "" {
+			continue
+		}
+		filtered = append(filtered, c)
+	}
+
+	rejoined := filepath.Join(filtered...)
+	if rejoined == "" {
+		return "."
+	}
+
+	return vol + rejoined
+}

--- a/internal/utility/pathfilter/pathfilter.go
+++ b/internal/utility/pathfilter/pathfilter.go
@@ -1,3 +1,4 @@
+// Package pathfilter provides utilities for filtering and sanitizing file paths to prevent path traversal.
 package pathfilter
 
 import (

--- a/internal/utility/pathfilter/pathfilter_test.go
+++ b/internal/utility/pathfilter/pathfilter_test.go
@@ -1,0 +1,69 @@
+package pathfilter_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/google/osv-scanner/v2/internal/utility/pathfilter"
+)
+
+func TestFilterPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "safe path",
+			input:    "GHSA-1234",
+			expected: "GHSA-1234",
+		},
+		{
+			name:     "safe path with subdirs",
+			input:    "npm/all.zip",
+			expected: filepath.FromSlash("npm/all.zip"),
+		},
+		{
+			name:     "path traversal attempt",
+			input:    "../../GHSA-1234",
+			expected: "GHSA-1234",
+		},
+		{
+			name:     "nested path traversal attempt",
+			input:    "npm/../../all.zip",
+			expected: "all.zip",
+		},
+		{
+			name:     "absolute path becomes relative",
+			input:    "/etc/passwd",
+			expected: filepath.FromSlash("etc/passwd"),
+		},
+		{
+			name:     "absolute path with traversal",
+			input:    "/tmp/../../etc/passwd",
+			expected: filepath.FromSlash("etc/passwd"),
+		},
+		{
+			name:     "empty path",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "only traversal",
+			input:    "../../..",
+			expected: ".",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := pathfilter.FilterPath(tt.input)
+			if got != tt.expected {
+				t.Errorf("FilterPath(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR introduces `os.OpenRoot` (available in Go 1.25+) to secure file writing operations in temporary and cache directories, preventing path traversal vulnerabilities from untrusted inputs escaping these directories.

Secure areas:
1. `internal/sourceanalysis/go.go`: temporary `govulncheck` database directory.
2. `internal/clients/clientimpl/localmatcher`: local database cache directory.

Added path traversal prevention test in `zip_test.go` to verify `os.OpenRoot` behavior.