### PR TITLE
fix: harden experimental MCP server access

### DIFF
--- a/cmd/osv-scanner/mcp/__snapshots__/integration_test.snap
+++ b/cmd/osv-scanner/mcp/__snapshots__/integration_test.snap
@@ -17,12 +17,12 @@ Total 1 package affected by 1 known vulnerability (0 Critical, 0 High, 1 Medium,
 
 Go
 
-lockfile:<rootdir>/testdata/go-project/go.mod: found 1 package with issues
+lockfile:<workspace>/testdata/go-project/go.mod: found 1 package with issues
 
   github.com/ipfs/go-bitfield@1.0.0 has the following known vulnerabilities:
     GO-2023-1558: Denial of service via malformed size parameters in github.com/ipfs/go-bitfield
       Severity: '5.9'; Minimal Fix Version: '1.1.0';
 
-  1 known vulnerability found in lockfile:<rootdir>/testdata/go-project/go.mod
+  1 known vulnerability found in lockfile:<workspace>/testdata/go-project/go.mod
 
 ---

--- a/cmd/osv-scanner/mcp/command.go
+++ b/cmd/osv-scanner/mcp/command.go
@@ -3,15 +3,18 @@ package mcp
 
 import (
 	"context"
+	"crypto/subtle"
 	_ "embed"
 	"errors"
 	"fmt"
 	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
-
-	"net/http"
 
 	"github.com/google/osv-scanner/v2/internal/cmdlogger"
 	"github.com/google/osv-scanner/v2/internal/output"
@@ -44,6 +47,16 @@ func Command(_, _ io.Writer, _ *http.Client) *cli.Command {
 				Value:       "localhost:8080",
 				Usage:       "The listening address for the SSE server, e.g. localhost:8080",
 			},
+			&cli.StringFlag{
+				Name:    "sse-token",
+				Usage:   "Bearer token required by SSE clients. Required when --sse listens on a non-loopback address.",
+				Sources: cli.EnvVars("OSV_SCANNER_MCP_SSE_TOKEN"),
+			},
+			&cli.StringSliceFlag{
+				Name:  "workspace",
+				Usage: "Workspace root that MCP scan paths must stay within. May be repeated.",
+				Value: []string{"."},
+			},
 		},
 		Action: action,
 	}
