### PR TITLE
feat: add RPM scan plugin wiring

### DIFF
--- a/internal/scalibrplugin/__snapshots__/resolve_test.snap
+++ b/internal/scalibrplugin/__snapshots__/resolve_test.snap
@@ -34,6 +34,7 @@ misc/brew-source
 os/apk
 os/dpkg
 os/homebrew
+os/rpm
 osv/osvscannerjson
 php/composerlock
 python/pdmlock
@@ -54,6 +55,7 @@ transitivedependency/requirements
 vcs/gitrepo
 vex/os-duplicate/apk
 vex/os-duplicate/dpkg
+vex/os-duplicate/rpm
 vulnmatch/osvdev
 vulnmatch/osvlocal
 weakcredentials/codeserver
@@ -71,10 +73,12 @@ misc/brew-source
 os/apk
 os/dpkg
 os/homebrew
+os/rpm
 python/wheelegg
 rust/cargoauditable
 vex/os-duplicate/apk
 vex/os-duplicate/dpkg
+vex/os-duplicate/rpm
 ---
 
 [TestResolve_Detectors_Presets/cis - 1]
@@ -110,10 +114,12 @@ misc/brew-source
 os/apk
 os/dpkg
 os/homebrew
+os/rpm
 python/wheelegg
 rust/cargoauditable
 vex/os-duplicate/apk
 vex/os-duplicate/dpkg
+vex/os-duplicate/rpm
 ---
 
 [TestResolve_Enrichers_Presets/licenses - 1]
@@ -138,10 +144,12 @@ misc/brew-source
 os/apk
 os/dpkg
 os/homebrew
+os/rpm
 python/wheelegg
 rust/cargoauditable
 vex/os-duplicate/apk
 vex/os-duplicate/dpkg
+vex/os-duplicate/rpm
 ---
 
 [TestResolve_Extractors_Presets/directory - 1]
@@ -168,6 +176,7 @@ javascript/pnpmlock
 javascript/yarnlock
 os/apk
 os/dpkg
+os/rpm
 osv/osvscannerjson
 php/composerlock
 python/pdmlock

--- a/internal/scalibrplugin/presets.go
+++ b/internal/scalibrplugin/presets.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/osv-scalibr/annotator/misc/brewsource"
 	apkanno "github.com/google/osv-scalibr/annotator/osduplicate/apk"
 	dpkganno "github.com/google/osv-scalibr/annotator/osduplicate/dpkg"
+	rpmanno "github.com/google/osv-scalibr/annotator/osduplicate/rpm"
 	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
 	detectors "github.com/google/osv-scalibr/detector/list"
 	"github.com/google/osv-scalibr/enricher"
@@ -48,6 +49,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/os/apk"
 	"github.com/google/osv-scalibr/extractor/filesystem/os/dpkg"
 	"github.com/google/osv-scalibr/extractor/filesystem/os/homebrew"
+	rpmextractor "github.com/google/osv-scalibr/extractor/filesystem/os/rpm"
 	"github.com/google/osv-scalibr/extractor/filesystem/sbom/cdx"
 	"github.com/google/osv-scalibr/extractor/filesystem/sbom/spdx"
 	"github.com/google/osv-scanner/v2/internal/scalibrextract/filesystem/vendored"
@@ -130,6 +132,8 @@ var ExtractorPresets = map[string]extractors.InitMap{
 		apk.Name: {apk.New},
 		// Debian
 		dpkg.Name: {dpkg.New},
+		// RPM
+		rpmextractor.Name: {rpmextractor.New},
 	},
 	"directory": {
 		gitrepo.Name:  {gitrepo.New},
@@ -153,6 +157,8 @@ var ExtractorPresets = map[string]extractors.InitMap{
 		apk.Name: {apk.New},
 		// Debian
 		dpkg.Name: {dpkg.New},
+		// RPM
+		rpmextractor.Name: {rpmextractor.New},
 		// Homebrew
 		homebrew.Name: {homebrew.New},
 	},
@@ -174,6 +180,7 @@ var annotatorPresets = map[string]annotatorlist.InitMap{
 	"artifact": {
 		apkanno.Name:    {apkanno.New},
 		dpkganno.Name:   {dpkganno.New},
+		rpmanno.Name:    {rpmanno.New},
 		brewsource.Name: {brewsource.New},
 	},
 }

--- a/internal/scalibrplugin/resolve_test.go
+++ b/internal/scalibrplugin/resolve_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/osv-scalibr/annotator/misc/brewsource"
 	apkanno "github.com/google/osv-scalibr/annotator/osduplicate/apk"
 	dpkganno "github.com/google/osv-scalibr/annotator/osduplicate/dpkg"
+	rpmanno "github.com/google/osv-scalibr/annotator/osduplicate/rpm"
 	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
 	"github.com/google/osv-scalibr/detector/cis/generic_linux/etcpasswdpermissions"
 	"github.com/google/osv-scalibr/detector/govulncheck/binary"
@@ -31,6 +32,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/os/apk"
 	"github.com/google/osv-scalibr/extractor/filesystem/os/dpkg"
 	"github.com/google/osv-scalibr/extractor/filesystem/os/homebrew"
+	rpmextractor "github.com/google/osv-scalibr/extractor/filesystem/os/rpm"
 	"github.com/google/osv-scalibr/extractor/filesystem/sbom/cdx"
 	"github.com/google/osv-scalibr/extractor/filesystem/sbom/spdx"
 	"github.com/google/osv-scanner/v2/internal/scalibrextract/filesystem/vendored"
@@ -521,9 +523,11 @@ func TestResolve_Extractors(t *testing.T) {
 				homebrew.Name,
 				gobinary.Name,
 				nodemodules.Name,
+				rpmextractor.Name,
 				wheelegg.Name,
 				apkanno.Name,
 				dpkganno.Name,
+				rpmanno.Name,
 				brewsource.Name,
 			},
 		},
