### PR TITLE
feat: add rpm release package

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -151,6 +151,18 @@ archives:
     name_template: "{{ .Binary }}_{{ .Os }}_{{ .Arch }}"
     ids:
       - osv-scanner
+nfpms:
+  - id: osv-scanner-rpm
+    package_name: osv-scanner
+    ids:
+      - osv-scanner
+    formats:
+      - rpm
+    vendor: Google
+    homepage: https://github.com/google/osv-scanner
+    maintainer: OSV Scanner maintainers
+    description: Vulnerability scanner written in Go which uses the data provided by https://osv.dev
+    license: Apache-2.0
 checksum:
   name_template: "{{ .ProjectName }}_SHA256SUMS"
   algorithm: sha256


### PR DESCRIPTION
## What changed
- Added an RPM package to the GoReleaser config for the main osv-scanner binary.

## Why
This gives RPM-based distributions a native release package option.

Fixes #55.

## Testing
- go run github.com/goreleaser/goreleaser/v2@latest check