@@ -57,6 +70,12 @@ type scanVulnerableDependenciesInput struct {
 }
 
 func action(ctx context.Context, cmd *cli.Command) error {
+	workspaceRoots, err := resolveWorkspaceRoots(cmd.StringSlice("workspace"))
+	if err != nil {
+		return err
+	}
+	scanner := scanHandler{workspaceRoots: workspaceRoots}
+
 	s := mcp.NewServer(&mcp.Implementation{
 		Name: "OSV-Scanner", Version: version.OSVVersion,
 	}, nil)
@@ -66,7 +85,7 @@ func action(ctx context.Context, cmd *cli.Command) error {
 		Description: "Scans a source directory for vulnerable dependencies." +
 			" Walks the given directory and uses osv.dev to query for vulnerabilities matching the found dependencies." +
 			" Use this tool to check that the user's project is not depending on known vulnerable code.",
-	}, handleScan)
+	}, scanner.handleScan)
 
 	// TODO(another-rex): Ideally both of the following tools would be resources, but gemini-cli does not support those yet.
 	mcp.AddTool(s, &mcp.Tool{
@@ -87,13 +106,18 @@ func action(ctx context.Context, cmd *cli.Command) error {
 	// Provide two options, sse on a network port, or stdio.
 	if cmd.IsSet("sse") {
 		sseAddr := cmd.String("sse")
+		sseToken := cmd.String("sse-token")
+		if sseToken == "" && !isLoopbackListenAddr(sseAddr) {
+			return fmt.Errorf("--sse-token or OSV_SCANNER_MCP_SSE_TOKEN is required when --sse listens on a non-loopback address")
+		}
+
 		cmdlogger.Infof("Starting SSE server on %s", sseAddr)
 		handler := mcp.NewSSEHandler(func(_ *http.Request) *mcp.Server {
 			return s
 		}, nil)
 		srv := &http.Server{
 			Addr:         sseAddr,
-			Handler:      handler,
+			Handler:      requireBearerToken(handler, sseToken),
 			ReadTimeout:  30 * time.Second,
 			WriteTimeout: 30 * time.Second,
 			IdleTimeout:  120 * time.Second,
@@ -114,14 +138,28 @@ func action(ctx context.Context, cmd *cli.Command) error {
 	return nil
 }
 
-func handleScan(_ context.Context, _ *mcp.CallToolRequest, input *scanVulnerableDependenciesInput) (*mcp.CallToolResult, any, error) {
-	statsCollector := fileOpenedLogger{}
+type scanHandler struct {
+	workspaceRoots []string
+}
+
+func (h scanHandler) handleScan(_ context.Context, _ *mcp.CallToolRequest, input *scanVulnerableDependenciesInput) (*mcp.CallToolResult, any, error) {
+	if input == nil {
+		return nil, nil, errors.New("missing scan input")
+	}
+
+	scanPaths, err := h.validateScanPaths(input.Paths)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	statsCollector := fileOpenedLogger{workspaceRoots: h.workspaceRoots}
 
 	action := osvscanner.ScannerActions{
-		DirectoryPaths:      input.Paths,
+		DirectoryPaths:      scanPaths,
 		ScanLicensesSummary: false,
 		ExperimentalScannerActions: osvscanner.ExperimentalScannerActions{
-			StatsCollector: &statsCollector,
+			ExcludePatterns: input.IgnoreGlobPatterns,
+			StatsCollector:  &statsCollector,
 		},
 		CallAnalysisStates: map[string]bool{
 			"go": true,
@@ -160,9 +198,136 @@ func handleScan(_ context.Context, _ *mcp.CallToolRequest, input *scanVulnerable
 
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
-			&mcp.TextContent{Text: buf.String()},
+			&mcp.TextContent{Text: h.redactWorkspaceRoots(buf.String())},
 		},
 	}, nil, nil
+}
+
+func resolveWorkspaceRoots(paths []string) ([]string, error) {
+	if len(paths) == 0 {
+		paths = []string{"."}
+	}
+
+	roots := make([]string, 0, len(paths))
+	for _, path := range paths {
+		absPath, err := filepath.Abs(path)
+		if err != nil {
+			return nil, fmt.Errorf("resolve workspace %q: %w", path, err)
+		}
+
+		resolvedPath, err := filepath.EvalSymlinks(absPath)
+		if err != nil {
+			return nil, fmt.Errorf("resolve workspace %q: %w", path, err)
+		}
+
+		info, err := os.Stat(resolvedPath)
+		if err != nil {
+			return nil, fmt.Errorf("stat workspace %q: %w", path, err)
+		}
+		if !info.IsDir() {
+			return nil, fmt.Errorf("workspace %q is not a directory", path)
+		}
+
+		roots = append(roots, filepath.Clean(resolvedPath))
+	}
+
+	return roots, nil
+}
+
+func (h scanHandler) validateScanPaths(paths []string) ([]string, error) {
+	scanPaths := make([]string, 0, len(paths))
+	for _, path := range paths {
+		resolvedPath, err := resolveScanPath(path)
+		if err != nil {
+			return nil, err
+		}
+		if !pathInAnyRoot(resolvedPath, h.workspaceRoots) {
+			return nil, fmt.Errorf("scan path %q is outside the configured MCP workspace", path)
+		}
+
+		scanPaths = append(scanPaths, resolvedPath)
+	}
+
+	return scanPaths, nil
+}
+
+func resolveScanPath(path string) (string, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("resolve scan path %q: %w", path, err)
+	}
+
+	resolvedPath, err := filepath.EvalSymlinks(absPath)
+	if err == nil {
+		return filepath.Clean(resolvedPath), nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return filepath.Clean(absPath), nil
+	}
+
+	return "", fmt.Errorf("resolve scan path %q: %w", path, err)
+}
+
+func pathInAnyRoot(path string, roots []string) bool {
+	for _, root := range roots {
+		if pathInRoot(path, root) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func pathInRoot(path, root string) bool {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel))
+}
+
+func (h scanHandler) redactWorkspaceRoots(text string) string {
+	return redactWorkspaceRoots(text, h.workspaceRoots)
+}
+
+func redactWorkspaceRoots(text string, roots []string) string {
+	for _, root := range roots {
+		text = strings.ReplaceAll(text, root, "<workspace>")
+		text = strings.ReplaceAll(text, filepath.ToSlash(root), "<workspace>")
+	}
+
+	return text
+}
+
+func requireBearerToken(next http.Handler, token string) http.Handler {
+	if token == "" {
+		return next
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+		if subtle.ConstantTimeCompare([]byte(got), []byte(token)) != 1 {
+			w.Header().Set("WWW-Authenticate", "Bearer")
+			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func isLoopbackListenAddr(addr string) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return false
+	}
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 // getVulnerabilityDetailsInput is the input for the get_vulnerability_details tool.

--- a/cmd/osv-scanner/mcp/command_internal_test.go
+++ b/cmd/osv-scanner/mcp/command_internal_test.go
@@ -1,0 +1,150 @@
+package mcp
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestIsLoopbackListenAddr(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		addr string
+		want bool
+	}{
+		{name: "localhost", addr: "localhost:8080", want: true},
+		{name: "ipv4 loopback", addr: "127.0.0.1:8080", want: true},
+		{name: "ipv6 loopback", addr: "[::1]:8080", want: true},
+		{name: "all interfaces", addr: ":8080", want: false},
+		{name: "ipv4 all interfaces", addr: "0.0.0.0:8080", want: false},
+		{name: "public host", addr: "example.com:8080", want: false},
+		{name: "missing port", addr: "localhost", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := isLoopbackListenAddr(tt.addr); got != tt.want {
+				t.Fatalf("isLoopbackListenAddr(%q) = %t, want %t", tt.addr, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRequireBearerToken(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	handler := requireBearerToken(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusNoContent)
+	}), "secret")
+
+	req := httptest.NewRequest(http.MethodGet, "/sse", nil)
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusUnauthorized {
+		t.Fatalf("missing token response code = %d, want %d", resp.Code, http.StatusUnauthorized)
+	}
+	if called {
+		t.Fatal("handler called without bearer token")
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/sse", nil)
+	req.Header.Set("Authorization", "Bearer wrong")
+	resp = httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusUnauthorized {
+		t.Fatalf("wrong token response code = %d, want %d", resp.Code, http.StatusUnauthorized)
+	}
+	if called {
+		t.Fatal("handler called with wrong bearer token")
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/sse", nil)
+	req.Header.Set("Authorization", "Bearer secret")
+	resp = httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusNoContent {
+		t.Fatalf("valid token response code = %d, want %d", resp.Code, http.StatusNoContent)
+	}
+	if !called {
+		t.Fatal("handler not called with valid bearer token")
+	}
+}
+
+func TestValidateScanPathsRequiresWorkspaceDescendant(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	inside := filepath.Join(root, "project")
+	if err := os.Mkdir(inside, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	roots, err := resolveWorkspaceRoots([]string{root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler := scanHandler{workspaceRoots: roots}
+
+	if _, err := handler.validateScanPaths([]string{inside}); err != nil {
+		t.Fatalf("inside workspace path rejected: %v", err)
+	}
+
+	outside := t.TempDir()
+	if _, err := handler.validateScanPaths([]string{outside}); err == nil {
+		t.Fatal("outside workspace path accepted")
+	}
+}
+
+func TestValidateScanPathsRejectsSymlinkEscape(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated privileges on some Windows builders")
+	}
+
+	root := t.TempDir()
+	outside := t.TempDir()
+	link := filepath.Join(root, "outside-link")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Fatal(err)
+	}
+
+	roots, err := resolveWorkspaceRoots([]string{root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler := scanHandler{workspaceRoots: roots}
+
+	if _, err := handler.validateScanPaths([]string{link}); err == nil {
+		t.Fatal("symlink escape path accepted")
+	}
+}
+
+func TestRedactWorkspaceRoots(t *testing.T) {
+	t.Parallel()
+
+	roots, err := resolveWorkspaceRoots([]string{t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler := scanHandler{workspaceRoots: roots}
+
+	fullPath := filepath.Join(roots[0], "go.mod")
+	got := handler.redactWorkspaceRoots("scanned " + fullPath)
+	if strings.Contains(got, roots[0]) {
+		t.Fatalf("redacted text still contains workspace root %q: %q", roots[0], got)
+	}
+	if !strings.Contains(got, "<workspace>") {
+		t.Fatalf("redacted text = %q, want workspace marker", got)
+	}
+}

--- a/cmd/osv-scanner/mcp/integration_test.go
+++ b/cmd/osv-scanner/mcp/integration_test.go
@@ -26,6 +26,7 @@ func TestIntegration_MCP_SSE_Subprocess(t *testing.T) {
 	if testing.Short() {
 		testutility.Skip(t, "skipping integration test in short mode")
 	}
+	t.Setenv("OSV_SCANNER_MCP_SSE_TOKEN", "")
 
 	binPath := buildTestBinary(t)
 	addr := findFreePort(t)

--- a/cmd/osv-scanner/mcp/stats.go
+++ b/cmd/osv-scanner/mcp/stats.go
@@ -11,6 +11,7 @@ import (
 type fileOpenedLogger struct {
 	stats.NoopCollector
 
+	workspaceRoots []string
 	collectedLines []string
 }
 
@@ -26,7 +27,7 @@ func (c *fileOpenedLogger) AfterExtractorRun(_ string, extractorstats *stats.Aft
 	c.collectedLines = append(c.collectedLines,
 		fmt.Sprintf(
 			"Scanned %s file and found %d %s",
-			filepath.Join(extractorstats.Root, extractorstats.Path),
+			redactWorkspaceRoots(filepath.Join(extractorstats.Root, extractorstats.Path), c.workspaceRoots),
 			pkgsFound,
 			output.Form(pkgsFound, "package", "packages"),
 		))


### PR DESCRIPTION
## Summary
- restrict experimental MCP scan paths to configured workspace roots, including symlink-aware path resolution
- require an SSE bearer token when listening on non-loopback addresses, with optional `OSV_SCANNER_MCP_SSE_TOKEN` support
- redact workspace roots from MCP scan output and wire `ignore_glob_patterns` into scanner exclude patterns

Refs #2785. Thanks @Tobsboy2 for the public report and suggested hardening direction.

## Tests
- `go test ./cmd/osv-scanner/mcp ./pkg/osvscanner`
- `UPDATE_SNAPS=true go test ./cmd/osv-scanner/mcp`