### PR TITLE
feat: add GitLab Security Report output format

### DIFF
--- a/cmd/osv-scanner/scan/source/__snapshots__/command_test.snap
+++ b/cmd/osv-scanner/scan/source/__snapshots__/command_test.snap
@@ -1864,7 +1864,7 @@ Total 1 package affected by 1 known vulnerability (0 Critical, 1 High, 0 Medium,
 ---
 
 [TestCommand/output_format:_unsupported - 2]
-unsupported output format "unknown" - must be one of: table, html, vertical, json, markdown, sarif, gh-annotations, cyclonedx-1-4, cyclonedx-1-5, cyclonedx-1-6, cyclonedx-1-7, spdx-2-3
+unsupported output format "unknown" - must be one of: table, html, vertical, json, markdown, sarif, gh-annotations, cyclonedx-1-4, cyclonedx-1-5, cyclonedx-1-6, cyclonedx-1-7, spdx-2-3, gitlab
 
 ---
 

--- a/internal/output/__snapshots__/gitlab_test.snap
+++ b/internal/output/__snapshots__/gitlab_test.snap
@@ -1,0 +1,3993 @@
+
+[TestPrintGitLabResults_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages,_no_license_violations - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages,_some_license_violations - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages,_some_license_violations#01 - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages_across_ecosystems,_some_license_violations - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages_and_groups,_some_license_violations - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithLicenseViolations/multiple_sources_with_no_packages - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithLicenseViolations/no_sources - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithLicenseViolations/one_source_with_no_packages - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithLicenseViolations/one_source_with_one_package,_no_license_violations - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithLicenseViolations/one_source_with_one_package,_no_licenses - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithLicenseViolations/one_source_with_one_package_and_an_unknown_license - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithLicenseViolations/one_source_with_one_package_and_multiple_license_violations - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithLicenseViolations/one_source_with_one_package_and_one_license_violation - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithLicenseViolations/one_source_with_one_package_and_one_license_violation_(dev) - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithLicenseViolations/one_source_with_one_package_with_both_a_version_and_a_commit_and_one_license_violation - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithLicenseViolations/one_source_with_one_package_with_just_a_commit_and_one_license_violation - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithLicenseViolations/two_sources_with_packages,_one_license_violation - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithMixedIssues/multiple_sources_with_a_mixed_count_of_packages,_some_called_vulnerabilities_and_license_violations - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [
+    {
+      "id": "a144cccfbec55737fb2a925cf90a97472dd1e7350722b7e25c8d6f23c58e1018",
+      "name": "OSV-1",
+      "message": "Something scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/first/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine1"
+          },
+          "version": "1.2.3"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/first/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-1",
+          "value": "OSV-1"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    },
+    {
+      "id": "bbf730559b5a49062cd42db03d2fdc502a36ced8a254d10c96e1ee191117ef6c",
+      "name": "OSV-2",
+      "message": "Something less scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/second/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine2"
+          },
+          "version": "3.2.5"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/second/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-2",
+          "value": "OSV-2"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    },
+    {
+      "id": "ac9c534a05c557e7ba166b70882c5a6eb93912dc47dad6d9f92d7ba7447da4ed",
+      "name": "OSV-1",
+      "message": "Something scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/third/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine1"
+          },
+          "version": "1.2.3"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/third/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-1",
+          "value": "OSV-1"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    }
+  ],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithMixedIssues/multiple_sources_with_a_mixed_count_of_packages,_some_vulnerabilities_and_license_violations - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [
+    {
+      "id": "a144cccfbec55737fb2a925cf90a97472dd1e7350722b7e25c8d6f23c58e1018",
+      "name": "OSV-1",
+      "message": "Something scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/first/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine1"
+          },
+          "version": "1.2.3"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/first/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-1",
+          "value": "OSV-1"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    },
+    {
+      "id": "bbf730559b5a49062cd42db03d2fdc502a36ced8a254d10c96e1ee191117ef6c",
+      "name": "OSV-2",
+      "message": "Something less scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/second/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine2"
+          },
+          "version": "3.2.5"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/second/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-2",
+          "value": "OSV-2"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    },
+    {
+      "id": "ac9c534a05c557e7ba166b70882c5a6eb93912dc47dad6d9f92d7ba7447da4ed",
+      "name": "OSV-1",
+      "message": "Something scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/third/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine1"
+          },
+          "version": "1.2.3"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/third/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-1",
+          "value": "OSV-1"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    }
+  ],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithMixedIssues/multiple_sources_with_a_mixed_count_of_packages_with_versions_and_commits,_some_vulnerabilities_and_license_violations - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [
+    {
+      "id": "a144cccfbec55737fb2a925cf90a97472dd1e7350722b7e25c8d6f23c58e1018",
+      "name": "OSV-1",
+      "message": "Something scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/first/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine1"
+          },
+          "version": "1.2.3"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/first/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-1",
+          "value": "OSV-1"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    },
+    {
+      "id": "3f649118d9781fb40f0ee6312b9f690cf8a0bb71f8bf1389836e075eb73fe025",
+      "name": "OSV-2",
+      "message": "Something less scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/second/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine2"
+          }
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/second/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-2",
+          "value": "OSV-2"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    },
+    {
+      "id": "ac9c534a05c557e7ba166b70882c5a6eb93912dc47dad6d9f92d7ba7447da4ed",
+      "name": "OSV-1",
+      "message": "Something scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/third/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine1"
+          },
+          "version": "1.2.3"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/third/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-1",
+          "value": "OSV-1"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    }
+  ],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithMixedIssues/one_source_in_working_directory_with_one_package,_one_vulnerability,_and_one_license_violation - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [
+    {
+      "id": "a144cccfbec55737fb2a925cf90a97472dd1e7350722b7e25c8d6f23c58e1018",
+      "name": "OSV-1",
+      "message": "Something scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/first/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine1"
+          },
+          "version": "1.2.3"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/first/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-1",
+          "value": "OSV-1"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    }
+  ],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithMixedIssues/one_source_with_one_deprecated_package - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithMixedIssues/one_source_with_one_package,_one_called_vulnerability,_and_one_license_violation - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [
+    {
+      "id": "a144cccfbec55737fb2a925cf90a97472dd1e7350722b7e25c8d6f23c58e1018",
+      "name": "OSV-1",
+      "message": "Something scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/first/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine1"
+          },
+          "version": "1.2.3"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/first/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-1",
+          "value": "OSV-1"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    }
+  ],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithMixedIssues/one_source_with_one_package,_one_uncalled_vulnerability,_and_one_license_violation - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [
+    {
+      "id": "a144cccfbec55737fb2a925cf90a97472dd1e7350722b7e25c8d6f23c58e1018",
+      "name": "OSV-1",
+      "message": "Something scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/first/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine1"
+          },
+          "version": "1.2.3"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/first/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-1",
+          "value": "OSV-1"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    }
+  ],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithMixedIssues/one_source_with_one_package,_one_vulnerability,_and_one_license_violation - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [
+    {
+      "id": "a144cccfbec55737fb2a925cf90a97472dd1e7350722b7e25c8d6f23c58e1018",
+      "name": "OSV-1",
+      "message": "Something scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/first/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine1"
+          },
+          "version": "1.2.3"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/first/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-1",
+          "value": "OSV-1"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    }
+  ],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithMixedIssues/two_sources_with_packages,_one_vulnerability,_one_license_violation - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [
+    {
+      "id": "a144cccfbec55737fb2a925cf90a97472dd1e7350722b7e25c8d6f23c58e1018",
+      "name": "OSV-1",
+      "message": "Something scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/first/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine1"
+          },
+          "version": "1.2.3"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/first/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-1",
+          "value": "OSV-1"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    }
+  ],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithVulnerabilities/multiple_sources_with_a_mixed_count_of_grouped_packages,_and_multiple_vulnerabilities - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [
+    {
+      "id": "a144cccfbec55737fb2a925cf90a97472dd1e7350722b7e25c8d6f23c58e1018",
+      "name": "OSV-1",
+      "message": "Something scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/first/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine1"
+          },
+          "version": "1.2.3"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/first/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-1",
+          "value": "OSV-1"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    },
+    {
+      "id": "b44093b1b011261246b0b662db0b141f74798f9324a11b36dab25a34721aee66",
+      "name": "OSV-5",
+      "message": "Something scarier!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/first/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine1"
+          },
+          "version": "1.2.3"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/first/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-5",
+          "value": "OSV-5"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    },
+    {
+      "id": "50b0f53ac304a940e705ceb6793e97215dd67e3fc5de712cb93185c792cd9bfb",
+      "name": "OSV-1",
+      "message": "Something scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/first/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine1"
+          },
+          "version": "1.2.2"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/first/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-1",
+          "value": "OSV-1"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    },
+    {
+      "id": "bbf730559b5a49062cd42db03d2fdc502a36ced8a254d10c96e1ee191117ef6c",
+      "name": "OSV-2",
+      "message": "Something less scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/second/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine2"
+          },
+          "version": "3.2.5"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/second/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-2",
+          "value": "OSV-2"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    },
+    {
+      "id": "552270fc451ee2a5377bc059151e48670e11c2b93142f0f3cbbd7fa11508877d",
+      "name": "OSV-3",
+      "message": "Something mildly scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/second/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine3"
+          },
+          "version": "0.4.1"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/second/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-3",
+          "value": "OSV-3"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    },
+    {
+      "id": "d53a83ac8e601b78d788288fe7cb1d5783ee6588d088c5b1415b541925bf22e0",
+      "name": "OSV-5",
+      "message": "Something scarier!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/second/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine3"
+          },
+          "version": "0.4.1"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/second/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-5",
+          "value": "OSV-5"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    }
+  ],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithVulnerabilities/multiple_sources_with_a_mixed_count_of_packages,_and_multiple_vulnerabilities - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [
+    {
+      "id": "a144cccfbec55737fb2a925cf90a97472dd1e7350722b7e25c8d6f23c58e1018",
+      "name": "OSV-1",
+      "message": "Something scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/first/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine1"
+          },
+          "version": "1.2.3"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/first/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-1",
+          "value": "OSV-1"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    },
+    {
+      "id": "b44093b1b011261246b0b662db0b141f74798f9324a11b36dab25a34721aee66",
+      "name": "OSV-5",
+      "message": "Something scarier!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/first/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine1"
+          },
+          "version": "1.2.3"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/first/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-5",
+          "value": "OSV-5"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    },
+    {
+      "id": "50b0f53ac304a940e705ceb6793e97215dd67e3fc5de712cb93185c792cd9bfb",
+      "name": "OSV-1",
+      "message": "Something scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/first/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine1"
+          },
+          "version": "1.2.2"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/first/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-1",
+          "value": "OSV-1"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    },
+    {
+      "id": "bbf730559b5a49062cd42db03d2fdc502a36ced8a254d10c96e1ee191117ef6c",
+      "name": "OSV-2",
+      "message": "Something less scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/second/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine2"
+          },
+          "version": "3.2.5"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/second/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-2",
+          "value": "OSV-2"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    },
+    {
+      "id": "552270fc451ee2a5377bc059151e48670e11c2b93142f0f3cbbd7fa11508877d",
+      "name": "OSV-3",
+      "message": "Something mildly scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/second/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine3"
+          },
+          "version": "0.4.1"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/second/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-3",
+          "value": "OSV-3"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    },
+    {
+      "id": "d53a83ac8e601b78d788288fe7cb1d5783ee6588d088c5b1415b541925bf22e0",
+      "name": "OSV-5",
+      "message": "Something scarier!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/second/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine3"
+          },
+          "version": "0.4.1"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/second/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-5",
+          "value": "OSV-5"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    }
+  ],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithVulnerabilities/multiple_sources_with_a_mixed_count_of_packages,_no_vulnerabilities - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithVulnerabilities/multiple_sources_with_a_mixed_count_of_packages,_some_vulnerabilities - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [
+    {
+      "id": "a144cccfbec55737fb2a925cf90a97472dd1e7350722b7e25c8d6f23c58e1018",
+      "name": "OSV-1",
+      "message": "Something scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/first/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine1"
+          },
+          "version": "1.2.3"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/first/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-1",
+          "value": "OSV-1"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    },
+    {
+      "id": "bbf730559b5a49062cd42db03d2fdc502a36ced8a254d10c96e1ee191117ef6c",
+      "name": "OSV-2",
+      "message": "Something less scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/second/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine2"
+          },
+          "version": "3.2.5"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/second/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-2",
+          "value": "OSV-2"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    },
+    {
+      "id": "ac9c534a05c557e7ba166b70882c5a6eb93912dc47dad6d9f92d7ba7447da4ed",
+      "name": "OSV-1",
+      "message": "Something scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/third/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine1"
+          },
+          "version": "1.2.3"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/third/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-1",
+          "value": "OSV-1"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    }
+  ],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithVulnerabilities/multiple_sources_with_a_mixed_count_of_packages_across_ecosystems,_and_multiple_vulnerabilities - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [
+    {
+      "id": "9e231753200bbe123d6e94f439a25060336330ae976ede156d4796bd1a757f77",
+      "name": "OSV-1",
+      "message": "Something scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/first/lockfile",
+        "dependency": {
+          "package": {
+            "name": "author1/mine1"
+          },
+          "version": "1.2.3"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/first/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-1",
+          "value": "OSV-1"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    },
+    {
+      "id": "3c124751cdfecd2a0aa81027c355d780d4904bd5d4e2e31cb17568ba93f19741",
+      "name": "OSV-5",
+      "message": "Something scarier!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/first/lockfile",
+        "dependency": {
+          "package": {
+            "name": "author1/mine1"
+          },
+          "version": "1.2.3"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/first/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-5",
+          "value": "OSV-5"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    },
+    {
+      "id": "50b0f53ac304a940e705ceb6793e97215dd67e3fc5de712cb93185c792cd9bfb",
+      "name": "OSV-1",
+      "message": "Something scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/first/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine1"
+          },
+          "version": "1.2.2"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/first/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-1",
+          "value": "OSV-1"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    },
+    {
+      "id": "bbf730559b5a49062cd42db03d2fdc502a36ced8a254d10c96e1ee191117ef6c",
+      "name": "OSV-2",
+      "message": "Something less scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/second/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine2"
+          },
+          "version": "3.2.5"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/second/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-2",
+          "value": "OSV-2"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    },
+    {
+      "id": "fddd4528907fa3081d692505cb504bbc5356ae0f2758c0b57b53111f62e864ec",
+      "name": "OSV-3",
+      "message": "Something mildly scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/second/lockfile",
+        "dependency": {
+          "package": {
+            "name": "author3/mine3"
+          },
+          "version": "0.4.1"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/second/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-3",
+          "value": "OSV-3"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    },
+    {
+      "id": "214f8a9e43ff41bfb02f85ae24720315311bf1e05ef6e571480e22d2525b0e72",
+      "name": "OSV-5",
+      "message": "Something scarier!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/second/lockfile",
+        "dependency": {
+          "package": {
+            "name": "author3/mine3"
+          },
+          "version": "0.4.1"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/second/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-5",
+          "value": "OSV-5"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    }
+  ],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithVulnerabilities/multiple_sources_with_a_mixed_count_of_packages_across_ecosystems,_and_multiple_vulnerabilities,_but_some_uncalled - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [
+    {
+      "id": "9e231753200bbe123d6e94f439a25060336330ae976ede156d4796bd1a757f77",
+      "name": "OSV-1",
+      "message": "Something scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/first/lockfile",
+        "dependency": {
+          "package": {
+            "name": "author1/mine1"
+          },
+          "version": "1.2.3"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/first/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-1",
+          "value": "OSV-1"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    },
+    {
+      "id": "3c124751cdfecd2a0aa81027c355d780d4904bd5d4e2e31cb17568ba93f19741",
+      "name": "OSV-5",
+      "message": "Something scarier!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/first/lockfile",
+        "dependency": {
+          "package": {
+            "name": "author1/mine1"
+          },
+          "version": "1.2.3"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/first/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-5",
+          "value": "OSV-5"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    },
+    {
+      "id": "50b0f53ac304a940e705ceb6793e97215dd67e3fc5de712cb93185c792cd9bfb",
+      "name": "OSV-1",
+      "message": "Something scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/first/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine1"
+          },
+          "version": "1.2.2"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/first/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-1",
+          "value": "OSV-1"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    },
+    {
+      "id": "bbf730559b5a49062cd42db03d2fdc502a36ced8a254d10c96e1ee191117ef6c",
+      "name": "OSV-2",
+      "message": "Something less scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/second/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine2"
+          },
+          "version": "3.2.5"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/second/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-2",
+          "value": "OSV-2"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    },
+    {
+      "id": "fddd4528907fa3081d692505cb504bbc5356ae0f2758c0b57b53111f62e864ec",
+      "name": "OSV-3",
+      "message": "Something mildly scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/second/lockfile",
+        "dependency": {
+          "package": {
+            "name": "author3/mine3"
+          },
+          "version": "0.4.1"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/second/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-3",
+          "value": "OSV-3"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    },
+    {
+      "id": "214f8a9e43ff41bfb02f85ae24720315311bf1e05ef6e571480e22d2525b0e72",
+      "name": "OSV-5",
+      "message": "Something scarier!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/second/lockfile",
+        "dependency": {
+          "package": {
+            "name": "author3/mine3"
+          },
+          "version": "0.4.1"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/second/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-5",
+          "value": "OSV-5"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    }
+  ],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithVulnerabilities/multiple_sources_with_a_mixed_count_of_packages_across_ecosystems_using_commits_and_version,_and_multiple_vulnerabilities - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [
+    {
+      "id": "9e231753200bbe123d6e94f439a25060336330ae976ede156d4796bd1a757f77",
+      "name": "OSV-1",
+      "message": "Something scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/first/lockfile",
+        "dependency": {
+          "package": {
+            "name": "author1/mine1"
+          },
+          "version": "1.2.3"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/first/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-1",
+          "value": "OSV-1"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    },
+    {
+      "id": "3c124751cdfecd2a0aa81027c355d780d4904bd5d4e2e31cb17568ba93f19741",
+      "name": "OSV-5",
+      "message": "Something scarier!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/first/lockfile",
+        "dependency": {
+          "package": {
+            "name": "author1/mine1"
+          },
+          "version": "1.2.3"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/first/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-5",
+          "value": "OSV-5"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    },
+    {
+      "id": "1590360c9aaa3e696461b333625249f508bcc540129f807b8de67ce1a7b1ae14",
+      "name": "OSV-1",
+      "message": "Something scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/first/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine1"
+          }
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/first/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-1",
+          "value": "OSV-1"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    },
+    {
+      "id": "bbf730559b5a49062cd42db03d2fdc502a36ced8a254d10c96e1ee191117ef6c",
+      "name": "OSV-2",
+      "message": "Something less scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/second/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine2"
+          },
+          "version": "3.2.5"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/second/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-2",
+          "value": "OSV-2"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    },
+    {
+      "id": "fddd4528907fa3081d692505cb504bbc5356ae0f2758c0b57b53111f62e864ec",
+      "name": "OSV-3",
+      "message": "Something mildly scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/second/lockfile",
+        "dependency": {
+          "package": {
+            "name": "author3/mine3"
+          },
+          "version": "0.4.1"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/second/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-3",
+          "value": "OSV-3"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    },
+    {
+      "id": "214f8a9e43ff41bfb02f85ae24720315311bf1e05ef6e571480e22d2525b0e72",
+      "name": "OSV-5",
+      "message": "Something scarier!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/second/lockfile",
+        "dependency": {
+          "package": {
+            "name": "author3/mine3"
+          },
+          "version": "0.4.1"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/second/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-5",
+          "value": "OSV-5"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    }
+  ],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithVulnerabilities/multiple_sources_with_no_packages - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithVulnerabilities/no_sources - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithVulnerabilities/one_source_with_no_packages - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithVulnerabilities/one_source_with_one_package,_no_vulnerabilities - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithVulnerabilities/one_source_with_one_package,_one_uncalled_vulnerability,_and_one_called_vulnerability - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [
+    {
+      "id": "a144cccfbec55737fb2a925cf90a97472dd1e7350722b7e25c8d6f23c58e1018",
+      "name": "OSV-1",
+      "message": "Something scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/first/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine1"
+          },
+          "version": "1.2.3"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/first/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-1",
+          "value": "OSV-1"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    },
+    {
+      "id": "d71cf841a1d70d0ea2df9d9e82f4a9835c39a8f75d246683b980ee086f1f0daa",
+      "name": "GHSA-123",
+      "message": "Something scarier!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/first/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine1"
+          },
+          "version": "1.2.3"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/first/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "ghsa",
+          "name": "GHSA-123",
+          "value": "GHSA-123",
+          "url": "https://github.com/advisories/GHSA-123"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    }
+  ],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithVulnerabilities/one_source_with_one_package,_one_vulnerability,_and_a_max_severity - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [
+    {
+      "id": "a144cccfbec55737fb2a925cf90a97472dd1e7350722b7e25c8d6f23c58e1018",
+      "name": "OSV-1",
+      "message": "Something scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/first/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine1"
+          },
+          "version": "1.2.3"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/first/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-1",
+          "value": "OSV-1"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    }
+  ],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithVulnerabilities/one_source_with_one_package_and_one_called_vulnerability - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [
+    {
+      "id": "a144cccfbec55737fb2a925cf90a97472dd1e7350722b7e25c8d6f23c58e1018",
+      "name": "OSV-1",
+      "message": "Something scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/first/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine1"
+          },
+          "version": "1.2.3"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/first/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-1",
+          "value": "OSV-1"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    }
+  ],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithVulnerabilities/one_source_with_one_package_and_one_uncalled_vulnerability - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [
+    {
+      "id": "a144cccfbec55737fb2a925cf90a97472dd1e7350722b7e25c8d6f23c58e1018",
+      "name": "OSV-1",
+      "message": "Something scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/first/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine1"
+          },
+          "version": "1.2.3"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/first/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-1",
+          "value": "OSV-1"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    }
+  ],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithVulnerabilities/one_source_with_one_package_and_one_vulnerability - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [
+    {
+      "id": "a144cccfbec55737fb2a925cf90a97472dd1e7350722b7e25c8d6f23c58e1018",
+      "name": "OSV-1",
+      "message": "Something scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/first/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine1"
+          },
+          "version": "1.2.3"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/first/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-1",
+          "value": "OSV-1"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    }
+  ],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithVulnerabilities/one_source_with_one_package_and_one_vulnerability_(dev) - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [
+    {
+      "id": "a144cccfbec55737fb2a925cf90a97472dd1e7350722b7e25c8d6f23c58e1018",
+      "name": "OSV-1",
+      "message": "Something scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/first/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine1"
+          },
+          "version": "1.2.3"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/first/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-1",
+          "value": "OSV-1"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    }
+  ],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithVulnerabilities/one_source_with_one_package_and_two_aliases_of_a_single_uncalled_vulnerability - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [
+    {
+      "id": "a144cccfbec55737fb2a925cf90a97472dd1e7350722b7e25c8d6f23c58e1018",
+      "name": "OSV-1",
+      "message": "Something scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/first/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine1"
+          },
+          "version": "1.2.3"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/first/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-1",
+          "value": "OSV-1"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    },
+    {
+      "id": "62acb699b44c86bc540867adebb4c8709ef233e05d028f8d1d0135fff457719c",
+      "name": "GHSA-123",
+      "message": "Something scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/first/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine1"
+          },
+          "version": "1.2.3"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/first/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "ghsa",
+          "name": "GHSA-123",
+          "value": "GHSA-123",
+          "url": "https://github.com/advisories/GHSA-123"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    }
+  ],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithVulnerabilities/one_source_with_one_package_and_two_aliases_of_a_single_vulnerability_with_a_max_severity - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [
+    {
+      "id": "a144cccfbec55737fb2a925cf90a97472dd1e7350722b7e25c8d6f23c58e1018",
+      "name": "OSV-1",
+      "message": "Something scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/first/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine1"
+          },
+          "version": "1.2.3"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/first/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-1",
+          "value": "OSV-1"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    },
+    {
+      "id": "62acb699b44c86bc540867adebb4c8709ef233e05d028f8d1d0135fff457719c",
+      "name": "GHSA-123",
+      "message": "Something scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/first/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine1"
+          },
+          "version": "1.2.3"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/first/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "ghsa",
+          "name": "GHSA-123",
+          "value": "GHSA-123",
+          "url": "https://github.com/advisories/GHSA-123"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    }
+  ],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithVulnerabilities/one_source_with_one_package_and_two_aliases_of_a_single_vulnerability_without_a_max_severity - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [
+    {
+      "id": "a144cccfbec55737fb2a925cf90a97472dd1e7350722b7e25c8d6f23c58e1018",
+      "name": "OSV-1",
+      "message": "Something scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/first/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine1"
+          },
+          "version": "1.2.3"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/first/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-1",
+          "value": "OSV-1"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    },
+    {
+      "id": "62acb699b44c86bc540867adebb4c8709ef233e05d028f8d1d0135fff457719c",
+      "name": "GHSA-123",
+      "message": "Something scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/first/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine1"
+          },
+          "version": "1.2.3"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/first/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "ghsa",
+          "name": "GHSA-123",
+          "value": "GHSA-123",
+          "url": "https://github.com/advisories/GHSA-123"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    }
+  ],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithVulnerabilities/one_source_with_one_package_with_both_a_version_and_commit_and_one_vulnerability - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [
+    {
+      "id": "a144cccfbec55737fb2a925cf90a97472dd1e7350722b7e25c8d6f23c58e1018",
+      "name": "OSV-1",
+      "message": "Something scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/first/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine1"
+          },
+          "version": "1.2.3"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/first/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-1",
+          "value": "OSV-1"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    }
+  ],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithVulnerabilities/one_source_with_one_package_with_just_a_commit_and_one_vulnerability - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [
+    {
+      "id": "1590360c9aaa3e696461b333625249f508bcc540129f807b8de67ce1a7b1ae14",
+      "name": "OSV-1",
+      "message": "Something scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/first/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine1"
+          }
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/first/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-1",
+          "value": "OSV-1"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    }
+  ],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithVulnerabilities/one_source_with_vulnerabilities,_some_missing_content - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [
+    {
+      "id": "e168971937f4fabd1dc86266b47f6d503929e8ccafd14d3a53a46574dd589e99",
+      "name": "OSV-1",
+      "description": "This vulnerability allows for some very scary stuff to happen - seriously, you'd not believe it!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/first/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine1"
+          },
+          "version": "1.2.3"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/first/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-1",
+          "value": "OSV-1"
+        }
+      ]
+    },
+    {
+      "id": "d7be56bfac71257a431de4a276c242a877594dae813ae03878767b5d1722418d",
+      "name": "OSV-2",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/first/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine3"
+          },
+          "version": "0.10.2-rc"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/first/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-2",
+          "value": "OSV-2"
+        }
+      ]
+    }
+  ],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithVulnerabilities/two_sources_with_packages,_one_vulnerability - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [
+    {
+      "id": "a144cccfbec55737fb2a925cf90a97472dd1e7350722b7e25c8d6f23c58e1018",
+      "name": "OSV-1",
+      "message": "Something scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/first/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine1"
+          },
+          "version": "1.2.3"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/first/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-1",
+          "value": "OSV-1"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    }
+  ],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---
+
+[TestPrintGitLabResults_WithVulnerabilities/two_sources_with_the_same_vulnerable_package - 1]
+{
+  "version": "15.2.4",
+  "vulnerabilities": [
+    {
+      "id": "a144cccfbec55737fb2a925cf90a97472dd1e7350722b7e25c8d6f23c58e1018",
+      "name": "OSV-1",
+      "message": "Something scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/first/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine1"
+          },
+          "version": "1.2.3"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/first/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-1",
+          "value": "OSV-1"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    },
+    {
+      "id": "7f8e3994464148063a2c6336e1af55e6835c1ed1f313385d567c1caefea42e4e",
+      "name": "OSV-1",
+      "message": "Something scary!",
+      "severity": "Unknown",
+      "solution": "No solution provided",
+      "location": {
+        "file": "<rootdir>/path/to/my/second/lockfile",
+        "dependency": {
+          "package": {
+            "name": "mine1"
+          },
+          "version": "1.2.3"
+        },
+        "files": [
+          {
+            "path": "<rootdir>/path/to/my/second/lockfile",
+            "type": "lockfile"
+          }
+        ]
+      },
+      "identifiers": [
+        {
+          "type": "osv",
+          "name": "OSV-1",
+          "value": "OSV-1"
+        }
+      ],
+      "cvss_vectors": [
+        {
+          "vendor": "unknown",
+          "vector": "1"
+        }
+      ]
+    }
+  ],
+  "scan": {
+    "analyzer": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "scanner": {
+      "id": "osv-scanner",
+      "name": "osv-scanner",
+      "url": "https://github.com/google/osv-scanner",
+      "vendor": {
+        "name": "Google"
+      },
+      "version": "2.3.5"
+    },
+    "type": "dependency_scanning",
+    "status": "success",
+    "start_time": "2024-01-01T00:00:00",
+    "end_time": "2024-01-01T00:00:00"
+  }
+}
+
+---

