### PR TITLE
chore: update Go version to 1.26.4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ You are acting as an AI contributor to the OSV project.
 
 Before requesting review, ensure these pass:
 
-- **Linting:** Run `./scripts/run_lints.sh` and resolve all warnings and errors. If you run into a toolchain error about go being tool old. Use the GOTOOLCHAIN=go<version> to change the go compiler version to be the same as what's in go.mod. Example `GOTOOLCHAIN=go1.26.3 ./scripts/run_lints.sh`
+- **Linting:** Run `./scripts/run_lints.sh` and resolve all warnings and errors. If you run into a toolchain error about go being tool old. Use the GOTOOLCHAIN=go<version> to change the go compiler version to be the same as what's in go.mod. Example `GOTOOLCHAIN=go1.26.4 ./scripts/run_lints.sh`
 - **Tests:** Run `make test` and ensure all tests pass.
 
 ### 4.2 Testing Standards

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Misc:
 
+- Update Go version to 1.26.4.
 - Update `osv-scalibr` to `v0.4.6-0.20260612031204-164402d9140e`.
 - Tag built Docker and GitHub Action images with the major version (e.g. `:v2`) to allow users to pin to a major version (#2857).
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.26.3-alpine3.23@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS builder
+FROM golang:1.26.4-alpine3.23@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f AS builder
 
 WORKDIR /src
 COPY ./go.mod ./go.sum ./

--- a/action.dockerfile
+++ b/action.dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # WARNING, this workflow is for legacy purposes. To view the current workflow see: https://github.com/google/osv-scanner-action
-FROM golang:1.26.3-alpine3.23@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d
+FROM golang:1.26.4-alpine3.23@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f
 
 RUN mkdir /src
 WORKDIR /src

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/osv-scanner/v2
 
-go 1.26.3
+go 1.26.4
 
 require (
 	charm.land/glamour/v2 v2.0.0

--- a/goreleaser-action.dockerfile
+++ b/goreleaser-action.dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.26.3-alpine3.23@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d
+FROM golang:1.26.4-alpine3.23@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f
 RUN apk --no-cache add \
   ca-certificates \
   git \

--- a/goreleaser.dockerfile
+++ b/goreleaser.dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.26.3-alpine3.23@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d
+FROM golang:1.26.4-alpine3.23@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f
 RUN apk add --no-cache \
     ca-certificates \
     git

--- a/scripts/run_lints.sh
+++ b/scripts/run_lints.sh
@@ -2,5 +2,5 @@
 
 set -ex
 
-export GOTOOLCHAIN="${GOTOOLCHAIN:-go1.26.3}"
+export GOTOOLCHAIN="${GOTOOLCHAIN:-go1.26.4}"
 go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(cat .golangci-lint-version) run ./... "$@"

--- a/scripts/test_env.dockerfile
+++ b/scripts/test_env.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.3-alpine3.23@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d
+FROM golang:1.26.4-alpine3.23@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f
 
 RUN apk --no-cache add \
   npm \


### PR DESCRIPTION
Upgrades the Go version to 1.26.4 to address vulnerabilities:
- **go.mod**: Bump Go version to `1.26.4`.
- **Dockerfiles**: Updated `golang:1.26.3-alpine3.23` base images to `golang:1.26.4-alpine3.23` with the updated digest `sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f`.
- **CHANGELOG.md**: Prepend the Go version update entry under the `v2.4.0` release notes.
- **Linter & Docs**: Update the default `GOTOOLCHAIN` environment variable in `scripts/run_lints.sh` and instructions in `AGENTS.md`.