### PR TITLE
fix(vulns): skip version comparison instead of panicking on unsupported ecosystems

### DIFF
--- a/internal/utility/vulns/vulnerability.go
+++ b/internal/utility/vulns/vulnerability.go
@@ -42,7 +42,14 @@ func rangeContainsVersion(ar *osvschema.Range, pkg *extractor.Package) bool {
 		return false
 	}
 
-	vp := semantic.MustParse(imodels.Version(pkg), string(imodels.Ecosystem(pkg).Ecosystem))
+	ecosystem := string(imodels.Ecosystem(pkg).Ecosystem)
+	vp, err := semantic.Parse(imodels.Version(pkg), ecosystem)
+	if err != nil {
+		// Skip version comparison when the ecosystem has no semantic parser
+		// (e.g. GitHub Actions). Returning false matches online-mode behavior.
+		cmdlogger.Debugf("skipping version comparison for %s package %s@%s: %v", ecosystem, imodels.Name(pkg), imodels.Version(pkg), err)
+		return false
+	}
 
 	sort.Slice(ar.GetEvents(), func(i, j int) bool {
 		a := ar.GetEvents()[i]
@@ -56,8 +63,12 @@ func rangeContainsVersion(ar *osvschema.Range, pkg *extractor.Package) bool {
 			return false
 		}
 
-		// Ignore errors as we assume the version is correct
-		order, _ := semantic.MustParse(eventVersion(a), string(imodels.Ecosystem(pkg).Ecosystem)).CompareStr((eventVersion(b)))
+		// Fall back to stable sort order if an advisory event version fails to parse.
+		av, errA := semantic.Parse(eventVersion(a), ecosystem)
+		if errA != nil {
+			return false
+		}
+		order, _ := av.CompareStr(eventVersion(b))
 
 		return order < 0
 	})

--- a/internal/utility/vulns/vulnerability_test.go
+++ b/internal/utility/vulns/vulnerability_test.go
@@ -735,3 +735,44 @@ func TestOSV_EcosystemsWithSuffix(t *testing.T) {
 		t.Errorf("Expected OSV to affect package version %s but it did not", "0.0.0")
 	}
 }
+
+// TestOSV_IsAffected_UnsupportedEcosystemDoesNotPanic is a regression test for
+// https://github.com/google/osv-scanner/issues/2831, where an SBOM containing
+// a `pkg:github/...` component crashed the offline matcher because
+// `semantic.MustParse` panicked on the "GitHub Actions" ecosystem string.
+func TestOSV_IsAffected_UnsupportedEcosystemDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("IsAffected panicked on unsupported ecosystem: %v", r)
+		}
+	}()
+
+	pkg := &extractor.Package{
+		Name:     "actions/download-artifact",
+		Version:  "v3",
+		PURLType: purl.TypeGithub,
+	}
+
+	vuln := &osvschema.Vulnerability{
+		Id: "GHSA-test-unsupported",
+		Affected: []*osvschema.Affected{{
+			Package: &osvschema.Package{
+				Name:      "actions/download-artifact",
+				Ecosystem: "GitHub Actions",
+			},
+			Ranges: []*osvschema.Range{{
+				Type: osvschema.Range_ECOSYSTEM,
+				Events: []*osvschema.Event{
+					{Introduced: "0"},
+					{Fixed: "v4.0.0"},
+				},
+			}},
+		}},
+	}
+
+	if vulns.IsAffected(vuln, pkg) {
+		t.Errorf("Expected IsAffected to return false for unsupported ecosystem (no version comparison possible)")
+	}
+}


### PR DESCRIPTION
## Overview

Fixes #2831

Offline scans crash with `panic: unsupported ecosystem GitHub Actions` when an SBOM contains `pkg:github/...` components. `internal/utility/vulns/vulnerability.go:45` calls `semantic.MustParse(version, ecosystem)`, which panics on any ecosystem osv-scalibr's `semantic` package doesn't implement.

## Details

Two changes in `rangeContainsVersion`:

1. The top-level version parse swaps `semantic.MustParse` for `semantic.Parse` and returns `false` on error (with a debug log noting the skipped package). False matches the behavior of online mode, which silently reports no findings for the same input.
2. The inner sort closure also used `MustParse`. Switched to `Parse` + skip on error so a malformed advisory event version can't take the whole scan down either.

This is intentionally defensive at the osv-scanner layer rather than adding `GitHub Actions` semantics to osv-scalibr. The benefit is the scanner becomes robust to any future ecosystem the parser doesn't know yet, not just this one.

Note: there is also a separate false-negative bug (online mode silently drops GitHub Actions advisories) the reporter mentioned — that's a data path issue, not in scope for this PR.

## Testing

- Added `TestOSV_IsAffected_UnsupportedEcosystemDoesNotPanic` reproducing the original crash; fails on `main` (panic), passes with this patch.
- `go test ./internal/utility/vulns/...` and `go test ./internal/clients/clientimpl/localmatcher/...` (also in the panic stack) both pass.
- `./scripts/run_lints.sh` clean on the touched files.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/).
- [x] I have run the linter using `./scripts/run_lints.sh`.
- [x] I have run the unit tests using `./scripts/run_tests.sh`.
- [x] I have made my commits and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