--- a/internal/output/gitlab.go
+++ b/internal/output/gitlab.go
@@ -1,0 +1,191 @@
+package output
+
+import (
+	"encoding/json"
+	"io"
+	"time"
+
+	"github.com/google/osv-scanner/v2/internal/output/gitlab"
+	"github.com/google/osv-scanner/v2/internal/utility/severity"
+	"github.com/google/osv-scanner/v2/internal/version"
+	"github.com/google/osv-scanner/v2/pkg/models"
+	"github.com/ossf/osv-schema/bindings/go/osvschema"
+)
+
+// GitlabTimeNow is used to get the current time for GitLab reports.
+// It can be overridden in tests to produce deterministic output.
+var GitlabTimeNow = time.Now
+
+func PrintGitLabResults(vulnResult *models.VulnerabilityResults, outputWriter io.Writer) error {
+	scanType := determineScanType(vulnResult)
+	vulnerabilities := buildVulnerabilities(vulnResult, scanType)
+	report := buildReport(vulnerabilities, scanType)
+	return encodeReport(report, outputWriter)
+}
+
+func determineScanType(vulnResult *models.VulnerabilityResults) gitlab.Category {
+	if vulnResult.ImageMetadata != nil {
+		return gitlab.CategoryContainerScanning
+	}
+	return gitlab.CategoryDependencyScanning
+}
+
+func buildVulnerabilities(vulnResult *models.VulnerabilityResults, scanType gitlab.Category) []gitlab.Vulnerability {
+	vulnerabilities := make([]gitlab.Vulnerability, 0)
+	for _, result := range vulnResult.Results {
+		for _, packageItem := range result.Packages {
+			for _, vulnerability := range packageItem.Vulnerabilities {
+				gitlabVuln := buildVulnerability(vulnerability, packageItem, result, vulnResult, scanType)
+				vulnerabilities = append(vulnerabilities, gitlabVuln)
+			}
+		}
+	}
+	return vulnerabilities
+}
+
+func buildVulnerability(vulnerability *osvschema.Vulnerability, packageItem models.PackageVulns, result models.PackageSource, vulnResult *models.VulnerabilityResults, scanType gitlab.Category) gitlab.Vulnerability {
+	severityLevel := gitlab.SeverityLevelUnknown
+	_, rating, err := severity.CalculateScoreBasedOnMostRecentCvssVersionAvailable(vulnerability.GetSeverity())
+	// Keep the "Unknown" default when the rating can't be mapped to a defined level
+	// (e.g. a "NONE" rating from a 0.0 CVSS score), so the severity is never silently
+	// dropped from the report by the omitempty zero value.
+	if mapped := gitlab.MapRatingToSeverityLevel(rating); err == nil && mapped != gitlab.SeverityLevelUndefined {
+		severityLevel = mapped
+	}
+
+	return gitlab.Vulnerability{
+		Name:        vulnerability.GetId(),
+		Message:     vulnerability.GetSummary(),
+		Description: vulnerability.GetDetails(),
+		Severity:    severityLevel,
+		Solution:    "No solution provided",
+		Location:    buildLocation(packageItem, result, vulnResult, scanType),
+		Identifiers: buildIdentifiers(vulnerability),
+		CVSSRatings: buildCVSSRatings(vulnerability.GetSeverity()),
+		Links:       buildLinks(vulnerability.GetReferences()),
+	}
+}
+
+func buildLocation(packageItem models.PackageVulns, result models.PackageSource, vulnResult *models.VulnerabilityResults, scanType gitlab.Category) gitlab.Location {
+	dependency := &gitlab.Dependency{
+		Package: gitlab.Package{Name: packageItem.Package.Name},
+		Version: packageItem.Package.Version,
+	}
+
+	if scanType == gitlab.CategoryContainerScanning {
+		return gitlab.Location{
+			Dependency:      dependency,
+			OperatingSystem: vulnResult.ImageMetadata.OS,
+			Image:           result.Source.Path,
+		}
+	}
+	return gitlab.Location{
+		File:       result.Source.Path,
+		Dependency: dependency,
+		Files:      buildFiles(result.Source),
+	}
+}
+
+func buildFiles(source models.SourceInfo) []gitlab.File {
+	// GitLab's FileType enum only distinguishes requirements/lockfile/graphfile, and
+	// osv-scanner's SourceType does not carry that distinction (every project source is
+	// SourceTypeProjectPackage="lockfile"), so all dependency sources are reported as lockfiles.
+	return []gitlab.File{
+		{
+			Path: source.Path,
+			Type: gitlab.FileTypeLockfile,
+		},
+	}
+}
+
+func buildIdentifiers(vulnerability *osvschema.Vulnerability) []gitlab.Identifier {
+	identifiers := make([]gitlab.Identifier, 0)
+	if id, ok := gitlab.ParseIdentifierID(vulnerability.GetId()); ok {
+		identifiers = append(identifiers, id)
+	}
+	for _, alias := range vulnerability.GetAliases() {
+		if id, ok := gitlab.ParseIdentifierID(alias); ok {
+			identifiers = append(identifiers, id)
+		}
+	}
+	// GitLab schema requires at least one identifier. If no known identifier types
+	// were parsed, use the vulnerability ID with a
+	// generic "osv" type.
+	if len(identifiers) == 0 {
+		identifiers = append(identifiers, gitlab.Identifier{
+			Type:  "osv",
+			Name:  vulnerability.GetId(),
+			Value: vulnerability.GetId(),
+		})
+	}
+	return identifiers
+}
+
+func buildCVSSRatings(severities []*osvschema.Severity) []gitlab.CVSSRating {
+	ratings := make([]gitlab.CVSSRating, 0, len(severities))
+	for _, sev := range severities {
+		// Only CVSS severities carry a CVSS vector string. Other types (e.g. Ubuntu)
+		// store a rating word in GetScore(), which is not a valid cvss_vectors value.
+		if !isCVSSSeverity(sev.GetType()) {
+			continue
+		}
+		ratings = append(ratings, gitlab.CVSSRating{
+			Vendor: "unknown",
+			Vector: sev.GetScore(),
+		})
+	}
+	return ratings
+}
+
+func isCVSSSeverity(t osvschema.Severity_Type) bool {
+	switch t {
+	case osvschema.Severity_CVSS_V2, osvschema.Severity_CVSS_V3, osvschema.Severity_CVSS_V4:
+		return true
+	default:
+		return false
+	}
+}
+
+func buildLinks(references []*osvschema.Reference) []gitlab.Link {
+	links := make([]gitlab.Link, 0, len(references))
+	for _, ref := range references {
+		links = append(links, gitlab.Link{URL: ref.GetUrl()})
+	}
+	return links
+}
+
+func buildReport(vulnerabilities []gitlab.Vulnerability, scanType gitlab.Category) gitlab.Report {
+	return gitlab.Report{
+		Version:         gitlab.CurrentVersion(),
+		Vulnerabilities: vulnerabilities,
+		Scan:            buildScanDetails(scanType),
+	}
+}
+
+// gitlabTimeFormat is the ISO8601 UTC format required by GitLab schema (yyyy-mm-ddThh:mm:ss)
+const gitlabTimeFormat = "2006-01-02T15:04:05"
+
+func buildScanDetails(scanType gitlab.Category) gitlab.Scan {
+	analyzerDetails := gitlab.AnalyzerDetails{
+		ID:      "osv-scanner",
+		Name:    "osv-scanner",
+		URL:     "https://github.com/google/osv-scanner",
+		Vendor:  gitlab.Vendor{Name: "Google"},
+		Version: version.OSVVersion,
+	}
+	now := GitlabTimeNow().UTC().Format(gitlabTimeFormat)
+	return gitlab.Scan{
+		Analyzer:  analyzerDetails,
+		Scanner:   analyzerDetails,
+		Type:      scanType,
+		Status:    gitlab.StatusSuccess,
+		StartTime: now,
+		EndTime:   now,
+	}
+}
+
+func encodeReport(report gitlab.Report, outputWriter io.Writer) error {
+	encoder := json.NewEncoder(outputWriter)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(report)
+}

--- a/internal/output/gitlab/category.go
+++ b/internal/output/gitlab/category.go
@@ -1,0 +1,11 @@
+package gitlab
+
+// Category is an identifier of the security scanning tool
+type Category string
+
+const (
+	// CategoryDependencyScanning is the identifier for "Dependency Scanning" vulnerability category
+	CategoryDependencyScanning Category = "dependency_scanning"
+	// CategoryContainerScanning is the identifier for "Container Scanning" vulnerability category
+	CategoryContainerScanning Category = "container_scanning"
+)

--- a/internal/output/gitlab/cvss_rating.go
+++ b/internal/output/gitlab/cvss_rating.go
@@ -1,0 +1,7 @@
+package gitlab
+
+// CVSSRating contains a CVSS vector and the vendor that assigned the rating.
+type CVSSRating struct {
+	Vendor string `json:"vendor"`
+	Vector string `json:"vector"`
+}

--- a/internal/output/gitlab/dependency.go
+++ b/internal/output/gitlab/dependency.go
@@ -1,0 +1,12 @@
+package gitlab
+
+// Dependency contains the information about the software dependency
+// (package details, version, etc.).
+type Dependency struct {
+	// Direct is true if this is a direct dependency of the scanned project,
+	// and not a transient (or transitive) dependency.
+	Direct bool `json:"direct,omitempty"`
+
+	Package `json:"package,omitempty"`
+	Version string `json:"version,omitempty"`
+}

--- a/internal/output/gitlab/file.go
+++ b/internal/output/gitlab/file.go
@@ -1,0 +1,20 @@
+package gitlab
+
+// FileType represents the type of dependency file.
+type FileType string
+
+const (
+	// FileTypeRequirements represents a requirements file (e.g., requirements.txt).
+	FileTypeRequirements FileType = "requirements"
+	// FileTypeLockfile represents a lockfile (e.g., package-lock.json, yarn.lock).
+	FileTypeLockfile FileType = "lockfile"
+	// FileTypeGraphfile represents a graph file.
+	FileTypeGraphfile FileType = "graphfile"
+)
+
+// File represents a file where a dependency is declared.
+type File struct {
+	Path         string   `json:"path"`                    // Path to the file.
+	Type         FileType `json:"type"`                    // Type of the file.
+	InRepository *bool    `json:"in_repository,omitempty"` // Whether the file exists in the repository.
+}

--- a/internal/output/gitlab/identifier.go
+++ b/internal/output/gitlab/identifier.go
@@ -1,0 +1,240 @@
+package gitlab
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// IdentifierType is the unique ID ("slug") for identifier "kind" bound to a certain vulnerabilities database (CVE, CWE, etc.)
+type IdentifierType string
+
+const (
+	// IdentifierTypeCVE is the identifier type for CVE IDs (https://cve.mitre.org/cve/)
+	IdentifierTypeCVE IdentifierType = "cve"
+
+	// IdentifierTypeCWE is the identifier type for CWE IDs (https://cwe.mitre.org/data/index.html)
+	IdentifierTypeCWE IdentifierType = "cwe"
+
+	// IdentifierTypeOWASPTop10 is the identifier type for OWASP Top10 IDs (https://owasp.org/Top10)
+	IdentifierTypeOWASPTop10 IdentifierType = "owasp"
+
+	// IdentifierTypeOSVDB is the identifier type for OSVDB IDs (https://cve.mitre.org/data/refs/refmap/source-OSVDB.html)
+	IdentifierTypeOSVDB IdentifierType = "osvdb"
+
+	// IdentifierTypeUSN is the identifier type for Ubuntu Security Notice IDs (https://usn.ubuntu.com/)
+	IdentifierTypeUSN IdentifierType = "usn"
+
+	// IdentifierTypeRHSA is the identifier type for RHSA IDs (https://access.redhat.com/errata)
+	IdentifierTypeRHSA IdentifierType = "rhsa"
+
+	// IdentifierTypeGHSA is the identifier type for GHSA IDs (https://github.com/advisories)
+	IdentifierTypeGHSA IdentifierType = "ghsa"
+
+	// IdentifierTypeELSA is the identifier type for Oracle Linux Security Data IDs (https://linux.oracle.com/security/)
+	IdentifierTypeELSA IdentifierType = "elsa"
+
+	// IdentifierTypeH1 is the identifier type for IDs in hackerone reports (https://api.hackerone.com/core-resources/#reports)
+	IdentifierTypeH1 IdentifierType = "hackerone"
+
+	// IdentifierTypeGLAM is the identifier type for GitLab Malware Advisory IDs
+	IdentifierTypeGLAM IdentifierType = "glam"
+
+	// IdentifierTypeMAL is the identifier type for OpenSSF Malicious Package IDs
+	IdentifierTypeMAL IdentifierType = "mal"
+)
+
+// Identifier holds reference and matching information about a concrete vulnerability
+type Identifier struct {
+	Type  IdentifierType `json:"type"`          // Type of the identifier (CVE, CWE, VENDOR_X, etc.)
+	Name  string         `json:"name"`          // Name of the identifier for display purpose
+	Value string         `json:"value"`         // Value of the identifier for matching purpose
+	URL   string         `json:"url,omitempty"` // URL to identifier's documentation
+}
+
+// Vendor returns the canonical name of the vendor that assigned the vulnerability identifier.
+func (i Identifier) Vendor() string {
+	switch i.Type {
+	case IdentifierTypeCVE:
+		return "NVD"
+	case IdentifierTypeELSA:
+		return "Oracle"
+	case IdentifierTypeGHSA:
+		return "GitHub"
+	case IdentifierTypeGLAM:
+		return "GitLab"
+	case IdentifierTypeH1:
+		return "HackerOne"
+	case IdentifierTypeMAL:
+		return "OpenSSF"
+	case IdentifierTypeOSVDB:
+		return "OSVDB"
+	case IdentifierTypeRHSA:
+		return "RedHat"
+	case IdentifierTypeUSN:
+		return "Ubuntu"
+	default:
+		return "Unknown"
+	}
+}
+
+// ParseIdentifierID builds an Identifier of correct IdentifierType from a human-readable ID slug
+// (e.g., "CWE-1", "RHSA-01")
+func ParseIdentifierID(idStr string) (Identifier, bool) {
+	parts := strings.SplitN(idStr, "-", 2)
+	switch strings.ToUpper(parts[0]) {
+	case "CVE":
+		return CVEIdentifier(idStr), true
+	case "CWE":
+		if len(parts) > 1 {
+			if idInt, err := strconv.Atoi(parts[1]); err == nil {
+				return CWEIdentifier(idInt), true
+			}
+		}
+	case "ELSA":
+		return ELSAIdentifier(idStr), true
+	case "GHSA":
+		return GHSAIdentifier(idStr), true
+	case "GLAM":
+		return GLAMIdentifier(idStr), true
+	case "HACKERONE":
+		// H1Identifier reads the part after the "-", so require it to avoid an out-of-range panic.
+		if len(parts) > 1 {
+			return H1Identifier(idStr), true
+		}
+	case "MAL":
+		return MALIdentifier(idStr), true
+	case "OSVDB":
+		return OSVDBIdentifier(idStr), true
+	case "RHSA":
+		return RHSAIdentifier(idStr), true
+	case "USN":
+		// USNIdentifier reads the part after the "-", so require it to avoid an out-of-range panic.
+		if len(parts) > 1 {
+			return USNIdentifier(idStr), true
+		}
+	}
+	return Identifier{}, false
+}
+
+// CVEIdentifier returns a structured Identifier for a given CVE-ID
+// Given ID must follow this format: CVE-YYYY-NNNNN
+func CVEIdentifier(ID string) Identifier {
+	return Identifier{
+		Type:  IdentifierTypeCVE,
+		Name:  ID,
+		Value: ID,
+		URL:   fmt.Sprintf("https://cve.mitre.org/cgi-bin/cvename.cgi?name=%s", ID),
+	}
+}
+
+// CWEIdentifier returns a structured Identifier for a given CWE ID
+// Given ID must follow this format: NNN (just the number, no prefix)
+func CWEIdentifier(ID int) Identifier {
+	return Identifier{
+		Type:  IdentifierTypeCWE,
+		Name:  fmt.Sprintf("CWE-%d", ID),
+		Value: strconv.Itoa(ID),
+		URL:   fmt.Sprintf("https://cwe.mitre.org/data/definitions/%d.html", ID),
+	}
+}
+
+// OWASPTop10Identifier returns a structured Identifier for a given OWASP Top10 Category
+// Given ID must follow this format: "NNN:XXXX", where "XXXX" is the year designation
+func OWASPTop10Identifier(ID string, desc string) Identifier {
+	return Identifier{
+		Type:  IdentifierType("owasp"),
+		Name:  ID + " - " + desc,
+		Value: ID,
+	}
+}
+
+// OSVDBIdentifier returns a structured Identifier for a given OSVDB-ID
+// Given ID must follow this format: OSVDB-XXXXXX
+func OSVDBIdentifier(ID string) Identifier {
+	return Identifier{
+		Type:  IdentifierTypeOSVDB,
+		Name:  ID,
+		Value: ID,
+		URL:   "https://cve.mitre.org/data/refs/refmap/source-OSVDB.html",
+	}
+}
+
+// USNIdentifier returns a structured Identifier for a Ubuntu Security Notice.
+// Given ID must follow this format: USN-XXXXXX.
+func USNIdentifier(ID string) Identifier {
+	parts := strings.SplitN(ID, "-", 2)
+	return Identifier{
+		Type:  IdentifierTypeUSN,
+		Name:  ID,
+		Value: ID,
+		URL:   fmt.Sprintf("https://usn.ubuntu.com/%s/", parts[1]),
+	}
+}
+
+// RHSAIdentifier returns a structured Identifier for a given RHSA-ID
+// Given ID must follow this format: RHSA-YYYY:NNNN
+func RHSAIdentifier(ID string) Identifier {
+	return Identifier{
+		Type:  IdentifierTypeRHSA,
+		Name:  ID,
+		Value: ID,
+		URL:   fmt.Sprintf("https://access.redhat.com/errata/%s", ID),
+	}
+}
+
+// GHSAIdentifier returns a structured Identifier for a given GHSA-ID
+// Given ID must follow this format: GHSA-xxxx-xxxx-xxxx
+func GHSAIdentifier(ID string) Identifier {
+	return Identifier{
+		Type:  IdentifierTypeGHSA,
+		Name:  ID,
+		Value: ID,
+		URL:   fmt.Sprintf("https://github.com/advisories/%s", ID),
+	}
+}
+
+// ELSAIdentifier returns a structured Identifier for a given ELSA-ID
+// Given ID must follow this format: ELSA-YYYY-NNNN(-N)?$
+func ELSAIdentifier(ID string) Identifier {
+	return Identifier{
+		Type:  IdentifierTypeELSA,
+		Name:  ID,
+		Value: ID,
+		URL:   fmt.Sprintf("https://linux.oracle.com/errata/%s.html", ID),
+	}
+}
+
+// H1Identifier returns a structured Identifier for a given hackerone report
+// Given ID must follow this format: HACKERONE-XXXXXX
+// The HACKERONE prefix is an internal GitLab identifier and is ignored in
+// the value field
+func H1Identifier(ID string) Identifier {
+	parts := strings.SplitN(ID, "-", 2)
+	return Identifier{
+		Type:  IdentifierTypeH1,
+		Name:  ID,
+		Value: parts[1],
+		URL:   fmt.Sprintf("https://hackerone.com/reports/%s", parts[1]),
+	}
+}
+
+// GLAMIdentifier returns a structured Identifier for a GitLab Malware Advisory
+// Given ID must follow this format: GLAM-XXXXXX
+func GLAMIdentifier(ID string) Identifier {
+	return Identifier{
+		Type:  IdentifierTypeGLAM,
+		Name:  ID,
+		Value: ID,
+	}
+}
+
+// MALIdentifier returns a structured Identifier for an OpenSSF Malicious Package
+// Given ID must follow this format: MAL-YYYY-NNNN
+func MALIdentifier(ID string) Identifier {
+	return Identifier{
+		Type:  IdentifierTypeMAL,
+		Name:  ID,
+		Value: ID,
+	}
+}

