### PR TITLE
test: fail fast on missing VCR cassettes by converting errors to 404

### DIFF
--- a/cmd/osv-scanner/internal/testcmd/vcr.go
+++ b/cmd/osv-scanner/internal/testcmd/vcr.go
@@ -3,6 +3,7 @@ package testcmd
 import (
 	"bytes"
 	"cmp"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -173,7 +174,10 @@ func InsertCassette(t *testing.T) *http.Client {
 		sortCassetteInteractions(t, path)
 	})
 
-	return r.GetDefaultClient()
+	client := r.GetDefaultClient()
+	client.Transport = &vcrErrorWrappingTransport{wrapper: client.Transport}
+
+	return client
 }
 
 // sortCassetteInteractions reorders the interactions in the given cassette, based
@@ -254,4 +258,24 @@ func matchBody(r *http.Request, i cassette.Request) bool {
 	}
 
 	return true
+}
+
+type vcrErrorWrappingTransport struct {
+	wrapper http.RoundTripper
+}
+
+func (t *vcrErrorWrappingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.wrapper.RoundTrip(req)
+	if err != nil && errors.Is(err, cassette.ErrInteractionNotFound) {
+		// Convert VCR error to a 404 response to avoid retries by the client
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Status:     "404 Not Found (VCR: requested interaction not found)",
+			Body:       io.NopCloser(strings.NewReader("VCR: requested interaction not found")),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	}
+
+	return resp, err
 }


### PR DESCRIPTION
If a VCR cassette or a specific interaction is missing, the OSV client would previously retry the request 4 times with exponential backoff, causing significant delays in test execution (over 20 seconds).

This change wraps the VCR client transport in tests to intercept the "requested interaction not found" error (using `errors.Is` with `cassette.ErrInteractionNotFound` for robust matching) and convert it to a "404 Not Found" response. Since the OSV client does not retry on 404 status codes, this allows tests to fail immediately (~0.02s) when a cassette or interaction is missing while still preserving retry behavior for genuine transient network errors.

This approach avoids modifying the core `osvscanner` library API or adding new CLI flags.

- Implemented `vcrErrorWrappingTransport` in `internal/testcmd/vcr.go`
- Wrapped the VCR client transport in `InsertCassette`
- Used `errors.Is` with `cassette.ErrInteractionNotFound` for robust error matching