### PR TITLE
fix: replace log.Fatalf with proper error return in rlib parsing

### DIFF
--- a/internal/sourceanalysis/rust.go
+++ b/internal/sourceanalysis/rust.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -194,7 +193,7 @@ func extractRlibArchive(rlibPath string) (bytes.Buffer, error) {
 	for {
 		header, err := reader.Next()
 		if err != nil {
-			log.Fatalf("%v", err)
+			return bytes.Buffer{}, fmt.Errorf("failed to read ar archive in '%s': %w", rlibPath, err)
 		}
 		if header.Name == "//" { // "//" is used in GNU ar format as a store for long file names
 			fileBuf := bytes.Buffer{}


### PR DESCRIPTION
## Summary

Replace `log.Fatalf` with proper error return in `internal/sourceanalysis/rust.go`.

## Problem

In `extractRlibArchive`, when `reader.Next()` fails during ar archive iteration, `log.Fatalf` is called which terminates the entire process immediately. This prevents callers from handling the error gracefully and can cause data loss or incomplete scans.

## Fix

Replace `log.Fatalf("%v", err)` with a proper error return using `fmt.Errorf` with `%w` wrapping, consistent with the error handling pattern used elsewhere in the same function. Also remove the now-unused `"log"` import.

## Checklist

- [x] Single-focused change
- [x] No conflicting open PRs found
- [x] Local environment limitations, relying on CI/CD automated testing

I apologize for any inconvenience and appreciate the maintainers' time reviewing this contribution.
