### PR TITLE
fix: scope package VEX suppression to package

### DIFF
--- a/cmd/osv-scanner/fix/__snapshots__/command_test.snap
+++ b/cmd/osv-scanner/fix/__snapshots__/command_test.snap
@@ -5383,8 +5383,8 @@ UNFIXABLE-VULNS: 9
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
       "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "concat-map": "0.0.1",
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/caseless": {
@@ -6303,8 +6303,8 @@ UNFIXABLE-VULNS: 9
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
       "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "requires": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "concat-map": "0.0.1",
+        "balanced-match": "^1.0.0"
       }
     },
     "caseless": {
@@ -7419,8 +7419,8 @@ Guided remediation (the fix command) can be risky when run on untrusted projects
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
       "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "concat-map": "0.0.1",
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/caseless": {
@@ -8339,8 +8339,8 @@ Guided remediation (the fix command) can be risky when run on untrusted projects
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
       "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "requires": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "concat-map": "0.0.1",
+        "balanced-match": "^1.0.0"
       }
     },
     "caseless": {
@@ -9771,8 +9771,8 @@ UNFIXABLE-VULNS: 9
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
       "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "concat-map": "0.0.1",
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/caseless": {
@@ -10691,8 +10691,8 @@ UNFIXABLE-VULNS: 9
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
       "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "requires": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "concat-map": "0.0.1",
+        "balanced-match": "^1.0.0"
       }
     },
     "caseless": {
@@ -11590,8 +11590,8 @@ UNFIXABLE-VULNS: 9
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
       "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "concat-map": "0.0.1",
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/caseless": {
@@ -12510,8 +12510,8 @@ UNFIXABLE-VULNS: 9
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
       "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "requires": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "concat-map": "0.0.1",
+        "balanced-match": "^1.0.0"
       }
     },
     "caseless": {

--- a/cmd/osv-scanner/scan/source/__snapshots__/command_test.snap
+++ b/cmd/osv-scanner/scan/source/__snapshots__/command_test.snap
@@ -4779,7 +4779,7 @@ Loaded Alpine local db from <tempdir>/osv-scanner/Alpine/all.zip
 Loaded Packagist local db from <tempdir>/osv-scanner/Packagist/all.zip
 Loaded npm local db from <tempdir>/osv-scanner/npm/all.zip
 
-Total 5 packages affected by 16 known vulnerabilities (1 Critical, 2 High, 3 Medium, 3 Low, 7 Unknown) from 3 ecosystems.
+Total 5 packages affected by 16 known vulnerabilities (2 Critical, 2 High, 3 Medium, 3 Low, 6 Unknown) from 3 ecosystems.
 15 vulnerabilities can be fixed.
 
 +-----------------------------------------+------+--------------+-----------------------+----------+---------------+-----------------------------------------------------+
@@ -4797,7 +4797,8 @@ Total 5 packages affected by 16 known vulnerabilities (1 Critical, 2 High, 3 Med
 | https://osv.dev/GHSA-f3cj-mjqm-fhvj     |      |              |                       |          |               |                                                     |
 | https://osv.dev/DRUPAL-CORE-2026-002    | 6.6  | Packagist    | drupal/core           | 10.4.5   | 10.5.9        | testdata/locks-many-with-insecure/composer.lock     |
 | https://osv.dev/GHSA-xmjc-63pr-2mpg     |      |              |                       |          |               |                                                     |
-| https://osv.dev/DRUPAL-CORE-2026-004    |      | Packagist    | drupal/core           | 10.4.5   | 10.4.10       | testdata/locks-many-with-insecure/composer.lock     |
+| https://osv.dev/DRUPAL-CORE-2026-004    | 9.8  | Packagist    | drupal/core           | 10.4.5   | 10.4.10       | testdata/locks-many-with-insecure/composer.lock     |
+| https://osv.dev/GHSA-ghwc-95x2-682j     |      |              |                       |          |               |                                                     |
 | https://osv.dev/DRUPAL-CORE-2026-005    |      | Packagist    | drupal/core           | 10.4.5   | 10.5.12       | testdata/locks-many-with-insecure/composer.lock     |
 | https://osv.dev/DRUPAL-CORE-2026-006    |      | Packagist    | drupal/core           | 10.4.5   | 10.5.12       | testdata/locks-many-with-insecure/composer.lock     |
 | https://osv.dev/DRUPAL-CORE-2026-007    |      | Packagist    | drupal/core           | 10.4.5   | 10.5.12       | testdata/locks-many-with-insecure/composer.lock     |
@@ -4828,7 +4829,7 @@ Loaded Alpine local db from <tempdir>/osv-scanner/Alpine/all.zip
 Loaded Packagist local db from <tempdir>/osv-scanner/Packagist/all.zip
 Loaded npm local db from <tempdir>/osv-scanner/npm/all.zip
 
-Total 5 packages affected by 16 known vulnerabilities (1 Critical, 2 High, 3 Medium, 3 Low, 7 Unknown) from 3 ecosystems.
+Total 5 packages affected by 16 known vulnerabilities (2 Critical, 2 High, 3 Medium, 3 Low, 6 Unknown) from 3 ecosystems.
 15 vulnerabilities can be fixed.
 
 +-----------------------------------------+------+--------------+-----------------------+----------+---------------+-----------------------------------------------------+
@@ -4846,7 +4847,8 @@ Total 5 packages affected by 16 known vulnerabilities (1 Critical, 2 High, 3 Med
 | https://osv.dev/GHSA-f3cj-mjqm-fhvj     |      |              |                       |          |               |                                                     |
 | https://osv.dev/DRUPAL-CORE-2026-002    | 6.6  | Packagist    | drupal/core           | 10.4.5   | 10.5.9        | testdata/locks-many-with-insecure/composer.lock     |
 | https://osv.dev/GHSA-xmjc-63pr-2mpg     |      |              |                       |          |               |                                                     |
-| https://osv.dev/DRUPAL-CORE-2026-004    |      | Packagist    | drupal/core           | 10.4.5   | 10.4.10       | testdata/locks-many-with-insecure/composer.lock     |
+| https://osv.dev/DRUPAL-CORE-2026-004    | 9.8  | Packagist    | drupal/core           | 10.4.5   | 10.4.10       | testdata/locks-many-with-insecure/composer.lock     |
+| https://osv.dev/GHSA-ghwc-95x2-682j     |      |              |                       |          |               |                                                     |
 | https://osv.dev/DRUPAL-CORE-2026-005    |      | Packagist    | drupal/core           | 10.4.5   | 10.5.12       | testdata/locks-many-with-insecure/composer.lock     |
 | https://osv.dev/DRUPAL-CORE-2026-006    |      | Packagist    | drupal/core           | 10.4.5   | 10.5.12       | testdata/locks-many-with-insecure/composer.lock     |
 | https://osv.dev/DRUPAL-CORE-2026-007    |      | Packagist    | drupal/core           | 10.4.5   | 10.5.12       | testdata/locks-many-with-insecure/composer.lock     |
@@ -5027,8 +5029,8 @@ Filtered 1 local/unscannable package/s from the scan.
 Loaded Debian local db from <tempdir>/osv-scanner/Debian/all.zip
 Loaded Go local db from <tempdir>/osv-scanner/Go/all.zip
 
-Total 22 packages affected by 215 known vulnerabilities (23 Critical, 91 High, 67 Medium, 6 Low, 28 Unknown) from 2 ecosystems.
-12 vulnerabilities can be fixed.
+Total 22 packages affected by 220 known vulnerabilities (23 Critical, 93 High, 70 Medium, 6 Low, 28 Unknown) from 2 ecosystems.
+13 vulnerabilities can be fixed.
 
 +---------------------------------------+------+-----------+--------------------------------+------------------------------------+-----------------------------------+-------------------------------------------------+
 | OSV URL                               | CVSS | ECOSYSTEM | PACKAGE                        | VERSION                            | FIXED VERSION                     | SOURCE                                          |
@@ -5053,6 +5055,7 @@ Total 22 packages affected by 215 known vulnerabilities (23 Critical, 91 High, 6
 | https://osv.dev/GHSA-qw9x-cqr3-wc7r   |      |           |                                |                                    |                                   |                                                 |
 | https://osv.dev/GO-2025-4098          | 7.3  | Go        | github.com/opencontainers/runc | v1.0.1                             | 1.2.8                             | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/GHSA-cgrx-mc8f-2prm   |      |           |                                |                                    |                                   |                                                 |
+| https://osv.dev/GHSA-xjvp-4fhw-gc47   | 4.8  | Go        | github.com/opencontainers/runc | v1.0.1                             | 1.3.6                             | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/GO-2022-0493          | 5.3  | Go        | golang.org/x/sys               | v0.0.0-20210817142637-7d9622a276b7 | 0.0.0-20220412211240-33da011f77ad | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/GHSA-p782-xgp4-8hr8   |      |           |                                |                                    |                                   |                                                 |
 | https://osv.dev/GO-2026-5024          |      | Go        | golang.org/x/sys               | v0.0.0-20210817142637-7d9622a276b7 | 0.44.0                            | testdata/sbom-insecure/postgres-stretch.cdx.xml |
@@ -5072,6 +5075,8 @@ Total 22 packages affected by 215 known vulnerabilities (23 Critical, 91 High, 6
 | https://osv.dev/DEBIAN-CVE-2022-1304  | 7.8  | Debian    | e2fsprogs                      | 1.43.4-2+deb9u2                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DLA-3910-1            |      |           |                                |                                    |                                   |                                                 |
 | https://osv.dev/DSA-5122-1            | 8.8  | Debian    | gzip                           | 1.6-5+deb9u1                       | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
+| https://osv.dev/DEBIAN-CVE-2026-41991 | 4.7  | Debian    | gzip                           | 1.6-5+deb9u1                       | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
+| https://osv.dev/DEBIAN-CVE-2026-41992 | 7.5  | Debian    | gzip                           | 1.6-5+deb9u1                       | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DEBIAN-CVE-2017-0379  | 7.5  | Debian    | libgcrypt20                    | 1.7.6-2+deb9u4                     | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DEBIAN-CVE-2017-7526  | 6.8  | Debian    | libgcrypt20                    | 1.7.6-2+deb9u4                     | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DEBIAN-CVE-2018-0495  | 4.7  | Debian    | libgcrypt20                    | 1.7.6-2+deb9u4                     | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
@@ -5124,6 +5129,7 @@ Total 22 packages affected by 215 known vulnerabilities (23 Critical, 91 High, 6
 | https://osv.dev/DEBIAN-CVE-2026-0989  | 3.7  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DEBIAN-CVE-2026-0990  | 5.9  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DEBIAN-CVE-2026-0992  | 2.9  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
+| https://osv.dev/DEBIAN-CVE-2026-6653  | 7.0  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DEBIAN-CVE-2026-6732  | 7.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DSA-4539-1            | 4.7  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DSA-4539-3            |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
@@ -5267,6 +5273,7 @@ Total 22 packages affected by 215 known vulnerabilities (23 Critical, 91 High, 6
 | https://osv.dev/DSA-5055-1            | 5.5  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DSA-5650-1            | 5.5  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DEBIAN-CVE-2016-2779  | 7.8  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
+| https://osv.dev/DEBIAN-CVE-2026-13595 | 6.8  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DEBIAN-CVE-2026-27456 | 4.7  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DEBIAN-CVE-2026-3184  | 5.3  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DEBIAN-CVE-2026-53612 |      | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
@@ -5292,8 +5299,8 @@ Filtered 1 local/unscannable package/s from the scan.
 Loaded Debian local db from <tempdir>/osv-scanner/Debian/all.zip
 Loaded Go local db from <tempdir>/osv-scanner/Go/all.zip
 
-Total 22 packages affected by 215 known vulnerabilities (23 Critical, 91 High, 67 Medium, 6 Low, 28 Unknown) from 2 ecosystems.
-12 vulnerabilities can be fixed.
+Total 22 packages affected by 220 known vulnerabilities (23 Critical, 93 High, 70 Medium, 6 Low, 28 Unknown) from 2 ecosystems.
+13 vulnerabilities can be fixed.
 
 +---------------------------------------+------+-----------+--------------------------------+------------------------------------+-----------------------------------+-------------------------------------------------+
 | OSV URL                               | CVSS | ECOSYSTEM | PACKAGE                        | VERSION                            | FIXED VERSION                     | SOURCE                                          |
@@ -5318,6 +5325,7 @@ Total 22 packages affected by 215 known vulnerabilities (23 Critical, 91 High, 6
 | https://osv.dev/GHSA-qw9x-cqr3-wc7r   |      |           |                                |                                    |                                   |                                                 |
 | https://osv.dev/GO-2025-4098          | 7.3  | Go        | github.com/opencontainers/runc | v1.0.1                             | 1.2.8                             | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/GHSA-cgrx-mc8f-2prm   |      |           |                                |                                    |                                   |                                                 |
+| https://osv.dev/GHSA-xjvp-4fhw-gc47   | 4.8  | Go        | github.com/opencontainers/runc | v1.0.1                             | 1.3.6                             | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/GO-2022-0493          | 5.3  | Go        | golang.org/x/sys               | v0.0.0-20210817142637-7d9622a276b7 | 0.0.0-20220412211240-33da011f77ad | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/GHSA-p782-xgp4-8hr8   |      |           |                                |                                    |                                   |                                                 |
 | https://osv.dev/GO-2026-5024          |      | Go        | golang.org/x/sys               | v0.0.0-20210817142637-7d9622a276b7 | 0.44.0                            | testdata/sbom-insecure/postgres-stretch.cdx.xml |
@@ -5337,6 +5345,8 @@ Total 22 packages affected by 215 known vulnerabilities (23 Critical, 91 High, 6
 | https://osv.dev/DEBIAN-CVE-2022-1304  | 7.8  | Debian    | e2fsprogs                      | 1.43.4-2+deb9u2                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DLA-3910-1            |      |           |                                |                                    |                                   |                                                 |
 | https://osv.dev/DSA-5122-1            | 8.8  | Debian    | gzip                           | 1.6-5+deb9u1                       | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
+| https://osv.dev/DEBIAN-CVE-2026-41991 | 4.7  | Debian    | gzip                           | 1.6-5+deb9u1                       | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
+| https://osv.dev/DEBIAN-CVE-2026-41992 | 7.5  | Debian    | gzip                           | 1.6-5+deb9u1                       | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DEBIAN-CVE-2017-0379  | 7.5  | Debian    | libgcrypt20                    | 1.7.6-2+deb9u4                     | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DEBIAN-CVE-2017-7526  | 6.8  | Debian    | libgcrypt20                    | 1.7.6-2+deb9u4                     | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DEBIAN-CVE-2018-0495  | 4.7  | Debian    | libgcrypt20                    | 1.7.6-2+deb9u4                     | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
@@ -5389,6 +5399,7 @@ Total 22 packages affected by 215 known vulnerabilities (23 Critical, 91 High, 6
 | https://osv.dev/DEBIAN-CVE-2026-0989  | 3.7  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DEBIAN-CVE-2026-0990  | 5.9  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DEBIAN-CVE-2026-0992  | 2.9  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
+| https://osv.dev/DEBIAN-CVE-2026-6653  | 7.0  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DEBIAN-CVE-2026-6732  | 7.5  | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DSA-4539-1            | 4.7  | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DSA-4539-3            |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
@@ -5532,6 +5543,7 @@ Total 22 packages affected by 215 known vulnerabilities (23 Critical, 91 High, 6
 | https://osv.dev/DSA-5055-1            | 5.5  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DSA-5650-1            | 5.5  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DEBIAN-CVE-2016-2779  | 7.8  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
+| https://osv.dev/DEBIAN-CVE-2026-13595 | 6.8  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DEBIAN-CVE-2026-27456 | 4.7  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DEBIAN-CVE-2026-3184  | 5.3  | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DEBIAN-CVE-2026-53612 |      | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | --                                | testdata/sbom-insecure/postgres-stretch.cdx.xml |
@@ -6326,10 +6338,6 @@ Total 3 packages affected by 13 known vulnerabilities (1 Critical, 4 High, 7 Med
 Scanning dir ./testdata/locks-requirements/requirements.txt
 Scanned <rootdir>/testdata/locks-requirements/requirements.txt file and found 3 packages
 Loaded PyPI local db from <tempdir>/osv-scanner/PyPI/all.zip
-PYSEC-2011-28 does not have any ranges or versions - this is probably a mistake!
-PYSEC-2011-29 does not have any ranges or versions - this is probably a mistake!
-PYSEC-2011-30 does not have any ranges or versions - this is probably a mistake!
-PYSEC-2011-31 does not have any ranges or versions - this is probably a mistake!
 
 Total 3 packages affected by 13 known vulnerabilities (1 Critical, 4 High, 7 Medium, 1 Low, 0 Unknown) from 1 ecosystem.
 13 vulnerabilities can be fixed.

--- a/cmd/osv-scanner/scan/source/testdata/cassettes/TestCommand_Transitive.yaml
+++ b/cmd/osv-scanner/scan/source/testdata/cassettes/TestCommand_Transitive.yaml
@@ -1134,6 +1134,171 @@ interactions:
       proto: HTTP/1.1
       proto_major: 1
       proto_minor: 1
+      content_length: 997
+      host: api.osv.dev
+      body: |
+        {
+          "queries": [
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "click"
+              },
+              "version": "8.4.2"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "flask"
+              },
+              "version": "1.0.0"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "flask-cors"
+              },
+              "version": "1.0.0"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "itsdangerous"
+              },
+              "version": "2.2.0"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "jinja2"
+              },
+              "version": "3.1.6"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "markupsafe"
+              },
+              "version": "3.0.3"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "pandas"
+              },
+              "version": "0.23.4"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "werkzeug"
+              },
+              "version": "3.1.8"
+            }
+          ]
+        }
+      headers:
+        Content-Type:
+          - application/json
+        X-Test-Name:
+          - TestCommand_Transitive/requirements.txt_resolution_fallback
+      url: https://api.osv.dev/v1/querybatch
+      method: POST
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      content_length: 1003
+      body: |
+        {
+          "results": [
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "GHSA-68rp-wp8r-4726",
+                  "modified": "2026-02-23T23:43:45.778179Z"
+                },
+                {
+                  "id": "GHSA-m2qf-hxjv-5gpq",
+                  "modified": "2025-02-21T05:42:17.337040Z"
+                },
+                {
+                  "id": "PYSEC-2023-62",
+                  "modified": "2023-11-08T04:12:28.231927Z"
+                }
+              ]
+            },
+            {
+              "vulns": [
+                {
+                  "id": "GHSA-43qf-4rqw-9q2g",
+                  "modified": "2026-02-04T02:30:19.251090Z"
+                },
+                {
+                  "id": "GHSA-7rxf-gvfg-47g4",
+                  "modified": "2026-02-04T04:27:15.173118Z"
+                },
+                {
+                  "id": "GHSA-84pr-m4jr-85g5",
+                  "modified": "2026-06-05T18:00:15.147923Z"
+                },
+                {
+                  "id": "GHSA-8vgw-p6qm-5gr7",
+                  "modified": "2026-02-04T02:42:09.564281Z"
+                },
+                {
+                  "id": "GHSA-hxwh-jpp2-84pm",
+                  "modified": "2026-06-08T20:17:50Z"
+                },
+                {
+                  "id": "GHSA-xc3p-ff3m-f46v",
+                  "modified": "2024-09-20T20:01:25.449661Z"
+                },
+                {
+                  "id": "PYSEC-2020-43",
+                  "modified": "2025-10-09T07:22:50.566622Z"
+                },
+                {
+                  "id": "PYSEC-2024-260",
+                  "modified": "2026-05-21T15:00:12.457440Z"
+                },
+                {
+                  "id": "PYSEC-2024-271",
+                  "modified": "2026-06-10T17:01:16.365143Z"
+                },
+                {
+                  "id": "PYSEC-2024-71",
+                  "modified": "2026-06-10T17:01:16.604565Z"
+                }
+              ]
+            },
+            {},
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "PYSEC-2020-73",
+                  "modified": "2023-11-08T04:02:12.263851Z"
+                }
+              ]
+            },
+            {}
+          ]
+        }
+      headers:
+        Content-Length:
+          - "1003"
+        Content-Type:
+          - application/json
+      status: 200 OK
+      code: 200
+      duration: 0s
+  - request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
       content_length: 1604
       host: api.osv.dev
       body: |
