### PR TITLE
fix(output): harden GitHub Actions annotation escaping

### DIFF
--- a/internal/output/__snapshots__/githubannotation_test.snap
+++ b/internal/output/__snapshots__/githubannotation_test.snap
@@ -196,7 +196,7 @@
 ---
 
 [TestPrintGHAnnotationReport_WithVulnerabilities/one_source_with_workflow_command_injection_attempt_in_path - 1]
-::error file=dir%0D::stop-commands::T%0D::error::INJECTED%0A::warning::pwn/lockfile::dir%0D::stop-commands::T%0D::error::INJECTED%0A::warning::pwn/lockfile%0A+---------+-----------------------+------+-----------------+---------------+%0A| PACKAGE | VULNERABILITY ID      | CVSS | CURRENT VERSION | FIXED VERSION |%0A+---------+-----------------------+------+-----------------+---------------+%0A| mine1   | https://osv.dev/OSV-1 |      | 1.2.3           |               |%0A+---------+-----------------------+------+-----------------+---------------+
+::error file=dir%0D%3A%3Astop-commands%3A%3AT%0D%3A%3Aerror%3A%3AINJECTED%0A%3A%3Awarning%3A%3Apwn/lockfile::dir%0D%3A%3Astop-commands%3A%3AT%0D%3A%3Aerror%3A%3AINJECTED%0A%3A%3Awarning%3A%3Apwn/lockfile%0A+---------+-----------------------+------+-----------------+---------------+%0A| PACKAGE | VULNERABILITY ID      | CVSS | CURRENT VERSION | FIXED VERSION |%0A+---------+-----------------------+------+-----------------+---------------+%0A| mine1   | https://osv.dev/OSV-1 |      | 1.2.3           |               |%0A+---------+-----------------------+------+-----------------+---------------+
 ---
 
 [TestPrintGHAnnotationReport_WithVulnerabilities/two_sources_with_packages,_one_vulnerability - 1]

--- a/internal/output/githubannotation.go
+++ b/internal/output/githubannotation.go
@@ -10,6 +10,34 @@ import (
 	"github.com/jedib0t/go-pretty/v6/table"
 )
 
