### PR TITLE
fix: keep imodels package cache scan-local

### DIFF
--- a/internal/imodels/imodels.go
+++ b/internal/imodels/imodels.go
@@ -30,27 +30,54 @@ var gitExtractors = map[string]struct{}{
 	gitrepo.Name: {},
 }
 
-// todo: SBOM special case, to be removed after PURL to ESI conversion within each extractor is complete
-var cache = sync.Map{} // map[*extractor.Package]*models.PackageInfo
+type PackageResolver struct {
+	// TODO(v2): SBOM special case, to be removed after PURL to ESI conversion within each extractor is complete.
+	cache sync.Map // map[*extractor.Package]*models.PackageInfo
+}
 
-func toCachedPackageInfo(pkg *extractor.Package) *models.PackageInfo {
+func NewPackageResolver() *PackageResolver {
+	return &PackageResolver{}
+}
+
+func packageInfoFromPURL(pkg *extractor.Package) *models.PackageInfo {
 	if SourceType(pkg) != models.SourceTypeSBOM {
 		return nil
 	}
 
-	v, ok := cache.Load(pkg)
+	purlStruct := converter.ToPURL(pkg)
+
+	if purlStruct == nil {
+		return nil
+	}
+
+	purlCache, _ := purl.ToPackage(purlStruct.String())
+
+	return &purlCache
+}
+
+func toCachedPackageInfo(pkg *extractor.Package) *models.PackageInfo {
+	return packageInfoFromPURL(pkg)
+}
+
+func (r *PackageResolver) toCachedPackageInfo(pkg *extractor.Package) *models.PackageInfo {
+	if r == nil {
+		return toCachedPackageInfo(pkg)
+	}
+
+	if SourceType(pkg) != models.SourceTypeSBOM {
+		return nil
+	}
+
+	v, ok := r.cache.Load(pkg)
 
 	if !ok {
-		purlStruct := converter.ToPURL(pkg)
-
-		if purlStruct == nil {
+		purlCache := packageInfoFromPURL(pkg)
+		if purlCache == nil {
 			return nil
 		}
+		r.cache.Store(pkg, purlCache)
 
-		purlCache, _ := purl.ToPackage(purlStruct.String())
-		cache.Store(pkg, &purlCache)
-
-		return &purlCache
+		return purlCache
 	}
 
 	if v == nil {
@@ -61,20 +88,28 @@ func toCachedPackageInfo(pkg *extractor.Package) *models.PackageInfo {
 }
 
 func Name(pkg *extractor.Package) string {
+	return name(pkg, nil)
+}
+
+func (r *PackageResolver) Name(pkg *extractor.Package) string {
+	return name(pkg, r)
+}
+
+func name(pkg *extractor.Package, resolver *PackageResolver) string {
 	// TODO(v2): SBOM special case, to be removed after PURL to ESI conversion within each extractor is complete
-	if purlCache := toCachedPackageInfo(pkg); purlCache != nil {
+	if purlCache := resolver.toCachedPackageInfo(pkg); purlCache != nil {
 		return purlCache.Name
 	}
 
 	// --- Make specific patches to names as necessary ---
 	// Patch Go package to stdlib
-	if Ecosystem(pkg).Ecosystem == osvconstants.EcosystemGo && pkg.Name == "go" {
+	if ecosystem(pkg, resolver).Ecosystem == osvconstants.EcosystemGo && pkg.Name == "go" {
 		return "stdlib"
 	}
 
 	// TODO: Move the normalization to another place where matching logic happens.
 	// Patch python package names to be normalized
-	if Ecosystem(pkg).Ecosystem == osvconstants.EcosystemPyPI {
+	if ecosystem(pkg, resolver).Ecosystem == osvconstants.EcosystemPyPI {
 		// per https://peps.python.org/pep-0503/#normalized-names
 		return strings.ToLower(cachedregexp.MustCompile(`[-_.]+`).ReplaceAllLiteralString(pkg.Name, "-"))
 	}
@@ -101,7 +136,7 @@ func Name(pkg *extractor.Package) string {
 		}
 	}
 
-	if Ecosystem(pkg).String() == "GIT" && pkg.SourceCode != nil && pkg.SourceCode.Repo != "" {
+	if ecosystem(pkg, resolver).String() == "GIT" && pkg.SourceCode != nil && pkg.SourceCode.Repo != "" {
 		return pkg.SourceCode.Repo
 	}
 
@@ -109,6 +144,14 @@ func Name(pkg *extractor.Package) string {
 }
 
 func Ecosystem(pkg *extractor.Package) osvecosystem.Parsed {
+	return ecosystem(pkg, nil)
+}
+
+func (r *PackageResolver) Ecosystem(pkg *extractor.Package) osvecosystem.Parsed {
+	return ecosystem(pkg, r)
+}
+
+func ecosystem(pkg *extractor.Package, resolver *PackageResolver) osvecosystem.Parsed {
 	eco := pkg.Ecosystem()
 
 	if metadata, ok := pkg.Metadata.(*osvscannerjson.Metadata); ok {
@@ -128,7 +171,7 @@ func Ecosystem(pkg *extractor.Package) osvecosystem.Parsed {
 	}
 
 	// TODO(v2): SBOM special case, to be removed after PURL to ESI conversion within each extractor is complete
-	if purlCache := toCachedPackageInfo(pkg); purlCache != nil {
+	if purlCache := resolver.toCachedPackageInfo(pkg); purlCache != nil {
 		newEco, err := osvecosystem.Parse(purlCache.Ecosystem)
 		if err != nil {
 			cmdlogger.Warnf("Warning: error parsing osvscanner.json ecosystem: %s", err.Error())
@@ -142,8 +185,16 @@ func Ecosystem(pkg *extractor.Package) osvecosystem.Parsed {
 }
 
 func Version(pkg *extractor.Package) string {
+	return version(pkg, nil)
+}
+
+func (r *PackageResolver) Version(pkg *extractor.Package) string {
+	return version(pkg, r)
+}
+
+func version(pkg *extractor.Package, resolver *PackageResolver) string {
 	// TODO(v2): SBOM special case, to be removed after PURL to ESI conversion within each extractor is complete
-	if purlCache := toCachedPackageInfo(pkg); purlCache != nil {
+	if purlCache := resolver.toCachedPackageInfo(pkg); purlCache != nil {
 		return purlCache.Version
 	}
 
@@ -155,7 +206,7 @@ func Version(pkg *extractor.Package) string {
 	// However, if we assume patch version as .0, this will cause a lot of
 	// false positives. This compromise still allows osv-scanner to pick up
 	// when the user is using a minor version that is out-of-support.
-	if Ecosystem(pkg).Ecosystem == osvconstants.EcosystemGo && Name(pkg) == "stdlib" {
+	if ecosystem(pkg, resolver).Ecosystem == osvconstants.EcosystemGo && name(pkg, resolver) == "stdlib" {
 		v := semverlike.ParseSemverLikeVersion(pkg.Version, 3)
 		if len(v.Components) == 2 {
 			return fmt.Sprintf(

--- a/pkg/osvscanner/filter.go
+++ b/pkg/osvscanner/filter.go
@@ -17,13 +17,13 @@ import (
 // filterUnscannablePackages removes packages that don't have enough information to be scanned or
 // are not a supported ecosystem, and returns the list of removed packages (if --all-packages flag is passed in)
 // e,g, local packages that specified by path
-func filterUnscannablePackages(scanResults *results.ScanResults, actions ScannerActions) []*extractor.Package {
+func filterUnscannablePackages(scanResults *results.ScanResults, actions ScannerActions, packageResolver *imodels.PackageResolver) []*extractor.Package {
 	packageResults := make([]*extractor.Package, 0, len(scanResults.Inventory.Packages))
 	filteredPsr := make([]*extractor.Package, 0, len(scanResults.Inventory.Packages))
 	for _, psr := range scanResults.Inventory.Packages {
 		switch {
 		// If **none** of the cases match, skip this package since it's not scannable
-		case !imodels.Ecosystem(psr).IsEmpty() && imodels.Name(psr) != "" && imodels.Version(psr) != "":
+		case !packageResolver.Ecosystem(psr).IsEmpty() && packageResolver.Name(psr) != "" && packageResolver.Version(psr) != "":
 		case imodels.Commit(psr) != "":
 		default:
 			if actions.ShowAllPackages {
@@ -35,8 +35,8 @@ func filterUnscannablePackages(scanResults *results.ScanResults, actions Scanner
 
 		switch {
 		// If **any** of the following cases are true, skip this package
-		case imodels.Ecosystem(psr).Ecosystem == osvconstants.EcosystemMaven && imodels.Name(psr) == "unknown", // Is Maven with package name unknown
-			imodels.Ecosystem(psr).GetValidity() != nil && !imodels.Ecosystem(psr).IsEmpty(): // Is invalid and not empty
+		case packageResolver.Ecosystem(psr).Ecosystem == osvconstants.EcosystemMaven && packageResolver.Name(psr) == "unknown", // Is Maven with package name unknown
+			packageResolver.Ecosystem(psr).GetValidity() != nil && !packageResolver.Ecosystem(psr).IsEmpty(): // Is invalid and not empty
 			if actions.ShowAllPackages {
 				filteredPsr = append(filteredPsr, psr)
 			}
@@ -45,7 +45,7 @@ func filterUnscannablePackages(scanResults *results.ScanResults, actions Scanner
 		// Short commit hashes (< 40 hex chars) are rejected by the OSV API with
 		// "Invalid hash". Skip them with a warning rather than aborting the scan.
 		case imodels.Commit(psr) != "" && len(imodels.Commit(psr)) < 40:
-			cmdlogger.Warnf("Skipping %s: short commit hash %q cannot be queried; OSV API requires a full 40-character SHA.", imodels.Name(psr), imodels.Commit(psr))
+			cmdlogger.Warnf("Skipping %s: short commit hash %q cannot be queried; OSV API requires a full 40-character SHA.", packageResolver.Name(psr), imodels.Commit(psr))
 
 			if actions.ShowAllPackages {
 				filteredPsr = append(filteredPsr, psr)
@@ -67,12 +67,12 @@ func filterUnscannablePackages(scanResults *results.ScanResults, actions Scanner
 }
 
 // filterNonContainerRelevantPackages removes packages that are not relevant when doing container scanning
-func filterNonContainerRelevantPackages(scanResults *results.ScanResults) {
+func filterNonContainerRelevantPackages(scanResults *results.ScanResults, packageResolver *imodels.PackageResolver) {
 	packageResults := make([]*extractor.Package, 0, len(scanResults.Inventory.Packages))
 	for _, psr := range scanResults.Inventory.Packages {
 		// Almost all packages with linux as a SourceName are kernel packages
 		// which does not apply within a container, as containers use the host's kernel
-		if imodels.Name(psr) == "linux" {
+		if packageResolver.Name(psr) == "linux" {
 			continue
 		}
 

--- a/pkg/osvscanner/filter_internal_test.go
+++ b/pkg/osvscanner/filter_internal_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/osv-scalibr/extractor"
 	"github.com/google/osv-scalibr/inventory"
 	"github.com/google/osv-scanner/v2/internal/config"
+	"github.com/google/osv-scanner/v2/internal/imodels"
 	"github.com/google/osv-scanner/v2/internal/imodels/results"
 	"github.com/google/osv-scanner/v2/internal/testutility"
 	"github.com/google/osv-scanner/v2/pkg/models"
@@ -59,7 +60,7 @@ func Test_filterUnscannablePackages_shortCommitHash(t *testing.T) {
 				},
 			}
 
-			filtered := filterUnscannablePackages(scanResults, ScannerActions{})
+			filtered := filterUnscannablePackages(scanResults, ScannerActions{}, imodels.NewPackageResolver())
 
 			if len(scanResults.Inventory.Packages) != tt.wantKept {
 				t.Errorf("packages kept = %d, want %d", len(scanResults.Inventory.Packages), tt.wantKept)

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -208,13 +208,14 @@ func DoScan(actions ScannerActions) (models.VulnerabilityResults, error) {
 	}
 
 	scanResults.Inventory = *packagesAndFindings
+	packageResolver := imodels.NewPackageResolver()
 
 	// ----- Filtering -----
-	unscannablePackages := filterUnscannablePackages(&scanResults, actions)
+	unscannablePackages := filterUnscannablePackages(&scanResults, actions, packageResolver)
 	filterIgnoredPackages(&scanResults)
 
 	// ----- Custom Overrides -----
-	filterAndOverrideGoVersion(&scanResults)
+	filterAndOverrideGoVersion(&scanResults, packageResolver)
 
 	// --- Make Vulnerability Requests ---
 	if accessors.VulnMatcher != nil {
@@ -237,7 +238,7 @@ func DoScan(actions ScannerActions) (models.VulnerabilityResults, error) {
 		scanResults.Inventory.Packages = slices.Concat(scanResults.Inventory.Packages, unscannablePackages)
 	}
 
-	return finalizeScanResult(scanResults, actions)
+	return finalizeScanResult(scanResults, actions, packageResolver)
 }
 
 func DoContainerScan(actions ScannerActions) (models.VulnerabilityResults, error) {
@@ -334,6 +335,7 @@ func DoContainerScan(actions ScannerActions) (models.VulnerabilityResults, error
 
 	// --- Save Scalibr Scan Results ---
 	scanResults.Inventory = scalibrSR.Inventory
+	packageResolver := imodels.NewPackageResolver()
 
 	// --- Fill Image Metadata ---
 	pssr, err := proto.ScanResultToProto(scalibrSR)
@@ -348,10 +350,10 @@ func DoContainerScan(actions ScannerActions) (models.VulnerabilityResults, error
 	}
 
 	// ----- Filtering -----
-	unscannablePackages := filterUnscannablePackages(&scanResults, actions)
+	unscannablePackages := filterUnscannablePackages(&scanResults, actions, packageResolver)
 	filterIgnoredPackages(&scanResults)
 
-	filterNonContainerRelevantPackages(&scanResults)
+	filterNonContainerRelevantPackages(&scanResults, packageResolver)
 
 	// --- Make Vulnerability Requests ---
 	if accessors.VulnMatcher != nil {
@@ -374,11 +376,11 @@ func DoContainerScan(actions ScannerActions) (models.VulnerabilityResults, error
 		scanResults.Inventory.Packages = slices.Concat(scanResults.Inventory.Packages, unscannablePackages)
 	}
 
-	return finalizeScanResult(scanResults, actions)
+	return finalizeScanResult(scanResults, actions, packageResolver)
 }
 
-func finalizeScanResult(scanResult results.ScanResults, actions ScannerActions) (models.VulnerabilityResults, error) {
-	vulnerabilityResults := buildVulnerabilityResults(actions, &scanResult)
+func finalizeScanResult(scanResult results.ScanResults, actions ScannerActions, packageResolver *imodels.PackageResolver) (models.VulnerabilityResults, error) {
+	vulnerabilityResults := buildVulnerabilityResults(actions, &scanResult, packageResolver)
 
 	if actions.ScanLicensesSummary {
 		vulnerabilityResults.LicenseSummary = buildLicenseSummary(&scanResult)
@@ -520,10 +522,10 @@ func makeVulnRequestWithMatcher(
 }
 
 // Filters out Go version or Overrides it using osv-scanner.toml
-func filterAndOverrideGoVersion(scanResults *results.ScanResults) {
+func filterAndOverrideGoVersion(scanResults *results.ScanResults, packageResolver *imodels.PackageResolver) {
 	// Filter inventory packages
 	scanResults.Inventory.Packages = slices.DeleteFunc(scanResults.Inventory.Packages, func(pkg *extractor.Package) bool {
-		if imodels.Name(pkg) == "stdlib" && imodels.Ecosystem(pkg).Ecosystem == osvconstants.EcosystemGo {
+		if packageResolver.Name(pkg) == "stdlib" && packageResolver.Ecosystem(pkg).Ecosystem == osvconstants.EcosystemGo {
 			// Only apply the filter if it's from a go.mod file.
 			// The 'go' directive in go.mod specifies the minimum required language version,
 			// not the actual toolchain version used to build/run, which can lead to false positives.
@@ -540,7 +542,7 @@ func filterAndOverrideGoVersion(scanResults *results.ScanResults) {
 
 	// Override versions for remaining inventory packages
 	for i, pkg := range scanResults.Inventory.Packages {
-		if imodels.Name(pkg) == "stdlib" && imodels.Ecosystem(pkg).Ecosystem == osvconstants.EcosystemGo {
+		if packageResolver.Name(pkg) == "stdlib" && packageResolver.Ecosystem(pkg).Ecosystem == osvconstants.EcosystemGo {
 			configToUse := scanResults.ConfigManager.Get(imodels.Location(pkg))
 			if configToUse.GoVersionOverride != "" {
 				scanResults.Inventory.Packages[i].Version = configToUse.GoVersionOverride

--- a/pkg/osvscanner/vulnerability_result.go
+++ b/pkg/osvscanner/vulnerability_result.go
@@ -29,6 +29,7 @@ import (
 func buildVulnerabilityResults(
 	actions ScannerActions,
 	scanResults *results.ScanResults,
+	packageResolver *imodels.PackageResolver,
 ) models.VulnerabilityResults {
 	vulnResults := models.VulnerabilityResults{
 		Results:                     []models.PackageSource{},
@@ -51,12 +52,12 @@ func buildVulnerabilityResults(
 
 		if imodels.Commit(p) != "" {
 			pkg.Package.Commit = imodels.Commit(p)
-			pkg.Package.Name = imodels.Name(p)
+			pkg.Package.Name = packageResolver.Name(p)
 		}
 
-		pkg.Package.Name = imodels.Name(p)
-		pkg.Package.Version = imodels.Version(p)
-		pkg.Package.Ecosystem = imodels.Ecosystem(p).String()
+		pkg.Package.Name = packageResolver.Name(p)
+		pkg.Package.Version = packageResolver.Version(p)
+		pkg.Package.Ecosystem = packageResolver.Ecosystem(p).String()
 		pkg.Package.OSPackageName = imodels.OSPackageName(p)
 		pkg.Package.Deprecated = p.Deprecated
 

--- a/pkg/osvscanner/vulnerability_result_internal_test.go
+++ b/pkg/osvscanner/vulnerability_result_internal_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/osv-scalibr/inventory"
 	"github.com/google/osv-scalibr/purl"
 	"github.com/google/osv-scanner/v2/internal/config"
+	"github.com/google/osv-scanner/v2/internal/imodels"
 	"github.com/google/osv-scanner/v2/internal/imodels/results"
 	"github.com/google/osv-scanner/v2/internal/testutility"
 	"github.com/ossf/osv-schema/bindings/go/osvschema"
@@ -167,7 +168,7 @@ func Test_assembleResult(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			tt.args.scanResults.ConfigManager = tt.args.config
-			got := buildVulnerabilityResults(tt.args.actions, tt.args.scanResults)
+			got := buildVulnerabilityResults(tt.args.actions, tt.args.scanResults, imodels.NewPackageResolver())
 			testutility.NewSnapshot().MatchJSON(t, got)
 		})
 	}


### PR DESCRIPTION
## What changed
- Replaced the process-wide SBOM package cache with a resolver-owned cache.
- Use a scan-local resolver while filtering packages and building results.

## Why
The old cache used package pointers as keys and kept them alive across scans. Long-running callers could retain package data after each scan finished.

Fixes #2859.

## Testing
- go test ./internal/imodels ./pkg/osvscanner