### PR TITLE
fix: skip unknown advisory ecosystems

### DIFF
--- a/internal/utility/vulns/vulnerability.go
+++ b/internal/utility/vulns/vulnerability.go
@@ -108,9 +108,24 @@ func rangeAffectsVersion(vulnID string, a []*osvschema.Range, pkg *extractor.Pac
 	return false
 }
 
+func parseAffectedEcosystem(affected *osvschema.Affected) (osvecosystem.Parsed, bool) {
+	ecosystem := affected.GetPackage().GetEcosystem()
+	parsed, err := osvecosystem.Parse(ecosystem)
+	if err != nil {
+		cmdlogger.Debugf("skipping affected entry with unsupported ecosystem %q: %v", ecosystem, err)
+		return osvecosystem.Parsed{}, false
+	}
+
+	return parsed, true
+}
+
 func AffectsEcosystem(v *osvschema.Vulnerability, ecosystemAffected osvecosystem.Parsed) bool {
 	for _, affected := range v.GetAffected() {
-		if osvecosystem.MustParse(affected.GetPackage().GetEcosystem()).Equal(ecosystemAffected) {
+		affectedEcosystem, ok := parseAffectedEcosystem(affected)
+		if !ok {
+			continue
+		}
+		if affectedEcosystem.Equal(ecosystemAffected) {
 			return true
 		}
 	}
@@ -157,8 +172,11 @@ func IsAffected(v *osvschema.Vulnerability, pkg *extractor.Package) bool {
 		if affected.GetPackage() == nil {
 			continue
 		}
-		if osvecosystem.MustParse(affected.GetPackage().GetEcosystem()).Equal(imodels.Ecosystem(pkg)) &&
-			affected.GetPackage().GetName() == imodels.Name(pkg) {
+		affectedEcosystem, ok := parseAffectedEcosystem(affected)
+		if !ok {
+			continue
+		}
+		if affectedEcosystem.Equal(imodels.Ecosystem(pkg)) && affected.GetPackage().GetName() == imodels.Name(pkg) {
 			if len(affected.GetRanges()) == 0 && len(affected.GetVersions()) == 0 {
 				cmdlogger.Warnf("%s does not have any ranges or versions - this is probably a mistake!", v.GetId())
 

--- a/internal/utility/vulns/vulnerability_test.go
+++ b/internal/utility/vulns/vulnerability_test.go
@@ -86,6 +86,14 @@ func TestOSV_AffectsEcosystem(t *testing.T) {
 			Ecosystem: "npm",
 			Expected:  true,
 		},
+		{
+			Affected: []*osvschema.Affected{
+				{Package: &osvschema.Package{Ecosystem: "unknown-ecosystem"}},
+				{Package: &osvschema.Package{Ecosystem: "npm"}},
+			},
+			Ecosystem: "npm",
+			Expected:  true,
+		},
 	}
 
 	for i, tt := range tests {
@@ -121,6 +129,27 @@ func TestOSV_AffectsEcosystem(t *testing.T) {
 			"Expected OSV to report 'false' when it doesn't have an Affected, but it reported true!",
 		)
 	}
+}
+
+func TestOSV_IsAffected_SkipsUnknownAffectedEcosystem(t *testing.T) {
+	t.Parallel()
+
+	vuln := buildOSVWithAffected(
+		&osvschema.Affected{
+			Package: &osvschema.Package{Ecosystem: "unknown-ecosystem", Name: "my-package"},
+			Ranges: []*osvschema.Range{
+				buildEcosystemAffectsRange(&osvschema.Event{Introduced: "0"}),
+			},
+		},
+		&osvschema.Affected{
+			Package: &osvschema.Package{Ecosystem: string(osvconstants.EcosystemNPM), Name: "my-package"},
+			Ranges: []*osvschema.Range{
+				buildEcosystemAffectsRange(&osvschema.Event{Introduced: "0"}),
+			},
+		},
+	)
+
+	expectIsAffected(t, vuln, "1.0.0", true)
 }
 
 func TestOSV_IsAffected_AffectsWithEcosystem_DifferentEcosystem(t *testing.T) {


### PR DESCRIPTION
## What changed
- Parse advisory affected ecosystems without panicking.
- Skip affected entries with unsupported ecosystem names.
- Added regression coverage for unknown advisory ecosystems.

## Why
A malformed or unsupported ecosystem in one advisory entry should not stop offline matching for the whole vulnerability.

Fixes #2867.

## Testing
- go test ./internal/utility/vulns