@@ -542,9 +546,11 @@ func TestResolve_Extractors(t *testing.T) {
 				homebrew.Name,
 				gobinary.Name,
 				nodemodules.Name,
+				rpmextractor.Name,
 				wheelegg.Name,
 				apkanno.Name,
 				dpkganno.Name,
+				rpmanno.Name,
 				brewsource.Name,
 			},
 		},
@@ -569,8 +575,10 @@ func TestResolve_Extractors(t *testing.T) {
 				gobinary.Name,
 				homebrew.Name,
 				nodemodules.Name,
+				rpmextractor.Name,
 				apkanno.Name,
 				dpkganno.Name,
+				rpmanno.Name,
 				brewsource.Name,
 			},
 		},
@@ -591,10 +599,12 @@ func TestResolve_Extractors(t *testing.T) {
 				gitrepo.Name,
 				gobinary.Name,
 				nodemodules.Name,
+				rpmextractor.Name,
 				vendored.Name,
 				wheelegg.Name,
 				apkanno.Name,
 				dpkganno.Name,
+				rpmanno.Name,
 				brewsource.Name,
 			},
 		},
@@ -700,6 +710,21 @@ func TestResolve_Extractors_Presets(t *testing.T) {
 
 			testutility.NewSnapshot().MatchText(t, strings.Join(gotNames, "\n"))
 		})
+	}
+}
+
+func TestResolve_LockfilePresetIncludesRPM(t *testing.T) {
+	t.Parallel()
+
+	got := scalibrplugin.Resolve([]string{"lockfile"}, []string{}, &cpb.PluginConfig{})
+
+	gotNames := make([]string, 0, len(got))
+	for _, extractor := range got {
+		gotNames = append(gotNames, extractor.Name())
+	}
+
+	if !slices.Contains(gotNames, rpmextractor.Name) {
+		t.Fatalf("lockfile preset does not include %s", rpmextractor.Name)
 	}
 }
 

--- a/pkg/osvscanner/internal/scanners/lockfile.go
+++ b/pkg/osvscanner/internal/scanners/lockfile.go
@@ -38,6 +38,7 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem/language/rust/cargolock"
 	"github.com/google/osv-scalibr/extractor/filesystem/os/apk"
 	"github.com/google/osv-scalibr/extractor/filesystem/os/dpkg"
+	"github.com/google/osv-scalibr/extractor/filesystem/os/rpm"
 	"github.com/google/osv-scalibr/plugin"
 	"github.com/google/osv-scanner/v2/internal/scalibrextract/language/osv/osvscannerjson"
 )
@@ -74,6 +75,10 @@ var osvscannerScalibrExtractionMapping = map[string][]string{
 	"gems.locked":                 {gemfilelock.Name},
 	"cabal.project.freeze":        {cabal.Name},
 	"stack.yaml.lock":             {stacklock.Name},
+	"rpmdb":                       {rpm.Name},
+	"rpmdb.sqlite":                {rpm.Name},
+	"Packages":                    {rpm.Name},
+	"Packages.db":                 {rpm.Name},
 	// "Package.resolved":            {packageresolved.Name},
 }
 

--- a/pkg/osvscanner/internal/scanners/lockfile_test.go
+++ b/pkg/osvscanner/internal/scanners/lockfile_test.go
@@ -1,0 +1,32 @@
+package scanners_test
+
+import (
+	"testing"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+	rpmextractor "github.com/google/osv-scalibr/extractor/filesystem/os/rpm"
+	"github.com/google/osv-scanner/v2/internal/scalibrplugin"
+	"github.com/google/osv-scanner/v2/pkg/osvscanner/internal/scanners"
+)
+
+func TestParseAsToPlugin_RPM(t *testing.T) {
+	t.Parallel()
+
+	plugins := scalibrplugin.Resolve([]string{"lockfile"}, []string{}, &cpb.PluginConfig{})
+
+	tests := []string{"rpmdb", "Packages", "Packages.db", "rpmdb.sqlite"}
+	for _, parseAs := range tests {
+		t.Run(parseAs, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := scanners.ParseAsToPlugin(parseAs, plugins)
+			if err != nil {
+				t.Fatalf("ParseAsToPlugin(%q) returned error: %v", parseAs, err)
+			}
+
+			if got.Name() != rpmextractor.Name {
+				t.Fatalf("ParseAsToPlugin(%q) got %q, want %q", parseAs, got.Name(), rpmextractor.Name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds OSV-Scalibr's RPM package database extractor to OSV-Scanner's default plugin wiring so RPM databases can be scanned alongside the existing APK and DPKG OS package sources.

This also wires the RPM duplicate-package annotator for artifact scans and adds explicit lockfile parse aliases for common RPM database filenames: `rpmdb`, `rpmdb.sqlite`, `Packages`, and `Packages.db`.

Fixes #254.

## Testing

- `go test ./internal/scalibrplugin ./pkg/osvscanner/...`