### PR TITLE
test: include acceptance tests in update-snapshots target

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,7 +126,7 @@ Note that some long-running tests may be skipped and their snapshots will not be
 
 ```shell
 make update-snapshots
-# Equivalent to: make test SNAPS=true SHORT=false
+# Equivalent to: make test SNAPS=true ACC=true SHORT=false
 ```
 
 To update all snapshots for all tests, matching the CI test environment, use:

--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,8 @@ test: ## Run tests
 	if [ "$(SHORT)" = "true" ]; then ARGS="$$ARGS -short"; fi; \
 	scripts/run_tests.sh $$ARGS
 
-update-snapshots: ## Update all snapshots (Equivalent to make test SNAPS=true SHORT=false)
-	$(MAKE) test SNAPS=true SHORT=false
+update-snapshots: ## Update all snapshots (Equivalent to make test SNAPS=true ACC=true SHORT=false)
+	$(MAKE) test SNAPS=true ACC=true SHORT=false
 
 refresh-all: ## Refresh all snaps, matching CI test (Usage: make refresh-all REBUILD_IMAGES=true)
 	@if [ "$(REBUILD_IMAGES)" = "true" ]; then $(MAKE) clean; fi


### PR DESCRIPTION
## Overview

Updates the `make update-snapshots` command target in the Makefile to run both unit tests and acceptance tests, matching the behavior of `make test SNAPS=true ACC=true SHORT=false`.

## Details

- Modified `update-snapshots` Makefile target to run `$(MAKE) test SNAPS=true ACC=true SHORT=false`.
- Updated `CONTRIBUTING.md` description for `make update-snapshots`.
- Regenerated all snapshot and cassette files.

## Testing

- Ran `./scripts/run_lints.sh` and verified 0 lint issues.
- Ran `make update-snapshots` to verify all unit and acceptance tests successfully pass.

## Checklist

- [x] I have signed the Contributor License Agreement.
- [x] I have run the linter using `./scripts/run_lints.sh`.
- [x] I have run the unit tests using `./scripts/run_tests.sh`.
- [x] I have made my commits and PR title follow the Conventional Commits specification.

agy