### PR TITLE
fix(output): harden GitHub annotation escaping

### DIFF
--- a/internal/output/__snapshots__/githubannotation_test.snap
+++ b/internal/output/__snapshots__/githubannotation_test.snap
@@ -196,7 +196,7 @@
 ---
 
 [TestPrintGHAnnotationReport_WithVulnerabilities/one_source_with_workflow_command_injection_attempt_in_path - 1]
-::error file=dir%0D::stop-commands::T%0D::error::INJECTED%0A::warning::pwn/lockfile::dir%0D::stop-commands::T%0D::error::INJECTED%0A::warning::pwn/lockfile%0A+---------+-----------------------+------+-----------------+---------------+%0A| PACKAGE | VULNERABILITY ID      | CVSS | CURRENT VERSION | FIXED VERSION |%0A+---------+-----------------------+------+-----------------+---------------+%0A| mine1   | https://osv.dev/OSV-1 |      | 1.2.3           |               |%0A+---------+-----------------------+------+-----------------+---------------+
+::error file=dir%0D%3A%3Astop-commands%3A%3AT%0D%3A%3Aerror%3A%3AINJECTED%0A%3A%3Awarning%3A%3Apwn/lockfile::dir%0D::stop-commands::T%0D::error::INJECTED%0A::warning::pwn/lockfile%0A+---------+-----------------------+------+-----------------+---------------+%0A| PACKAGE | VULNERABILITY ID      | CVSS | CURRENT VERSION | FIXED VERSION |%0A+---------+-----------------------+------+-----------------+---------------+%0A| mine1   | https://osv.dev/OSV-1 |      | 1.2.3           |               |%0A+---------+-----------------------+------+-----------------+---------------+
 ---
 
 [TestPrintGHAnnotationReport_WithVulnerabilities/two_sources_with_packages,_one_vulnerability - 1]

--- a/internal/output/githubannotation.go
+++ b/internal/output/githubannotation.go
@@ -82,30 +82,23 @@ func PrintGHAnnotationReport(vulnResult *models.VulnerabilityResults, outputWrit
 		// Sanitize artifactPath to prevent GitHub Actions workflow command injection.
 		// \r and \n in the file= parameter can terminate the annotation early and inject
 		// arbitrary workflow commands (e.g. ::warning::, ::add-mask::) into the runner output.
-		artifactPath = strings.ReplaceAll(artifactPath, "\r", "%0D")
-		artifactPath = strings.ReplaceAll(artifactPath, "\n", "%0A")
+		// The file property also needs the standard workflow command property escapes.
+		annotationFile := escapeWorkflowCommandProperty(artifactPath)
+		annotationPath := escapeWorkflowCommandData(artifactPath)
 
 		remediationTable, hasVulnTable := createSourceRemediationTable(source, groupedFixedVersions)
 		if hasVulnTable {
-			renderedTable := remediationTable.Render()
-			// This is required as github action annotations must be on the same terminal line
-			// so we URL encode the new line character
-			renderedTable = strings.ReplaceAll(renderedTable, "\n", "%0A")
-			// Sanitize \r to prevent workflow command injection via carriage return in package names
-			renderedTable = strings.ReplaceAll(renderedTable, "\r", "%0D")
+			renderedTable := escapeWorkflowCommandData(remediationTable.Render())
 
 			// Prepend the table with a new line to look nicer in the output
-			fmt.Fprintf(outputWriter, "::error file=%s::%s%s", artifactPath, artifactPath, "%0A"+renderedTable)
+			fmt.Fprintf(outputWriter, "::error file=%s::%s%s", annotationFile, annotationPath, "%0A"+renderedTable)
 		}
 
 		// Create and render package deprecation table
 		deprecationTable, hasDeprecationTable := createDeprecationTable(source)
 		if hasDeprecationTable {
-			renderedDeprecationTable := deprecationTable.Render()
-			renderedDeprecationTable = strings.ReplaceAll(renderedDeprecationTable, "\n", "%0A")
-			// Sanitize \r to prevent workflow command injection via carriage return in package names
-			renderedDeprecationTable = strings.ReplaceAll(renderedDeprecationTable, "\r", "%0D")
-			fmt.Fprintf(outputWriter, "::error file=%s::%s%s", artifactPath, artifactPath, "%0A"+renderedDeprecationTable)
+			renderedDeprecationTable := escapeWorkflowCommandData(deprecationTable.Render())
+			fmt.Fprintf(outputWriter, "::error file=%s::%s%s", annotationFile, annotationPath, "%0A"+renderedDeprecationTable)
 		}
 	}
 

