### PR TITLE
fix: preserve non-ignored vulns when all groups are filtered out

### DIFF
--- a/pkg/osvscanner/filter.go
+++ b/pkg/osvscanner/filter.go
@@ -182,11 +182,9 @@ func filterPackageVulns(pkgVulns models.PackageVulns, configToUse config.Config)
 	}
 
 	var newVulns []*osvschema.Vulnerability
-	if len(newGroups) > 0 { // If there are no groups left then there would be no vulnerabilities.
-		for _, vuln := range pkgVulns.Vulnerabilities {
-			if _, filtered := ignoredVulns[vuln.GetId()]; !filtered {
-				newVulns = append(newVulns, vuln)
-			}
+	for _, vuln := range pkgVulns.Vulnerabilities {
+		if _, filtered := ignoredVulns[vuln.GetId()]; !filtered {
+			newVulns = append(newVulns, vuln)
 		}
 	}
 

--- a/pkg/osvscanner/filter_internal_test.go
+++ b/pkg/osvscanner/filter_internal_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/osv-scanner/v2/internal/imodels/results"
 	"github.com/google/osv-scanner/v2/internal/testutility"
 	"github.com/google/osv-scanner/v2/pkg/models"
+	"github.com/ossf/osv-schema/bindings/go/osvschema"
 )
 
 func Test_filterUnscannablePackages_shortCommitHash(t *testing.T) {
@@ -69,6 +70,48 @@ func Test_filterUnscannablePackages_shortCommitHash(t *testing.T) {
 				t.Errorf("packages in filtered slice = %d, want %d", len(filtered), tt.wantFiltered)
 			}
 		})
+	}
+}
+
+func Test_filterPackageVulns_orphanVulnsPreserved(t *testing.T) {
+	t.Parallel()
+
+	// CVE-2024-001 is in both the group aliases and the vuln list.
+	// CVE-2024-999 is in the vuln list but NOT referenced by any group alias.
+	// When all groups are ignored (because CVE-2024-001 is ignored), the old guard
+	// `if len(newGroups) > 0` would skip the vuln loop entirely, silently dropping
+	// CVE-2024-999 even though it was never ignored.
+	pkgVulns := models.PackageVulns{
+		Groups: []models.GroupInfo{
+			{
+				IDs:     []string{"CVE-2024-001"},
+				Aliases: []string{"CVE-2024-001"},
+			},
+		},
+		Vulnerabilities: []*osvschema.Vulnerability{
+			{Id: "CVE-2024-001"},
+			{Id: "CVE-2024-999"},
+		},
+	}
+
+	cfg := config.Config{
+		IgnoredVulns: []*config.IgnoreEntry{
+			{ID: "CVE-2024-001"},
+		},
+	}
+
+	got := filterPackageVulns(pkgVulns, cfg)
+
+	if len(got.Groups) != 0 {
+		t.Errorf("groups after filter = %d, want 0", len(got.Groups))
+	}
+
+	if len(got.Vulnerabilities) != 1 {
+		t.Fatalf("vulnerabilities after filter = %d, want 1", len(got.Vulnerabilities))
+	}
+
+	if got.Vulnerabilities[0].GetId() != "CVE-2024-999" {
+		t.Errorf("remaining vuln id = %q, want %q", got.Vulnerabilities[0].GetId(), "CVE-2024-999")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #2756.

`filterPackageVulns` in `pkg/osvscanner/filter.go` had a logic guard:

```go
if len(newGroups) > 0 { // If there are no groups left then there would be no vulnerabilities.
    for _, vuln := range pkgVulns.Vulnerabilities { ... }
}
```

This assumption does not hold. A vulnerability can exist in the `Vulnerabilities` slice without being referenced by any group's `Aliases`. When the ignore config caused all groups to be filtered out, the entire vulnerability loop was skipped -- silently dropping any vulnerability that was not explicitly ignored.

**Example scenario that was broken:**

- Groups: `[G1{Aliases: ["CVE-2024-001"]}]`
- Vulnerabilities: `[{ID: "CVE-2024-001"}, {ID: "CVE-2024-999"}]`
- Ignore config: ignore `"CVE-2024-001"`
- Before fix: both vulns dropped (CVE-2024-999 never ignored, but silently lost)
- After fix: CVE-2024-999 correctly preserved

## Changes

- `pkg/osvscanner/filter.go`: removed the `if len(newGroups) > 0` guard; the `ignoredVulns` map already handles filtering correctly on its own
- `pkg/osvscanner/filter_internal_test.go`: added `Test_filterPackageVulns_orphanVulnsPreserved` that directly exercises the bug scenario

## Test plan

- [x] New unit test `Test_filterPackageVulns_orphanVulnsPreserved` covers the exact failure case
- [x] All existing `Test_filterResults` snapshot tests still pass