### PR TITLE
docs: add scanner help docs link

### DIFF
--- a/cmd/osv-scanner/__snapshots__/main_test.snap
+++ b/cmd/osv-scanner/__snapshots__/main_test.snap
@@ -9,6 +9,8 @@ USAGE:
 DESCRIPTION:
    scans projects and container images for dependencies, and checks them against the OSV database.
 
+   For full usage details, see https://google.github.io/osv-scanner/
+
 COMMANDS:
    source  scans a source project's dependencies for known vulnerabilities using the OSV database.
    image   detects vulnerabilities in a container image's dependencies, pulling the image if it's not found locally
@@ -31,6 +33,8 @@ USAGE:
 
 DESCRIPTION:
    scans projects and container images for dependencies, and checks them against the OSV database.
+
+   For full usage details, see https://google.github.io/osv-scanner/
 
 COMMANDS:
    source  scans a source project's dependencies for known vulnerabilities using the OSV database.

--- a/cmd/osv-scanner/scan/command.go
+++ b/cmd/osv-scanner/scan/command.go
@@ -20,7 +20,7 @@ func Command(stdout, stderr io.Writer, client *http.Client) *cli.Command {
 	return &cli.Command{
 		Name:        "scan",
 		Usage:       "scans projects and container images for dependencies, and checks them against the OSV database.",
-		Description: "scans projects and container images for dependencies, and checks them against the OSV database.",
+		Description: "scans projects and container images for dependencies, and checks them against the OSV database.\n\nFor full usage details, see https://google.github.io/osv-scanner/",
 		Commands: []*cli.Command{
 			source.Command(stdout, stderr, client),
 			image.Command(stdout, stderr, client),


### PR DESCRIPTION
## Description

Fixes #2796.

Adds the OSV Scanner documentation URL to the `scan` command help text, so users who run `osv-scanner --help` or `osv-scanner scan --help` can find the full web documentation from the CLI output.

## Testing

- Updated the CLI snapshot in `cmd/osv-scanner/__snapshots__/main_test.snap`.
- I could not run `go test ./cmd/osv-scanner` locally because this environment does not have the `go` command installed.
