### PR TITLE
fix(filter): preserve vulnerabilities not covered by any group when all groups are ignored

### DIFF
--- a/pkg/osvscanner/filter.go
+++ b/pkg/osvscanner/filter.go
@@ -182,11 +182,9 @@ func filterPackageVulns(pkgVulns models.PackageVulns, configToUse config.Config)
 	}
 
 	var newVulns []*osvschema.Vulnerability
-	if len(newGroups) > 0 { // If there are no groups left then there would be no vulnerabilities.
-		for _, vuln := range pkgVulns.Vulnerabilities {
-			if _, filtered := ignoredVulns[vuln.GetId()]; !filtered {
-				newVulns = append(newVulns, vuln)
-			}
+	for _, vuln := range pkgVulns.Vulnerabilities {
+		if _, filtered := ignoredVulns[vuln.GetId()]; !filtered {
+			newVulns = append(newVulns, vuln)
 		}
 	}
 


### PR DESCRIPTION
﻿Fixes #2756

`filterPackageVulns` skipped the vulnerability loop entirely when `len(newGroups) == 0` (all groups filtered by ignore config). This silently dropped any vulnerability whose ID was not in `ignoredVulns` -- i.e., not explicitly ignored but also not referenced by any group alias.

The `ignoredVulns` map already handles per-vulnerability filtering correctly. The outer guard was a premature optimization based on the assumption "no groups = no vulns", which is not an enforced invariant.

Removing the guard makes the behavior safe: if the invariant holds, output is identical; if it ever breaks (data inconsistency, schema changes), vulnerabilities are correctly preserved rather than silently lost.