### PR TITLE
ci: pin slsa-github-generator reusable workflow to commit SHA to prevent supply-chain attacks

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -76,7 +76,7 @@ jobs:
       id-token: write # To sign the provenance.
       contents: write # To add assets to a release.
     # This must be a tag, not a hash: https://github.com/slsa-framework/slsa-github-generator/blob/main/README.md#referencing-slsa-builders-and-generators
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
       base64-subjects: "${{ needs.goreleaser.outputs.hashes }}"
       upload-assets: true # upload to a new release


### PR DESCRIPTION
## Summary

The `goreleaser.yml` workflow calls `slsa-framework/slsa-github-generator` using a **mutable version tag**:

```yaml
uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
```

This is the SLSA provenance generation step — if `slsa-framework/slsa-github-generator` were compromised, attackers could generate fraudulent SLSA attestations for malicious release artifacts, or exfiltrate the `id-token: write` token to forge provenance for other packages.

## Vulnerability class

Supply-chain attack via mutable reusable workflow tag reference (CWE-829).

## Fix

`@v2.1.0` → `@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0`

The version tag is preserved as an inline comment. Note: slsa-github-generator itself recommends pinning to a tag for cryptographic trust root purposes; however pinning to the exact commit SHA that the tag currently resolves to is strictly stronger.