### PR TITLE
feat: introduce top-level plugins list command for active scalibr plugins

### DIFF
--- a/cmd/osv-scanner/main.go
+++ b/cmd/osv-scanner/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/google/osv-scanner/v2/cmd/osv-scanner/fix"
 	"github.com/google/osv-scanner/v2/cmd/osv-scanner/internal/cmd"
 	"github.com/google/osv-scanner/v2/cmd/osv-scanner/mcp"
+	"github.com/google/osv-scanner/v2/cmd/osv-scanner/plugins"
 	"github.com/google/osv-scanner/v2/cmd/osv-scanner/scan"
 	"github.com/google/osv-scanner/v2/cmd/osv-scanner/update"
 )
@@ -15,6 +16,7 @@ func main() {
 		cmd.Run(os.Args, os.Stdout, os.Stderr, nil, []cmd.CommandBuilder{
 			scan.Command,
 			fix.Command,
+			plugins.Command,
 			update.Command,
 			mcp.Command,
 		}),

--- a/cmd/osv-scanner/plugins/command.go
+++ b/cmd/osv-scanner/plugins/command.go
@@ -1,0 +1,45 @@
+package plugins
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/google/osv-scanner/v2/internal/scalibrplugin"
+	"github.com/urfave/cli/v3"
+)
+
+func Command(stdout, _ io.Writer, _ *http.Client) *cli.Command {
+	return &cli.Command{
+		Name:        "plugins",
+		Usage:       "lists the available experimental plugin presets and exact plugin names",
+		Description: "Lists the available experimental plugin presets and exact plugin names that can be passed to --experimental-plugins or --experimental-disable-plugins.",
+		Commands: []*cli.Command{
+			{
+				Name:        "list",
+				Usage:       "lists the available plugin presets and exact plugin names",
+				Description: "Lists the available experimental plugin presets and exact plugin names that can be passed to --experimental-plugins or --experimental-disable-plugins.",
+				Action: func(_ context.Context, _ *cli.Command) error {
+					printPluginCatalog(stdout)
+					return nil
+				},
+			},
+		},
+	}
+}
+
+func printPluginCatalog(stdout io.Writer) {
+	fmt.Fprintln(stdout, "Available plugin presets:")
+	fmt.Fprintf(stdout, "  extractors: %s\n", strings.Join(scalibrplugin.ExtractorPresetNames(), ", "))
+	fmt.Fprintf(stdout, "  detectors: %s\n", strings.Join(scalibrplugin.DetectorPresetNames(), ", "))
+	fmt.Fprintf(stdout, "  annotators: %s\n", strings.Join(scalibrplugin.AnnotatorPresetNames(), ", "))
+	fmt.Fprintf(stdout, "  enrichers: %s\n", strings.Join(scalibrplugin.EnricherPresetNames(), ", "))
+	fmt.Fprintln(stdout)
+
+	fmt.Fprintln(stdout, "Available exact plugin names:")
+	for _, name := range scalibrplugin.PluginNames() {
+		fmt.Fprintf(stdout, "  %s\n", name)
+	}
+}

--- a/cmd/osv-scanner/plugins/command_test.go
+++ b/cmd/osv-scanner/plugins/command_test.go
@@ -1,0 +1,58 @@
+package plugins_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/osv-scanner/v2/cmd/osv-scanner/internal/testcmd"
+)
+
+func TestCommand_List(t *testing.T) {
+	t.Parallel()
+
+	stdout, stderr := testcmd.RunAndNormalize(t, testcmd.Case{
+		Name: "list",
+		Args: []string{"", "plugins", "list"},
+		Exit: 0,
+	})
+
+	if stderr != "" {
+		t.Fatalf("plugins list wrote to stderr: %q", stderr)
+	}
+
+	for _, want := range []string{
+		"Available plugin presets:",
+		"extractors: artifact, directory, lockfile, sbom",
+		"detectors: cis, govulncheck, untested, weakcreds",
+		"annotators: artifact",
+		"enrichers: artifact, licenses, transitive, vulns",
+		"Available exact plugin names:",
+		"javascript/packagelockjson",
+		"os/apk",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("plugins list output missing %q\noutput:\n%s", want, stdout)
+		}
+	}
+}
+
+func TestCommand_Help(t *testing.T) {
+	t.Parallel()
+
+	stdout, stderr := testcmd.RunAndNormalize(t, testcmd.Case{
+		Name: "help",
+		Args: []string{"", "plugins", "--help"},
+		Exit: 127,
+	})
+
+	combined := stdout + "\n" + stderr
+	for _, want := range []string{
+		"osv-scanner plugins",
+		"lists the available experimental plugin presets and exact plugin names",
+		"list",
+	} {
+		if !strings.Contains(combined, want) {
+			t.Fatalf("plugins help output missing %q\noutput:\n%s", want, combined)
+		}
+	}
+}

