### PR TITLE
chore: adjust "report uncleaned snapshots" script to output valid GHA annotations

### DIFF
--- a/scripts/report_uncleaned_snapshots.py
+++ b/scripts/report_uncleaned_snapshots.py
@@ -6,7 +6,7 @@ import glob
 
 def annotate_file(file, msg):
   if os.getenv('CI') is not None:
-    print(f'::error file={file}::{msg}')
+    print(f'::error file={file},line=1::{msg}')
 
 
 def does_clean_snapshots(pkg_dir):

--- a/scripts/report_uncleaned_snapshots.py
+++ b/scripts/report_uncleaned_snapshots.py
@@ -6,7 +6,7 @@ import glob
 
 def annotate_file(file, msg):
   if os.getenv('CI') is not None:
-    print(f'::error file={file} msg={msg}')
+    print(f'::error file={file}::{msg}')
 
 
 def does_clean_snapshots(pkg_dir):


### PR DESCRIPTION
While technically `line` is optional, if its not present then the annotations won't be shown on the PR diff page; also `msg=` is just plain invalid syntax 😅