--- a/internal/output/gitlab/identifier_test.go
+++ b/internal/output/gitlab/identifier_test.go
@@ -1,0 +1,218 @@
+package gitlab
+
+import (
+	"testing"
+)
+
+func TestIdentifier_Vendor(t *testing.T) {
+	tests := []struct {
+		identifierType IdentifierType
+		expectedVendor string
+	}{
+		{IdentifierTypeCVE, "NVD"},
+		{IdentifierTypeELSA, "Oracle"},
+		{IdentifierTypeGHSA, "GitHub"},
+		{IdentifierTypeGLAM, "GitLab"},
+		{IdentifierTypeH1, "HackerOne"},
+		{IdentifierTypeMAL, "OpenSSF"},
+		{IdentifierTypeOSVDB, "OSVDB"},
+		{IdentifierTypeRHSA, "RedHat"},
+		{IdentifierTypeUSN, "Ubuntu"},
+		{IdentifierTypeCWE, "Unknown"},
+		{IdentifierTypeOWASPTop10, "Unknown"},
+		{IdentifierType("unknown"), "Unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.identifierType), func(t *testing.T) {
+			id := Identifier{Type: tt.identifierType}
+			if got := id.Vendor(); got != tt.expectedVendor {
+				t.Errorf("Vendor() = %v, want %v", got, tt.expectedVendor)
+			}
+		})
+	}
+}
+
+func TestParseIdentifierID(t *testing.T) {
+	tests := []struct {
+		input        string
+		expectedType IdentifierType
+		expectedOK   bool
+	}{
+		{"CVE-2023-1234", IdentifierTypeCVE, true},
+		{"cve-2023-1234", IdentifierTypeCVE, true},
+		{"CWE-79", IdentifierTypeCWE, true},
+		{"CWE-invalid", IdentifierType(""), false},
+		{"CWE", IdentifierType(""), false}, // No number part
+		{"ELSA-2023-1234", IdentifierTypeELSA, true},
+		{"GHSA-xxxx-yyyy-zzzz", IdentifierTypeGHSA, true},
+		{"GLAM-12345", IdentifierTypeGLAM, true},
+		{"HACKERONE-12345", IdentifierTypeH1, true},
+		{"MAL-2023-1234", IdentifierTypeMAL, true},
+		{"OSVDB-12345", IdentifierTypeOSVDB, true},
+		{"RHSA-2023:1234", IdentifierTypeRHSA, true},
+		{"USN-1234-1", IdentifierTypeUSN, true},
+		{"USN", IdentifierType(""), false},       // No suffix part (must not panic)
+		{"HACKERONE", IdentifierType(""), false}, // No suffix part (must not panic)
+		{"INVALID-123", IdentifierType(""), false},
+		{"", IdentifierType(""), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			id, ok := ParseIdentifierID(tt.input)
+			if ok != tt.expectedOK {
+				t.Errorf("ParseIdentifierID(%q) ok = %v, want %v", tt.input, ok, tt.expectedOK)
+				return
+			}
+			if ok && id.Type != tt.expectedType {
+				t.Errorf("ParseIdentifierID(%q) type = %v, want %v", tt.input, id.Type, tt.expectedType)
+			}
+		})
+	}
+}
+
+func TestCVEIdentifier(t *testing.T) {
+	id := CVEIdentifier("CVE-2023-1234")
+
+	if id.Type != IdentifierTypeCVE {
+		t.Errorf("expected type %v, got %v", IdentifierTypeCVE, id.Type)
+	}
+	if id.Name != "CVE-2023-1234" {
+		t.Errorf("expected name CVE-2023-1234, got %v", id.Name)
+	}
+	if id.Value != "CVE-2023-1234" {
+		t.Errorf("expected value CVE-2023-1234, got %v", id.Value)
+	}
+	if id.URL != "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-1234" {
+		t.Errorf("unexpected URL: %v", id.URL)
+	}
+}
+
+func TestCWEIdentifier(t *testing.T) {
+	id := CWEIdentifier(79)
+
+	if id.Type != IdentifierTypeCWE {
+		t.Errorf("expected type %v, got %v", IdentifierTypeCWE, id.Type)
+	}
+	if id.Name != "CWE-79" {
+		t.Errorf("expected name CWE-79, got %v", id.Name)
+	}
+	if id.Value != "79" {
+		t.Errorf("expected value 79, got %v", id.Value)
+	}
+	if id.URL != "https://cwe.mitre.org/data/definitions/79.html" {
+		t.Errorf("unexpected URL: %v", id.URL)
+	}
+}
+
+func TestGHSAIdentifier(t *testing.T) {
+	id := GHSAIdentifier("GHSA-xxxx-yyyy-zzzz")
+
+	if id.Type != IdentifierTypeGHSA {
+		t.Errorf("expected type %v, got %v", IdentifierTypeGHSA, id.Type)
+	}
+	if id.URL != "https://github.com/advisories/GHSA-xxxx-yyyy-zzzz" {
+		t.Errorf("unexpected URL: %v", id.URL)
+	}
+}
+
+func TestGLAMIdentifier(t *testing.T) {
+	id := GLAMIdentifier("GLAM-12345")
+
+	if id.Type != IdentifierTypeGLAM {
+		t.Errorf("expected type %v, got %v", IdentifierTypeGLAM, id.Type)
+	}
+	if id.Name != "GLAM-12345" {
+		t.Errorf("expected name GLAM-12345, got %v", id.Name)
+	}
+	if id.URL != "" {
+		t.Errorf("expected no URL for GLAM, got %v", id.URL)
+	}
+}
+
+func TestMALIdentifier(t *testing.T) {
+	id := MALIdentifier("MAL-2023-1234")
+
+	if id.Type != IdentifierTypeMAL {
+		t.Errorf("expected type %v, got %v", IdentifierTypeMAL, id.Type)
+	}
+	if id.Name != "MAL-2023-1234" {
+		t.Errorf("expected name MAL-2023-1234, got %v", id.Name)
+	}
+	if id.URL != "" {
+		t.Errorf("expected no URL for MAL, got %v", id.URL)
+	}
+}
+
+func TestRHSAIdentifier(t *testing.T) {
+	id := RHSAIdentifier("RHSA-2023:1234")
+
+	if id.Type != IdentifierTypeRHSA {
+		t.Errorf("expected type %v, got %v", IdentifierTypeRHSA, id.Type)
+	}
+	if id.URL != "https://access.redhat.com/errata/RHSA-2023:1234" {
+		t.Errorf("unexpected URL: %v", id.URL)
+	}
+}
+
+func TestUSNIdentifier(t *testing.T) {
+	id := USNIdentifier("USN-1234-1")
+
+	if id.Type != IdentifierTypeUSN {
+		t.Errorf("expected type %v, got %v", IdentifierTypeUSN, id.Type)
+	}
+	if id.URL != "https://usn.ubuntu.com/1234-1/" {
+		t.Errorf("unexpected URL: %v", id.URL)
+	}
+}
+
+func TestELSAIdentifier(t *testing.T) {
+	id := ELSAIdentifier("ELSA-2023-1234")
+
+	if id.Type != IdentifierTypeELSA {
+		t.Errorf("expected type %v, got %v", IdentifierTypeELSA, id.Type)
+	}
+	if id.URL != "https://linux.oracle.com/errata/ELSA-2023-1234.html" {
+		t.Errorf("unexpected URL: %v", id.URL)
+	}
+}
+
+func TestH1Identifier(t *testing.T) {
+	id := H1Identifier("HACKERONE-12345")
+
+	if id.Type != IdentifierTypeH1 {
+		t.Errorf("expected type %v, got %v", IdentifierTypeH1, id.Type)
+	}
+	if id.Value != "12345" {
+		t.Errorf("expected value 12345, got %v", id.Value)
+	}
+	if id.URL != "https://hackerone.com/reports/12345" {
+		t.Errorf("unexpected URL: %v", id.URL)
+	}
+}
+
+func TestOSVDBIdentifier(t *testing.T) {
+	id := OSVDBIdentifier("OSVDB-12345")
+
+	if id.Type != IdentifierTypeOSVDB {
+		t.Errorf("expected type %v, got %v", IdentifierTypeOSVDB, id.Type)
+	}
+	if id.URL != "https://cve.mitre.org/data/refs/refmap/source-OSVDB.html" {
+		t.Errorf("unexpected URL: %v", id.URL)
+	}
+}
+
+func TestOWASPTop10Identifier(t *testing.T) {
+	id := OWASPTop10Identifier("A01:2021", "Broken Access Control")
+
+	if id.Type != IdentifierTypeOWASPTop10 {
+		t.Errorf("expected type %v, got %v", IdentifierTypeOWASPTop10, id.Type)
+	}
+	if id.Name != "A01:2021 - Broken Access Control" {
+		t.Errorf("expected name 'A01:2021 - Broken Access Control', got %v", id.Name)
+	}
+	if id.Value != "A01:2021" {
+		t.Errorf("expected value A01:2021, got %v", id.Value)
+	}
+}

--- a/internal/output/gitlab/link.go
+++ b/internal/output/gitlab/link.go
@@ -1,0 +1,6 @@
+package gitlab
+
+// Link contains the hyperlink to the detailed information about a vulnerability.
+type Link struct {
+	URL string `json:"url"` // URL of the document (mandatory)
+}

--- a/internal/output/gitlab/location.go
+++ b/internal/output/gitlab/location.go
@@ -1,0 +1,12 @@
+package gitlab
+
+// Location represents the location of the vulnerability occurrence
+// be it a source code line, a dependency package identifier or
+// whatever else.
+type Location struct {
+	File            string      `json:"file,omitempty"`             // File is the path relative to the search path.
+	Dependency      *Dependency `json:"dependency,omitempty"`       // Dependency is the affected package.
+	OperatingSystem string      `json:"operating_system,omitempty"` // OperatingSystem is the operating system and optionally its version, separated by a semicolon: linux, debian:10, etc
+	Image           string      `json:"image,omitempty"`            // Name of the Docker image
+	Files           []File      `json:"files,omitempty"`            // Files where the dependency is declared.
+}

--- a/internal/output/gitlab/package.go
+++ b/internal/output/gitlab/package.go
@@ -1,0 +1,6 @@
+package gitlab
+
+// Package contains the information about the software dependency package.
+type Package struct {
+	Name string `json:"name,omitempty"`
+}

--- a/internal/output/gitlab/remediation.go
+++ b/internal/output/gitlab/remediation.go
@@ -1,0 +1,20 @@
+package gitlab
+
+// Remediation holds the patch required to fix a set of vulnerability occurrences.
+type Remediation struct {
+	Fixes   []Ref  `json:"fixes"`   // Refs to fixed vulnerability occurrences
+	Summary string `json:"summary"` // Overview of how the vulnerabilities have been fixed
+	Diff    string `json:"diff"`    // Base64 encoded diff, compatible with "git apply"
+}
+
+// Ref is a reference to a vulnerability occurrence in context of the remediation.
+type Ref struct {
+	ID string `json:"id"` // ID of a vulnerability
+}
+
+// NewRef creates a reference to a vulnerability.
+func NewRef(vuln Vulnerability) Ref {
+	return Ref{
+		ID: vuln.ID(),
+	}
+}

--- a/internal/output/gitlab/report.go
+++ b/internal/output/gitlab/report.go
@@ -1,0 +1,9 @@
+package gitlab
+
+// Report is the output of an analyzer.
+type Report struct {
+	Version         Version         `json:"version"`
+	Vulnerabilities []Vulnerability `json:"vulnerabilities"`
+	Remediations    []Remediation   `json:"remediations,omitempty"`
+	Scan            Scan            `json:"scan"`
+}

--- a/internal/output/gitlab/scan.go
+++ b/internal/output/gitlab/scan.go
@@ -1,0 +1,21 @@
+package gitlab
+
+// Status represents the status of a scan, either `success` or `failure`
+type Status string
+
+const (
+	// StatusSuccess is the identifier for a successful scan
+	StatusSuccess Status = "success"
+	// StatusFailure is the identifier for a failed scan
+	StatusFailure Status = "failure"
+)
+
+// Scan contains the identifying information about a security scanner.
+type Scan struct {
+	Analyzer  AnalyzerDetails `json:"analyzer"`          // Analyzer describes the analyzer tool which wraps the scanner
+	Scanner   ScannerDetails  `json:"scanner"`           // Scanner is an Object defining the scanner used to perform the scan
+	Type      Category        `json:"type"`              // Type of the scan (container_scanning, dependency_scanning, dast, sast)
+	Status    Status          `json:"status,omitempty"`  // Status is the status of the scan, either `success` or `failure`. Hardcoded to `success` for now
+	StartTime string          `json:"start_time"`        // StartTime is the ISO8601 UTC time when the scan started (format: yyyy-mm-ddThh:mm:ss)
+	EndTime   string          `json:"end_time"`          // EndTime is the ISO8601 UTC time when the scan finished (format: yyyy-mm-ddThh:mm:ss)
+}

--- a/internal/output/gitlab/scanner.go
+++ b/internal/output/gitlab/scanner.go
@@ -1,0 +1,21 @@
+package gitlab
+
+import (
+	"fmt"
+)
+
+// ScannerDetails contains detailed information about the scanner
+type ScannerDetails struct {
+	ID      string `json:"id"`            // Unique id that identifies the scanner
+	Name    string `json:"name"`          // A human readable value that identifies the scanner, not required to be unique
+	URL     string `json:"url,omitempty"` // A link to more information about the scanner
+	Vendor  Vendor `json:"vendor"`        // The vendor/maintainer of the scanner
+	Version string `json:"version"`       // The version of the scanner
+}
+
+// AnalyzerDetails contains detailed information about the analyzer
+type AnalyzerDetails = ScannerDetails
+
+func (s ScannerDetails) String() string {
+	return fmt.Sprintf("%s %s analyzer v%s", s.Vendor.Name, s.Name, s.Version)
+}

--- a/internal/output/gitlab/severity.go
+++ b/internal/output/gitlab/severity.go
@@ -1,0 +1,100 @@
+package gitlab
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/google/osv-scanner/v2/internal/utility/severity"
+)
+
+// SeverityLevel is the vulnerability severity level reported by scanner.
+type SeverityLevel int
+
+const (
+	// SeverityLevelUndefined is a stub severity value for the case when it was not reported by scanner.
+	SeverityLevelUndefined SeverityLevel = iota
+	// SeverityLevelInfo represents the "info" or "ignore" severity level.
+	SeverityLevelInfo
+	// SeverityLevelUnknown represents the "experimental" or "unknown" severity level.
+	SeverityLevelUnknown
+	// SeverityLevelLow represents the "low" severity level.
+	SeverityLevelLow
+	// SeverityLevelMedium represents the "medium" severity level.
+	SeverityLevelMedium
+	// SeverityLevelHigh represents the "high" severity level.
+	SeverityLevelHigh
+	// SeverityLevelCritical represents the "critical" severity level.
+	SeverityLevelCritical
+)
+
+// MarshalJSON converts a SeverityLevel value into the JSON representation
+func (l SeverityLevel) MarshalJSON() ([]byte, error) {
+	return json.Marshal(l.String())
+}
+
+// UnmarshalJSON parses a SeverityLevel value from JSON representation
+func (l *SeverityLevel) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	*l = ParseSeverityLevel(s)
+	return nil
+}
+
+func (l SeverityLevel) String() string {
+	switch l {
+	case SeverityLevelCritical:
+		return "Critical"
+	case SeverityLevelHigh:
+		return "High"
+	case SeverityLevelMedium:
+		return "Medium"
+	case SeverityLevelLow:
+		return "Low"
+	case SeverityLevelInfo:
+		return "Info"
+	case SeverityLevelUnknown:
+		return "Unknown"
+	}
+	return ""
+}
+
+// ParseSeverityLevel parses a SeverityLevel value from string
+func ParseSeverityLevel(s string) SeverityLevel {
+	switch strings.ToLower(s) {
+	case "critical":
+		return SeverityLevelCritical
+	case "high":
+		return SeverityLevelHigh
+	case "medium":
+		return SeverityLevelMedium
+	case "low":
+		return SeverityLevelLow
+	case "experimental", "unknown":
+		return SeverityLevelUnknown
+	case "ignore", "info":
+		return SeverityLevelInfo
+	default:
+		return SeverityLevelUnknown
+	}
+}
+
+func MapRatingToSeverityLevel(s string) SeverityLevel {
+	switch s {
+	case severity.CriticalRating.String():
+		return SeverityLevelCritical
+	case severity.HighRating.String():
+		return SeverityLevelHigh
+	case severity.MediumRating.String():
+		return SeverityLevelMedium
+	case severity.LowRating.String():
+		return SeverityLevelLow
+	case SeverityLevelInfo.String():
+		return SeverityLevelInfo
+	case severity.UnknownRating.String():
+		return SeverityLevelUnknown
+	default:
+		return SeverityLevelUndefined
+	}
+}

