### PR TITLE
fix(security): sanitize package identity in workflow-parsed log sinks

### DIFF
--- a/pkg/osvscanner/filter.go
+++ b/pkg/osvscanner/filter.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/osv-scanner/v2/internal/config"
 	"github.com/google/osv-scanner/v2/internal/imodels"
 	"github.com/google/osv-scanner/v2/internal/imodels/results"
+	"github.com/google/osv-scanner/v2/internal/output"
 	"github.com/google/osv-scanner/v2/pkg/models"
 	"github.com/ossf/osv-schema/bindings/go/osvconstants"
 	"github.com/ossf/osv-schema/bindings/go/osvschema"
@@ -45,7 +46,7 @@ func filterUnscannablePackages(scanResults *results.ScanResults, actions Scanner
 		// Short commit hashes (< 40 hex chars) are rejected by the OSV API with
 		// "Invalid hash". Skip them with a warning rather than aborting the scan.
 		case imodels.Commit(psr) != "" && len(imodels.Commit(psr)) < 40:
-			cmdlogger.Warnf("Skipping %s: short commit hash %q cannot be queried; OSV API requires a full 40-character SHA.", imodels.Name(psr), imodels.Commit(psr))
+			cmdlogger.Warnf("Skipping %s: short commit hash %q cannot be queried; OSV API requires a full 40-character SHA.", output.SanitizeForWorkflowCommand(imodels.Name(psr)), imodels.Commit(psr))
 
 			if actions.ShowAllPackages {
 				filteredPsr = append(filteredPsr, psr)
@@ -101,7 +102,7 @@ func filterIgnoredPackages(scanResults *results.ScanResults) {
 			if reason == "" {
 				reason = "(no reason given)"
 			}
-			cmdlogger.Infof("Package %s has been filtered out because: %s", pkgString, reason)
+			cmdlogger.Infof("Package %s has been filtered out because: %s", output.SanitizeForWorkflowCommand(pkgString), output.SanitizeForWorkflowCommand(reason))
 
 			continue
 		}

--- a/pkg/osvscanner/vulnerability_result.go
+++ b/pkg/osvscanner/vulnerability_result.go
@@ -107,10 +107,10 @@ func buildVulnerabilityResults(
 		if actions.ScanLicensesSummary || len(actions.ScanLicensesAllowlist) > 0 {
 			if override, entry := configToUse.ShouldOverridePackageLicense(p); override {
 				if entry.License.Ignore {
-					cmdlogger.Infof("ignoring license for package %s/%s/%s", pkg.Package.Ecosystem, pkg.Package.Name, pkg.Package.Version)
+					cmdlogger.Infof("ignoring license for package %s/%s/%s", output.SanitizeForWorkflowCommand(pkg.Package.Ecosystem), output.SanitizeForWorkflowCommand(pkg.Package.Name), output.SanitizeForWorkflowCommand(pkg.Package.Version))
 					p.Licenses = []string{}
 				} else {
-					cmdlogger.Infof("overriding license for package %s/%s/%s with %s", pkg.Package.Ecosystem, pkg.Package.Name, pkg.Package.Version, strings.Join(entry.License.Override, ","))
+					cmdlogger.Infof("overriding license for package %s/%s/%s with %s", output.SanitizeForWorkflowCommand(pkg.Package.Ecosystem), output.SanitizeForWorkflowCommand(pkg.Package.Name), output.SanitizeForWorkflowCommand(pkg.Package.Version), output.SanitizeForWorkflowCommand(strings.Join(entry.License.Override, ",")))
 					p.Licenses = entry.License.Override
 				}
 			}


### PR DESCRIPTION
## Problem

Several `Info`/`Warn` log sites emit a package **name / version / ecosystem** derived from **lockfile or SBOM contents** to stdout without applying `output.SanitizeForWorkflowCommand`. The `cmdlogger` handler writes the message verbatim to stdout (`internal/cmdlogger/handler.go`), and the GitHub Actions runner parses stdout for `::command::value` sequences.

On the `pull_request`-triggered `google/osv-scanner-action` path an attacker controls those values, and a package name may legally contain `\r`/`\n` (e.g. a `package-lock.json` `packages` path key, or a CycloneDX component). That lets an attacker break out of the log line and inject `::error::`, `::add-mask::`, `::stop-commands::`, `::notice::`, etc. into the runner's output.

Unlike the file-path sinks, this vector needs only crafted lockfile **contents** — no unusual filenames in the repository.

## Prior art in this repo

`pkg/osvscanner/scan.go:158` already applies the guard for the directory-name log line, and its comment states the exact threat model. This change extends the same guard to the remaining **package-identity** sinks that were not covered:

- `pkg/osvscanner/filter.go:48` — short-commit skip warning; reachable **with no config** via a git dependency whose commit hash is `< 40` chars
- `pkg/osvscanner/filter.go:104` — ignored-package notice
- `pkg/osvscanner/vulnerability_result.go:110,113` — license-override notices

## Reproduction (before this change)

`package-lock.json` git dependency with a short commit and a newline in the package name (no config needed):

```
Skipping ev
::error::INJECTED: short commit hash "abc1234" cannot be queried; ...
```

The `::error::` lands at the start of its own stdout line → parsed as a workflow command. After this change the bytes are URL-encoded (`ev%0A::error::INJECTED...`) and stay on one line.

## No behaviour change for benign metadata

`SanitizeForWorkflowCommand` is an identity function on strings that contain no `\r` or `\n`, so typical package name/version/ecosystem output is unchanged. `go test ./pkg/osvscanner/` passes with no snapshot changes.