--- a/internal/output/githubannotation_test.go
+++ b/internal/output/githubannotation_test.go
@@ -114,3 +114,50 @@ func TestPrintGHAnnotationReport_CRSanitization(t *testing.T) {
 		t.Errorf("GH annotation output does not contain %%0D encoding for \\r character.\nOutput: %q", result)
 	}
 }
+
+func TestPrintGHAnnotationReport_EscapesWorkflowCommandSpecialChars(t *testing.T) {
+	t.Parallel()
+
+	vulnResult := &models.VulnerabilityResults{
+		Results: []models.PackageSource{
+			{
+				Source: models.SourceInfo{
+					Path: "scan,line=1:title%25/package-lock.json",
+					Type: "lockfile",
+				},
+				Packages: []models.PackageVulns{
+					{
+						Package: models.PackageInfo{
+							Name:      "lodash%0A::warning::INJECTED",
+							Version:   "4.17.20",
+							Ecosystem: "npm",
+						},
+						Groups: []models.GroupInfo{
+							{
+								IDs:         []string{"GHSA-35jh-r3h4-6jhm"},
+								MaxSeverity: "7.2",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	outputWriter := &bytes.Buffer{}
+	err := output.PrintGHAnnotationReport(vulnResult, outputWriter)
+	if err != nil {
+		t.Errorf("Error writing GH annotation output: %s", err)
+	}
+
+	result := outputWriter.String()
+	if strings.Contains(result, "file=scan,line=1:title%25") {
+		t.Errorf("GH annotation file property contains unescaped workflow command property characters.\nOutput: %q", result)
+	}
+
+	for _, want := range []string{"scan%2Cline=1%3Atitle%2525", "lodash%250A::warning::INJECTED"} {
+		if !strings.Contains(result, want) {
+			t.Errorf("GH annotation output is missing escaped value %q.\nOutput: %q", want, result)
+		}
+	}
+}

--- a/internal/output/sanitize.go
+++ b/internal/output/sanitize.go
@@ -15,3 +15,21 @@ var workflowCommandReplacer = strings.NewReplacer("\r", "%0D", "\n", "%0A")
 func SanitizeForWorkflowCommand(s string) string {
 	return workflowCommandReplacer.Replace(s)
 }
+
+var workflowCommandDataReplacer = strings.NewReplacer("%", "%25", "\r", "%0D", "\n", "%0A")
+
+var workflowCommandPropertyReplacer = strings.NewReplacer(
+	"%", "%25",
+	"\r", "%0D",
+	"\n", "%0A",
+	":", "%3A",
+	",", "%2C",
+)
+
+func escapeWorkflowCommandData(s string) string {
+	return workflowCommandDataReplacer.Replace(s)
+}
+
+func escapeWorkflowCommandProperty(s string) string {
+	return workflowCommandPropertyReplacer.Replace(s)
+}


### PR DESCRIPTION
## Overview

Harden the `gh-annotations` output format by applying GitHub Actions workflow command escaping rules separately for command properties and command data.

Fixes #2889

## Details

`PrintGHAnnotationReport` emits GitHub Actions workflow commands directly to stdout. The existing implementation encoded raw `\r` and `\n` bytes, which prevents direct line-break command injection. This change extends the escaping to match the workflow command grammar used by `actions/toolkit`:

- command data escapes `%`, `\r`, and `\n`
- command properties escape `%`, `\r`, `\n`, `:`, and `,`

The change is scoped to GitHub annotation output:

- `file=` uses property escaping
- the annotation message path and rendered tables use data escaping

Normal terminal table/vertical output remains unchanged.

## Testing

- Added regression coverage for workflow command special characters in `PrintGHAnnotationReport`.
- Ran:

```shell
go test ./internal/output
```

## Checklist

- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/).
- [ ] I have run the linter using `./scripts/run_lints.sh`.
- [ ] I have run the unit tests using `./scripts/run_tests.sh`.
- [x] I have made my commits and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