--- a/internal/output/gitlab/severity_test.go
+++ b/internal/output/gitlab/severity_test.go
@@ -1,0 +1,136 @@
+package gitlab
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/osv-scanner/v2/internal/utility/severity"
+)
+
+func TestSeverityLevel_String(t *testing.T) {
+	tests := []struct {
+		level    SeverityLevel
+		expected string
+	}{
+		{SeverityLevelCritical, "Critical"},
+		{SeverityLevelHigh, "High"},
+		{SeverityLevelMedium, "Medium"},
+		{SeverityLevelLow, "Low"},
+		{SeverityLevelInfo, "Info"},
+		{SeverityLevelUnknown, "Unknown"},
+		{SeverityLevelUndefined, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			if got := tt.level.String(); got != tt.expected {
+				t.Errorf("SeverityLevel.String() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSeverityLevel_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		level    SeverityLevel
+		expected string
+	}{
+		{SeverityLevelCritical, `"Critical"`},
+		{SeverityLevelHigh, `"High"`},
+		{SeverityLevelMedium, `"Medium"`},
+		{SeverityLevelLow, `"Low"`},
+		{SeverityLevelUnknown, `"Unknown"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			got, err := json.Marshal(tt.level)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if string(got) != tt.expected {
+				t.Errorf("MarshalJSON() = %v, want %v", string(got), tt.expected)
+			}
+		})
+	}
+}
+
+func TestSeverityLevel_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected SeverityLevel
+	}{
+		{`"Critical"`, SeverityLevelCritical},
+		{`"critical"`, SeverityLevelCritical},
+		{`"High"`, SeverityLevelHigh},
+		{`"Medium"`, SeverityLevelMedium},
+		{`"Low"`, SeverityLevelLow},
+		{`"Info"`, SeverityLevelInfo},
+		{`"ignore"`, SeverityLevelInfo},
+		{`"Unknown"`, SeverityLevelUnknown},
+		{`"experimental"`, SeverityLevelUnknown},
+		{`"invalid"`, SeverityLevelUnknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			var got SeverityLevel
+			err := json.Unmarshal([]byte(tt.input), &got)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.expected {
+				t.Errorf("UnmarshalJSON() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseSeverityLevel(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected SeverityLevel
+	}{
+		{"critical", SeverityLevelCritical},
+		{"CRITICAL", SeverityLevelCritical},
+		{"high", SeverityLevelHigh},
+		{"medium", SeverityLevelMedium},
+		{"low", SeverityLevelLow},
+		{"info", SeverityLevelInfo},
+		{"ignore", SeverityLevelInfo},
+		{"unknown", SeverityLevelUnknown},
+		{"experimental", SeverityLevelUnknown},
+		{"something-else", SeverityLevelUnknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := ParseSeverityLevel(tt.input); got != tt.expected {
+				t.Errorf("ParseSeverityLevel(%q) = %v, want %v", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestMapRatingToSeverityLevel(t *testing.T) {
+	tests := []struct {
+		rating   string
+		expected SeverityLevel
+	}{
+		{severity.CriticalRating.String(), SeverityLevelCritical},
+		{severity.HighRating.String(), SeverityLevelHigh},
+		{severity.MediumRating.String(), SeverityLevelMedium},
+		{severity.LowRating.String(), SeverityLevelLow},
+		{severity.UnknownRating.String(), SeverityLevelUnknown},
+		{"Info", SeverityLevelInfo},
+		{"invalid", SeverityLevelUndefined},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.rating, func(t *testing.T) {
+			if got := MapRatingToSeverityLevel(tt.rating); got != tt.expected {
+				t.Errorf("MapRatingToSeverityLevel(%q) = %v, want %v", tt.rating, got, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/output/gitlab/testdata/schemas/container-scanning-report-format.json
+++ b/internal/output/gitlab/testdata/schemas/container-scanning-report-format.json
@@ -1,0 +1,1212 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://gitlab.com/gitlab-org/security-products/security-report-schemas/-/raw/master/dist/container-scanning-report-format.json",
+  "title": "Report format for GitLab Container Scanning",
+  "description": "This schema provides the the report format for Container Scanning (https://docs.gitlab.com/ee/user/application_security/container_scanning).",
+  "definitions": {
+    "detail_type": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/named_list"
+        },
+        {
+          "$ref": "#/definitions/list"
+        },
+        {
+          "$ref": "#/definitions/table"
+        },
+        {
+          "$ref": "#/definitions/text"
+        },
+        {
+          "$ref": "#/definitions/url"
+        },
+        {
+          "$ref": "#/definitions/code"
+        },
+        {
+          "$ref": "#/definitions/value"
+        },
+        {
+          "$ref": "#/definitions/diff"
+        },
+        {
+          "$ref": "#/definitions/markdown"
+        },
+        {
+          "$ref": "#/definitions/commit"
+        },
+        {
+          "$ref": "#/definitions/file_location"
+        },
+        {
+          "$ref": "#/definitions/module_location"
+        },
+        {
+          "$ref": "#/definitions/code_flows"
+        }
+      ]
+    },
+    "text_value": {
+      "type": "string"
+    },
+    "named_field": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/text_value",
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "$ref": "#/definitions/text_value"
+        }
+      }
+    },
+    "named_list": {
+      "type": "object",
+      "description": "An object with named and typed fields",
+      "required": [
+        "type",
+        "items"
+      ],
+      "properties": {
+        "type": {
+          "const": "named-list"
+        },
+        "items": {
+          "type": "object",
+          "patternProperties": {
+            "^.*$": {
+              "allOf": [
+                {
+                  "$ref": "#/definitions/named_field"
+                },
+                {
+                  "$ref": "#/definitions/detail_type"
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "list": {
+      "type": "object",
+      "description": "A list of typed fields",
+      "required": [
+        "type",
+        "items"
+      ],
+      "properties": {
+        "type": {
+          "const": "list"
+        },
+        "items": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/detail_type"
+          }
+        }
+      }
+    },
+    "table": {
+      "type": "object",
+      "description": "A table of typed fields",
+      "required": [
+        "type",
+        "rows"
+      ],
+      "properties": {
+        "type": {
+          "const": "table"
+        },
+        "header": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/detail_type"
+          }
+        },
+        "rows": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/detail_type"
+            }
+          }
+        }
+      }
+    },
+    "text": {
+      "type": "object",
+      "description": "Raw text",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "const": "text"
+        },
+        "value": {
+          "$ref": "#/definitions/text_value"
+        }
+      }
+    },
+    "url": {
+      "type": "object",
+      "description": "A single URL",
+      "required": [
+        "type",
+        "href"
+      ],
+      "properties": {
+        "type": {
+          "const": "url"
+        },
+        "text": {
+          "$ref": "#/definitions/text_value"
+        },
+        "href": {
+          "type": "string",
+          "minLength": 1,
+          "examples": [
+            "http://mysite.com"
+          ]
+        }
+      }
+    },
+    "code": {
+      "type": "object",
+      "description": "A codeblock",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "const": "code"
+        },
+        "value": {
+          "type": "string"
+        },
+        "lang": {
+          "type": "string",
+          "description": "A programming language"
+        }
+      }
+    },
+    "value": {
+      "type": "object",
+      "description": "A field that can store a range of types of value",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "const": "value"
+        },
+        "value": {
+          "type": [
+            "number",
+            "string",
+            "boolean"
+          ]
+        }
+      }
+    },
+    "diff": {
+      "type": "object",
+      "description": "A diff",
+      "required": [
+        "type",
+        "before",
+        "after"
+      ],
+      "properties": {
+        "type": {
+          "const": "diff"
+        },
+        "before": {
+          "type": "string"
+        },
+        "after": {
+          "type": "string"
+        }
+      }
+    },
+    "markdown": {
+      "type": "object",
+      "description": "GitLab flavoured markdown, see https://docs.gitlab.com/ee/user/markdown.html",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "const": "markdown"
+        },
+        "value": {
+          "$ref": "#/definitions/text_value",
+          "examples": [
+            "Here is markdown `inline code` #1 [test](gitlab.com)\n\n![GitLab Logo](https://about.gitlab.com/images/press/logo/preview/gitlab-logo-white-preview.png)"
+          ]
+        }
+      }
+    },
+    "commit": {
+      "type": "object",
+      "description": "A commit/tag/branch within the GitLab project",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "const": "commit"
+        },
+        "value": {
+          "type": "string",
+          "description": "The commit SHA",
+          "minLength": 1
+        }
+      }
+    },
+    "file_location": {
+      "type": "object",
+      "description": "A location within a file in the project",
+      "required": [
+        "type",
+        "file_name",
+        "line_start"
+      ],
+      "properties": {
+        "type": {
+          "const": "file-location"
+        },
+        "file_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "line_start": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "line_end": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "column_start": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "column_end": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      "dependencies": {
+        "column_end": [
+          "column_start"
+        ],
+        "column_start": [
+          "column_end"
+        ]
+      }
+    },
+    "module_location": {
+      "type": "object",
+      "description": "A location within a binary module of the form module+relative_offset",
+      "required": [
+        "type",
+        "module_name",
+        "offset"
+      ],
+      "properties": {
+        "type": {
+          "const": "module-location"
+        },
+        "module_name": {
+          "type": "string",
+          "minLength": 1,
+          "examples": [
+            "compiled_binary"
+          ]
+        },
+        "offset": {
+          "type": "integer",
+          "examples": [
+            100
+          ]
+        }
+      }
+    },
+    "code_flow_node": {
+      "type": "object",
+      "description": "A code flow node representing a part of a vulnerability flow from source to sink",
+      "required": [
+        "file_location",
+        "node_type"
+      ],
+      "properties": {
+        "type": {
+          "const": "code-flow-node"
+        },
+        "file_location": {
+          "$ref": "#/definitions/file_location"
+        },
+        "node_type": {
+          "type": "string",
+          "description": "Describes a code flow node type",
+          "enum": [
+            "source",
+            "sink",
+            "propagation"
+          ]
+        }
+      },
+      "examples": [
+        {
+          "type": "code-flow-node",
+          "node_type": "propagation",
+          "file_location": {
+            "type": "file-location",
+            "file_name": "file_name.py",
+            "line_start": 4,
+            "line_end": 6
+          }
+        }
+      ]
+    },
+    "code_flows": {
+      "type": "object",
+      "description": "A code flow representing a vulnerability flow from source to sink",
+      "required": [
+        "items",
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "const": "code-flows"
+        },
+        "items": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 10,
+          "items": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "$ref": "#/definitions/code_flow_node"
+            }
+          }
+        }
+      },
+      "examples": [
+        {
+          "type": "code-flows",
+          "items": [
+            [
+              {
+                "type": "code-flow-node",
+                "node_type": "source",
+                "file_location": {
+                  "type": "file-location",
+                  "file_name": "file_name.py",
+                  "line_start": 1,
+                  "line_end": 2
+                }
+              },
+              {
+                "type": "code-flow-node",
+                "node_type": "propagation",
+                "file_location": {
+                  "type": "file-location",
+                  "file_name": "file_name.py",
+                  "line_start": 3
+                }
+              },
+              {
+                "type": "code-flow-node",
+                "node_type": "sink",
+                "file_location": {
+                  "type": "file-location",
+                  "file_name": "file_name.py",
+                  "line_start": 4,
+                  "line_end": 6
+                }
+              }
+            ],
+            [
+              {
+                "type": "code-flow-node",
+                "node_type": "source",
+                "file_location": {
+                  "type": "file-location",
+                  "file_name": "different_flow.py",
+                  "line_start": 100,
+                  "line_end": 102
+                }
+              },
+              {
+                "type": "code-flow-node",
+                "node_type": "sink",
+                "file_location": {
+                  "type": "file-location",
+                  "file_name": "file_name.py",
+                  "line_start": 4,
+                  "line_end": 6
+                }
+              }
+            ]
+          ]
+        }
+      ]
+    }
+  },
+  "self": {
+    "version": "15.2.4"
+  },
+  "type": "object",
+  "required": [
+    "scan",
+    "version",
+    "vulnerabilities"
+  ],
+  "additionalProperties": true,
+  "properties": {
+    "scan": {
+      "type": "object",
+      "required": [
+        "analyzer",
+        "end_time",
+        "scanner",
+        "start_time",
+        "status",
+        "type"
+      ],
+      "properties": {
+        "end_time": {
+          "type": "string",
+          "description": "ISO8601 UTC value with format yyyy-mm-ddThh:mm:ss, representing when the scan finished.",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$",
+          "examples": [
+            "2020-01-28T03:26:02"
+          ]
+        },
+        "messages": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "description": "Communication intended for the initiator of a scan.",
+            "required": [
+              "level",
+              "value"
+            ],
+            "properties": {
+              "level": {
+                "type": "string",
+                "description": "Describes the severity of the communication. Use info to communicate normal scan behaviour; warn to communicate a potentially recoverable problem, or a partial error; fatal to communicate an issue that causes the scan to halt.",
+                "enum": [
+                  "info",
+                  "warn",
+                  "fatal"
+                ],
+                "examples": [
+                  "info"
+                ]
+              },
+              "value": {
+                "type": "string",
+                "description": "The message to communicate.",
+                "minLength": 1,
+                "examples": [
+                  "Permission denied, scanning aborted"
+                ]
+              }
+            }
+          }
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "description": "A configuration option used for this scan.",
+            "required": [
+              "name",
+              "value"
+            ],
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "The configuration option name.",
+                "maxLength": 255,
+                "minLength": 1,
+                "examples": [
+                  "DAST_FF_ENABLE_BAS",
+                  "DOCKER_TLS_CERTDIR",
+                  "DS_MAX_DEPTH",
+                  "SECURE_LOG_LEVEL"
+                ]
+              },
+              "source": {
+                "type": "string",
+                "description": "The source of this option.",
+                "enum": [
+                  "argument",
+                  "file",
+                  "env_variable",
+                  "other"
+                ]
+              },
+              "value": {
+                "type": [
+                  "boolean",
+                  "integer",
+                  "null",
+                  "string"
+                ],
+                "description": "The value used for this scan.",
+                "examples": [
+                  true,
+                  2,
+                  null,
+                  "fatal",
+                  ""
+                ]
+              }
+            }
+          }
+        },
+        "analyzer": {
+          "type": "object",
+          "description": "Object defining the analyzer used to perform the scan. Analyzers typically delegate to an underlying scanner to run the scan.",
+          "required": [
+            "id",
+            "name",
+            "version",
+            "vendor"
+          ],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "Unique id that identifies the analyzer.",
+              "minLength": 1,
+              "examples": [
+                "gitlab-dast"
+              ]
+            },
+            "name": {
+              "type": "string",
+              "description": "A human readable value that identifies the analyzer, not required to be unique.",
+              "minLength": 1,
+              "examples": [
+                "GitLab DAST"
+              ]
+            },
+            "url": {
+              "type": "string",
+              "pattern": "^https?://.+",
+              "description": "A link to more information about the analyzer.",
+              "examples": [
+                "https://docs.gitlab.com/ee/user/application_security/dast"
+              ]
+            },
+            "vendor": {
+              "description": "The vendor/maintainer of the analyzer.",
+              "type": "object",
+              "required": [
+                "name"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "The name of the vendor.",
+                  "minLength": 1,
+                  "examples": [
+                    "GitLab"
+                  ]
+                }
+              }
+            },
+            "version": {
+              "type": "string",
+              "description": "The version of the analyzer.",
+              "minLength": 1,
+              "examples": [
+                "1.0.2"
+              ]
+            }
+          }
+        },
+        "scanner": {
+          "type": "object",
+          "description": "Object defining the scanner used to perform the scan.",
+          "required": [
+            "id",
+            "name",
+            "version",
+            "vendor"
+          ],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "Unique id that identifies the scanner.",
+              "minLength": 1,
+              "examples": [
+                "my-sast-scanner"
+              ]
+            },
+            "name": {
+              "type": "string",
+              "description": "A human readable value that identifies the scanner, not required to be unique.",
+              "minLength": 1,
+              "examples": [
+                "My SAST Scanner"
+              ]
+            },
+            "url": {
+              "type": "string",
+              "description": "A link to more information about the scanner.",
+              "examples": [
+                "https://scanner.url"
+              ]
+            },
+            "version": {
+              "type": "string",
+              "description": "The version of the scanner.",
+              "minLength": 1,
+              "examples": [
+                "1.0.2"
+              ]
+            },
+            "vendor": {
+              "description": "The vendor/maintainer of the scanner.",
+              "type": "object",
+              "required": [
+                "name"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "The name of the vendor.",
+                  "minLength": 1,
+                  "examples": [
+                    "GitLab"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "start_time": {
+          "type": "string",
+          "description": "ISO8601 UTC value with format yyyy-mm-ddThh:mm:ss, representing when the scan started.",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$",
+          "examples": [
+            "2020-02-14T16:01:59"
+          ]
+        },
+        "status": {
+          "type": "string",
+          "description": "Result of the scan.",
+          "enum": [
+            "success",
+            "failure"
+          ]
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the scan.",
+          "enum": [
+            "container_scanning",
+            "container_scanning_for_registry"
+          ]
+        },
+        "partial_scan": {
+          "type": "object",
+          "description": "Indicates the mode of a partial scan.",
+          "required": [
+            "mode"
+          ],
+          "properties": {
+            "mode": {
+              "type": "string",
+              "enum": [
+                "differential"
+              ],
+              "description": "The mode of the partial scan"
+            }
+          }
+        },
+        "primary_identifiers": {
+          "type": "array",
+          "description": "An unordered array containing an exhaustive list of primary identifiers for which the analyzer may return results",
+          "items": {
+            "type": "object",
+            "required": [
+              "type",
+              "name",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "description": "for example, cve, cwe, osvdb, usn, or an analyzer-dependent type such as gemnasium).",
+                "minLength": 1
+              },
+              "name": {
+                "type": "string",
+                "description": "Human-readable name of the identifier.",
+                "minLength": 1
+              },
+              "url": {
+                "type": "string",
+                "description": "URL of the identifier's documentation.",
+                "pattern": "^(https?|ftp)://.+"
+              },
+              "value": {
+                "type": "string",
+                "description": "Value of the identifier, for matching purpose.",
+                "minLength": 1
+              }
+            }
+          }
+        },
+        "observability": {
+          "type": "object",
+          "description": "Internal GitLab use only. Observability data such as metrics collected by the analyzers.",
+          "properties": {
+            "events": {
+              "type": "array",
+              "description": "Internal GitLab use only. Array of events containing metrics logged via the GitLab internal event tracking system. Recommend working with the analytics instrumentation team to define events.",
+              "items": {
+                "type": "object",
+                "description": "Internal GitLab use only. An event with zero or more values. Additional properties can be used to collect various metrics associated with event. Recommend working with the analytics instrumentation team to define events.",
+                "required": [
+                  "event"
+                ],
+                "properties": {
+                  "event": {
+                    "type": "string",
+                    "description": "Name of the event. Events must be defined and added to the security reports observability events allow list."
+                  },
+                  "property": {
+                    "type": "string",
+                    "description": "Data related to given event. Column in the data warehouse, fast to filter on in queries."
+                  },
+                  "label": {
+                    "type": "string",
+                    "description": "Data related to given event. Column in the data warehouse, fast to filter on in queries."
+                  },
+                  "value": {
+                    "type": "number",
+                    "description": "Data related to given event. Column in the data warehouse, fast to filter on in queries."
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "schema": {
+      "type": "string",
+      "description": "URI pointing to the validating security report schema.",
+      "pattern": "^https?://.+"
+    },
+    "version": {
+      "type": "string",
+      "description": "The version of the schema to which the JSON report conforms.",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "vulnerabilities": {
+      "type": "array",
+      "description": "Array of vulnerability objects.",
+      "items": {
+        "type": "object",
+        "description": "Describes the vulnerability using GitLab Flavored Markdown",
+        "required": [
+          "id",
+          "identifiers",
+          "location"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Unique identifier of the vulnerability. This is recommended to be a UUID.",
+            "examples": [
+              "642735a5-1425-428d-8d4e-3c854885a3c9"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "maxLength": 255,
+            "description": "The name of the vulnerability. This must not include the finding's specific information."
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 1048576,
+            "description": "A long text section describing the vulnerability more fully."
+          },
+          "severity": {
+            "type": "string",
+            "description": "How much the vulnerability impacts the software. Possible values are Info, Unknown, Low, Medium, High, or Critical. Note that some analyzers may not report all these possible values.",
+            "enum": [
+              "Info",
+              "Unknown",
+              "Low",
+              "Medium",
+              "High",
+              "Critical"
+            ]
+          },
+          "solution": {
+            "type": "string",
+            "maxLength": 7000,
+            "description": "Explanation of how to fix the vulnerability."
+          },
+          "identifiers": {
+            "type": "array",
+            "minItems": 1,
+            "description": "An ordered array of references that identify a vulnerability on internal or external databases. The first identifier is the Primary Identifier, which has special meaning.",
+            "items": {
+              "type": "object",
+              "required": [
+                "type",
+                "name",
+                "value"
+              ],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "description": "for example, cve, cwe, osvdb, usn, or an analyzer-dependent type such as gemnasium).",
+                  "minLength": 1
+                },
+                "name": {
+                  "type": "string",
+                  "description": "Human-readable name of the identifier.",
+                  "minLength": 1
+                },
+                "url": {
+                  "type": "string",
+                  "description": "URL of the identifier's documentation.",
+                  "pattern": "^(https?|ftp)://.+"
+                },
+                "value": {
+                  "type": "string",
+                  "description": "Value of the identifier, for matching purpose.",
+                  "minLength": 1
+                }
+              }
+            }
+          },
+          "cvss_vectors": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 10,
+            "description": "An ordered array of CVSS vectors, each issued by a vendor to rate the vulnerability. The first item in the array is used as the primary CVSS vector, and is used to filter and sort the vulnerability.",
+            "items": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "vendor": {
+                      "type": "string",
+                      "minLength": 1,
+                      "default": "unknown"
+                    },
+                    "vector": {
+                      "type": "string",
+                      "minLength": 16,
+                      "maxLength": 128,
+                      "pattern": "^((AV:[NAL]|AC:[LMH]|Au:[MSN]|[CIA]:[NPC]|E:(U|POC|F|H|ND)|RL:(OF|TF|W|U|ND)|RC:(UC|UR|C|ND)|CDP:(N|L|LM|MH|H|ND)|TD:(N|L|M|H|ND)|[CIA]R:(L|M|H|ND))/)*(AV:[NAL]|AC:[LMH]|Au:[MSN]|[CIA]:[NPC]|E:(U|POC|F|H|ND)|RL:(OF|TF|W|U|ND)|RC:(UC|UR|C|ND)|CDP:(N|L|LM|MH|H|ND)|TD:(N|L|M|H|ND)|[CIA]R:(L|M|H|ND))$"
+                    }
+                  },
+                  "required": [
+                    "vendor",
+                    "vector"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "vendor": {
+                      "type": "string",
+                      "minLength": 1,
+                      "default": "unknown"
+                    },
+                    "vector": {
+                      "type": "string",
+                      "minLength": 32,
+                      "maxLength": 128,
+                      "pattern": "^CVSS:3[.][01]/((AV:[NALP]|AC:[LH]|PR:[NLH]|UI:[NR]|S:[UC]|[CIA]:[NLH]|E:[XUPFH]|RL:[XOTWU]|RC:[XURC]|[CIA]R:[XLMH]|MAV:[XNALP]|MAC:[XLH]|MPR:[XNLH]|MUI:[XNR]|MS:[XUC]|M[CIA]:[XNLH])/)*(AV:[NALP]|AC:[LH]|PR:[NLH]|UI:[NR]|S:[UC]|[CIA]:[NLH]|E:[XUPFH]|RL:[XOTWU]|RC:[XURC]|[CIA]R:[XLMH]|MAV:[XNALP]|MAC:[XLH]|MPR:[XNLH]|MUI:[XNR]|MS:[XUC]|M[CIA]:[XNLH])$"
+                    }
+                  },
+                  "required": [
+                    "vendor",
+                    "vector"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "vendor": {
+                      "type": "string",
+                      "minLength": 1,
+                      "default": "unknown"
+                    },
+                    "vector": {
+                      "type": "string",
+                      "minLength": 32,
+                      "maxLength": 256,
+                      "pattern": "^CVSS:4[.]0/AV:[NALP]/AC:[LH]/AT:[NP]/PR:[NLH]/UI:[NPA]/VC:[HLN]/VI:[HLN]/VA:[HLN]/SC:[HLN]/SI:[HLN]/SA:[HLN](/E:[XAPU])?(/CR:[XHML])?(/IR:[XHML])?(/AR:[XHML])?(/MAV:[XNALP])?(/MAC:[XLH])?(/MAT:[XNP])?(/MPR:[XNLH])?(/MUI:[XNPA])?(/MVC:[XNLH])?(/MVI:[XNLH])?(/MVA:[XNLH])?(/MSC:[XNLH])?(/MSI:[XNLHS])?(/MSA:[XNLHS])?(/S:[XNP])?(/AU:[XNY])?(/R:[XAUI])?(/V:[XDC])?(/RE:[XLMH])?(/U:(X|Clear|Green|Amber|Red))?$"
+                    }
+                  },
+                  "required": [
+                    "vendor",
+                    "vector"
+                  ]
+                }
+              ]
+            }
+          },
+          "links": {
+            "type": "array",
+            "description": "An array of references to external documentation or articles that describe the vulnerability.",
+            "items": {
+              "type": "object",
+              "required": [
+                "url"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Name of the vulnerability details link."
+                },
+                "url": {
+                  "type": "string",
+                  "description": "URL of the vulnerability details document.",
+                  "pattern": "^(https?|ftp)://.+"
+                }
+              }
+            }
+          },
+          "details": {
+            "$ref": "#/definitions/named_list/properties/items"
+          },
+          "tracking": {
+            "type": "object",
+            "description": "Describes how this vulnerability should be tracked as the project changes.",
+            "oneOf": [
+              {
+                "description": "Declares that a series of items should be tracked using source-specific tracking methods.",
+                "required": [
+                  "items"
+                ],
+                "properties": {
+                  "type": {
+                    "const": "source"
+                  },
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "description": "An item that should be tracked using source-specific tracking methods.",
+                      "type": "object",
+                      "required": [
+                        "signatures"
+                      ],
+                      "properties": {
+                        "file": {
+                          "type": "string",
+                          "description": "Path to the file where the vulnerability is located."
+                        },
+                        "start_line": {
+                          "type": "number",
+                          "description": "The first line of the file that includes the vulnerability."
+                        },
+                        "end_line": {
+                          "type": "number",
+                          "description": "The last line of the file that includes the vulnerability."
+                        },
+                        "signatures": {
+                          "type": "array",
+                          "description": "An array of calculated tracking signatures for this tracking item.",
+                          "minItems": 1,
+                          "items": {
+                            "description": "A calculated tracking signature value and metadata.",
+                            "type": "object",
+                            "required": [
+                              "algorithm",
+                              "value"
+                            ],
+                            "properties": {
+                              "algorithm": {
+                                "type": "string",
+                                "description": "The algorithm used to generate the signature."
+                              },
+                              "value": {
+                                "type": "string",
+                                "description": "The result of this signature algorithm."
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "description": "Each tracking type must declare its own type."
+              }
+            }
+          },
+          "flags": {
+            "description": "Flags that can be attached to vulnerabilities.",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "description": "Informational flags identified and assigned to a vulnerability.",
+              "required": [
+                "type",
+                "origin",
+                "description"
+              ],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "Result of the scan.",
+                  "enum": [
+                    "flagged-as-likely-false-positive"
+                  ]
+                },
+                "origin": {
+                  "minLength": 1,
+                  "description": "Tool that issued the flag.",
+                  "type": "string"
+                },
+                "description": {
+                  "minLength": 1,
+                  "description": "What the flag is about.",
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "location": {
+            "type": "object",
+            "description": "Identifies the vulnerability's location.",
+            "required": [
+              "dependency",
+              "operating_system",
+              "image"
+            ],
+            "properties": {
+              "dependency": {
+                "type": "object",
+                "description": "Describes the dependency of a project where the vulnerability is located.",
+                "required": [
+                  "package",
+                  "version"
+                ],
+                "properties": {
+                  "package": {
+                    "type": "object",
+                    "description": "Provides information on the package where the vulnerability is located.",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "description": "Name of the package where the vulnerability is located."
+                      }
+                    }
+                  },
+                  "version": {
+                    "type": "string",
+                    "description": "Version of the vulnerable package."
+                  },
+                  "direct": {
+                    "type": "boolean",
+                    "description": "Tells whether this is a direct, top-level dependency of the scanned project."
+                  }
+                }
+              },
+              "operating_system": {
+                "type": "string",
+                "minLength": 1,
+                "description": "The operating system that contains the vulnerable package."
+              },
+              "image": {
+                "type": "string",
+                "minLength": 1,
+                "description": "The analyzed Docker image."
+              },
+              "default_branch_image": {
+                "type": "string",
+                "maxLength": 255,
+                "description": "The name of the image on the default branch."
+              }
+            }
+          }
+        }
+      }
+    },
+    "remediations": {
+      "type": "array",
+      "description": "An array of objects containing information on available remediations, along with patch diffs to apply.",
+      "items": {
+        "type": "object",
+        "required": [
+          "fixes",
+          "summary",
+          "diff"
+        ],
+        "properties": {
+          "fixes": {
+            "type": "array",
+            "description": "An array of strings that represent references to vulnerabilities fixed by this remediation.",
+            "items": {
+              "type": "object",
+              "required": [
+                "id"
+              ],
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "Unique identifier of the vulnerability. This is recommended to be a UUID.",
+                  "examples": [
+                    "642735a5-1425-428d-8d4e-3c854885a3c9"
+                  ]
+                }
+              }
+            }
+          },
+          "summary": {
+            "type": "string",
+            "minLength": 1,
+            "description": "An overview of how the vulnerabilities were fixed."
+          },
+          "diff": {
+            "type": "string",
+            "minLength": 1,
+            "description": "A base64-encoded remediation code diff, compatible with git apply."
+          }
+        }
+      }
+    }
+  }
+}

--- a/internal/output/gitlab/testdata/schemas/dependency-scanning-report-format.json
+++ b/internal/output/gitlab/testdata/schemas/dependency-scanning-report-format.json
@@ -1,0 +1,1231 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://gitlab.com/gitlab-org/security-products/security-report-schemas/-/raw/master/dist/dependency-scanning-report-format.json",
+  "title": "Report format for GitLab Dependency Scanning",
+  "description": "This schema provides the the report format for Dependency Scanning analyzers (https://docs.gitlab.com/ee/user/application_security/dependency_scanning).",
+  "definitions": {
+    "detail_type": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/named_list"
+        },
+        {
+          "$ref": "#/definitions/list"
+        },
+        {
+          "$ref": "#/definitions/table"
+        },
+        {
+          "$ref": "#/definitions/text"
+        },
+        {
+          "$ref": "#/definitions/url"
+        },
+        {
+          "$ref": "#/definitions/code"
+        },
+        {
+          "$ref": "#/definitions/value"
+        },
+        {
+          "$ref": "#/definitions/diff"
+        },
+        {
+          "$ref": "#/definitions/markdown"
+        },
+        {
+          "$ref": "#/definitions/commit"
+        },
+        {
+          "$ref": "#/definitions/file_location"
+        },
+        {
+          "$ref": "#/definitions/module_location"
+        },
+        {
+          "$ref": "#/definitions/code_flows"
+        }
+      ]
+    },
+    "text_value": {
+      "type": "string"
+    },
+    "named_field": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/text_value",
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "$ref": "#/definitions/text_value"
+        }
+      }
+    },
+    "named_list": {
+      "type": "object",
+      "description": "An object with named and typed fields",
+      "required": [
+        "type",
+        "items"
+      ],
+      "properties": {
+        "type": {
+          "const": "named-list"
+        },
+        "items": {
+          "type": "object",
+          "patternProperties": {
+            "^.*$": {
+              "allOf": [
+                {
+                  "$ref": "#/definitions/named_field"
+                },
+                {
+                  "$ref": "#/definitions/detail_type"
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "list": {
+      "type": "object",
+      "description": "A list of typed fields",
+      "required": [
+        "type",
+        "items"
+      ],
+      "properties": {
+        "type": {
+          "const": "list"
+        },
+        "items": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/detail_type"
+          }
+        }
+      }
+    },
+    "table": {
+      "type": "object",
+      "description": "A table of typed fields",
+      "required": [
+        "type",
+        "rows"
+      ],
+      "properties": {
+        "type": {
+          "const": "table"
+        },
+        "header": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/detail_type"
+          }
+        },
+        "rows": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/detail_type"
+            }
+          }
+        }
+      }
+    },
+    "text": {
+      "type": "object",
+      "description": "Raw text",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "const": "text"
+        },
+        "value": {
+          "$ref": "#/definitions/text_value"
+        }
+      }
+    },
+    "url": {
+      "type": "object",
+      "description": "A single URL",
+      "required": [
+        "type",
+        "href"
+      ],
+      "properties": {
+        "type": {
+          "const": "url"
+        },
+        "text": {
+          "$ref": "#/definitions/text_value"
+        },
+        "href": {
+          "type": "string",
+          "minLength": 1,
+          "examples": [
+            "http://mysite.com"
+          ]
+        }
+      }
+    },
+    "code": {
+      "type": "object",
+      "description": "A codeblock",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "const": "code"
+        },
+        "value": {
+          "type": "string"
+        },
+        "lang": {
+          "type": "string",
+          "description": "A programming language"
+        }
+      }
+    },
+    "value": {
+      "type": "object",
+      "description": "A field that can store a range of types of value",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "const": "value"
+        },
+        "value": {
+          "type": [
+            "number",
+            "string",
+            "boolean"
+          ]
+        }
+      }
+    },
+    "diff": {
+      "type": "object",
+      "description": "A diff",
+      "required": [
+        "type",
+        "before",
+        "after"
+      ],
+      "properties": {
+        "type": {
+          "const": "diff"
+        },
+        "before": {
+          "type": "string"
+        },
+        "after": {
+          "type": "string"
+        }
+      }
+    },
+    "markdown": {
+      "type": "object",
+      "description": "GitLab flavoured markdown, see https://docs.gitlab.com/ee/user/markdown.html",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "const": "markdown"
+        },
+        "value": {
+          "$ref": "#/definitions/text_value",
+          "examples": [
+            "Here is markdown `inline code` #1 [test](gitlab.com)\n\n![GitLab Logo](https://about.gitlab.com/images/press/logo/preview/gitlab-logo-white-preview.png)"
+          ]
+        }
+      }
+    },
+    "commit": {
+      "type": "object",
+      "description": "A commit/tag/branch within the GitLab project",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "const": "commit"
+        },
+        "value": {
+          "type": "string",
+          "description": "The commit SHA",
+          "minLength": 1
+        }
+      }
+    },
+    "file_location": {
+      "type": "object",
+      "description": "A location within a file in the project",
+      "required": [
+        "type",
+        "file_name",
+        "line_start"
+      ],
+      "properties": {
+        "type": {
+          "const": "file-location"
+        },
+        "file_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "line_start": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "line_end": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "column_start": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "column_end": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      "dependencies": {
+        "column_end": [
+          "column_start"
+        ],
+        "column_start": [
+          "column_end"
+        ]
+      }
+    },
+    "module_location": {
+      "type": "object",
+      "description": "A location within a binary module of the form module+relative_offset",
+      "required": [
+        "type",
+        "module_name",
+        "offset"
+      ],
+      "properties": {
+        "type": {
+          "const": "module-location"
+        },
+        "module_name": {
+          "type": "string",
+          "minLength": 1,
+          "examples": [
+            "compiled_binary"
+          ]
+        },
+        "offset": {
+          "type": "integer",
+          "examples": [
+            100
+          ]
+        }
+      }
+    },
+    "code_flow_node": {
+      "type": "object",
+      "description": "A code flow node representing a part of a vulnerability flow from source to sink",
+      "required": [
+        "file_location",
+        "node_type"
+      ],
+      "properties": {
+        "type": {
+          "const": "code-flow-node"
+        },
+        "file_location": {
+          "$ref": "#/definitions/file_location"
+        },
+        "node_type": {
+          "type": "string",
+          "description": "Describes a code flow node type",
+          "enum": [
+            "source",
+            "sink",
+            "propagation"
+          ]
+        }
+      },
+      "examples": [
+        {
+          "type": "code-flow-node",
+          "node_type": "propagation",
+          "file_location": {
+            "type": "file-location",
+            "file_name": "file_name.py",
+            "line_start": 4,
+            "line_end": 6
+          }
+        }
+      ]
+    },
+    "code_flows": {
+      "type": "object",
+      "description": "A code flow representing a vulnerability flow from source to sink",
+      "required": [
+        "items",
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "const": "code-flows"
+        },
+        "items": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 10,
+          "items": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "$ref": "#/definitions/code_flow_node"
+            }
+          }
+        }
+      },
+      "examples": [
+        {
+          "type": "code-flows",
+          "items": [
+            [
+              {
+                "type": "code-flow-node",
+                "node_type": "source",
+                "file_location": {
+                  "type": "file-location",
+                  "file_name": "file_name.py",
+                  "line_start": 1,
+                  "line_end": 2
+                }
+              },
+              {
+                "type": "code-flow-node",
+                "node_type": "propagation",
+                "file_location": {
+                  "type": "file-location",
+                  "file_name": "file_name.py",
+                  "line_start": 3
+                }
+              },
+              {
+                "type": "code-flow-node",
+                "node_type": "sink",
+                "file_location": {
+                  "type": "file-location",
+                  "file_name": "file_name.py",
+                  "line_start": 4,
+                  "line_end": 6
+                }
+              }
+            ],
+            [
+              {
+                "type": "code-flow-node",
+                "node_type": "source",
+                "file_location": {
+                  "type": "file-location",
+                  "file_name": "different_flow.py",
+                  "line_start": 100,
+                  "line_end": 102
+                }
+              },
+              {
+                "type": "code-flow-node",
+                "node_type": "sink",
+                "file_location": {
+                  "type": "file-location",
+                  "file_name": "file_name.py",
+                  "line_start": 4,
+                  "line_end": 6
+                }
+              }
+            ]
+          ]
+        }
+      ]
+    }
+  },
+  "self": {
+    "version": "15.2.4"
+  },
+  "type": "object",
+  "required": [
+    "scan",
+    "version",
+    "vulnerabilities"
+  ],
+  "additionalProperties": true,
+  "properties": {
+    "scan": {
+      "type": "object",
+      "required": [
+        "analyzer",
+        "end_time",
+        "scanner",
+        "start_time",
+        "status",
+        "type"
+      ],
+      "properties": {
+        "end_time": {
+          "type": "string",
+          "description": "ISO8601 UTC value with format yyyy-mm-ddThh:mm:ss, representing when the scan finished.",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$",
+          "examples": [
+            "2020-01-28T03:26:02"
+          ]
+        },
+        "messages": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "description": "Communication intended for the initiator of a scan.",
+            "required": [
+              "level",
+              "value"
+            ],
+            "properties": {
+              "level": {
+                "type": "string",
+                "description": "Describes the severity of the communication. Use info to communicate normal scan behaviour; warn to communicate a potentially recoverable problem, or a partial error; fatal to communicate an issue that causes the scan to halt.",
+                "enum": [
+                  "info",
+                  "warn",
+                  "fatal"
+                ],
+                "examples": [
+                  "info"
+                ]
+              },
+              "value": {
+                "type": "string",
+                "description": "The message to communicate.",
+                "minLength": 1,
+                "examples": [
+                  "Permission denied, scanning aborted"
+                ]
+              }
+            }
+          }
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "description": "A configuration option used for this scan.",
+            "required": [
+              "name",
+              "value"
+            ],
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "The configuration option name.",
+                "maxLength": 255,
+                "minLength": 1,
+                "examples": [
+                  "DAST_FF_ENABLE_BAS",
+                  "DOCKER_TLS_CERTDIR",
+                  "DS_MAX_DEPTH",
+                  "SECURE_LOG_LEVEL"
+                ]
+              },
+              "source": {
+                "type": "string",
+                "description": "The source of this option.",
+                "enum": [
+                  "argument",
+                  "file",
+                  "env_variable",
+                  "other"
+                ]
+              },
+              "value": {
+                "type": [
+                  "boolean",
+                  "integer",
+                  "null",
+                  "string"
+                ],
+                "description": "The value used for this scan.",
+                "examples": [
+                  true,
+                  2,
+                  null,
+                  "fatal",
+                  ""
+                ]
+              }
+            }
+          }
+        },
+        "analyzer": {
+          "type": "object",
+          "description": "Object defining the analyzer used to perform the scan. Analyzers typically delegate to an underlying scanner to run the scan.",
+          "required": [
+            "id",
+            "name",
+            "version",
+            "vendor"
+          ],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "Unique id that identifies the analyzer.",
+              "minLength": 1,
+              "examples": [
+                "gitlab-dast"
+              ]
+            },
+            "name": {
+              "type": "string",
+              "description": "A human readable value that identifies the analyzer, not required to be unique.",
+              "minLength": 1,
+              "examples": [
+                "GitLab DAST"
+              ]
+            },
+            "url": {
+              "type": "string",
+              "pattern": "^https?://.+",
+              "description": "A link to more information about the analyzer.",
+              "examples": [
+                "https://docs.gitlab.com/ee/user/application_security/dast"
+              ]
+            },
+            "vendor": {
+              "description": "The vendor/maintainer of the analyzer.",
+              "type": "object",
+              "required": [
+                "name"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "The name of the vendor.",
+                  "minLength": 1,
+                  "examples": [
+                    "GitLab"
+                  ]
+                }
+              }
+            },
+            "version": {
+              "type": "string",
+              "description": "The version of the analyzer.",
+              "minLength": 1,
+              "examples": [
+                "1.0.2"
+              ]
+            }
+          }
+        },
+        "scanner": {
+          "type": "object",
+          "description": "Object defining the scanner used to perform the scan.",
+          "required": [
+            "id",
+            "name",
+            "version",
+            "vendor"
+          ],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "Unique id that identifies the scanner.",
+              "minLength": 1,
+              "examples": [
+                "my-sast-scanner"
+              ]
+            },
+            "name": {
+              "type": "string",
+              "description": "A human readable value that identifies the scanner, not required to be unique.",
+              "minLength": 1,
+              "examples": [
+                "My SAST Scanner"
+              ]
+            },
+            "url": {
+              "type": "string",
+              "description": "A link to more information about the scanner.",
+              "examples": [
+                "https://scanner.url"
+              ]
+            },
+            "version": {
+              "type": "string",
+              "description": "The version of the scanner.",
+              "minLength": 1,
+              "examples": [
+                "1.0.2"
+              ]
+            },
+            "vendor": {
+              "description": "The vendor/maintainer of the scanner.",
+              "type": "object",
+              "required": [
+                "name"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "The name of the vendor.",
+                  "minLength": 1,
+                  "examples": [
+                    "GitLab"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "start_time": {
+          "type": "string",
+          "description": "ISO8601 UTC value with format yyyy-mm-ddThh:mm:ss, representing when the scan started.",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$",
+          "examples": [
+            "2020-02-14T16:01:59"
+          ]
+        },
+        "status": {
+          "type": "string",
+          "description": "Result of the scan.",
+          "enum": [
+            "success",
+            "failure"
+          ]
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the scan.",
+          "enum": [
+            "dependency_scanning"
+          ]
+        },
+        "partial_scan": {
+          "type": "object",
+          "description": "Indicates the mode of a partial scan.",
+          "required": [
+            "mode"
+          ],
+          "properties": {
+            "mode": {
+              "type": "string",
+              "enum": [
+                "differential"
+              ],
+              "description": "The mode of the partial scan"
+            }
+          }
+        },
+        "primary_identifiers": {
+          "type": "array",
+          "description": "An unordered array containing an exhaustive list of primary identifiers for which the analyzer may return results",
+          "items": {
+            "type": "object",
+            "required": [
+              "type",
+              "name",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "description": "for example, cve, cwe, osvdb, usn, or an analyzer-dependent type such as gemnasium).",
+                "minLength": 1
+              },
+              "name": {
+                "type": "string",
+                "description": "Human-readable name of the identifier.",
+                "minLength": 1
+              },
+              "url": {
+                "type": "string",
+                "description": "URL of the identifier's documentation.",
+                "pattern": "^(https?|ftp)://.+"
+              },
+              "value": {
+                "type": "string",
+                "description": "Value of the identifier, for matching purpose.",
+                "minLength": 1
+              }
+            }
+          }
+        },
+        "observability": {
+          "type": "object",
+          "description": "Internal GitLab use only. Observability data such as metrics collected by the analyzers.",
+          "properties": {
+            "events": {
+              "type": "array",
+              "description": "Internal GitLab use only. Array of events containing metrics logged via the GitLab internal event tracking system. Recommend working with the analytics instrumentation team to define events.",
+              "items": {
+                "type": "object",
+                "description": "Internal GitLab use only. An event with zero or more values. Additional properties can be used to collect various metrics associated with event. Recommend working with the analytics instrumentation team to define events.",
+                "required": [
+                  "event"
+                ],
+                "properties": {
+                  "event": {
+                    "type": "string",
+                    "description": "Name of the event. Events must be defined and added to the security reports observability events allow list."
+                  },
+                  "property": {
+                    "type": "string",
+                    "description": "Data related to given event. Column in the data warehouse, fast to filter on in queries."
+                  },
+                  "label": {
+                    "type": "string",
+                    "description": "Data related to given event. Column in the data warehouse, fast to filter on in queries."
+                  },
+                  "value": {
+                    "type": "number",
+                    "description": "Data related to given event. Column in the data warehouse, fast to filter on in queries."
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "schema": {
+      "type": "string",
+      "description": "URI pointing to the validating security report schema.",
+      "pattern": "^https?://.+"
+    },
+    "version": {
+      "type": "string",
+      "description": "The version of the schema to which the JSON report conforms.",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "vulnerabilities": {
+      "type": "array",
+      "description": "Array of vulnerability objects.",
+      "items": {
+        "type": "object",
+        "description": "Describes the vulnerability using GitLab Flavored Markdown",
+        "required": [
+          "id",
+          "identifiers",
+          "location"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Unique identifier of the vulnerability. This is recommended to be a UUID.",
+            "examples": [
+              "642735a5-1425-428d-8d4e-3c854885a3c9"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "maxLength": 255,
+            "description": "The name of the vulnerability. This must not include the finding's specific information."
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 1048576,
+            "description": "A long text section describing the vulnerability more fully."
+          },
+          "severity": {
+            "type": "string",
+            "description": "How much the vulnerability impacts the software. Possible values are Info, Unknown, Low, Medium, High, or Critical. Note that some analyzers may not report all these possible values.",
+            "enum": [
+              "Info",
+              "Unknown",
+              "Low",
+              "Medium",
+              "High",
+              "Critical"
+            ]
+          },
+          "solution": {
+            "type": "string",
+            "maxLength": 7000,
+            "description": "Explanation of how to fix the vulnerability."
+          },
+          "identifiers": {
+            "type": "array",
+            "minItems": 1,
+            "description": "An ordered array of references that identify a vulnerability on internal or external databases. The first identifier is the Primary Identifier, which has special meaning.",
+            "items": {
+              "type": "object",
+              "required": [
+                "type",
+                "name",
+                "value"
+              ],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "description": "for example, cve, cwe, osvdb, usn, or an analyzer-dependent type such as gemnasium).",
+                  "minLength": 1
+                },
+                "name": {
+                  "type": "string",
+                  "description": "Human-readable name of the identifier.",
+                  "minLength": 1
+                },
+                "url": {
+                  "type": "string",
+                  "description": "URL of the identifier's documentation.",
+                  "pattern": "^(https?|ftp)://.+"
+                },
+                "value": {
+                  "type": "string",
+                  "description": "Value of the identifier, for matching purpose.",
+                  "minLength": 1
+                }
+              }
+            }
+          },
+          "cvss_vectors": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 10,
+            "description": "An ordered array of CVSS vectors, each issued by a vendor to rate the vulnerability. The first item in the array is used as the primary CVSS vector, and is used to filter and sort the vulnerability.",
+            "items": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "vendor": {
+                      "type": "string",
+                      "minLength": 1,
+                      "default": "unknown"
+                    },
+                    "vector": {
+                      "type": "string",
+                      "minLength": 16,
+                      "maxLength": 128,
+                      "pattern": "^((AV:[NAL]|AC:[LMH]|Au:[MSN]|[CIA]:[NPC]|E:(U|POC|F|H|ND)|RL:(OF|TF|W|U|ND)|RC:(UC|UR|C|ND)|CDP:(N|L|LM|MH|H|ND)|TD:(N|L|M|H|ND)|[CIA]R:(L|M|H|ND))/)*(AV:[NAL]|AC:[LMH]|Au:[MSN]|[CIA]:[NPC]|E:(U|POC|F|H|ND)|RL:(OF|TF|W|U|ND)|RC:(UC|UR|C|ND)|CDP:(N|L|LM|MH|H|ND)|TD:(N|L|M|H|ND)|[CIA]R:(L|M|H|ND))$"
+                    }
+                  },
+                  "required": [
+                    "vendor",
+                    "vector"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "vendor": {
+                      "type": "string",
+                      "minLength": 1,
+                      "default": "unknown"
+                    },
+                    "vector": {
+                      "type": "string",
+                      "minLength": 32,
+                      "maxLength": 128,
+                      "pattern": "^CVSS:3[.][01]/((AV:[NALP]|AC:[LH]|PR:[NLH]|UI:[NR]|S:[UC]|[CIA]:[NLH]|E:[XUPFH]|RL:[XOTWU]|RC:[XURC]|[CIA]R:[XLMH]|MAV:[XNALP]|MAC:[XLH]|MPR:[XNLH]|MUI:[XNR]|MS:[XUC]|M[CIA]:[XNLH])/)*(AV:[NALP]|AC:[LH]|PR:[NLH]|UI:[NR]|S:[UC]|[CIA]:[NLH]|E:[XUPFH]|RL:[XOTWU]|RC:[XURC]|[CIA]R:[XLMH]|MAV:[XNALP]|MAC:[XLH]|MPR:[XNLH]|MUI:[XNR]|MS:[XUC]|M[CIA]:[XNLH])$"
+                    }
+                  },
+                  "required": [
+                    "vendor",
+                    "vector"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "vendor": {
+                      "type": "string",
+                      "minLength": 1,
+                      "default": "unknown"
+                    },
+                    "vector": {
+                      "type": "string",
+                      "minLength": 32,
+                      "maxLength": 256,
+                      "pattern": "^CVSS:4[.]0/AV:[NALP]/AC:[LH]/AT:[NP]/PR:[NLH]/UI:[NPA]/VC:[HLN]/VI:[HLN]/VA:[HLN]/SC:[HLN]/SI:[HLN]/SA:[HLN](/E:[XAPU])?(/CR:[XHML])?(/IR:[XHML])?(/AR:[XHML])?(/MAV:[XNALP])?(/MAC:[XLH])?(/MAT:[XNP])?(/MPR:[XNLH])?(/MUI:[XNPA])?(/MVC:[XNLH])?(/MVI:[XNLH])?(/MVA:[XNLH])?(/MSC:[XNLH])?(/MSI:[XNLHS])?(/MSA:[XNLHS])?(/S:[XNP])?(/AU:[XNY])?(/R:[XAUI])?(/V:[XDC])?(/RE:[XLMH])?(/U:(X|Clear|Green|Amber|Red))?$"
+                    }
+                  },
+                  "required": [
+                    "vendor",
+                    "vector"
+                  ]
+                }
+              ]
+            }
+          },
+          "links": {
+            "type": "array",
+            "description": "An array of references to external documentation or articles that describe the vulnerability.",
+            "items": {
+              "type": "object",
+              "required": [
+                "url"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Name of the vulnerability details link."
+                },
+                "url": {
+                  "type": "string",
+                  "description": "URL of the vulnerability details document.",
+                  "pattern": "^(https?|ftp)://.+"
+                }
+              }
+            }
+          },
+          "details": {
+            "$ref": "#/definitions/named_list/properties/items"
+          },
+          "tracking": {
+            "type": "object",
+            "description": "Describes how this vulnerability should be tracked as the project changes.",
+            "oneOf": [
+              {
+                "description": "Declares that a series of items should be tracked using source-specific tracking methods.",
+                "required": [
+                  "items"
+                ],
+                "properties": {
+                  "type": {
+                    "const": "source"
+                  },
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "description": "An item that should be tracked using source-specific tracking methods.",
+                      "type": "object",
+                      "required": [
+                        "signatures"
+                      ],
+                      "properties": {
+                        "file": {
+                          "type": "string",
+                          "description": "Path to the file where the vulnerability is located."
+                        },
+                        "start_line": {
+                          "type": "number",
+                          "description": "The first line of the file that includes the vulnerability."
+                        },
+                        "end_line": {
+                          "type": "number",
+                          "description": "The last line of the file that includes the vulnerability."
+                        },
+                        "signatures": {
+                          "type": "array",
+                          "description": "An array of calculated tracking signatures for this tracking item.",
+                          "minItems": 1,
+                          "items": {
+                            "description": "A calculated tracking signature value and metadata.",
+                            "type": "object",
+                            "required": [
+                              "algorithm",
+                              "value"
+                            ],
+                            "properties": {
+                              "algorithm": {
+                                "type": "string",
+                                "description": "The algorithm used to generate the signature."
+                              },
+                              "value": {
+                                "type": "string",
+                                "description": "The result of this signature algorithm."
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "description": "Each tracking type must declare its own type."
+              }
+            }
+          },
+          "flags": {
+            "description": "Flags that can be attached to vulnerabilities.",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "description": "Informational flags identified and assigned to a vulnerability.",
+              "required": [
+                "type",
+                "origin",
+                "description"
+              ],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "Result of the scan.",
+                  "enum": [
+                    "flagged-as-likely-false-positive"
+                  ]
+                },
+                "origin": {
+                  "minLength": 1,
+                  "description": "Tool that issued the flag.",
+                  "type": "string"
+                },
+                "description": {
+                  "minLength": 1,
+                  "description": "What the flag is about.",
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "location": {
+            "type": "object",
+            "description": "Identifies the vulnerability's location.",
+            "required": [
+              "file",
+              "dependency"
+            ],
+            "properties": {
+              "file": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Path to the manifest or lock file where the dependency is declared (such as yarn.lock)."
+              },
+              "files": {
+                "type": "array",
+                "description": "Array of files where the dependency is declared.",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "path",
+                    "type"
+                  ],
+                  "properties": {
+                    "path": {
+                      "type": "string",
+                      "minLength": 1,
+                      "description": "Path to the file."
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "requirements",
+                        "lockfile",
+                        "graphfile"
+                      ],
+                      "description": "Type of the file."
+                    },
+                    "in_repository": {
+                      "type": "boolean",
+                      "description": "Indicates whether the file is in the repository."
+                    }
+                  }
+                }
+              },
+              "dependency": {
+                "type": "object",
+                "description": "Describes the dependency of a project where the vulnerability is located.",
+                "required": [
+                  "package",
+                  "version"
+                ],
+                "properties": {
+                  "package": {
+                    "type": "object",
+                    "description": "Provides information on the package where the vulnerability is located.",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "description": "Name of the package where the vulnerability is located."
+                      }
+                    }
+                  },
+                  "version": {
+                    "type": "string",
+                    "description": "Version of the vulnerable package."
+                  },
+                  "direct": {
+                    "type": "boolean",
+                    "description": "Tells whether this is a direct, top-level dependency of the scanned project."
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "remediations": {
+      "type": "array",
+      "description": "An array of objects containing information on available remediations, along with patch diffs to apply.",
+      "items": {
+        "type": "object",
+        "required": [
+          "fixes",
+          "summary",
+          "diff"
+        ],
+        "properties": {
+          "fixes": {
+            "type": "array",
+            "description": "An array of strings that represent references to vulnerabilities fixed by this remediation.",
+            "items": {
+              "type": "object",
+              "required": [
+                "id"
+              ],
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "Unique identifier of the vulnerability. This is recommended to be a UUID.",
+                  "examples": [
+                    "642735a5-1425-428d-8d4e-3c854885a3c9"
+                  ]
+                }
+              }
+            }
+          },
+          "summary": {
+            "type": "string",
+            "minLength": 1,
+            "description": "An overview of how the vulnerabilities were fixed."
+          },
+          "diff": {
+            "type": "string",
+            "minLength": 1,
+            "description": "A base64-encoded remediation code diff, compatible with git apply."
+          }
+        }
+      }
+    }
+  }
+}

--- a/internal/output/gitlab/vendor.go
+++ b/internal/output/gitlab/vendor.go
@@ -1,0 +1,6 @@
+package gitlab
+
+// Vendor is the vendor/maintainer of the scanner
+type Vendor struct {
+	Name string `json:"name"` // The name of the vendor
+}

--- a/internal/output/gitlab/version.go
+++ b/internal/output/gitlab/version.go
@@ -1,0 +1,91 @@
+package gitlab
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const (
+	// VersionMajor is the major number of the current version
+	VersionMajor = 15
+	// VersionMinor is the minor number of the current version
+	VersionMinor = 2
+	// VersionPatch is the patch number of the current version
+	VersionPatch = 4
+	// VersionPreRelease is the optional suffix for pre-releases
+	VersionPreRelease = ""
+)
+
+// CurrentVersion returns the current version of the report syntax.
+func CurrentVersion() Version {
+	return Version{VersionMajor, VersionMinor, VersionPatch, VersionPreRelease}
+}
+
+// Version represents the version of the report syntax.
+// It matches a release of the Security Report Schemas, and is used for JSON schema validation.
+// See https://gitlab.com/gitlab-org/security-products/security-report-schemas/-/releases
+type Version struct {
+	Major      uint
+	Minor      uint
+	Patch      uint
+	PreRelease string
+}
+
+// MarshalJSON encodes a version to JSON.
+func (v Version) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.String())
+}
+
+// UnmarshalJSON decodes a version.
+func (v *Version) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+
+	// set to default version if empty string
+	if s == "" {
+		v.Major = VersionMajor
+		v.Minor = VersionMinor
+		v.Patch = VersionPatch
+		return nil
+	}
+
+	// parse pre-release
+	parts := strings.SplitN(s, "-", 2)
+	if len(parts) > 1 {
+		v.PreRelease = parts[1]
+	}
+
+	// parse segments
+	parts = strings.SplitN(parts[0], ".", 3)
+	for i := range parts {
+		un, err := strconv.ParseUint(parts[i], 10, 32)
+		if err != nil {
+			return err
+		}
+
+		n := uint(un)
+		switch i {
+		case 0:
+			v.Major = n
+		case 1:
+			v.Minor = n
+		case 2:
+			v.Patch = n
+		}
+	}
+
+	return nil
+}
+
+// String turns the version into a "MAJOR.MINOR.PATCH" string, with an optional "-PRERELEASE" suffix.
+func (v Version) String() string {
+	var pre string
+	if v.PreRelease != "" {
+		pre = fmt.Sprintf("-%s", v.PreRelease)
+	}
+	return fmt.Sprintf("%d.%d.%d%s", v.Major, v.Minor, v.Patch, pre)
+}

--- a/internal/output/gitlab/version_test.go
+++ b/internal/output/gitlab/version_test.go
@@ -1,0 +1,119 @@
+package gitlab
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestCurrentVersion(t *testing.T) {
+	v := CurrentVersion()
+	if v.Major != VersionMajor {
+		t.Errorf("expected Major %d, got %d", VersionMajor, v.Major)
+	}
+	if v.Minor != VersionMinor {
+		t.Errorf("expected Minor %d, got %d", VersionMinor, v.Minor)
+	}
+	if v.Patch != VersionPatch {
+		t.Errorf("expected Patch %d, got %d", VersionPatch, v.Patch)
+	}
+}
+
+func TestVersion_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		version  Version
+		expected string
+	}{
+		{
+			name:     "standard version",
+			version:  Version{Major: 15, Minor: 2, Patch: 4},
+			expected: "15.2.4",
+		},
+		{
+			name:     "with pre-release",
+			version:  Version{Major: 15, Minor: 2, Patch: 4, PreRelease: "beta1"},
+			expected: "15.2.4-beta1",
+		},
+		{
+			name:     "zero version",
+			version:  Version{},
+			expected: "0.0.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.version.String(); got != tt.expected {
+				t.Errorf("Version.String() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestVersion_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		version  Version
+		expected string
+	}{
+		{
+			name:     "standard version",
+			version:  Version{Major: 15, Minor: 2, Patch: 4},
+			expected: `"15.2.4"`,
+		},
+		{
+			name:     "with pre-release",
+			version:  Version{Major: 1, Minor: 0, Patch: 0, PreRelease: "rc1"},
+			expected: `"1.0.0-rc1"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := json.Marshal(tt.version)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if string(got) != tt.expected {
+				t.Errorf("MarshalJSON() = %v, want %v", string(got), tt.expected)
+			}
+		})
+	}
+}
+
+func TestVersion_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected Version
+	}{
+		{
+			name:     "standard version",
+			input:    `"15.2.4"`,
+			expected: Version{Major: 15, Minor: 2, Patch: 4},
+		},
+		{
+			name:     "with pre-release",
+			input:    `"1.0.0-beta1"`,
+			expected: Version{Major: 1, Minor: 0, Patch: 0, PreRelease: "beta1"},
+		},
+		{
+			name:     "empty string uses defaults",
+			input:    `""`,
+			expected: Version{Major: VersionMajor, Minor: VersionMinor, Patch: VersionPatch},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got Version
+			err := json.Unmarshal([]byte(tt.input), &got)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.expected {
+				t.Errorf("UnmarshalJSON() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/output/gitlab/vulnerability.go
+++ b/internal/output/gitlab/vulnerability.go
@@ -1,0 +1,54 @@
+package gitlab
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+)
+
+// Vulnerability represents a generic vulnerability occurrence reported by scanner.
+type Vulnerability struct {
+	Name        string        `json:"name,omitempty"`         // Name of the vulnerability, this must not include occurence's specific information.
+	Message     string        `json:"message,omitempty"`      // Message is a short text that describes the vulnerability, it may include occurence's specific information.
+	Description string        `json:"description,omitempty"`  // Description is a long text that describes the vulnerability.
+	Severity    SeverityLevel `json:"severity,omitempty"`     // Severity describes how much the vulnerability impacts the software.
+	Solution    string        `json:"solution,omitempty"`     // Solution explains how to fix the vulnerability.
+	Location    Location      `json:"location"`               // Location tells which class and/or method is affected by the vulnerability.
+	Identifiers []Identifier  `json:"identifiers"`            // Identifiers are references that identify a vulnerability on internal or external DBs.
+	CVSSRatings []CVSSRating  `json:"cvss_vectors,omitempty"` // CVSSRatings provide context about the risk, impact and severity of a vulnerability. Different vendors may score the Vulnerability differently. Thus, we provide all known vectors for completeness.
+	Links       []Link        `json:"links,omitempty"`        // Links are external documentations or articles that further describes the vulnerability.
+}
+
+// MarshalJSON adds an id field when encoding the vulnerability.
+func (i Vulnerability) MarshalJSON() ([]byte, error) {
+	type rawVulnerability Vulnerability
+	withID := struct {
+		ID string `json:"id"`
+		rawVulnerability
+	}{
+		i.ID(),
+		rawVulnerability(i),
+	}
+	return json.Marshal(withID)
+}
+
+// ID returns a hash combining all the fields of the vulnerability.
+// This should be a randomly generated UUID but currently it needs to be predictable
+// because of limitations in the implementation of klar and gemnasium analyzers.
+func (i Vulnerability) ID() string {
+	h := sha256.New()
+
+	// convert the struct to a JSON string so that struct fields
+	// that are pointers to structs (like Location.Commit)
+	// are rendered as predictable JSON objects with keys and values,
+	// and not as memory addresses that changes across executions
+	type VulnerabilityAlias Vulnerability
+	b, err := json.Marshal(VulnerabilityAlias(i))
+	if err != nil {
+		return ""
+	}
+	if _, err := h.Write(b); err != nil {
+		return ""
+	}
+	return fmt.Sprintf("%x", h.Sum(nil))
+}

--- a/internal/output/gitlab/vulnerability_test.go
+++ b/internal/output/gitlab/vulnerability_test.go
@@ -1,0 +1,117 @@
+package gitlab
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestVulnerability_ID(t *testing.T) {
+	vuln := Vulnerability{
+		Name:     "CVE-2023-1234",
+		Message:  "Test vulnerability",
+		Severity: SeverityLevelHigh,
+		Location: Location{
+			File: "/test/path",
+			Dependency: &Dependency{
+				Package: Package{Name: "test-pkg"},
+				Version: "1.0.0",
+			},
+		},
+		Identifiers: []Identifier{
+			{Type: IdentifierTypeCVE, Name: "CVE-2023-1234", Value: "CVE-2023-1234"},
+		},
+	}
+
+	id := vuln.ID()
+
+	// ID should be a non-empty SHA256 hash (64 hex characters)
+	if len(id) != 64 {
+		t.Errorf("expected ID length 64, got %d", len(id))
+	}
+
+	// Same vulnerability should produce same ID
+	id2 := vuln.ID()
+	if id != id2 {
+		t.Errorf("expected same ID for same vulnerability, got %s and %s", id, id2)
+	}
+
+	// Different vulnerability should produce different ID
+	vuln2 := vuln
+	vuln2.Name = "CVE-2023-5678"
+	id3 := vuln2.ID()
+	if id == id3 {
+		t.Errorf("expected different ID for different vulnerability")
+	}
+}
+
+func TestVulnerability_MarshalJSON(t *testing.T) {
+	vuln := Vulnerability{
+		Name:     "CVE-2023-1234",
+		Message:  "Test vulnerability",
+		Severity: SeverityLevelHigh,
+		Location: Location{
+			File: "/test/path",
+		},
+		Identifiers: []Identifier{},
+	}
+
+	data, err := json.Marshal(vuln)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify the JSON contains an "id" field
+	var result map[string]interface{}
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+
+	if _, ok := result["id"]; !ok {
+		t.Error("expected 'id' field in JSON output")
+	}
+
+	if result["name"] != "CVE-2023-1234" {
+		t.Errorf("expected name 'CVE-2023-1234', got %v", result["name"])
+	}
+
+	if result["severity"] != "High" {
+		t.Errorf("expected severity 'High', got %v", result["severity"])
+	}
+}
+
+func TestVulnerability_ID_Deterministic(t *testing.T) {
+	// Test that the same input always produces the same ID
+	vuln := Vulnerability{
+		Name:        "CVE-2023-1234",
+		Message:     "A test vulnerability",
+		Description: "Detailed description",
+		Severity:    SeverityLevelCritical,
+		Solution:    "Update to latest version",
+		Location: Location{
+			File: "/package.json",
+			Dependency: &Dependency{
+				Package: Package{Name: "lodash"},
+				Version: "4.17.20",
+			},
+		},
+		Identifiers: []Identifier{
+			{Type: IdentifierTypeCVE, Name: "CVE-2023-1234", Value: "CVE-2023-1234"},
+		},
+		Links: []Link{
+			{URL: "https://example.com"},
+		},
+	}
+
+	// Generate ID multiple times
+	ids := make([]string, 10)
+	for i := 0; i < 10; i++ {
+		ids[i] = vuln.ID()
+	}
+
+	// All IDs should be identical
+	for i := 1; i < len(ids); i++ {
+		if ids[i] != ids[0] {
+			t.Errorf("ID generation not deterministic: got %s and %s", ids[0], ids[i])
+		}
+	}
+}

--- a/internal/output/gitlab_internal_test.go
+++ b/internal/output/gitlab_internal_test.go
@@ -1,0 +1,926 @@
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/osv-scanner/v2/internal/output/gitlab"
+	"github.com/google/osv-scanner/v2/pkg/models"
+	"github.com/ossf/osv-schema/bindings/go/osvschema"
+	"github.com/xeipuuv/gojsonschema"
+)
+
+// gitlabSchemaVersion documents the release of the GitLab Security Report Schemas
+// that the vendored schemas under testdata/schemas were copied from. It should match
+// the report version we generate (see gitlab/version.go). To refresh the vendored
+// schemas, download the matching files from:
+//
+//	https://gitlab.com/gitlab-org/security-products/security-report-schemas/-/raw/<gitlabSchemaVersion>/dist/<schemaFile>
+const gitlabSchemaVersion = "v15.2.4"
+
+// loadGitLabSchema loads a vendored GitLab schema from testdata so validation stays
+// hermetic (no network access at test time).
+func loadGitLabSchema(t *testing.T, schemaFile string) gojsonschema.JSONLoader {
+	t.Helper()
+
+	schemaPath := filepath.Join("gitlab", "testdata", "schemas", schemaFile)
+	schemaBytes, err := os.ReadFile(schemaPath)
+	if err != nil {
+		t.Fatalf("failed to read vendored schema %q: %v", schemaPath, err)
+	}
+
+	return gojsonschema.NewBytesLoader(schemaBytes)
+}
+
+func validateGitLabReport(t *testing.T, schemaLoader gojsonschema.JSONLoader, report any) {
+	t.Helper()
+
+	reportJSON, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("failed to marshal report: %v", err)
+	}
+
+	validateGitLabReportBytes(t, schemaLoader, reportJSON)
+}
+
+// validateGitLabReportBytes validates already-encoded report JSON against a GitLab schema.
+func validateGitLabReportBytes(t *testing.T, schemaLoader gojsonschema.JSONLoader, reportJSON []byte) {
+	t.Helper()
+
+	documentLoader := gojsonschema.NewBytesLoader(reportJSON)
+	result, err := gojsonschema.Validate(schemaLoader, documentLoader)
+	if err != nil {
+		t.Fatalf("validation error: %v", err)
+	}
+
+	if !result.Valid() {
+		t.Errorf("report does not validate against GitLab schema:")
+		for _, desc := range result.Errors() {
+			t.Errorf("  - %s", desc)
+		}
+		t.Logf("Generated report:\n%s", string(reportJSON))
+	}
+}
+
+func TestDetermineScanType(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *models.VulnerabilityResults
+		expected gitlab.Category
+	}{
+		{
+			name:     "container scanning",
+			input:    &models.VulnerabilityResults{ImageMetadata: &models.ImageMetadata{}},
+			expected: gitlab.CategoryContainerScanning,
+		},
+		{
+			name:     "dependency scanning",
+			input:    &models.VulnerabilityResults{},
+			expected: gitlab.CategoryDependencyScanning,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := determineScanType(tt.input)
+			if result != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestBuildIdentifiers(t *testing.T) {
+	vuln := &osvschema.Vulnerability{
+		Id:      "CVE-2023-1234",
+		Aliases: []string{"GHSA-xxxx-yyyy-zzzz", "invalid-id"},
+	}
+
+	identifiers := buildIdentifiers(vuln)
+
+	if len(identifiers) != 2 {
+		t.Errorf("expected 2 identifiers, got %d", len(identifiers))
+	}
+
+	if identifiers[0].Type != gitlab.IdentifierTypeCVE {
+		t.Errorf("expected CVE type, got %v", identifiers[0].Type)
+	}
+
+	if identifiers[1].Type != gitlab.IdentifierTypeGHSA {
+		t.Errorf("expected GHSA type, got %v", identifiers[1].Type)
+	}
+}
+
+func TestBuildIdentifiers_AllTypes(t *testing.T) {
+	tests := []struct {
+		id           string
+		expectedType gitlab.IdentifierType
+	}{
+		{"CVE-2023-1234", gitlab.IdentifierTypeCVE},
+		{"CWE-79", gitlab.IdentifierTypeCWE},
+		{"GHSA-xxxx-yyyy-zzzz", gitlab.IdentifierTypeGHSA},
+		{"GLAM-12345", gitlab.IdentifierTypeGLAM},
+		{"MAL-2023-1234", gitlab.IdentifierTypeMAL},
+		{"RHSA-2023:1234", gitlab.IdentifierTypeRHSA},
+		{"USN-1234-1", gitlab.IdentifierTypeUSN},
+		{"ELSA-2023-1234", gitlab.IdentifierTypeELSA},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.id, func(t *testing.T) {
+			vuln := &osvschema.Vulnerability{Id: tt.id}
+			identifiers := buildIdentifiers(vuln)
+
+			if len(identifiers) != 1 {
+				t.Errorf("expected 1 identifier for %s, got %d", tt.id, len(identifiers))
+				return
+			}
+			if identifiers[0].Type != tt.expectedType {
+				t.Errorf("expected type %v for %s, got %v", tt.expectedType, tt.id, identifiers[0].Type)
+			}
+		})
+	}
+}
+
+func TestBuildCVSSRatings(t *testing.T) {
+	severities := []*osvschema.Severity{
+		{Score: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"},
+		{Score: "7.5"},
+	}
+
+	ratings := buildCVSSRatings(severities)
+
+	if len(ratings) != 2 {
+		t.Errorf("expected 2 ratings, got %d", len(ratings))
+	}
+
+	for _, rating := range ratings {
+		if rating.Vendor != "unknown" {
+			t.Errorf("expected vendor 'unknown', got %v", rating.Vendor)
+		}
+	}
+}
+
+func TestBuildLinks(t *testing.T) {
+	references := []*osvschema.Reference{
+		{Url: "https://example.com/vuln1"},
+		{Url: "https://example.com/vuln2"},
+	}
+
+	links := buildLinks(references)
+
+	if len(links) != 2 {
+		t.Errorf("expected 2 links, got %d", len(links))
+	}
+
+	if links[0].URL != "https://example.com/vuln1" {
+		t.Errorf("expected first URL to be https://example.com/vuln1, got %v", links[0].URL)
+	}
+}
+
+func TestBuildLocation(t *testing.T) {
+	packageItem := models.PackageVulns{
+		Package: models.PackageInfo{Name: "test-package", Version: "1.0.0"},
+	}
+	result := models.PackageSource{Source: models.SourceInfo{Path: "/test/path", Type: models.SourceTypeProjectPackage}}
+
+	t.Run("dependency scanning", func(t *testing.T) {
+		location := buildLocation(packageItem, result, &models.VulnerabilityResults{}, gitlab.CategoryDependencyScanning)
+
+		if location.File != "/test/path" {
+			t.Errorf("expected file path '/test/path', got %v", location.File)
+		}
+		if location.Dependency.Package.Name != "test-package" {
+			t.Errorf("expected package name 'test-package', got %v", location.Dependency.Package.Name)
+		}
+		if len(location.Files) != 1 {
+			t.Errorf("expected 1 file, got %d", len(location.Files))
+		} else {
+			if location.Files[0].Path != "/test/path" {
+				t.Errorf("expected file path '/test/path', got %v", location.Files[0].Path)
+			}
+			if location.Files[0].Type != gitlab.FileTypeLockfile {
+				t.Errorf("expected file type 'lockfile', got %v", location.Files[0].Type)
+			}
+		}
+	})
+
+	t.Run("container scanning", func(t *testing.T) {
+		vulnResult := &models.VulnerabilityResults{
+			ImageMetadata: &models.ImageMetadata{OS: "ubuntu:20.04"},
+		}
+		location := buildLocation(packageItem, result, vulnResult, gitlab.CategoryContainerScanning)
+
+		if location.Image != "/test/path" {
+			t.Errorf("expected image '/test/path', got %v", location.Image)
+		}
+		if location.OperatingSystem != "ubuntu:20.04" {
+			t.Errorf("expected OS 'ubuntu:20.04', got %v", location.OperatingSystem)
+		}
+		if len(location.Files) != 0 {
+			t.Errorf("expected no files for container scanning, got %d", len(location.Files))
+		}
+	})
+}
+
+func TestPrintGitLabResults(t *testing.T) {
+	vulnResult := &models.VulnerabilityResults{
+		Results: []models.PackageSource{
+			{
+				Source: models.SourceInfo{Path: "/test/package.json"},
+				Packages: []models.PackageVulns{
+					{
+						Package: models.PackageInfo{Name: "test-pkg", Version: "1.0.0"},
+						Vulnerabilities: []*osvschema.Vulnerability{
+							{
+								Id:      "CVE-2023-1234",
+								Summary: "Short summary of the vulnerability",
+								Details: "Detailed description of the vulnerability",
+								Severity: []*osvschema.Severity{
+									{Type: osvschema.Severity_CVSS_V3, Score: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"},
+								},
+								References: []*osvschema.Reference{
+									{Url: "https://example.com/vuln"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	err := PrintGitLabResults(vulnResult, &buf)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var report gitlab.Report
+	if err := json.Unmarshal(buf.Bytes(), &report); err != nil {
+		t.Fatalf("failed to unmarshal JSON: %v", err)
+	}
+
+	if len(report.Vulnerabilities) != 1 {
+		t.Errorf("expected 1 vulnerability, got %d", len(report.Vulnerabilities))
+		return
+	}
+
+	vuln := report.Vulnerabilities[0]
+	if vuln.Name != "CVE-2023-1234" {
+		t.Errorf("expected vulnerability name 'CVE-2023-1234', got %v", vuln.Name)
+	}
+
+	if vuln.Message != "Short summary of the vulnerability" {
+		t.Errorf("expected Message to be summary, got %v", vuln.Message)
+	}
+
+	if vuln.Description != "Detailed description of the vulnerability" {
+		t.Errorf("expected Description to be details, got %v", vuln.Description)
+	}
+
+	if report.Scan.Type != gitlab.CategoryDependencyScanning {
+		t.Errorf("expected dependency scanning type, got %v", report.Scan.Type)
+	}
+}
+
+func TestPrintGitLabResults_VulnerabilityWithoutCVSS(t *testing.T) {
+	vulnResult := &models.VulnerabilityResults{
+		Results: []models.PackageSource{
+			{
+				Source: models.SourceInfo{Path: "/test/package.json"},
+				Packages: []models.PackageVulns{
+					{
+						Package: models.PackageInfo{Name: "test-pkg", Version: "1.0.0"},
+						Vulnerabilities: []*osvschema.Vulnerability{
+							{
+								Id:      "GHSA-xxxx-yyyy-zzzz",
+								Details: "Vulnerability without CVSS score",
+								// No Severity field - should not be skipped
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	err := PrintGitLabResults(vulnResult, &buf)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var report gitlab.Report
+	if err := json.Unmarshal(buf.Bytes(), &report); err != nil {
+		t.Fatalf("failed to unmarshal JSON: %v", err)
+	}
+
+	if len(report.Vulnerabilities) != 1 {
+		t.Errorf("expected 1 vulnerability (should not be skipped), got %d", len(report.Vulnerabilities))
+		return
+	}
+
+	vuln := report.Vulnerabilities[0]
+	if vuln.Severity != gitlab.SeverityLevelUnknown {
+		t.Errorf("expected Unknown severity for vulnerability without CVSS, got %v", vuln.Severity)
+	}
+}
+
+func TestPrintGitLabResults_ContainerScanning(t *testing.T) {
+	vulnResult := &models.VulnerabilityResults{
+		ImageMetadata: &models.ImageMetadata{OS: "debian:11"},
+		Results: []models.PackageSource{
+			{
+				Source: models.SourceInfo{Path: "nginx:1.21"},
+				Packages: []models.PackageVulns{
+					{
+						Package: models.PackageInfo{Name: "openssl", Version: "1.1.1k-1"},
+						Vulnerabilities: []*osvschema.Vulnerability{
+							{
+								Id:      "CVE-2023-0286",
+								Summary: "OpenSSL vulnerability",
+								Details: "There is a type confusion vulnerability in OpenSSL",
+								Severity: []*osvschema.Severity{
+									{Type: osvschema.Severity_CVSS_V3, Score: "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:H"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	err := PrintGitLabResults(vulnResult, &buf)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var report gitlab.Report
+	if err := json.Unmarshal(buf.Bytes(), &report); err != nil {
+		t.Fatalf("failed to unmarshal JSON: %v", err)
+	}
+
+	if report.Scan.Type != gitlab.CategoryContainerScanning {
+		t.Errorf("expected container_scanning type, got %v", report.Scan.Type)
+	}
+
+	if len(report.Vulnerabilities) != 1 {
+		t.Errorf("expected 1 vulnerability, got %d", len(report.Vulnerabilities))
+		return
+	}
+
+	vuln := report.Vulnerabilities[0]
+	if vuln.Location.Image != "nginx:1.21" {
+		t.Errorf("expected image 'nginx:1.21', got %v", vuln.Location.Image)
+	}
+	if vuln.Location.OperatingSystem != "debian:11" {
+		t.Errorf("expected OS 'debian:11', got %v", vuln.Location.OperatingSystem)
+	}
+	if vuln.Location.File != "" {
+		t.Errorf("expected no file for container scanning, got %v", vuln.Location.File)
+	}
+}
+
+func TestPrintGitLabResults_EmptyResults(t *testing.T) {
+	vulnResult := &models.VulnerabilityResults{
+		Results: []models.PackageSource{},
+	}
+
+	var buf bytes.Buffer
+	err := PrintGitLabResults(vulnResult, &buf)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var report gitlab.Report
+	if err := json.Unmarshal(buf.Bytes(), &report); err != nil {
+		t.Fatalf("failed to unmarshal JSON: %v", err)
+	}
+
+	if len(report.Vulnerabilities) != 0 {
+		t.Errorf("expected 0 vulnerabilities for empty results, got %d", len(report.Vulnerabilities))
+	}
+
+	// Should still have valid scan metadata
+	if report.Scan.Analyzer.ID != "osv-scanner" {
+		t.Errorf("expected analyzer ID 'osv-scanner', got %v", report.Scan.Analyzer.ID)
+	}
+}
+
+func TestPrintGitLabResults_MultipleVulnerabilities(t *testing.T) {
+	vulnResult := &models.VulnerabilityResults{
+		Results: []models.PackageSource{
+			{
+				Source: models.SourceInfo{Path: "/app/package.json", Type: models.SourceTypeProjectPackage},
+				Packages: []models.PackageVulns{
+					{
+						Package: models.PackageInfo{Name: "lodash", Version: "4.17.20"},
+						Vulnerabilities: []*osvschema.Vulnerability{
+							{
+								Id:      "CVE-2021-23337",
+								Summary: "Command Injection in lodash",
+								Severity: []*osvschema.Severity{
+									{Type: osvschema.Severity_CVSS_V3, Score: "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H"},
+								},
+							},
+							{
+								Id:      "CVE-2020-8203",
+								Summary: "Prototype Pollution in lodash",
+								Severity: []*osvschema.Severity{
+									{Type: osvschema.Severity_CVSS_V3, Score: "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:H/A:H"},
+								},
+							},
+						},
+					},
+					{
+						Package: models.PackageInfo{Name: "axios", Version: "0.21.0"},
+						Vulnerabilities: []*osvschema.Vulnerability{
+							{
+								Id:      "CVE-2021-3749",
+								Summary: "Server-Side Request Forgery in axios",
+								Severity: []*osvschema.Severity{
+									{Type: osvschema.Severity_CVSS_V3, Score: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"},
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Source: models.SourceInfo{Path: "/lib/requirements.txt", Type: models.SourceTypeProjectPackage},
+				Packages: []models.PackageVulns{
+					{
+						Package: models.PackageInfo{Name: "requests", Version: "2.25.0"},
+						Vulnerabilities: []*osvschema.Vulnerability{
+							{
+								Id:      "CVE-2023-32681",
+								Summary: "Unintended leak of Proxy-Authorization header in requests",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	err := PrintGitLabResults(vulnResult, &buf)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var report gitlab.Report
+	if err := json.Unmarshal(buf.Bytes(), &report); err != nil {
+		t.Fatalf("failed to unmarshal JSON: %v", err)
+	}
+
+	if len(report.Vulnerabilities) != 4 {
+		t.Errorf("expected 4 vulnerabilities, got %d", len(report.Vulnerabilities))
+	}
+
+	// Verify version is set
+	if report.Version.String() != gitlab.CurrentVersion().String() {
+		t.Errorf("expected version %s, got %s", gitlab.CurrentVersion().String(), report.Version.String())
+	}
+}
+
+func TestPrintGitLabResults_SeverityLevels(t *testing.T) {
+	tests := []struct {
+		cvssVector    string
+		expectedLevel gitlab.SeverityLevel
+	}{
+		{"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H", gitlab.SeverityLevelCritical}, // 10.0
+		{"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", gitlab.SeverityLevelCritical}, // 9.8
+		{"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N", gitlab.SeverityLevelHigh},     // 7.5
+		{"CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:N", gitlab.SeverityLevelMedium},   // 5.4
+		{"CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N", gitlab.SeverityLevelLow},      // 3.3
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expectedLevel.String(), func(t *testing.T) {
+			vulnResult := &models.VulnerabilityResults{
+				Results: []models.PackageSource{
+					{
+						Source: models.SourceInfo{Path: "/test/package.json"},
+						Packages: []models.PackageVulns{
+							{
+								Package: models.PackageInfo{Name: "test-pkg", Version: "1.0.0"},
+								Vulnerabilities: []*osvschema.Vulnerability{
+									{
+										Id: "CVE-2023-0001",
+										Severity: []*osvschema.Severity{
+											{Type: osvschema.Severity_CVSS_V3, Score: tt.cvssVector},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			var buf bytes.Buffer
+			err := PrintGitLabResults(vulnResult, &buf)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			var report gitlab.Report
+			if err := json.Unmarshal(buf.Bytes(), &report); err != nil {
+				t.Fatalf("failed to unmarshal JSON: %v", err)
+			}
+
+			if len(report.Vulnerabilities) != 1 {
+				t.Fatalf("expected 1 vulnerability, got %d", len(report.Vulnerabilities))
+			}
+
+			if report.Vulnerabilities[0].Severity != tt.expectedLevel {
+				t.Errorf("expected severity %v, got %v", tt.expectedLevel, report.Vulnerabilities[0].Severity)
+			}
+		})
+	}
+}
+
+// Schema validation tests
+
+func TestReport_ValidatesAgainstGitLabSchema(t *testing.T) {
+	schemaLoader := loadGitLabSchema(t, "dependency-scanning-report-format.json")
+
+	// Create a sample report
+	report := gitlab.Report{
+		Version: gitlab.CurrentVersion(),
+		Vulnerabilities: []gitlab.Vulnerability{
+			{
+				Name:        "CVE-2023-1234",
+				Message:     "Test vulnerability message",
+				Description: "A detailed description of the vulnerability",
+				Severity:    gitlab.SeverityLevelHigh,
+				Solution:    "Upgrade to version 2.0.0",
+				Location: gitlab.Location{
+					File: "/app/package.json",
+					Dependency: &gitlab.Dependency{
+						Package: gitlab.Package{Name: "lodash"},
+						Version: "4.17.20",
+					},
+					Files: []gitlab.File{
+						{
+							Path: "/app/package.json",
+							Type: gitlab.FileTypeLockfile,
+						},
+					},
+				},
+				Identifiers: []gitlab.Identifier{
+					{
+						Type:  gitlab.IdentifierTypeCVE,
+						Name:  "CVE-2023-1234",
+						Value: "CVE-2023-1234",
+						URL:   "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-1234",
+					},
+					{
+						Type:  gitlab.IdentifierTypeGHSA,
+						Name:  "GHSA-xxxx-yyyy-zzzz",
+						Value: "GHSA-xxxx-yyyy-zzzz",
+						URL:   "https://github.com/advisories/GHSA-xxxx-yyyy-zzzz",
+					},
+				},
+				CVSSRatings: []gitlab.CVSSRating{
+					{
+						Vendor: "NVD",
+						Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+					},
+				},
+				Links: []gitlab.Link{
+					{URL: "https://example.com/advisory"},
+				},
+			},
+		},
+		Scan: gitlab.Scan{
+			Analyzer: gitlab.AnalyzerDetails{
+				ID:      "osv-scanner",
+				Name:    "osv-scanner",
+				URL:     "https://github.com/google/osv-scanner",
+				Vendor:  gitlab.Vendor{Name: "Google"},
+				Version: "2.0.0",
+			},
+			Scanner: gitlab.AnalyzerDetails{
+				ID:      "osv-scanner",
+				Name:    "osv-scanner",
+				URL:     "https://github.com/google/osv-scanner",
+				Vendor:  gitlab.Vendor{Name: "Google"},
+				Version: "2.0.0",
+			},
+			Type:      gitlab.CategoryDependencyScanning,
+			Status:    gitlab.StatusSuccess,
+			StartTime: "2025-01-01T12:00:00",
+			EndTime:   "2025-01-01T12:00:01",
+		},
+	}
+
+	validateGitLabReport(t, schemaLoader, report)
+}
+
+// sampleVulnResults returns a representative VulnerabilityResults that exercises the
+// fields the GitLab report builder reads (ids, aliases, severities, references), so the
+// report validated against the schema is produced by the real PrintGitLabResults code
+// path rather than a hand-maintained fixture that can drift from the output.
+func sampleVulnResults() *models.VulnerabilityResults {
+	return &models.VulnerabilityResults{
+		Results: []models.PackageSource{
+			{
+				Source: models.SourceInfo{Path: "/app/package.json", Type: models.SourceTypeProjectPackage},
+				Packages: []models.PackageVulns{
+					{
+						Package: models.PackageInfo{Name: "lodash", Version: "4.17.20"},
+						Vulnerabilities: []*osvschema.Vulnerability{
+							{
+								Id:      "CVE-2021-23337",
+								Summary: "Command Injection in lodash",
+								Details: "lodash versions prior to 4.17.21 are vulnerable to command injection.",
+								Aliases: []string{"GHSA-35jh-r3h4-6jhm"},
+								Severity: []*osvschema.Severity{
+									{Type: osvschema.Severity_CVSS_V3, Score: "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H"},
+								},
+								References: []*osvschema.Reference{
+									{Url: "https://github.com/advisories/GHSA-35jh-r3h4-6jhm"},
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Source: models.SourceInfo{Path: "/lib/requirements.txt", Type: models.SourceTypeProjectPackage},
+				Packages: []models.PackageVulns{
+					{
+						Package: models.PackageInfo{Name: "requests", Version: "2.25.0"},
+						Vulnerabilities: []*osvschema.Vulnerability{
+							{
+								Id:      "CVE-2023-32681",
+								Summary: "Unintended leak of Proxy-Authorization header in requests",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestDependencyScanReport_ValidatesAgainstGitLabSchema(t *testing.T) {
+	schemaLoader := loadGitLabSchema(t, "dependency-scanning-report-format.json")
+
+	var buf bytes.Buffer
+	if err := PrintGitLabResults(sampleVulnResults(), &buf); err != nil {
+		t.Fatalf("unexpected error generating report: %v", err)
+	}
+
+	validateGitLabReportBytes(t, schemaLoader, buf.Bytes())
+}
+
+func TestContainerScanReport_ValidatesAgainstGitLabSchema(t *testing.T) {
+	schemaLoader := loadGitLabSchema(t, "container-scanning-report-format.json")
+
+	// ImageMetadata being set switches PrintGitLabResults to the container-scanning path.
+	vulnResult := sampleVulnResults()
+	vulnResult.ImageMetadata = &models.ImageMetadata{OS: "debian:12"}
+
+	var buf bytes.Buffer
+	if err := PrintGitLabResults(vulnResult, &buf); err != nil {
+		t.Fatalf("unexpected error generating report: %v", err)
+	}
+
+	validateGitLabReportBytes(t, schemaLoader, buf.Bytes())
+}
+
+func TestReport_MinimalValid(t *testing.T) {
+	schemaLoader := loadGitLabSchema(t, "dependency-scanning-report-format.json")
+
+	// Create a minimal valid report (empty vulnerabilities)
+	report := gitlab.Report{
+		Version:         gitlab.CurrentVersion(),
+		Vulnerabilities: []gitlab.Vulnerability{},
+		Scan: gitlab.Scan{
+			Analyzer: gitlab.AnalyzerDetails{
+				ID:      "osv-scanner",
+				Name:    "osv-scanner",
+				URL:     "https://github.com/google/osv-scanner",
+				Vendor:  gitlab.Vendor{Name: "Google"},
+				Version: "2.0.0",
+			},
+			Scanner: gitlab.AnalyzerDetails{
+				ID:      "osv-scanner",
+				Name:    "osv-scanner",
+				URL:     "https://github.com/google/osv-scanner",
+				Vendor:  gitlab.Vendor{Name: "Google"},
+				Version: "2.0.0",
+			},
+			Type:      gitlab.CategoryDependencyScanning,
+			Status:    gitlab.StatusSuccess,
+			StartTime: "2025-01-01T12:00:00",
+			EndTime:   "2025-01-01T12:00:01",
+		},
+	}
+
+	validateGitLabReport(t, schemaLoader, report)
+}
+
+func TestReport_AllSeverityLevels(t *testing.T) {
+	schemaLoader := loadGitLabSchema(t, "dependency-scanning-report-format.json")
+
+	severities := []gitlab.SeverityLevel{
+		gitlab.SeverityLevelCritical,
+		gitlab.SeverityLevelHigh,
+		gitlab.SeverityLevelMedium,
+		gitlab.SeverityLevelLow,
+		gitlab.SeverityLevelInfo,
+		gitlab.SeverityLevelUnknown,
+	}
+
+	for _, severity := range severities {
+		t.Run(severity.String(), func(t *testing.T) {
+			report := gitlab.Report{
+				Version: gitlab.CurrentVersion(),
+				Vulnerabilities: []gitlab.Vulnerability{
+					{
+						Name:     "CVE-2023-0001",
+						Severity: severity,
+						Location: gitlab.Location{
+							File: "/app/package.json",
+							Dependency: &gitlab.Dependency{
+								Package: gitlab.Package{Name: "test-pkg"},
+								Version: "1.0.0",
+							},
+						},
+						Identifiers: []gitlab.Identifier{
+							{
+								Type:  gitlab.IdentifierTypeCVE,
+								Name:  "CVE-2023-0001",
+								Value: "CVE-2023-0001",
+							},
+						},
+					},
+				},
+				Scan: gitlab.Scan{
+					Analyzer: gitlab.AnalyzerDetails{
+						ID:      "osv-scanner",
+						Name:    "osv-scanner",
+						URL:     "https://github.com/google/osv-scanner",
+						Vendor:  gitlab.Vendor{Name: "Google"},
+						Version: "2.0.0",
+					},
+					Scanner: gitlab.AnalyzerDetails{
+						ID:      "osv-scanner",
+						Name:    "osv-scanner",
+						URL:     "https://github.com/google/osv-scanner",
+						Vendor:  gitlab.Vendor{Name: "Google"},
+						Version: "2.0.0",
+					},
+					Type:      gitlab.CategoryDependencyScanning,
+					Status:    gitlab.StatusSuccess,
+					StartTime: "2025-01-01T12:00:00",
+					EndTime:   "2025-01-01T12:00:01",
+				},
+			}
+
+			validateGitLabReport(t, schemaLoader, report)
+		})
+	}
+}
+
+func TestReport_AllIdentifierTypes(t *testing.T) {
+	schemaLoader := loadGitLabSchema(t, "dependency-scanning-report-format.json")
+
+	identifiers := []struct {
+		idType gitlab.IdentifierType
+		name   string
+		value  string
+	}{
+		{gitlab.IdentifierTypeCVE, "CVE-2023-1234", "CVE-2023-1234"},
+		{gitlab.IdentifierTypeCWE, "CWE-79", "79"},
+		{gitlab.IdentifierTypeGHSA, "GHSA-xxxx-yyyy-zzzz", "GHSA-xxxx-yyyy-zzzz"},
+		{gitlab.IdentifierTypeGLAM, "GLAM-12345", "GLAM-12345"},
+		{gitlab.IdentifierTypeMAL, "MAL-2023-1234", "MAL-2023-1234"},
+		{gitlab.IdentifierTypeRHSA, "RHSA-2023:1234", "RHSA-2023:1234"},
+		{gitlab.IdentifierTypeUSN, "USN-1234-1", "USN-1234-1"},
+		{gitlab.IdentifierTypeELSA, "ELSA-2023-1234", "ELSA-2023-1234"},
+		{gitlab.IdentifierTypeH1, "HACKERONE-12345", "12345"},
+	}
+
+	for _, id := range identifiers {
+		t.Run(string(id.idType), func(t *testing.T) {
+			report := gitlab.Report{
+				Version: gitlab.CurrentVersion(),
+				Vulnerabilities: []gitlab.Vulnerability{
+					{
+						Name:     id.name,
+						Severity: gitlab.SeverityLevelMedium,
+						Location: gitlab.Location{
+							File: "/app/package.json",
+							Dependency: &gitlab.Dependency{
+								Package: gitlab.Package{Name: "test-pkg"},
+								Version: "1.0.0",
+							},
+						},
+						Identifiers: []gitlab.Identifier{
+							{
+								Type:  id.idType,
+								Name:  id.name,
+								Value: id.value,
+							},
+						},
+					},
+				},
+				Scan: gitlab.Scan{
+					Analyzer: gitlab.AnalyzerDetails{
+						ID:      "osv-scanner",
+						Name:    "osv-scanner",
+						URL:     "https://github.com/google/osv-scanner",
+						Vendor:  gitlab.Vendor{Name: "Google"},
+						Version: "2.0.0",
+					},
+					Scanner: gitlab.AnalyzerDetails{
+						ID:      "osv-scanner",
+						Name:    "osv-scanner",
+						URL:     "https://github.com/google/osv-scanner",
+						Vendor:  gitlab.Vendor{Name: "Google"},
+						Version: "2.0.0",
+					},
+					Type:      gitlab.CategoryDependencyScanning,
+					Status:    gitlab.StatusSuccess,
+					StartTime: "2025-01-01T12:00:00",
+					EndTime:   "2025-01-01T12:00:01",
+				},
+			}
+
+			validateGitLabReport(t, schemaLoader, report)
+		})
+	}
+}
+
+func TestReport_WithRemediations(t *testing.T) {
+	schemaLoader := loadGitLabSchema(t, "dependency-scanning-report-format.json")
+
+	vuln := gitlab.Vulnerability{
+		Name:     "CVE-2023-1234",
+		Severity: gitlab.SeverityLevelHigh,
+		Location: gitlab.Location{
+			File: "/app/package.json",
+			Dependency: &gitlab.Dependency{
+				Package: gitlab.Package{Name: "lodash"},
+				Version: "4.17.20",
+			},
+		},
+		Identifiers: []gitlab.Identifier{
+			{
+				Type:  gitlab.IdentifierTypeCVE,
+				Name:  "CVE-2023-1234",
+				Value: "CVE-2023-1234",
+			},
+		},
+	}
+
+	report := gitlab.Report{
+		Version:         gitlab.CurrentVersion(),
+		Vulnerabilities: []gitlab.Vulnerability{vuln},
+		Remediations: []gitlab.Remediation{
+			{
+				Fixes:   []gitlab.Ref{gitlab.NewRef(vuln)},
+				Summary: "Upgrade lodash to 4.17.21",
+				Diff:    "ZGlmZiAtLWdpdCBhL3BhY2thZ2UuanNvbiBiL3BhY2thZ2UuanNvbg==", // base64 encoded diff
+			},
+		},
+		Scan: gitlab.Scan{
+			Analyzer: gitlab.AnalyzerDetails{
+				ID:      "osv-scanner",
+				Name:    "osv-scanner",
+				URL:     "https://github.com/google/osv-scanner",
+				Vendor:  gitlab.Vendor{Name: "Google"},
+				Version: "2.0.0",
+			},
+			Scanner: gitlab.AnalyzerDetails{
+				ID:      "osv-scanner",
+				Name:    "osv-scanner",
+				URL:     "https://github.com/google/osv-scanner",
+				Vendor:  gitlab.Vendor{Name: "Google"},
+				Version: "2.0.0",
+			},
+			Type:      gitlab.CategoryDependencyScanning,
+			Status:    gitlab.StatusSuccess,
+			StartTime: "2025-01-01T12:00:00",
+			EndTime:   "2025-01-01T12:00:01",
+		},
+	}
+
+	validateGitLabReport(t, schemaLoader, report)
+}

--- a/internal/output/gitlab_test.go
+++ b/internal/output/gitlab_test.go
@@ -1,0 +1,68 @@
+package output_test
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/google/osv-scanner/v2/internal/output"
+	"github.com/google/osv-scanner/v2/internal/testutility"
+)
+
+func init() {
+	// Set a fixed time for deterministic snapshot testing
+	output.GitlabTimeNow = func() time.Time {
+		return time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	}
+}
+
+func TestPrintGitLabResults_WithVulnerabilities(t *testing.T) {
+	t.Parallel()
+
+	testOutputWithVulnerabilities(t, func(t *testing.T, args outputTestCaseArgs) {
+		t.Helper()
+
+		outputWriter := &bytes.Buffer{}
+		err := output.PrintGitLabResults(args.vulnResult, outputWriter)
+
+		if err != nil {
+			t.Errorf("Error writing output: %s", err)
+		}
+
+		testutility.NewSnapshot().MatchText(t, outputWriter.String())
+	})
+}
+
+func TestPrintGitLabResults_WithLicenseViolations(t *testing.T) {
+	t.Parallel()
+
+	testOutputWithLicenseViolations(t, func(t *testing.T, args outputTestCaseArgs) {
+		t.Helper()
+
+		outputWriter := &bytes.Buffer{}
+		err := output.PrintGitLabResults(args.vulnResult, outputWriter)
+
+		if err != nil {
+			t.Errorf("Error writing output: %s", err)
+		}
+
+		testutility.NewSnapshot().MatchText(t, outputWriter.String())
+	})
+}
+
+func TestPrintGitLabResults_WithMixedIssues(t *testing.T) {
+	t.Parallel()
+
+	testOutputWithMixedIssues(t, func(t *testing.T, args outputTestCaseArgs) {
+		t.Helper()
+
+		outputWriter := &bytes.Buffer{}
+		err := output.PrintGitLabResults(args.vulnResult, outputWriter)
+
+		if err != nil {
+			t.Errorf("Error writing output: %s", err)
+		}
+
+		testutility.NewSnapshot().MatchText(t, outputWriter.String())
+	})
+}

--- a/internal/reporter/format.go
+++ b/internal/reporter/format.go
@@ -7,38 +7,68 @@ import (
 	"github.com/google/osv-scanner/v2/pkg/models"
 )
 
-var format = []string{"table", "html", "vertical", "json", "markdown", "sarif", "gh-annotations", "cyclonedx-1-4", "cyclonedx-1-5", "cyclonedx-1-6", "cyclonedx-1-7", "spdx-2-3"}
+const (
+	FormatTable         = "table"
+	FormatHTML          = "html"
+	FormatVertical      = "vertical"
+	FormatJSON          = "json"
+	FormatMarkdown      = "markdown"
+	FormatSARIF         = "sarif"
+	FormatGHAnnotations = "gh-annotations"
+	FormatCycloneDX14   = "cyclonedx-1-4"
+	FormatCycloneDX15   = "cyclonedx-1-5"
+	FormatCycloneDX16   = "cyclonedx-1-6"
+	FormatCycloneDX17   = "cyclonedx-1-7"
+	FormatSPDX23        = "spdx-2-3"
+	FormatGitLab        = "gitlab"
+)
 
 func Format() []string {
-	return format
+	return []string{
+		FormatTable,
+		FormatHTML,
+		FormatVertical,
+		FormatJSON,
+		FormatMarkdown,
+		FormatSARIF,
+		FormatGHAnnotations,
+		FormatCycloneDX14,
+		FormatCycloneDX15,
+		FormatCycloneDX16,
+		FormatCycloneDX17,
+		FormatSPDX23,
+		FormatGitLab,
+	}
 }
 
 func newResultPrinter(format string, writer io.Writer, terminalWidth int, showAllVulns bool) (resultPrinter, error) {
 	switch format {
-	case "html":
+	case FormatHTML:
 		return &htmlReporter{writer}, nil
-	case "json":
+	case FormatJSON:
 		return &jsonReporter{writer}, nil
-	case "vertical":
+	case FormatVertical:
 		return &verticalReporter{writer, terminalWidth, showAllVulns}, nil
-	case "table":
+	case FormatTable:
 		return &tableReporter{writer, false, terminalWidth, showAllVulns}, nil
-	case "markdown":
+	case FormatMarkdown:
 		return &tableReporter{writer, true, terminalWidth, showAllVulns}, nil
-	case "sarif":
+	case FormatSARIF:
 		return &sarifReporter{writer}, nil
-	case "gh-annotations":
+	case FormatGHAnnotations:
 		return &ghAnnotationsReporter{writer}, nil
-	case "cyclonedx-1-4":
+	case FormatCycloneDX14:
 		return &cycloneDXReporter{writer, models.CycloneDXVersion14}, nil
-	case "cyclonedx-1-5":
+	case FormatCycloneDX15:
 		return &cycloneDXReporter{writer, models.CycloneDXVersion15}, nil
-	case "cyclonedx-1-6":
+	case FormatCycloneDX16:
 		return &cycloneDXReporter{writer, models.CycloneDXVersion16}, nil
-	case "cyclonedx-1-7":
+	case FormatCycloneDX17:
 		return &cycloneDXReporter{writer, models.CycloneDXVersion17}, nil
-	case "spdx-2-3":
+	case FormatSPDX23:
 		return &spdxReporter{writer}, nil
+	case FormatGitLab:
+		return &gitlabReporter{writer}, nil
 	default:
 		return nil, fmt.Errorf("%v is not a valid format", format)
 	}

--- a/internal/reporter/gitlab_reporter.go
+++ b/internal/reporter/gitlab_reporter.go
@@ -1,0 +1,16 @@
+package reporter
+
+import (
+	"io"
+
+	"github.com/google/osv-scanner/v2/internal/output"
+	"github.com/google/osv-scanner/v2/pkg/models"
+)
+
+type gitlabReporter struct {
+	writer io.Writer
+}
+
+func (r *gitlabReporter) PrintResult(vulnResult *models.VulnerabilityResults) error {
+	return output.PrintGitLabResults(vulnResult, r.writer)
+}

--- a/internal/utility/severity/severity.go
+++ b/internal/utility/severity/severity.go
@@ -2,6 +2,7 @@
 package severity
 
 import (
+	"errors"
 	"strconv"
 	"strings"
 
@@ -22,6 +23,10 @@ const (
 	LowRating      Rating = "LOW"
 	UnknownRating  Rating = "UNKNOWN"
 )
+
+func (r Rating) String() string {
+	return string(r)
+}
 
 func CalculateScore(severity *osvschema.Severity) (float64, string, error) {
 	score := -1.0
@@ -85,6 +90,34 @@ func CalculateOverallScore(severities []*osvschema.Severity) (float64, string, e
 	}
 
 	return maxScore, maxRating, nil
+}
+
+func CalculateScoreBasedOnMostRecentCvssVersionAvailable(severities []*osvschema.Severity) (float64, string, error) {
+	mappedSeverities := map[osvschema.Severity_Type]*osvschema.Severity{}
+	for _, severity := range severities {
+		if _, ok := mappedSeverities[severity.GetType()]; !ok {
+			mappedSeverities[severity.GetType()] = severity
+		}
+	}
+
+	var severity *osvschema.Severity
+	for _, severityType := range []osvschema.Severity_Type{osvschema.Severity_CVSS_V4, osvschema.Severity_CVSS_V3, osvschema.Severity_CVSS_V2} {
+		if value, ok := mappedSeverities[severityType]; ok {
+			severity = value
+			break
+		}
+	}
+
+	if severity == nil {
+		return -1, string(UnknownRating), errors.New("no CVSS severity found")
+	}
+
+	score, rating, err := CalculateScore(severity)
+	if err != nil {
+		return -1, string(UnknownRating), err
+	}
+
+	return score, rating, nil
 }
 
 func CalculateRating(score string) (Rating, error) {

--- a/internal/utility/severity/severity_test.go
+++ b/internal/utility/severity/severity_test.go
@@ -2,6 +2,7 @@ package severity_test
 
 import (
 	"math"
+	"strings"
 	"testing"
 
 	"github.com/google/osv-scanner/v2/internal/utility/severity"
@@ -86,6 +87,158 @@ func TestSeverity_CalculateScore(t *testing.T) {
 			// Multiply and round to get around potential precision issues.
 			if math.Round(10*gotScore) != math.Round(10*tt.want.score) || gotRating != tt.want.rating {
 				t.Errorf("CalculateScore() = (%.1f, %s), want (%.1f, %s)", gotScore, gotRating, tt.want.score, tt.want.rating)
+			}
+		})
+	}
+}
+
+func TestCalculateScoreBasedOnMostRecentCvssVersionAvailable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		severities []*osvschema.Severity
+		wantScore  float64
+		wantRating string
+		wantErr    bool
+	}{
+		{
+			name:       "Empty severities",
+			severities: []*osvschema.Severity{},
+			wantScore:  -1,
+			wantRating: "UNKNOWN",
+			wantErr:    true,
+		},
+		{
+			name: "Only CVSS v4.0",
+			severities: []*osvschema.Severity{
+				{
+					Type:  osvschema.Severity_CVSS_V4,
+					Score: "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N",
+				},
+			},
+			wantScore:  9.3,
+			wantRating: "CRITICAL",
+			wantErr:    false,
+		},
+		{
+			name: "Only CVSS v3.1",
+			severities: []*osvschema.Severity{
+				{
+					Type:  osvschema.Severity_CVSS_V3,
+					Score: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+				},
+			},
+			wantScore:  9.8,
+			wantRating: "CRITICAL",
+			wantErr:    false,
+		},
+		{
+			name: "Only CVSS v2.0",
+			severities: []*osvschema.Severity{
+				{
+					Type:  osvschema.Severity_CVSS_V2,
+					Score: "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+				},
+			},
+			wantScore:  7.5,
+			wantRating: "HIGH",
+			wantErr:    false,
+		},
+		{
+			name: "CVSS v4.0 and v3.1 - prefers v4.0",
+			severities: []*osvschema.Severity{
+				{
+					Type:  osvschema.Severity_CVSS_V3,
+					Score: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+				},
+				{
+					Type:  osvschema.Severity_CVSS_V4,
+					Score: "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:L/VA:L/SC:N/SI:N/SA:N",
+				},
+			},
+			wantScore:  6.9,
+			wantRating: "MEDIUM",
+			wantErr:    false,
+		},
+		{
+			name: "CVSS v3.1 and v2.0 - prefers v3.1",
+			severities: []*osvschema.Severity{
+				{
+					Type:  osvschema.Severity_CVSS_V2,
+					Score: "AV:N/AC:L/Au:N/C:C/I:C/A:C",
+				},
+				{
+					Type:  osvschema.Severity_CVSS_V3,
+					Score: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+				},
+			},
+			wantScore:  7.3,
+			wantRating: "HIGH",
+			wantErr:    false,
+		},
+		{
+			name: "All versions - prefers v4.0",
+			severities: []*osvschema.Severity{
+				{
+					Type:  osvschema.Severity_CVSS_V2,
+					Score: "AV:N/AC:L/Au:N/C:C/I:C/A:C",
+				},
+				{
+					Type:  osvschema.Severity_CVSS_V3,
+					Score: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+				},
+				{
+					Type:  osvschema.Severity_CVSS_V4,
+					Score: "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N",
+				},
+			},
+			wantScore:  9.3,
+			wantRating: "CRITICAL",
+			wantErr:    false,
+		},
+		{
+			name: "Duplicate CVSS versions - uses first occurrence",
+			severities: []*osvschema.Severity{
+				{
+					Type:  osvschema.Severity_CVSS_V3,
+					Score: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+				},
+				{
+					Type:  osvschema.Severity_CVSS_V3,
+					Score: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+				},
+			},
+			wantScore:  7.3,
+			wantRating: "HIGH",
+			wantErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotScore, gotRating, err := severity.CalculateScoreBasedOnMostRecentCvssVersionAvailable(tt.severities)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CalculateScoreBasedOnMostRecentCvssVersionAvailable() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr {
+				if !strings.Contains(err.Error(), "no CVSS severity found") {
+					t.Errorf("Expected 'no CVSS severity found' error, got: %v", err)
+				}
+				return
+			}
+
+			if math.Round(10*gotScore) != math.Round(10*tt.wantScore) {
+				t.Errorf("CalculateScoreBasedOnMostRecentCvssVersionAvailable() score = %.1f, want %.1f", gotScore, tt.wantScore)
+			}
+
+			if gotRating != tt.wantRating {
+				t.Errorf("CalculateScoreBasedOnMostRecentCvssVersionAvailable() rating = %v, want %v", gotRating, tt.wantRating)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Adds a new `gitlab` output format that emits a [GitLab Security Report](https://docs.gitlab.com/ee/development/integrations/secure.html), so osv-scanner results can be consumed directly by GitLab's vulnerability/dependency dashboards.

```
osv-scanner scan --format gitlab ...
```

- Produces a **dependency-scanning** report by default, or a **container-scanning** report when the scan has image metadata (auto-detected).
- Maps OSV vulnerabilities to GitLab's schema: identifiers (CVE, CWE, GHSA, USN, RHSA, ELSA, OSVDB, HackerOne, GLAM, MAL, …), severity (derived from the most recent available CVSS vector), CVSS vectors, and reference links.
- Report output is validated against GitLab's official dependency- and container-scanning report schemas.

## Notes on robustness

The report builder defends against malformed advisory data:

- `ParseIdentifierID` guards the `USN`/`HACKERONE` cases (which read the part after the `-`) so a hyphen-less id/alias can't cause an index-out-of-range panic.
- Severity falls back to `Unknown` rather than being silently dropped when a rating can't be mapped to a defined level (e.g. `NONE` from a 0.0 CVSS score).
- Only CVSS severity types are emitted into `cvss_vectors`, so non-CVSS scores (e.g. Ubuntu) aren't written as invalid CVSS vectors.

## Testing

- Unit tests for identifier parsing, severity mapping, and version handling.
- Snapshot tests of `PrintGitLabResults` output.
- Schema-conformance tests are **hermetic**: GitLab's dependency/container scanning schemas are vendored under `testdata/schemas` and loaded from disk (no network at test time), and the validated reports are produced by the real `PrintGitLabResults` code path rather than hand-maintained fixtures, so the output can't drift from the schema.