### PR TITLE
fix(scan): cap per-file allocation via MaxFileSize to prevent memory DoS

### DIFF
--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -97,6 +97,13 @@ type TransitiveScanningActions struct {
 	MavenRegistry    string
 }
 
+// defaultMaxFileSize caps per-file memory allocation for extractors.
+// Rationale: 20+ lockfile extractors call io.ReadAll(input.Reader) with no
+// per-parser limit; without a cap, a repository or container-image layer
+// entry can allocate arbitrary memory during extraction. 512 MiB matches
+// the image-layer scanner's MaxFileBytes default in osv-scalibr.
+const defaultMaxFileSize = 512 * 1024 * 1024
+
 type ExternalAccessors struct {
 	// Matchers
 	VulnMatcher    clientinterfaces.VulnerabilityMatcher
@@ -323,6 +330,7 @@ func DoContainerScan(actions ScannerActions) (models.VulnerabilityResults, error
 		Capabilities:      capabilities,
 		StoreAbsolutePath: true,
 		ExplicitPlugins:   true,
+		MaxFileSize:       defaultMaxFileSize,
 	})
 	if err != nil {
 		return models.VulnerabilityResults{}, fmt.Errorf("failed to scan container image: %w", err)

--- a/pkg/osvscanner/scan.go
+++ b/pkg/osvscanner/scan.go
@@ -238,6 +238,7 @@ SBOMLoop:
 	// For each root, run scalibr's scan() once.
 	for root, paths := range rootMap {
 		sr := scanner.Scan(context.Background(), &scalibr.ScanConfig{
+		MaxFileSize:           defaultMaxFileSize,
 			Plugins:               filteredPlugins,
 			Capabilities:          &capabilities,
 			ScanRoots:             fs.RealFSScanRoots(root),


### PR DESCRIPTION
## Problem
Both filesystem scan (`pkg/osvscanner/scan.go:240`) and container image scan (`pkg/osvscanner/osvscanner.go:321`) construct `scalibr.ScanConfig` without `MaxFileSize`. scalibr documents `0` as "no limit" (`osv-scalibr/extractor/filesystem/filesystem.go:114`), so 20+ lockfile/manifest extractors that call `io.ReadAll(input.Reader)` can allocate arbitrarily large memory for attacker-supplied files.

Realistic attack sources:
- Repo files up to 100 MB via standard git (or up to 2 GB via git-LFS with `actions/checkout` lfs: true)
- Container image layer entries — no upper bound

On GitHub-hosted runners (7 GB RAM), a single ~2 GB `package-lock.json` or `Cargo.lock` can OOM-kill the scanner during JSON parse (JSON parsing typically allocates 3-5× file size).

## Fix
- Add `defaultMaxFileSize = 512 * 1024 * 1024` (512 MiB) as a package-level constant, matching `osv-scalibr`'s image-layer scanner `MaxFileBytes` default.
- Wire it into both `scalibr.ScanConfig` sites.

Aligns with the JAR extractor's existing `defaultMaxZipBytes` pattern (`osv-scalibr/extractor/filesystem/language/java/archive/archive.go:52`) — extending the same safe-default philosophy to file-level ingestion.

## Related
- `docs/migrating-from-scalibr.md:104` currently lists `--max-file-size` as "Not yet available". This change wires the default so the safeguard exists regardless of whether the CLI flag lands.
- Related VRP report: https://issuetracker.google.com/issues/534007055

## Testing
Existing test suite exercises files well under 512 MiB — no behavior change for real-world scans. Manual verify: repo with `Cargo.lock` >512 MiB is now skipped (as documented by `filesystem.go:519-529` when `maxFileSize > 0`).