### PR TITLE
chore: tag built Docker images with major version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -113,6 +113,7 @@ dockers:
   # GitHub Action
   - image_templates:
       - "ghcr.io/google/osv-scanner-action:{{ .Tag }}"
+      - "ghcr.io/google/osv-scanner-action:v{{ .Major }}"
     dockerfile: goreleaser-action.dockerfile
     use: buildx
     extra_files:
@@ -133,6 +134,10 @@ dockers:
 
 docker_manifests:
   - name_template: "ghcr.io/google/osv-scanner:{{ .Tag }}"
+    image_templates:
+      - "ghcr.io/google/osv-scanner:{{ .Tag }}-amd64"
+      - "ghcr.io/google/osv-scanner:{{ .Tag }}-arm64"
+  - name_template: "ghcr.io/google/osv-scanner:v{{ .Major }}"
     image_templates:
       - "ghcr.io/google/osv-scanner:{{ .Tag }}-amd64"
       - "ghcr.io/google/osv-scanner:{{ .Tag }}-arm64"


### PR DESCRIPTION
Currently, release Docker images for `osv-scanner` are only tagged with their full semver version (`v2.x.x`), `latest`, and `stable`. 

This PR adds major version tags (e.g. `v2`) to both:
- The multi-architecture `osv-scanner` image manifest.
- The single-architecture `osv-scanner-action` GitHub Action image.

This allows consumers to pin their Docker-based workflows and Actions to a major release version (like `:v2`) to safely receive patch and minor updates without the risk of breaking changes from future major releases.

### Changes
*   Added `ghcr.io/google/osv-scanner-action:v{{ .Major }}` template under the action builds in `.goreleaser.yml`.
*   Added `ghcr.io/google/osv-scanner:v{{ .Major }}` manifest template in `.goreleaser.yml` to assemble the amd64 and arm64 builds.

Fixes: #2803 
