### PR TITLE
fix: encode scanner log fields for workflow output

### DIFF
--- a/pkg/osvscanner/filter.go
+++ b/pkg/osvscanner/filter.go
@@ -9,10 +9,19 @@ import (
 	"github.com/google/osv-scanner/v2/internal/config"
 	"github.com/google/osv-scanner/v2/internal/imodels"
 	"github.com/google/osv-scanner/v2/internal/imodels/results"
+	"github.com/google/osv-scanner/v2/internal/output"
 	"github.com/google/osv-scanner/v2/pkg/models"
 	"github.com/ossf/osv-schema/bindings/go/osvconstants"
 	"github.com/ossf/osv-schema/bindings/go/osvschema"
 )
+
+func sanitizeReasonForLog(reason string) string {
+	if reason == "" {
+		reason = "(no reason given)"
+	}
+
+	return output.SanitizeForWorkflowCommand(reason)
+}
 
 // filterUnscannablePackages removes packages that don't have enough information to be scanned or
 // are not a supported ecosystem, and returns the list of removed packages (if --all-packages flag is passed in)
@@ -97,10 +106,7 @@ func filterIgnoredPackages(scanResults *results.ScanResults) {
 		if ignore, ignoreLine := configToUse.ShouldIgnorePackage(psr); ignore {
 			pkgString := fmt.Sprintf("%s/%s/%s", imodels.Ecosystem(psr).String(), imodels.Name(psr), imodels.Version(psr))
 
-			reason := ignoreLine.Reason
-			if reason == "" {
-				reason = "(no reason given)"
-			}
+			reason := sanitizeReasonForLog(ignoreLine.Reason)
 			cmdlogger.Infof("Package %s has been filtered out because: %s", pkgString, reason)
 
 			continue
@@ -155,11 +161,7 @@ func filterPackageVulns(pkgVulns models.PackageVulns, configToUse config.Config)
 					ignoredVulns[id] = struct{}{}
 				}
 
-				reason := ignoreLine.Reason
-
-				if reason == "" {
-					reason = "(no reason given)"
-				}
+				reason := sanitizeReasonForLog(ignoreLine.Reason)
 
 				// NB: This only prints the first reason encountered in all the aliases.
 				switch len(group.Aliases) {

--- a/pkg/osvscanner/filter_internal_test.go
+++ b/pkg/osvscanner/filter_internal_test.go
@@ -2,15 +2,68 @@ package osvscanner
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/google/osv-scalibr/extractor"
 	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/plugin"
 	"github.com/google/osv-scanner/v2/internal/config"
 	"github.com/google/osv-scanner/v2/internal/imodels/results"
 	"github.com/google/osv-scanner/v2/internal/testutility"
 	"github.com/google/osv-scanner/v2/pkg/models"
 )
+
+func Test_sanitizeReasonForLog(t *testing.T) {
+	t.Parallel()
+
+	got := sanitizeReasonForLog("accepted risk\n::warning title=OSV_POC::injected")
+	want := "accepted risk%0A::warning title=OSV_POC::injected"
+	if got != want {
+		t.Errorf("sanitizeReasonForLog() = %q, want %q", got, want)
+	}
+
+	got = sanitizeReasonForLog("")
+	want = "(no reason given)"
+	if got != want {
+		t.Errorf("sanitizeReasonForLog(empty) = %q, want %q", got, want)
+	}
+}
+
+func Test_formatExtractionErrorSanitizesWorkflowCommandFields(t *testing.T) {
+	t.Parallel()
+
+	extractorName, msg := formatExtractionError(&plugin.Status{
+		Name: "npm\n::warning title=PLUGIN::injected",
+		Status: &plugin.ScanStatus{
+			FailureReason: "failed\n::warning title=FAILURE::injected",
+			FileErrors: []*plugin.FileError{
+				{
+					FilePath:     "repo\n::warning title=PATH::injected/package-lock.json",
+					ErrorMessage: "unexpected EOF\n::warning title=ERROR::injected",
+				},
+			},
+		},
+	})
+
+	for _, got := range []string{extractorName, msg} {
+		if strings.Contains(got, "\n::warning") {
+			t.Errorf("formatted extraction error contains workflow command line break: %q", got)
+		}
+	}
+
+	if !strings.Contains(extractorName, "%0A::warning title=PLUGIN::injected") {
+		t.Errorf("extractorName = %q, want encoded workflow command newline", extractorName)
+	}
+	for _, want := range []string{
+		"%0A::warning title=PATH::injected",
+		"%0A::warning title=ERROR::injected",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("msg = %q, want substring %q", msg, want)
+		}
+	}
+}
 
 func Test_filterUnscannablePackages_shortCommitHash(t *testing.T) {
 	t.Parallel()

--- a/pkg/osvscanner/scan.go
+++ b/pkg/osvscanner/scan.go
@@ -33,6 +33,26 @@ import (
 
 var ErrExtractorNotFound = errors.New("could not determine extractor suitable to this file")
 
+func formatExtractionError(status *plugin.Status) (string, string) {
+	msg := output.SanitizeForWorkflowCommand(status.Status.FailureReason)
+
+	if len(status.Status.FileErrors) > 0 {
+		builder := strings.Builder{}
+		for _, fileError := range status.Status.FileErrors {
+			if len(status.Status.FileErrors) > 1 {
+				// If there is more than 1 file error, write them on new lines
+				builder.WriteString("\n\t")
+			}
+			fmt.Fprintf(&builder, "%s: %s",
+				output.SanitizeForWorkflowCommand(fileError.FilePath),
+				output.SanitizeForWorkflowCommand(fileError.ErrorMessage))
+		}
+		msg = builder.String()
+	}
+
+	return output.SanitizeForWorkflowCommand(status.Name), msg
+}
+
 func configurePlugins(plugins []plugin.Plugin, accessors ExternalAccessors, actions ScannerActions) {
 	for _, plug := range plugins {
 		vendored.Configure(plug, vendored.Config{
@@ -271,28 +291,16 @@ SBOMLoop:
 
 		for _, status := range sr.PluginStatus {
 			if status.Status.Status != plugin.ScanStatusSucceeded {
-				builder := strings.Builder{}
 				criticalError := false
 				for _, fileError := range status.Status.FileErrors {
-					if len(status.Status.FileErrors) > 1 {
-						// If there is more than 1 file error, write them on new lines
-						builder.WriteString("\n\t")
-					}
-					fmt.Fprintf(&builder, "%s: %s", fileError.FilePath, fileError.ErrorMessage)
-
 					// Check if the erroring file was a path specifically passed in (not a result of a file walk)
 					if slices.Contains(specificPaths, filepath.Join(root, fileError.FilePath)) {
 						criticalError = true
 					}
 				}
 
-				msg := status.Status.FailureReason
-
-				if len(status.Status.FileErrors) > 0 {
-					msg = builder.String()
-				}
-
-				cmdlogger.Errorf("Error during extraction: (extracting as %s) %s", status.Name, msg)
+				extractorName, msg := formatExtractionError(status)
+				cmdlogger.Errorf("Error during extraction: (extracting as %s) %s", extractorName, msg)
 				if criticalError {
 					return nil, errors.New("extraction failed on specified lockfile")
 				}


### PR DESCRIPTION
## Summary
- encode config filter reasons with the existing `output.SanitizeForWorkflowCommand` helper before writing them through `cmdlogger`
- encode extractor status/file error fields before formatting extraction errors for workflow logs
- add regressions for newline-delimited workflow output in ignored-vuln reasons and extractor errors

This is related to #2749 and complements #2861. PR #2861 hardens carriage returns centrally in `cmdlogger`; these call sites also need newline encoding because workflow output treats newlines as record boundaries.

## Tests
- `GOMAXPROCS=2 go test -p=1 ./pkg/osvscanner -run 'Test_sanitizeReasonForLog|Test_formatExtractionErrorSanitizesWorkflowCommandFields'`\n- `GOMAXPROCS=2 go test -p=1 ./pkg/osvscanner`\n- `git diff --check`