@@ -1421,6 +1586,293 @@ interactions:
       proto: HTTP/1.1
       proto_major: 1
       proto_minor: 1
+      content_length: 1604
+      host: api.osv.dev
+      body: |
+        {
+          "queries": [
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "certifi"
+              },
+              "version": "2026.6.17"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "chardet"
+              },
+              "version": "3.0.4"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "click"
+              },
+              "version": "8.4.2"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "django"
+              },
+              "version": "1.11.29"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "flask"
+              },
+              "version": "1.0.0"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "idna"
+              },
+              "version": "2.7.0"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "itsdangerous"
+              },
+              "version": "2.2.0"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "jinja2"
+              },
+              "version": "3.1.6"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "markupsafe"
+              },
+              "version": "3.0.3"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "pytz"
+              },
+              "version": "2026.2.0"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "requests"
+              },
+              "version": "2.20.0"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "urllib3"
+              },
+              "version": "1.24.3"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "werkzeug"
+              },
+              "version": "3.1.8"
+            }
+          ]
+        }
+      headers:
+        Content-Type:
+          - application/json
+        X-Test-Name:
+          - TestCommand_Transitive/requirements.txt_transitive_default
+      url: https://api.osv.dev/v1/querybatch
+      method: POST
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      content_length: 2358
+      body: |
+        {
+          "results": [
+            {},
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "GHSA-68w8-qjq3-2gfm",
+                  "modified": "2024-09-20T15:46:52.557962Z"
+                },
+                {
+                  "id": "GHSA-6w2r-r2m5-xq5w",
+                  "modified": "2026-06-05T14:45:50.840275Z"
+                },
+                {
+                  "id": "GHSA-7xr5-9hcq-chf9",
+                  "modified": "2026-02-04T03:48:05.224740Z"
+                },
+                {
+                  "id": "GHSA-8x94-hmjh-97hq",
+                  "modified": "2026-02-04T02:45:55.690257Z"
+                },
+                {
+                  "id": "GHSA-frmv-pr5f-9mcr",
+                  "modified": "2026-06-05T14:45:52.053173Z"
+                },
+                {
+                  "id": "GHSA-qw25-v68c-qjf3",
+                  "modified": "2026-06-05T14:45:50.558008Z"
+                },
+                {
+                  "id": "GHSA-rrqc-c2jx-6jgv",
+                  "modified": "2024-10-30T19:23:59.139649Z"
+                },
+                {
+                  "id": "PYSEC-2021-98",
+                  "modified": "2023-12-06T01:01:16.755410Z"
+                }
+              ]
+            },
+            {
+              "vulns": [
+                {
+                  "id": "GHSA-68rp-wp8r-4726",
+                  "modified": "2026-02-23T23:43:45.778179Z"
+                },
+                {
+                  "id": "GHSA-m2qf-hxjv-5gpq",
+                  "modified": "2025-02-21T05:42:17.337040Z"
+                },
+                {
+                  "id": "PYSEC-2023-62",
+                  "modified": "2023-11-08T04:12:28.231927Z"
+                }
+              ]
+            },
+            {
+              "vulns": [
+                {
+                  "id": "GHSA-65pc-fj4g-8rjx",
+                  "modified": "2026-06-16T16:26:11.904403Z"
+                },
+                {
+                  "id": "GHSA-jjg7-2v4v-x38h",
+                  "modified": "2026-02-04T03:49:45.087439Z"
+                },
+                {
+                  "id": "PYSEC-2024-60",
+                  "modified": "2026-06-10T17:01:21.102419Z"
+                },
+                {
+                  "id": "PYSEC-2026-215",
+                  "modified": "2026-06-16T16:15:04.639265Z"
+                }
+              ]
+            },
+            {},
+            {},
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "GHSA-9hjg-9r4m-mvj7",
+                  "modified": "2026-02-04T03:44:00.676479Z"
+                },
+                {
+                  "id": "GHSA-9wx4-h78v-vm56",
+                  "modified": "2026-02-04T02:43:42.271895Z"
+                },
+                {
+                  "id": "GHSA-gc5v-m9x4-r6x2",
+                  "modified": "2026-03-27T22:17:33.595885Z"
+                },
+                {
+                  "id": "GHSA-j8r2-6x86-q33q",
+                  "modified": "2026-02-04T03:34:13.807518Z"
+                },
+                {
+                  "id": "PYSEC-2023-74",
+                  "modified": "2023-11-08T04:12:35.436175Z"
+                }
+              ]
+            },
+            {
+              "vulns": [
+                {
+                  "id": "GHSA-2xpw-w6gg-jr37",
+                  "modified": "2026-02-04T02:36:12.983430Z"
+                },
+                {
+                  "id": "GHSA-34jh-p97f-mpxf",
+                  "modified": "2026-02-04T03:37:44.850742Z"
+                },
+                {
+                  "id": "GHSA-38jv-5279-wg99",
+                  "modified": "2026-02-04T03:51:36.162029Z"
+                },
+                {
+                  "id": "GHSA-g4mx-q9vg-27p4",
+                  "modified": "2026-02-04T03:30:16.767903Z"
+                },
+                {
+                  "id": "GHSA-gm62-xv2j-4w53",
+                  "modified": "2026-02-04T03:37:15.919661Z"
+                },
+                {
+                  "id": "GHSA-pq67-6m6q-mj2v",
+                  "modified": "2026-02-04T04:38:01.163387Z"
+                },
+                {
+                  "id": "GHSA-qccp-gfcp-xxvc",
+                  "modified": "2026-05-20T08:11:43.145797Z"
+                },
+                {
+                  "id": "GHSA-v845-jxx5-vc9f",
+                  "modified": "2026-02-04T02:58:30.152562Z"
+                },
+                {
+                  "id": "GHSA-wqvq-5m8c-6g24",
+                  "modified": "2024-11-18T22:47:07.792720Z"
+                },
+                {
+                  "id": "PYSEC-2020-148",
+                  "modified": "2023-11-08T04:03:14.251187Z"
+                },
+                {
+                  "id": "PYSEC-2023-192",
+                  "modified": "2023-11-08T04:13:33.452167Z"
+                },
+                {
+                  "id": "PYSEC-2023-212",
+                  "modified": "2023-11-08T04:13:39.165450Z"
+                },
+                {
+                  "id": "PYSEC-2026-141",
+                  "modified": "2026-05-20T09:19:20.983812Z"
+                }
+              ]
+            },
+            {}
+          ]
+        }
+      headers:
+        Content-Length:
+          - "2358"
+        Content-Type:
+          - application/json
+      status: 200 OK
+      code: 200
+      duration: 0s
+  - request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
       content_length: 1598
       host: api.osv.dev
       body: |
