### PR TITLE
fix: sanitize carriage returns in cmdlogger to prevent GHA workflow command injection

### DIFF
--- a/internal/cmdlogger/handler.go
+++ b/internal/cmdlogger/handler.go
@@ -76,7 +76,14 @@ func (c *Handler) Handle(ctx context.Context, record slog.Record) error {
 		return c.overrideHandler.Handle(ctx, record)
 	}
 
-	_, err := fmt.Fprint(c.writer(record.Level), record.Message+"\n")
+	// Sanitize \r from the message before writing to stdout.
+	// The GitHub Actions runner treats \r as a line terminator when scanning
+	// for ::command::value workflow command sequences. Without this, an
+	// attacker-controlled path containing \r can inject arbitrary workflow
+	// commands (::error::, ::stop-commands::, etc.) via any log message,
+	// even if individual callsites use SanitizeForWorkflowCommand.
+	sanitized := strings.ReplaceAll(record.Message, "\r", "%0D")
+	_, err := fmt.Fprint(c.writer(record.Level), sanitized+"\n")
 
 	return err
 }


### PR DESCRIPTION
## Summary

Fix the incomplete `\r` sanitization reported in #2749 by adding defense-in-depth `\r` encoding in the `cmdlogger.Handler.Handle()` method.

## Vulnerability

PR #2669 (commit c2c9aae) fixed the `--format=gh-annotations` output path by encoding `\r` as `%0D`. However, the central `cmdlogger.Handler.Handle()` method at `internal/cmdlogger/handler.go:79` writes `record.Message` to stdout without any `\r` sanitization.

The GitHub Actions runner treats `\r` as a line terminator when scanning stdout for `::command::value` sequences. An attacker who introduces a directory name containing `\r::stop-commands::TOKEN\r` into a CI run can:

- Inject arbitrary workflow commands (`::error::`, `::warning::`, `::add-mask::`, `::stop-commands::`)
- Silently disable all subsequent command parsing, causing osv-scanner's error annotations to be dropped
- The PR status check turns green and the maintainer merges believing the dependency is clean

This fires on the scan invocation itself (`Scanning dir %s`) before any output format is selected, so it works regardless of `--format`.

## Fix

Add `strings.ReplaceAll(record.Message, "\r", "%0D")` in `Handler.Handle()` before writing to stdout. This provides defense-in-depth that protects all log output regardless of whether individual callsites pre-sanitize.

Fixes #2749
