### PR TITLE
fix: compare PR vulnerability occurrences by package metadata

### DIFF
--- a/internal/ci/__snapshots__/vulnerability_result_diff_test.snap
+++ b/internal/ci/__snapshots__/vulnerability_result_diff_test.snap
@@ -9,7 +9,7 @@
 
 [TestDiffVulnerabilityByUniqueVulnCountResults/same_package_with_new_vuln - 1]
 {
-  "GHSA-c3h9-896r-86jm": 1
+  "package=github.com/gogo/protobuf|os_package=|version=1.3.1|ecosystem=Go|commit=|groups=|vulnerability=GHSA-c3h9-896r-86jm|called=true|unimportant=false": 1
 }
 ---
 

--- a/internal/ci/vulnerability_result_diff.go
+++ b/internal/ci/vulnerability_result_diff.go
@@ -1,6 +1,9 @@
 package ci
 
 import (
+	"slices"
+	"strings"
+
 	"github.com/google/osv-scanner/v2/internal/grouper"
 	"github.com/google/osv-scanner/v2/internal/output"
 	"github.com/google/osv-scanner/v2/pkg/models"
@@ -39,7 +42,8 @@ func DiffVulnerabilityResults(oldRes, newRes models.VulnerabilityResults) models
 			})
 			resultPV := &resultPS.Packages[len(resultPS.Packages)-1]
 			for _, v := range pv.Vulnerabilities {
-				if !vulnToIndex[sourceIdx][pkgIdx][v.GetId()] {
+				vulnID := v.GetId()
+				if !vulnToIndex[sourceIdx][pkgIdx][vulnID] || vulnerabilityMetadataChanged(oldRes.Results[sourceIdx].Packages[pkgIdx], pv, vulnID) {
 					// Vulnerability is new, add it to the results
 					resultPV.Vulnerabilities = append(resultPV.Vulnerabilities, v)
 					continue
@@ -101,7 +105,7 @@ func initializeCaches(oldRes models.VulnerabilityResults) (map[models.SourceInfo
 
 // DiffVulnerabilityResultsByOccurrences will return the occurrence of each vulnerability that are in `newRes`
 // which is not present in `oldRes`, but not the reverse. This calculates the difference by vulnerability ID,
-// while ignoring the source of the vulnerability.
+// package, dependency group, and reachability metadata, while ignoring the source path of the vulnerability.
 //
 // This prevents us reporting "new" vulnerabilities in a PR when a previously vulnerable file is being moved.
 func DiffVulnerabilityResultsByOccurrences(oldRes, newRes models.VulnerabilityResults) map[string]int {
@@ -112,20 +116,74 @@ func DiffVulnerabilityResultsByOccurrences(oldRes, newRes models.VulnerabilityRe
 	newResMap := map[string]int{}
 
 	for _, vf := range oldResFlat {
-		oldResMap[vf.Vulnerability.GetId()] += 1
+		if vf.Vulnerability == nil {
+			continue
+		}
+		oldResMap[vulnerabilityOccurrenceKey(vf)] += 1
 	}
 
 	for _, vf := range newResFlat {
-		newResMap[vf.Vulnerability.GetId()] += 1
+		if vf.Vulnerability == nil {
+			continue
+		}
+		newResMap[vulnerabilityOccurrenceKey(vf)] += 1
 	}
 
-	for k, oldVulnCount := range oldResMap {
+	for k, oldOccurrenceCount := range oldResMap {
 		// If the new result has fewer vulnerabilities than the old result remove the entry from the new result.
 		// `map`'s default value is 0 when empty, and delete also works fine when the entry is empty
-		if newResMap[k] <= oldVulnCount {
+		if newResMap[k] <= oldOccurrenceCount {
 			delete(newResMap, k)
 		}
 	}
 
 	return newResMap
+}
+
+func vulnerabilityOccurrenceKey(vf models.VulnerabilityFlattened) string {
+	return strings.Join([]string{
+		"package=" + vf.Package.Name,
+		"os_package=" + vf.Package.OSPackageName,
+		"version=" + vf.Package.Version,
+		"ecosystem=" + vf.Package.Ecosystem,
+		"commit=" + vf.Package.Commit,
+		"groups=" + strings.Join(sortedStrings(vf.DepGroups), ","),
+		"vulnerability=" + vf.Vulnerability.GetId(),
+		"called=" + boolString(vf.GroupInfo.IsCalled()),
+		"unimportant=" + boolString(vf.GroupInfo.IsGroupUnimportant()),
+	}, "|")
+}
+
+func vulnerabilityMetadataChanged(oldPV, newPV models.PackageVulns, vulnID string) bool {
+	oldGroupInfo, _ := groupInfoForVuln(oldPV.Groups, vulnID)
+	newGroupInfo, _ := groupInfoForVuln(newPV.Groups, vulnID)
+
+	return strings.Join(sortedStrings(oldPV.DepGroups), "\x00") != strings.Join(sortedStrings(newPV.DepGroups), "\x00") ||
+		oldGroupInfo.IsCalled() != newGroupInfo.IsCalled() ||
+		oldGroupInfo.IsGroupUnimportant() != newGroupInfo.IsGroupUnimportant()
+}
+
+func groupInfoForVuln(groups []models.GroupInfo, vulnID string) (models.GroupInfo, bool) {
+	for _, group := range groups {
+		if slices.Contains(group.IDs, vulnID) {
+			return group, true
+		}
+	}
+
+	return models.GroupInfo{}, false
+}
+
+func sortedStrings(values []string) []string {
+	result := append([]string(nil), values...)
+	slices.Sort(result)
+
+	return result
+}
+
+func boolString(value bool) string {
+	if value {
+		return "true"
+	}
+
+	return "false"
 }

--- a/internal/ci/vulnerability_result_diff_test.go
+++ b/internal/ci/vulnerability_result_diff_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/google/osv-scanner/v2/internal/ci"
 	"github.com/google/osv-scanner/v2/internal/testutility"
 	"github.com/google/osv-scanner/v2/pkg/models"
+	"github.com/ossf/osv-schema/bindings/go/osvschema"
 )
 
 func TestDiffVulnerabilityResults(t *testing.T) {
@@ -133,5 +134,65 @@ func TestDiffVulnerabilityByUniqueVulnCountResults(t *testing.T) {
 			got := ci.DiffVulnerabilityResultsByOccurrences(tt.args.oldRes, tt.args.newRes)
 			testutility.NewSnapshot().MatchJSON(t, got)
 		})
+	}
+}
+
+func TestDiffVulnerabilityResultsByOccurrencesReportsDependencyGroupChanges(t *testing.T) {
+	t.Parallel()
+
+	oldRes := vulnResults("package-lock.json", "minimist", "0.0.8", "npm", "GHSA-same-id", []string{"dev"}, true, false)
+	newRes := vulnResults("package-lock.json", "minimist", "0.0.8", "npm", "GHSA-same-id", nil, true, false)
+
+	got := ci.DiffVulnerabilityResultsByOccurrences(oldRes, newRes)
+	if len(got) == 0 {
+		t.Fatal("expected dependency group changes to be reported as a new occurrence")
+	}
+}
+
+func TestDiffVulnerabilityResultsByOccurrencesReportsReachabilityChanges(t *testing.T) {
+	t.Parallel()
+
+	oldRes := vulnResults("go.mod", "github.com/ipfs/go-bitfield", "1.0.0", "Go", "GO-2023-1558", nil, false, false)
+	newRes := vulnResults("go.mod", "github.com/ipfs/go-bitfield", "1.0.0", "Go", "GO-2023-1558", nil, true, false)
+
+	got := ci.DiffVulnerabilityResultsByOccurrences(oldRes, newRes)
+	if len(got) == 0 {
+		t.Fatal("expected reachability changes to be reported as a new occurrence")
+	}
+}
+
+func TestDiffVulnerabilityResultsReportsReachabilityChanges(t *testing.T) {
+	t.Parallel()
+
+	oldRes := vulnResults("go.mod", "github.com/ipfs/go-bitfield", "1.0.0", "Go", "GO-2023-1558", nil, false, false)
+	newRes := vulnResults("go.mod", "github.com/ipfs/go-bitfield", "1.0.0", "Go", "GO-2023-1558", nil, true, false)
+
+	got := ci.DiffVulnerabilityResults(oldRes, newRes)
+	if len(got.Results) == 0 || len(got.Results[0].Packages) == 0 || len(got.Results[0].Packages[0].Vulnerabilities) == 0 {
+		t.Fatal("expected precise diff to include a vulnerability whose reachability changed")
+	}
+}
+
+func vulnResults(sourcePath, packageName, version, ecosystem, vulnID string, depGroups []string, called, unimportant bool) models.VulnerabilityResults {
+	return models.VulnerabilityResults{
+		Results: []models.PackageSource{{
+			Source: models.SourceInfo{Path: sourcePath, Type: models.SourceTypeProjectPackage},
+			Packages: []models.PackageVulns{{
+				Package:   models.PackageInfo{Name: packageName, Version: version, Ecosystem: ecosystem},
+				DepGroups: depGroups,
+				Vulnerabilities: []*osvschema.Vulnerability{{
+					Id: vulnID,
+				}},
+				Groups: []models.GroupInfo{{
+					IDs: []string{vulnID},
+					ExperimentalAnalysis: map[string]models.AnalysisInfo{
+						vulnID: {
+							Called:      called,
+							Unimportant: unimportant,
+						},
+					},
+				}},
+			}},
+		}},
 	}
 }


### PR DESCRIPTION
## Summary

- Compare PR vulnerability occurrences using package identity, dependency groups, and reachability metadata instead of vulnerability ID alone.
- Preserve the existing behavior that avoids reporting a vulnerability again when a lockfile is only moved.
- Report cases where the same vulnerability ID is newly introduced through a different package context, dependency group, or call-analysis state.

## Tests

- go test ./internal/ci -run "TestDiffVulnerability" -count=1
- go test ./internal/ci ./cmd/osv-reporter ./pkg/models ./pkg/osvscanner -count=1
