### PR TITLE
docs: replace retired Go Report Card badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ---
 
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/google/osv-scanner/badge)](https://scorecard.dev/viewer/?uri=github.com/google/osv-scanner)
-[![Go Report Card](https://goreportcard.com/badge/github.com/google/osv-scanner)](https://goreportcard.com/report/github.com/google/osv-scanner)
+[![Checks](https://img.shields.io/github/actions/workflow/status/google/osv-scanner/checks.yml?branch=main&label=checks&logo=go&logoColor=white)](https://github.com/google/osv-scanner/actions/workflows/checks.yml)
 [![codecov](https://codecov.io/gh/google/osv-scanner/graph/badge.svg?token=C8IDVX9LP5)](https://codecov.io/gh/google/osv-scanner)
 [![SLSA 3](https://slsa.dev/images/gh-badge-level3.svg)](https://slsa.dev)
 [![GitHub Release](https://img.shields.io/github/v/release/google/osv-scanner)](https://github.com/google/osv-scanner/releases)


### PR DESCRIPTION
https://goreportcard.com was sunset earlier this month, leaving the badge broken.
This PR replaces it with a shields.io badge for the checks workflow.