@@ -1446,6 +1898,293 @@ interactions:
                 "name": "click"
               },
               "version": "8.4.1"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "django"
+              },
+              "version": "1.11.29"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "flask"
+              },
+              "version": "1.0"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "idna"
+              },
+              "version": "2.7"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "itsdangerous"
+              },
+              "version": "2.2.0"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "jinja2"
+              },
+              "version": "3.1.6"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "markupsafe"
+              },
+              "version": "3.0.3"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "pytz"
+              },
+              "version": "2026.2"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "requests"
+              },
+              "version": "2.20.0"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "urllib3"
+              },
+              "version": "1.24.3"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "werkzeug"
+              },
+              "version": "3.1.8"
+            }
+          ]
+        }
+      headers:
+        Content-Type:
+          - application/json
+        X-Test-Name:
+          - TestCommand_Transitive/requirements.txt_transitive_native_source
+      url: https://api.osv.dev/v1/querybatch
+      method: POST
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      content_length: 2358
+      body: |
+        {
+          "results": [
+            {},
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "GHSA-68w8-qjq3-2gfm",
+                  "modified": "2024-09-20T15:46:52.557962Z"
+                },
+                {
+                  "id": "GHSA-6w2r-r2m5-xq5w",
+                  "modified": "2026-06-05T14:45:50.840275Z"
+                },
+                {
+                  "id": "GHSA-7xr5-9hcq-chf9",
+                  "modified": "2026-02-04T03:48:05.224740Z"
+                },
+                {
+                  "id": "GHSA-8x94-hmjh-97hq",
+                  "modified": "2026-02-04T02:45:55.690257Z"
+                },
+                {
+                  "id": "GHSA-frmv-pr5f-9mcr",
+                  "modified": "2026-06-05T14:45:52.053173Z"
+                },
+                {
+                  "id": "GHSA-qw25-v68c-qjf3",
+                  "modified": "2026-06-05T14:45:50.558008Z"
+                },
+                {
+                  "id": "GHSA-rrqc-c2jx-6jgv",
+                  "modified": "2024-10-30T19:23:59.139649Z"
+                },
+                {
+                  "id": "PYSEC-2021-98",
+                  "modified": "2023-12-06T01:01:16.755410Z"
+                }
+              ]
+            },
+            {
+              "vulns": [
+                {
+                  "id": "GHSA-68rp-wp8r-4726",
+                  "modified": "2026-02-23T23:43:45.778179Z"
+                },
+                {
+                  "id": "GHSA-m2qf-hxjv-5gpq",
+                  "modified": "2025-02-21T05:42:17.337040Z"
+                },
+                {
+                  "id": "PYSEC-2023-62",
+                  "modified": "2023-11-08T04:12:28.231927Z"
+                }
+              ]
+            },
+            {
+              "vulns": [
+                {
+                  "id": "GHSA-65pc-fj4g-8rjx",
+                  "modified": "2026-06-16T16:26:11.904403Z"
+                },
+                {
+                  "id": "GHSA-jjg7-2v4v-x38h",
+                  "modified": "2026-02-04T03:49:45.087439Z"
+                },
+                {
+                  "id": "PYSEC-2024-60",
+                  "modified": "2026-06-10T17:01:21.102419Z"
+                },
+                {
+                  "id": "PYSEC-2026-215",
+                  "modified": "2026-06-16T16:15:04.639265Z"
+                }
+              ]
+            },
+            {},
+            {},
+            {},
+            {},
+            {
+              "vulns": [
+                {
+                  "id": "GHSA-9hjg-9r4m-mvj7",
+                  "modified": "2026-02-04T03:44:00.676479Z"
+                },
+                {
+                  "id": "GHSA-9wx4-h78v-vm56",
+                  "modified": "2026-02-04T02:43:42.271895Z"
+                },
+                {
+                  "id": "GHSA-gc5v-m9x4-r6x2",
+                  "modified": "2026-03-27T22:17:33.595885Z"
+                },
+                {
+                  "id": "GHSA-j8r2-6x86-q33q",
+                  "modified": "2026-02-04T03:34:13.807518Z"
+                },
+                {
+                  "id": "PYSEC-2023-74",
+                  "modified": "2023-11-08T04:12:35.436175Z"
+                }
+              ]
+            },
+            {
+              "vulns": [
+                {
+                  "id": "GHSA-2xpw-w6gg-jr37",
+                  "modified": "2026-02-04T02:36:12.983430Z"
+                },
+                {
+                  "id": "GHSA-34jh-p97f-mpxf",
+                  "modified": "2026-02-04T03:37:44.850742Z"
+                },
+                {
+                  "id": "GHSA-38jv-5279-wg99",
+                  "modified": "2026-02-04T03:51:36.162029Z"
+                },
+                {
+                  "id": "GHSA-g4mx-q9vg-27p4",
+                  "modified": "2026-02-04T03:30:16.767903Z"
+                },
+                {
+                  "id": "GHSA-gm62-xv2j-4w53",
+                  "modified": "2026-02-04T03:37:15.919661Z"
+                },
+                {
+                  "id": "GHSA-pq67-6m6q-mj2v",
+                  "modified": "2026-02-04T04:38:01.163387Z"
+                },
+                {
+                  "id": "GHSA-qccp-gfcp-xxvc",
+                  "modified": "2026-05-20T08:11:43.145797Z"
+                },
+                {
+                  "id": "GHSA-v845-jxx5-vc9f",
+                  "modified": "2026-02-04T02:58:30.152562Z"
+                },
+                {
+                  "id": "GHSA-wqvq-5m8c-6g24",
+                  "modified": "2024-11-18T22:47:07.792720Z"
+                },
+                {
+                  "id": "PYSEC-2020-148",
+                  "modified": "2023-11-08T04:03:14.251187Z"
+                },
+                {
+                  "id": "PYSEC-2023-192",
+                  "modified": "2023-11-08T04:13:33.452167Z"
+                },
+                {
+                  "id": "PYSEC-2023-212",
+                  "modified": "2023-11-08T04:13:39.165450Z"
+                },
+                {
+                  "id": "PYSEC-2026-141",
+                  "modified": "2026-05-20T09:19:20.983812Z"
+                }
+              ]
+            },
+            {}
+          ]
+        }
+      headers:
+        Content-Length:
+          - "2358"
+        Content-Type:
+          - application/json
+      status: 200 OK
+      code: 200
+      duration: 0s
+  - request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
+      content_length: 1598
+      host: api.osv.dev
+      body: |
+        {
+          "queries": [
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "certifi"
+              },
+              "version": "2026.6.17"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "chardet"
+              },
+              "version": "3.0.4"
+            },
+            {
+              "package": {
+                "ecosystem": "PyPI",
+                "name": "click"
+              },
+              "version": "8.4.2"
             },
             {
               "package": {

--- a/internal/output/output_result.go
+++ b/internal/output/output_result.go
@@ -9,7 +9,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/google/osv-scalibr/inventory/vex"
 	"github.com/google/osv-scalibr/semantic"
 	"github.com/google/osv-scanner/v2/internal/cachedregexp"
 	"github.com/google/osv-scanner/v2/internal/identifiers"
@@ -190,14 +189,7 @@ func BuildResults(vulnResult *models.VulnerabilityResults) Result {
 	var resultCount VulnCount
 	pkgDeprecatedCount := 0
 
-RowLoop:
 	for _, packageSource := range vulnResult.Results {
-		for _, pes := range packageSource.ExperimentalPES {
-			if pes.MatchesAllVulns && pes.Justification == vex.ComponentNotPresent {
-				continue RowLoop
-			}
-		}
-
 		// Process vulnerabilities for each source
 		sourceResults := processSource(packageSource)
 		for ecosystem, source := range sourceResults {

--- a/pkg/osvscanner/vulnerability_result.go
+++ b/pkg/osvscanner/vulnerability_result.go
@@ -93,6 +93,8 @@ func buildVulnerabilityResults(
 			pkg.Groups[i].MaxSeverity = output.MaxSeverity(group, pkg)
 		}
 
+		setComponentNotPresent(&pkg)
+
 		// For Debian-based ecosystems, mark unimportant vulnerabilities within the package.
 		// Debian ecosystems may be listed with a version number, such as "Debian:10".
 		if strings.HasPrefix(pkg.Package.Ecosystem, string(osvconstants.EcosystemDebian)) ||
@@ -196,6 +198,35 @@ func buildVulnerabilityResults(
 	}
 
 	return vulnResults
+}
+
+func setComponentNotPresent(pv *models.PackageVulns) {
+	if pv.Package.Inventory == nil {
+		return
+	}
+
+	hasComponentNotPresentSignal := slices.ContainsFunc(
+		pv.Package.Inventory.ExploitabilitySignals,
+		func(signal *vex.PackageExploitabilitySignal) bool {
+			return signal.MatchesAllVulns && signal.Justification == vex.ComponentNotPresent
+		},
+	)
+	if !hasComponentNotPresentSignal {
+		return
+	}
+
+	for groupIdx := range pv.Groups {
+		if pv.Groups[groupIdx].ExperimentalAnalysis == nil {
+			pv.Groups[groupIdx].ExperimentalAnalysis = make(map[string]models.AnalysisInfo)
+		}
+
+		for _, vulnID := range pv.Groups[groupIdx].IDs {
+			analysis := pv.Groups[groupIdx].ExperimentalAnalysis[vulnID]
+			analysis.Called = true
+			analysis.Unimportant = true
+			pv.Groups[groupIdx].ExperimentalAnalysis[vulnID] = analysis
+		}
+	}
 }
 
 func setUncalled(pv *models.PackageVulns) {

--- a/pkg/osvscanner/vulnerability_result_internal_test.go
+++ b/pkg/osvscanner/vulnerability_result_internal_test.go
@@ -6,9 +6,11 @@ import (
 	"github.com/google/osv-scalibr/extractor"
 	"github.com/google/osv-scalibr/extractor/filesystem/language/javascript/packagelockjson"
 	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/inventory/vex"
 	"github.com/google/osv-scalibr/purl"
 	"github.com/google/osv-scanner/v2/internal/config"
 	"github.com/google/osv-scanner/v2/internal/imodels/results"
+	"github.com/google/osv-scanner/v2/internal/output"
 	"github.com/google/osv-scanner/v2/internal/testutility"
 	"github.com/ossf/osv-schema/bindings/go/osvschema"
 )
@@ -170,5 +172,64 @@ func Test_assembleResult(t *testing.T) {
 			got := buildVulnerabilityResults(tt.args.actions, tt.args.scanResults)
 			testutility.NewSnapshot().MatchJSON(t, got)
 		})
+	}
+}
+
+func TestBuildVulnerabilityResults_PackageVEXDoesNotSuppressSiblingPackages(t *testing.T) {
+	t.Parallel()
+
+	scanResults := &results.ScanResults{
+		Inventory: inventory.Inventory{
+			Packages: []*extractor.Package{
+				{
+					Name:     "vulnerable-runtime",
+					PURLType: purl.TypeNPM,
+					Plugins:  []string{packagelockjson.Name},
+					Version:  "1.0.0",
+					Location: extractor.LocationFromPath("shared/package-lock.json"),
+				},
+				{
+					Name:     "component-not-present-package",
+					PURLType: purl.TypeNPM,
+					Plugins:  []string{packagelockjson.Name},
+					Version:  "1.0.0",
+					Location: extractor.LocationFromPath("shared/package-lock.json"),
+					ExploitabilitySignals: []*vex.PackageExploitabilitySignal{
+						{
+							Plugin:          "poc/component-not-present",
+							Justification:   vex.ComponentNotPresent,
+							MatchesAllVulns: true,
+						},
+					},
+				},
+			},
+		},
+		ConfigManager: config.Manager{},
+	}
+	scanResults.Inventory.PackageVulns = []*inventory.PackageVuln{
+		{
+			Vulnerability: &osvschema.Vulnerability{Id: "OSV-RUNTIME"},
+			Package:       scanResults.Inventory.Packages[0],
+		},
+		{
+			Vulnerability: &osvschema.Vulnerability{Id: "OSV-SUPPRESSED"},
+			Package:       scanResults.Inventory.Packages[1],
+		},
+	}
+
+	vulnResults := buildVulnerabilityResults(ScannerActions{}, scanResults)
+	if got := len(vulnResults.Results); got != 1 {
+		t.Fatalf("buildVulnerabilityResults returned %d sources, want 1", got)
+	}
+	if got := len(vulnResults.Results[0].Packages); got != 2 {
+		t.Fatalf("buildVulnerabilityResults returned %d packages, want 2", got)
+	}
+
+	rendered := output.BuildResults(&vulnResults)
+	if got := rendered.VulnCount.AnalysisCount.Regular; got != 1 {
+		t.Fatalf("output.BuildResults rendered %d regular vulnerabilities, want 1", got)
+	}
+	if got := rendered.VulnCount.AnalysisCount.Hidden; got != 1 {
+		t.Fatalf("output.BuildResults rendered %d hidden vulnerabilities, want 1", got)
 	}
 }


### PR DESCRIPTION
## Summary
- apply ComponentNotPresent package VEX signals to the annotated package instead of the entire source
- remove source-wide rendered-output suppression for PackageSource ExperimentalPES
- add a regression test for sibling packages sharing one source
- update the affected transitive scan cassette/snapshots so replay-only tests have the required interactions

## Tests
- `go test ./pkg/osvscanner ./internal/output -count=1`
- `TEST_VCR_MODE=1 go test ./cmd/osv-scanner/scan/source -run TestCommand_Transitive -count=1`