--- a/cmd/osv-scanner/plugins/testmain_test.go
+++ b/cmd/osv-scanner/plugins/testmain_test.go
@@ -1,15 +1,12 @@
-package main
+package plugins_test
 
 import (
 	"log/slog"
 	"testing"
 
-	"github.com/google/osv-scanner/v2/cmd/osv-scanner/fix"
 	"github.com/google/osv-scanner/v2/cmd/osv-scanner/internal/cmd"
 	"github.com/google/osv-scanner/v2/cmd/osv-scanner/internal/testcmd"
 	"github.com/google/osv-scanner/v2/cmd/osv-scanner/plugins"
-	"github.com/google/osv-scanner/v2/cmd/osv-scanner/scan"
-	"github.com/google/osv-scanner/v2/cmd/osv-scanner/update"
 	"github.com/google/osv-scanner/v2/internal/config"
 	"github.com/google/osv-scanner/v2/internal/testlogger"
 	"github.com/google/osv-scanner/v2/internal/testutility"
@@ -17,25 +14,8 @@ import (
 
 func TestMain(m *testing.M) {
 	config.OSVScannerConfigName = "osv-scanner-test.toml"
-
-	cleanupGitFixtures, err := testcmd.SetupGitFixtures()
-
-	if err != nil {
-		cleanupGitFixtures()
-
-		panic(err)
-	}
-
 	slog.SetDefault(slog.New(testlogger.New()))
-	testcmd.CommandsUnderTest = []cmd.CommandBuilder{
-		scan.Command,
-		fix.Command,
-		plugins.Command,
-		update.Command,
-	}
+	testcmd.CommandsUnderTest = []cmd.CommandBuilder{plugins.Command}
 	m.Run()
-
-	cleanupGitFixtures()
-
 	testutility.CleanSnapshots(m)
 }

--- a/internal/scalibrplugin/resolve.go
+++ b/internal/scalibrplugin/resolve.go
@@ -3,6 +3,7 @@ package scalibrplugin
 
 import (
 	"fmt"
+	"maps"
 	"slices"
 
 	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
@@ -122,4 +123,64 @@ func filterPluginsMissingRequiredPlugins(pluginStatues map[string]bool, loaded [
 	}
 
 	return plugins
+}
+
+func sortedPresetNames[T any](presets map[string]T) []string {
+	names := slices.Collect(maps.Keys(presets))
+	slices.Sort(names)
+
+	return names
+}
+
+func sortedNestedPluginNames[T any](presets map[string]map[string]T) []string {
+	seen := map[string]struct{}{}
+
+	for _, preset := range presets {
+		for name := range preset {
+			seen[name] = struct{}{}
+		}
+	}
+
+	names := slices.Collect(maps.Keys(seen))
+	slices.Sort(names)
+
+	return names
+}
+
+func ExtractorPresetNames() []string {
+	return sortedPresetNames(ExtractorPresets)
+}
+
+func DetectorPresetNames() []string {
+	return sortedPresetNames(detectorPresets)
+}
+
+func AnnotatorPresetNames() []string {
+	return sortedPresetNames(annotatorPresets)
+}
+
+func EnricherPresetNames() []string {
+	return sortedPresetNames(enricherPresets)
+}
+
+func PluginNames() []string {
+	seen := map[string]struct{}{}
+
+	for _, name := range sortedNestedPluginNames(ExtractorPresets) {
+		seen[name] = struct{}{}
+	}
+	for _, name := range sortedNestedPluginNames(detectorPresets) {
+		seen[name] = struct{}{}
+	}
+	for _, name := range sortedNestedPluginNames(annotatorPresets) {
+		seen[name] = struct{}{}
+	}
+	for _, name := range sortedNestedPluginNames(enricherPresets) {
+		seen[name] = struct{}{}
+	}
+
+	names := slices.Collect(maps.Keys(seen))
+	slices.Sort(names)
+
+	return names
 }

--- a/internal/scalibrplugin/resolve_test.go
+++ b/internal/scalibrplugin/resolve_test.go
@@ -186,6 +186,34 @@ func TestResolve(t *testing.T) {
 	}
 }
 
+func TestExtractorPresetNames(t *testing.T) {
+	t.Parallel()
+
+	got := scalibrplugin.ExtractorPresetNames()
+	want := []string{"artifact", "directory", "lockfile", "sbom"}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("ExtractorPresetNames() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestPluginNames(t *testing.T) {
+	t.Parallel()
+
+	got := scalibrplugin.PluginNames()
+
+	for _, want := range []string{
+		composerlock.Name,
+		apk.Name,
+		transitivedependencypomxml.Name,
+		codeserver.Name,
+	} {
+		if !slices.Contains(got, want) {
+			t.Fatalf("PluginNames() missing %q", want)
+		}
+	}
+}
+
 func TestResolve_Detectors(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Description
This PR introduces a new top-level CLI command `plugins list` to address the missing capability of inspecting active/installed plugins directly via the CLI (resolving the capability requested in #2783).

Instead of adding complex output formats, the command is built as a lightweight, clean entry point that interfaces with the underlying plugin catalog helper layer.

## Changes
* **`cmd/osv-scanner/main.go` & `testmain_test.go`**: Registered the new `plugins` command group and wired dependencies.
* **`cmd/osv-scanner/plugins/`**: Created the new sub-command structure (`command.go`), integration tests (`command_test.go`), and testing bootstraps.
* **`internal/scalibrplugin/`**: Implemented `resolve.go` and its respective tests to cleanly fetch and expose the active plugin list from the catalog without bleeding internal structures into the CLI logic.

## Testing Strategy
* Added unit tests for the plugin resolution helper logic under `internal/scalibrplugin`.
* Added integration/CLI validation tests in `cmd/osv-scanner/plugins/command_test.go` using pure content-matching assertions instead of strict file-based snapshots to reduce future CI/CD friction and ensure test stability.