### PR TITLE
output/vertical: sanitize pkg name/version to prevent GHA workflow-command injection

### DIFF
--- a/internal/output/vertical.go
+++ b/internal/output/vertical.go
@@ -90,7 +90,7 @@ func printVerticalLicenseViolations(source SourceResult, out io.Writer) {
 
 		fmt.Fprintf(out,
 			"    %s (%s)\n",
-			text.FgYellow.Sprintf("%s@%s", pkg.Name, pkg.InstalledVersion),
+			text.FgYellow.Sprintf("%s@%s", SanitizeForWorkflowCommand(pkg.Name), SanitizeForWorkflowCommand(pkg.InstalledVersion)),
 			text.FgCyan.Sprintf("%s", strings.Join(violations, ", ")),
 		)
 	}
@@ -115,7 +115,7 @@ func printVerticalPkgDeprecatedSummary(source SourceResult, out io.Writer) {
 
 		fmt.Fprintf(out,
 			"    %s\n",
-			text.FgYellow.Sprintf("%s@%s", pkg.Name, pkg.InstalledVersion),
+			text.FgYellow.Sprintf("%s@%s", SanitizeForWorkflowCommand(pkg.Name), SanitizeForWorkflowCommand(pkg.InstalledVersion)),
 		)
 	}
 }
@@ -227,7 +227,7 @@ func printVerticalVulnerabilitiesForPackages(packages []PackageResult, out io.Wr
 
 		fmt.Fprintf(out,
 			"  %s%s %s\n",
-			text.FgYellow.Sprintf("%s@%s", pkgSourceName, pkg.InstalledVersion),
+			text.FgYellow.Sprintf("%s@%s", SanitizeForWorkflowCommand(pkgSourceName), SanitizeForWorkflowCommand(pkg.InstalledVersion)),
 			text.FgYellow.Sprintf("%s", pkgNameInfo),
 			text.FgRed.Sprintf("has the following %s vulnerabilities:", state),
 		)


### PR DESCRIPTION
## Summary

The April 2026 fix (PR #2750, commit `f466f65`) sanitised source-file path strings at several sinks in `vertical.go` to close the GitHub Actions workflow-command injection first reported as issue #2749. Three `fmt.Fprintf` call sites were not covered by that fix:

| Function | Unsanitized fields |
|---|---|
| `printVerticalVulnerabilitiesForPackages` | `pkgSourceName`, `pkg.InstalledVersion` |
| `printVerticalLicenseViolations` | `pkg.Name`, `pkg.InstalledVersion` |
| `printVerticalPkgDeprecatedSummary` | `pkg.Name`, `pkg.InstalledVersion` |

`pkg.Name` and `pkg.InstalledVersion` are extracted verbatim from lock files. A crafted lock file can encode `\r::stop-commands::TOKEN\r` inside a version field using the standard JSON escape `\r`; Go's `encoding/json` decodes this to the raw CR byte (0x0D) before osv-scanner sees it. When `--format=vertical` is used in a GitHub Actions step, the GHA runner interprets the injected line as a live workflow directive, silencing all subsequent `::error::` annotations.

Note: `--format=table` (default) is unaffected because the `go-pretty` table renderer strips control characters. `--format=gh-annotations` already had explicit sanitisation from PR #2669.

## Fix

Apply `SanitizeForWorkflowCommand` to `pkg.Name`, `pkgSourceName`, and `pkg.InstalledVersion` at all three affected call sites.

## Reproduction

```bash
# Craft a lock file with CR injected into a version field
cat > /tmp/poc/package-lock.json <<'JSON'
{
  "name": "test-project", "version": "1.0.0", "lockfileVersion": 3,
  "requires": true,
  "packages": {
    "": {"name":"test-project","version":"1.0.0","dependencies":{"lodash":"4.17.20"}},
    "node_modules/lodash": {
      "version": "4.17.20\r::stop-commands::DISABLEDXYZ\r",
      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
    }
  }
}
JSON

osv-scanner --format=vertical /tmp/poc/package-lock.json | tr -cd '\r' | wc -c
# Before fix: 2  (two raw CR bytes — injected directive present)
# After fix:  0
```

Fixes #2749 (incomplete fix — remaining sinks in `vertical.go`).