### PR TITLE
feat: add --dry-run mode to preview OSV.dev payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features:
 
+- [Feature #303](https://github.com/google/osv-scanner/issues/303) Add a `--dry-run` mode that prints the OSV.dev `querybatch` payload that would be sent without making network requests to OSV.dev.
 - [Feature #2815](https://github.com/google/osv-scanner/pull/2815) Add support for the CycloneDX 1.7 specification (bumps `cyclonedx-go` to v0.11.0).
 - [Feature #2799](https://github.com/google/osv-scanner/pull/2799) Enable `.csproj` and Central Package Management (`nugetcpm`) source scanning plugins by default.
 - [Feature #2871](https://github.com/google/osv-scanner/pull/2871) Extract and parse Alpine OS distro version (e.g. `Alpine:v3.17`, `Alpine:edge`) from PURL `distro` qualifiers to scan packages under their respective Alpine ecosystems.

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ OSV-Scanner communicates with the following external services during operation:
 
 ### [OSV.dev API](https://osv.dev/)
 
-The primary data source for vulnerability information. OSV-Scanner queries this API to check packages for known vulnerabilities and to identify vendored C/C++ dependencies. Data sent includes package names, versions, ecosystems, and file hashes. Use [`--offline` mode](https://google.github.io/osv-scanner/usage/offline-mode/) to disable network requests and scan against a local database instead.
+The primary data source for vulnerability information. OSV-Scanner queries this API to check packages for known vulnerabilities and to identify vendored C/C++ dependencies. Data sent includes package names, versions, ecosystems, and file hashes. Use [`--offline` mode](https://google.github.io/osv-scanner/usage/offline-mode/) to disable network requests and scan against a local database instead. Use `--dry-run` to print the OSV.dev requests that would be made without sending them.
 
 ### [deps.dev API](https://docs.deps.dev/api/)
 

--- a/cmd/osv-scanner/internal/helper/flags.go
+++ b/cmd/osv-scanner/internal/helper/flags.go
@@ -156,6 +156,10 @@ func BuildCommonScanFlags(defaultExtractors []string) []cli.Flag {
 			Name:  "download-offline-databases",
 			Usage: "downloads vulnerability databases for offline comparison",
 		},
+		&cli.BoolFlag{
+			Name:  "dry-run",
+			Usage: "display the OSV.dev requests that would be made without sending them or checking for vulnerabilities",
+		},
 		&cli.StringFlag{
 			Name:   "local-db-path",
 			Usage:  "sets the path that local databases should be stored",

--- a/cmd/osv-scanner/internal/helper/getters.go
+++ b/cmd/osv-scanner/internal/helper/getters.go
@@ -43,6 +43,7 @@ func GetCommonScannerActions(cmd *cli.Command, scanLicensesAllowlist []string) o
 		CompareOffline:        cmd.Bool("offline-vulnerabilities"),
 		DownloadDatabases:     cmd.Bool("download-offline-databases"),
 		LocalDBPath:           cmd.String("local-db-path"),
+		DryRun:                cmd.Bool("dry-run"),
 		PluginNetworkDisabled: cmd.Bool("offline"),
 		ScanLicensesSummary:   cmd.IsSet("licenses"),
 		ScanLicensesAllowlist: scanLicensesAllowlist,

--- a/cmd/osv-scanner/scan/source/__snapshots__/command_test.snap
+++ b/cmd/osv-scanner/scan/source/__snapshots__/command_test.snap
@@ -3003,6 +3003,44 @@ Total 23 packages affected by 223 known vulnerabilities (27 Critical, 93 High, 6
 
 ---
 
+[TestCommand_DryRun/dry_run_incompatible_with_offline_vulnerabilities - 1]
+
+---
+
+[TestCommand_DryRun/dry_run_incompatible_with_offline_vulnerabilities - 2]
+cannot use --dry-run together with --offline-vulnerabilities
+
+---
+
+[TestCommand_DryRun/dry_run_prints_osv_dev_payload_without_finding_vulns - 1]
+Scanning dir ./testdata/locks-many/composer.lock
+Scanned <rootdir>/testdata/locks-many/composer.lock file and found 1 package
+Loaded filter from: <rootdir>/testdata/locks-many/osv-scanner-test.toml
+Dry-run mode: no requests will be sent to OSV.dev
+The following request would be sent to OSV.dev:
+POST https://api.osv.dev/v1/querybatch
+{
+  "queries":  [
+    {
+      "version":  "2.0.4",
+      "package":  {
+        "name":  "sentry/sdk",
+        "ecosystem":  "Packagist"
+      }
+    }
+  ]
+}
+If vulnerabilities were returned, follow-up GET https://api.osv.dev/v1/vulns/{id} requests would be made for each vulnerability ID
+Vendored C/C++ determineversion requests to https://api.osv.dev/v1experimental/determineversion are also skipped in dry-run mode
+
+No issues found
+
+---
+
+[TestCommand_DryRun/dry_run_prints_osv_dev_payload_without_finding_vulns - 2]
+
+---
+
 [TestCommand_ExplicitExtractors_WithDefaults/empty_plugins_flag_does_default - 1]
 
 ---

--- a/cmd/osv-scanner/scan/source/command_test.go
+++ b/cmd/osv-scanner/scan/source/command_test.go
@@ -415,6 +415,35 @@ func TestCommand(t *testing.T) {
 	}
 }
 
+func TestCommand_DryRun(t *testing.T) {
+	t.Parallel()
+
+	// Dry-run does not contact OSV.dev, so no VCR cassette is required for matching.
+	// A plain client is still passed for any incidental HTTP used during extraction.
+	client := &http.Client{}
+
+	tests := []testcmd.Case{
+		{
+			Name: "dry_run_prints_osv_dev_payload_without_finding_vulns",
+			Args: []string{"", "source", "--dry-run", "./testdata/locks-many/composer.lock"},
+			Exit: 0,
+		},
+		{
+			Name: "dry_run_incompatible_with_offline_vulnerabilities",
+			Args: []string{"", "source", "--dry-run", "--offline-vulnerabilities", "./testdata/locks-many/composer.lock"},
+			Exit: 127,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.HTTPClient = client
+			testcmd.RunAndMatchSnapshots(t, tt)
+		})
+	}
+}
+
 func TestCommand_Config_UnusedIgnores(t *testing.T) {
 	t.Parallel()
 

--- a/internal/clients/clientimpl/osvmatcher/dryrun.go
+++ b/internal/clients/clientimpl/osvmatcher/dryrun.go
@@ -1,0 +1,91 @@
+package osvmatcher
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scanner/v2/internal/cmdlogger"
+	"github.com/ossf/osv-schema/bindings/go/osvschema"
+	"google.golang.org/protobuf/encoding/protojson"
+	"osv.dev/bindings/go/api"
+	"osv.dev/bindings/go/osvdev"
+)
+
+// DryRunMatcher implements VulnerabilityMatcher by printing the OSV.dev requests
+// that would be made without sending them over the network.
+//
+// This is intended for privacy-conscious users who want to inspect what package
+// names, versions, ecosystems, and commits would be shared with OSV.dev.
+type DryRunMatcher struct{}
+
+// MatchVulnerabilities builds the querybatch payload that would be sent to OSV.dev,
+// prints it, and returns empty vulnerability results for every package.
+func (matcher *DryRunMatcher) MatchVulnerabilities(_ context.Context, pkgs []*extractor.Package) ([][]*osvschema.Vulnerability, error) {
+	queries, _ := pkgsToUniqueQueries(pkgs)
+	queries = filterNilQueries(queries)
+
+	cmdlogger.Infof("Dry-run mode: no requests will be sent to OSV.dev")
+	cmdlogger.Infof("The following request would be sent to OSV.dev:")
+	cmdlogger.Infof("POST %s%s", osvdev.DefaultBaseURL, osvdev.QueryBatchEndpoint)
+
+	if len(queries) == 0 {
+		cmdlogger.Infof("(no package queries would be sent)")
+	} else {
+		body, err := marshalBatchQuery(queries)
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode dry-run querybatch payload: %w", err)
+		}
+		// Log each line separately so cmdlogger formatting stays readable.
+		for _, line := range strings.Split(strings.TrimRight(body, "\n"), "\n") {
+			cmdlogger.Infof("%s", line)
+		}
+	}
+
+	cmdlogger.Infof(
+		"If vulnerabilities were returned, follow-up GET %s%s/{id} requests would be made for each vulnerability ID",
+		osvdev.DefaultBaseURL,
+		osvdev.GetEndpoint,
+	)
+	cmdlogger.Infof(
+		"Vendored C/C++ determineversion requests to %s%s are also skipped in dry-run mode",
+		osvdev.DefaultBaseURL,
+		osvdev.DetermineVersionEndpoint,
+	)
+
+	// Return empty results matching the original package list length.
+	results := make([][]*osvschema.Vulnerability, len(pkgs))
+	for i := range results {
+		results[i] = []*osvschema.Vulnerability{}
+	}
+
+	return results, nil
+}
+
+func filterNilQueries(queries []*api.Query) []*api.Query {
+	filtered := make([]*api.Query, 0, len(queries))
+	for _, q := range queries {
+		if q != nil {
+			filtered = append(filtered, q)
+		}
+	}
+
+	return filtered
+}
+
+func marshalBatchQuery(queries []*api.Query) (string, error) {
+	batch := &api.BatchQuery{Queries: queries}
+	opts := protojson.MarshalOptions{
+		Multiline:       true,
+		Indent:          "  ",
+		EmitUnpopulated: false,
+	}
+
+	body, err := opts.Marshal(batch)
+	if err != nil {
+		return "", err
+	}
+
+	return string(body), nil
+}

--- a/internal/clients/clientimpl/osvmatcher/dryrun_test.go
+++ b/internal/clients/clientimpl/osvmatcher/dryrun_test.go
@@ -1,0 +1,93 @@
+package osvmatcher
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/osv-scalibr/extractor"
+	"github.com/google/osv-scalibr/purl"
+	"osv.dev/bindings/go/api"
+	"osv.dev/bindings/go/osvdev"
+)
+
+func TestDryRunMatcher_MatchVulnerabilities(t *testing.T) {
+	t.Parallel()
+
+	matcher := &DryRunMatcher{}
+	pkgs := []*extractor.Package{
+		{Name: "a", Version: "1.0.0", PURLType: purl.TypeNPM},
+		{Name: "a", Version: "1.0.0", PURLType: purl.TypeNPM}, // duplicate should be deduped in payload
+		{Name: "b", Version: "2.0.0", PURLType: purl.TypeNPM},
+	}
+
+	got, err := matcher.MatchVulnerabilities(t.Context(), pkgs)
+	if err != nil {
+		t.Fatalf("MatchVulnerabilities() error = %v", err)
+	}
+	if len(got) != len(pkgs) {
+		t.Fatalf("result length = %d, want %d", len(got), len(pkgs))
+	}
+	for i, vulns := range got {
+		if len(vulns) != 0 {
+			t.Fatalf("result[%d] = %#v, want empty", i, vulns)
+		}
+	}
+}
+
+func TestDryRunMatcher_MatchVulnerabilities_NoPackages(t *testing.T) {
+	t.Parallel()
+
+	matcher := &DryRunMatcher{}
+	got, err := matcher.MatchVulnerabilities(t.Context(), nil)
+	if err != nil {
+		t.Fatalf("MatchVulnerabilities() error = %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("result length = %d, want 0", len(got))
+	}
+}
+
+func TestMarshalBatchQuery(t *testing.T) {
+	t.Parallel()
+
+	queries, _ := pkgsToUniqueQueries([]*extractor.Package{
+		{Name: "a", Version: "1.0.0", PURLType: purl.TypeNPM},
+		{Name: "a", Version: "1.0.0", PURLType: purl.TypeNPM},
+		{Name: "b", Version: "2.0.0", PURLType: purl.TypeNPM},
+	})
+	queries = filterNilQueries(queries)
+
+	body, err := marshalBatchQuery(queries)
+	if err != nil {
+		t.Fatalf("marshalBatchQuery() error = %v", err)
+	}
+
+	// protojson Multiline may insert extra spaces after colons; match flexibly.
+	if !strings.Contains(body, `"a"`) || !strings.Contains(body, `"b"`) {
+		t.Fatalf("expected package names in payload, got:\n%s", body)
+	}
+	if strings.Count(body, `"a"`) != 1 {
+		t.Fatalf("expected package a to appear once after dedupe, got:\n%s", body)
+	}
+	if !strings.Contains(body, `"npm"`) {
+		t.Fatalf("expected ecosystem in payload, got:\n%s", body)
+	}
+
+	// Sanity-check the URL constants we surface to users still match the client.
+	if osvdev.DefaultBaseURL+osvdev.QueryBatchEndpoint != "https://api.osv.dev/v1/querybatch" {
+		t.Fatalf("unexpected querybatch URL: %s%s", osvdev.DefaultBaseURL, osvdev.QueryBatchEndpoint)
+	}
+}
+
+func TestFilterNilQueries(t *testing.T) {
+	t.Parallel()
+
+	got := filterNilQueries([]*api.Query{
+		nil,
+		{Param: &api.Query_Version{Version: "1.0.0"}},
+		nil,
+	})
+	if len(got) != 1 {
+		t.Fatalf("filterNilQueries() len = %d, want 1", len(got))
+	}
+}

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -59,6 +59,9 @@ type ScannerActions struct {
 	DownloadDatabases bool
 	LocalDBPath       string
 
+	// DryRun prints the OSV.dev requests that would be made without sending them.
+	DryRun bool
+
 	// network-backed plugins
 	PluginNetworkDisabled bool
 
@@ -126,6 +129,19 @@ func initializeExternalAccessors(actions ScannerActions) (ExternalAccessors, err
 		userAgent = actions.RequestUserAgent
 	}
 
+	// Dry-run Mode
+	// ------------
+	// Show OSV.dev payloads without making network requests to OSV.dev.
+	// Intentionally does not set OSVDevClient so vendored determineversion is skipped.
+	if actions.DryRun {
+		if len(actions.ScanLicensesAllowlist) > 0 || actions.ScanLicensesSummary {
+			cmdlogger.Warnf("License scanning is skipped in dry-run mode")
+		}
+		externalAccessors.VulnMatcher = &osvmatcher.DryRunMatcher{}
+
+		return externalAccessors, nil
+	}
+
 	// Offline Mode
 	// ------------
 	if actions.CompareOffline {
@@ -169,6 +185,10 @@ func initializeExternalAccessors(actions ScannerActions) (ExternalAccessors, err
 func DoScan(actions ScannerActions) (models.VulnerabilityResults, error) {
 	// --- Sanity check flags ----
 	// TODO(v2): Move the logic of the offline flag changing other flags into here from the main.go/scan.go
+	if actions.DryRun && actions.CompareOffline {
+		return models.VulnerabilityResults{}, errors.New("cannot use --dry-run together with --offline-vulnerabilities")
+	}
+
 	if actions.CompareOffline {
 		if actions.ScanLicensesSummary {
 			return models.VulnerabilityResults{}, errors.New("cannot retrieve licenses locally")
@@ -241,6 +261,10 @@ func DoScan(actions ScannerActions) (models.VulnerabilityResults, error) {
 }
 
 func DoContainerScan(actions ScannerActions) (models.VulnerabilityResults, error) {
+	if actions.DryRun && actions.CompareOffline {
+		return models.VulnerabilityResults{}, errors.New("cannot use --dry-run together with --offline-vulnerabilities")
+	}
+
 	scanResults := results.ScanResults{
 		ConfigManager: config.Manager{
 			DefaultConfig: config.Config{},


### PR DESCRIPTION
## Overview

Adds a `--dry-run` mode so privacy-conscious users can inspect what package data would be sent to OSV.dev without making any network requests to the API.

Fixes #303

## Details

Builds on earlier discussion in #698 / #746:

- Extracts packages as usual from lockfiles/SBOMs/dirs
- Builds the **deduplicated** `POST /v1/querybatch` payload (same construction path as the real matcher)
- Prints method, URL, and JSON body via `cmdlogger`
- Does **not** call OSV.dev (`querybatch`, `/v1/vulns/{id}`, or `determineversion`)
- Returns empty vulnerability results (exit 0)
- Skips license matching with a warning (deps.dev is out of scope for this issue)
- Incompatible with `--offline-vulnerabilities`

Example:

```text
$ osv-scanner scan source --dry-run ./path/to/lockfile
...
Dry-run mode: no requests will be sent to OSV.dev
The following request would be sent to OSV.dev:
POST https://api.osv.dev/v1/querybatch
{
  "queries": [
    {
      "version": "2.0.4",
      "package": {
        "name": "sentry/sdk",
        "ecosystem": "Packagist"
      }
    }
  ]
}
...
No issues found
```

## Testing

- Added unit tests for `DryRunMatcher` / query marshaling
- Added CLI snapshot tests under `TestCommand_DryRun`
- Manually verified with `osv-scanner scan source --dry-run` on the composer.lock fixture

## Checklist

- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/).
- [ ] I have run the linter using `./scripts/run_lints.sh`.
- [x] I have run the unit tests using relevant packages (`osvmatcher`, `osvscanner`, `scan/source` dry-run cases).
- [x] I have made my commits and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.