### PR TITLE
fix(security): sanitize extractor-emitted package identifiers in workflow-parsed log sinks

### DIFF
--- a/pkg/osvscanner/filter.go
+++ b/pkg/osvscanner/filter.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/osv-scanner/v2/internal/config"
 	"github.com/google/osv-scanner/v2/internal/imodels"
 	"github.com/google/osv-scanner/v2/internal/imodels/results"
+	"github.com/google/osv-scanner/v2/internal/output"
 	"github.com/google/osv-scanner/v2/pkg/models"
 	"github.com/ossf/osv-schema/bindings/go/osvconstants"
 	"github.com/ossf/osv-schema/bindings/go/osvschema"
@@ -45,7 +46,7 @@ func filterUnscannablePackages(scanResults *results.ScanResults, actions Scanner
 		// Short commit hashes (< 40 hex chars) are rejected by the OSV API with
 		// "Invalid hash". Skip them with a warning rather than aborting the scan.
 		case imodels.Commit(psr) != "" && len(imodels.Commit(psr)) < 40:
-			cmdlogger.Warnf("Skipping %s: short commit hash %q cannot be queried; OSV API requires a full 40-character SHA.", imodels.Name(psr), imodels.Commit(psr))
+			cmdlogger.Warnf("Skipping %s: short commit hash %q cannot be queried; OSV API requires a full 40-character SHA.", output.SanitizeForWorkflowCommand(imodels.Name(psr)), imodels.Commit(psr))
 
 			if actions.ShowAllPackages {
 				filteredPsr = append(filteredPsr, psr)
@@ -101,7 +102,7 @@ func filterIgnoredPackages(scanResults *results.ScanResults) {
 			if reason == "" {
 				reason = "(no reason given)"
 			}
-			cmdlogger.Infof("Package %s has been filtered out because: %s", pkgString, reason)
+			cmdlogger.Infof("Package %s has been filtered out because: %s", output.SanitizeForWorkflowCommand(pkgString), output.SanitizeForWorkflowCommand(reason))
 
 			continue
 		}

--- a/pkg/osvscanner/vulnerability_result.go
+++ b/pkg/osvscanner/vulnerability_result.go
@@ -107,10 +107,10 @@ func buildVulnerabilityResults(
 		if actions.ScanLicensesSummary || len(actions.ScanLicensesAllowlist) > 0 {
 			if override, entry := configToUse.ShouldOverridePackageLicense(p); override {
 				if entry.License.Ignore {
-					cmdlogger.Infof("ignoring license for package %s/%s/%s", pkg.Package.Ecosystem, pkg.Package.Name, pkg.Package.Version)
+					cmdlogger.Infof("ignoring license for package %s/%s/%s", output.SanitizeForWorkflowCommand(pkg.Package.Ecosystem), output.SanitizeForWorkflowCommand(pkg.Package.Name), output.SanitizeForWorkflowCommand(pkg.Package.Version))
 					p.Licenses = []string{}
 				} else {
-					cmdlogger.Infof("overriding license for package %s/%s/%s with %s", pkg.Package.Ecosystem, pkg.Package.Name, pkg.Package.Version, strings.Join(entry.License.Override, ","))
+					cmdlogger.Infof("overriding license for package %s/%s/%s with %s", output.SanitizeForWorkflowCommand(pkg.Package.Ecosystem), output.SanitizeForWorkflowCommand(pkg.Package.Name), output.SanitizeForWorkflowCommand(pkg.Package.Version), output.SanitizeForWorkflowCommand(strings.Join(entry.License.Override, ",")))
 					p.Licenses = entry.License.Override
 				}
 			}


### PR DESCRIPTION
Follow-up to #2925 (cc @BiswajeetRay7, who requested a separate scoped PR for these sinks in https://github.com/google/osv-scanner/pull/2925#issuecomment-4984310843).

## Scope
#2925 sanitizes the **filesystem-walk path** sinks. This PR covers the complementary **extractor-emitted package-identity** sinks — package name/version/ecosystem read from lockfile or SBOM *contents* — which reach stdout unsanitized through the same `cmdlogger` → `Handler.Handle` path (`record.Message` is written verbatim; there is no global guard). A package name can legally contain `\r`/`\n` (e.g. a `package-lock.json` `packages` path key, or a CycloneDX component), so this is a strictly wider primitive than the path sinks: it needs only crafted lockfile contents, no unusual filenames.

## Sinks guarded (same `output.SanitizeForWorkflowCommand` as `pkg/osvscanner/scan.go:158`)
- `pkg/osvscanner/filter.go:48` — short-commit skip warning (`imodels.Name`). Reachable with **no config** via a git dependency whose commit hash is `< 40` chars.
- `pkg/osvscanner/filter.go:104` — ignored-package notice (`pkgString` = ecosystem/name/version, plus `reason`).
- `pkg/osvscanner/vulnerability_result.go:110,113` — license-override notices.

## Verification
- Before: a crafted `package-lock.json` emits `::error::…` at the start of its own stdout line (workflow-command injection). After: the bytes are URL-encoded (`…%0A::error::…`) and stay on one line.
- `go test ./pkg/osvscanner/` passes with no snapshot changes (`SanitizeForWorkflowCommand` is identity on strings without `\r`/`\n`).

Related VRP report: https://issuetracker.google.com/issues/533784193 (same threat model). Supersedes #2927 (which I opened before seeing the contributing guide; reopening as a scoped follow-up per @BiswajeetRay7's request). Happy to instead fold this into #2925 if the review team prefers a single commit.