+// escapeWorkflowCommandData escapes a string for use as the message body of a
+// GitHub Actions workflow command. It percent-encodes %, \r, and \n so that an
+// attacker cannot inject line breaks or further percent-encoded sequences.
+// The GitHub Actions runner treats %25 as a literal percent sign, %0D as a
+// carriage return, and %0A as a line feed.
+// See: https://github.com/actions/toolkit/blob/main/packages/core/src/command.ts
+func escapeWorkflowCommandData(s string) string {
+	return strings.NewReplacer(
+		"%", "%25",
+		"\r", "%0D",
+		"\n", "%0A",
+	).Replace(s)
+}
+
+// escapeWorkflowCommandProperty escapes a string for use inside a property value
+// of a GitHub Actions workflow command (e.g. the file=... part). In addition to
+// the characters escaped by escapeWorkflowCommandData it also escapes : and ,,
+// because those delimit properties and property values respectively.
+func escapeWorkflowCommandProperty(s string) string {
+	return strings.NewReplacer(
+		"%", "%25",
+		"\r", "%0D",
+		"\n", "%0A",
+		":", "%3A",
+		",", "%2C",
+	).Replace(s)
+}
+
 // createSourceRemediationTable creates a vulnerability table which includes the fixed versions for a specific source file
 func createSourceRemediationTable(source models.PackageSource, groupedFixedVersions map[string][]string) (table.Writer, bool) {
 	hasRow := false
@@ -80,19 +108,17 @@ func PrintGHAnnotationReport(vulnResult *models.VulnerabilityResults, outputWrit
 		artifactPath = filepath.ToSlash(artifactPath)
 
 		// Sanitize artifactPath to prevent GitHub Actions workflow command injection.
-		// \r and \n in the file= parameter can terminate the annotation early and inject
-		// arbitrary workflow commands (e.g. ::warning::, ::add-mask::) into the runner output.
-		artifactPath = strings.ReplaceAll(artifactPath, "\r", "%0D")
-		artifactPath = strings.ReplaceAll(artifactPath, "\n", "%0A")
+		// Properties in workflow commands (file=...) must have %, \r, \n, :, and ,
+		// escaped so an attacker cannot terminate the annotation early or inject
+		// arbitrary workflow commands (e.g. ::warning::, ::add-mask::).
+		artifactPath = escapeWorkflowCommandProperty(artifactPath)
 
 		remediationTable, hasVulnTable := createSourceRemediationTable(source, groupedFixedVersions)
 		if hasVulnTable {
 			renderedTable := remediationTable.Render()
 			// This is required as github action annotations must be on the same terminal line
 			// so we URL encode the new line character
-			renderedTable = strings.ReplaceAll(renderedTable, "\n", "%0A")
-			// Sanitize \r to prevent workflow command injection via carriage return in package names
-			renderedTable = strings.ReplaceAll(renderedTable, "\r", "%0D")
+			renderedTable = escapeWorkflowCommandData(renderedTable)
 
 			// Prepend the table with a new line to look nicer in the output
 			fmt.Fprintf(outputWriter, "::error file=%s::%s%s", artifactPath, artifactPath, "%0A"+renderedTable)
@@ -102,9 +128,7 @@ func PrintGHAnnotationReport(vulnResult *models.VulnerabilityResults, outputWrit
 		deprecationTable, hasDeprecationTable := createDeprecationTable(source)
 		if hasDeprecationTable {
 			renderedDeprecationTable := deprecationTable.Render()
-			renderedDeprecationTable = strings.ReplaceAll(renderedDeprecationTable, "\n", "%0A")
-			// Sanitize \r to prevent workflow command injection via carriage return in package names
-			renderedDeprecationTable = strings.ReplaceAll(renderedDeprecationTable, "\r", "%0D")
+			renderedDeprecationTable = escapeWorkflowCommandData(renderedDeprecationTable)
 			fmt.Fprintf(outputWriter, "::error file=%s::%s%s", artifactPath, artifactPath, "%0A"+renderedDeprecationTable)
 		}
 	}

--- a/internal/output/githubannotation_test.go
+++ b/internal/output/githubannotation_test.go
@@ -114,3 +114,156 @@ func TestPrintGHAnnotationReport_CRSanitization(t *testing.T) {
 		t.Errorf("GH annotation output does not contain %%0D encoding for \\r character.\nOutput: %q", result)
 	}
 }
+
+// TestPrintGHAnnotationReport_PercentSanitization verifies that literal percent
+// signs in the file path and message body are percent-encoded as %25 so that an
+// attacker cannot inject pre-encoded sequences such as %0A or %0D.
+func TestPrintGHAnnotationReport_PercentSanitization(t *testing.T) {
+	t.Parallel()
+
+	vulnResult := &models.VulnerabilityResults{
+		Results: []models.PackageSource{
+			{
+				Source: models.SourceInfo{
+					Path: "project%0A::warning::INJECTED/package-lock.json",
+					Type: "lockfile",
+				},
+				Packages: []models.PackageVulns{
+					{
+						Package: models.PackageInfo{
+							Name:      "bad%0D::error::INJECTED",
+							Version:   "1.0.0",
+							Ecosystem: "npm",
+						},
+						Groups: []models.GroupInfo{
+							{
+								IDs:         []string{"GHSA-35jh-r3h4-6jhm"},
+								MaxSeverity: "7.2",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	outputWriter := &bytes.Buffer{}
+	err := output.PrintGHAnnotationReport(vulnResult, outputWriter)
+	if err != nil {
+		t.Errorf("Error writing GH annotation output: %s", err)
+	}
+
+	result := outputWriter.String()
+
+	if !strings.Contains(result, "%250A") {
+		t.Errorf("GH annotation output does not contain %%250A encoding for pre-encoded newline.\nOutput: %q", result)
+	}
+	if !strings.Contains(result, "%250D") {
+		t.Errorf("GH annotation output does not contain %%250D encoding for pre-encoded carriage return.\nOutput: %q", result)
+	}
+	if strings.Contains(result, "%0A::warning::") || strings.Contains(result, "%0D::error::") {
+		t.Errorf("GH annotation output contains unescaped pre-encoded workflow command injection.\nOutput: %q", result)
+	}
+}
+
+// TestPrintGHAnnotationReport_PropertyDelimiterSanitization verifies that colon
+// and comma characters in the file= property are percent-encoded so they cannot
+// be used to inject additional properties or terminate the current one.
+func TestPrintGHAnnotationReport_PropertyDelimiterSanitization(t *testing.T) {
+	t.Parallel()
+
+	vulnResult := &models.VulnerabilityResults{
+		Results: []models.PackageSource{
+			{
+				Source: models.SourceInfo{
+					Path: "project,title=FAKE::warning::pwned/package:lock.json",
+					Type: "lockfile",
+				},
+				Packages: []models.PackageVulns{
+					{
+						Package: models.PackageInfo{
+							Name:      "lodash",
+							Version:   "4.17.20",
+							Ecosystem: "npm",
+						},
+						Groups: []models.GroupInfo{
+							{
+								IDs:         []string{"GHSA-35jh-r3h4-6jhm"},
+								MaxSeverity: "7.2",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	outputWriter := &bytes.Buffer{}
+	err := output.PrintGHAnnotationReport(vulnResult, outputWriter)
+	if err != nil {
+		t.Errorf("Error writing GH annotation output: %s", err)
+	}
+
+	result := outputWriter.String()
+
+	if strings.Contains(result, "file=project,") || strings.Contains(result, "file=project,title=FAKE") {
+		t.Errorf("GH annotation output contains unescaped comma in file= property, enabling property injection.\nOutput: %q", result)
+	}
+	if strings.Contains(result, "file=project%3A") || strings.Contains(result, "::warning::pwned") {
+		t.Errorf("GH annotation output contains unescaped colon in file= property, enabling property injection.\nOutput: %q", result)
+	}
+	if !strings.Contains(result, "%2C") {
+		t.Errorf("GH annotation output does not contain %%2C encoding for comma.\nOutput: %q", result)
+	}
+	if !strings.Contains(result, "%3A") {
+		t.Errorf("GH annotation output does not contain %%3A encoding for colon.\nOutput: %q", result)
+	}
+}
+
+// TestPrintGHAnnotationReport_NewlineInMessageSanitization verifies that newlines
+// in the rendered table message body are encoded as %0A so they cannot break out
+// of the workflow command line.
+func TestPrintGHAnnotationReport_NewlineInMessageSanitization(t *testing.T) {
+	t.Parallel()
+
+	vulnResult := &models.VulnerabilityResults{
+		Results: []models.PackageSource{
+			{
+				Source: models.SourceInfo{
+					Path: "package-lock.json",
+					Type: "lockfile",
+				},
+				Packages: []models.PackageVulns{
+					{
+						Package: models.PackageInfo{
+							Name:      "bad\n::warning::INJECTED",
+							Version:   "1.0.0",
+							Ecosystem: "npm",
+						},
+						Groups: []models.GroupInfo{
+							{
+								IDs:         []string{"GHSA-35jh-r3h4-6jhm"},
+								MaxSeverity: "7.2",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	outputWriter := &bytes.Buffer{}
+	err := output.PrintGHAnnotationReport(vulnResult, outputWriter)
+	if err != nil {
+		t.Errorf("Error writing GH annotation output: %s", err)
+	}
+
+	result := outputWriter.String()
+
+	if strings.Contains(result, "\n::warning::") || strings.Contains(result, "\r::warning::") {
+		t.Errorf("GH annotation output contains unescaped line break in message body, enabling workflow command injection.\nOutput: %q", result)
+	}
+	if !strings.Contains(result, "%0A") {
+		t.Errorf("GH annotation output does not contain %%0A encoding for newline.\nOutput: %q", result)
+	}
+}


### PR DESCRIPTION
## Overview

Harden the `gh-annotations` output format by applying GitHub Actions workflow command escaping rules separately for command properties and command data.

Fixes #2889

## Details

`PrintGHAnnotationReport` emits GitHub Actions workflow commands directly to stdout. The existing implementation encoded raw `\r` and `\n`, but GitHub Actions workflow command escaping also requires `%` escaping for command data, and `%`, `\r`, `\n`, `:`, and `,` escaping for command properties.

This change adds dedicated helpers for the two escaping contexts:

- command data escapes `%`, `\r`, and `\n`
- command properties escape `%`, `\r`, `\n`, `:`, and `,`

The change is scoped to GitHub annotation output:

- `file=` uses property escaping
- annotation message/table bodies use data escaping

Normal terminal table/vertical output remains unchanged.

## Testing

Added regression tests for workflow command escaping in `PrintGHAnnotationReport`:

- `TestPrintGHAnnotationReport_PercentSanitization`
- `TestPrintGHAnnotationReport_PropertyDelimiterSanitization`
- `TestPrintGHAnnotationReport_NewlineInMessageSanitization`
- existing CR sanitization coverage remains

Updated the existing GH annotation snapshot for the workflow command injection attempt path.

Ran locally:

```sh
./scripts/run_tests.sh -run "TestPrintGHAnnotationReport" -count=1
go vet ./internal/output/...
./scripts/run_lints.sh
git diff --check
```

All commands above passed locally.

## Checklist

- [x] I have signed the Contributor License Agreement.
- [x] I have run the linter using `./scripts/run_lints.sh`.
- [x] I have run the relevant unit tests using `./scripts/run_tests.sh -run "TestPrintGHAnnotationReport" -count=1`.
- [x] I have made my commits and PR title follow the Conventional Commits specification.
