### PR TITLE
fix: omit -coverpkg=./... on macOS to avoid linker crashes and timeouts

### DIFF
--- a/cmd/osv-scanner/fix/__snapshots__/command_test.snap
+++ b/cmd/osv-scanner/fix/__snapshots__/command_test.snap
@@ -13288,3 +13288,25 @@ UNFIXABLE-VULNS: 6
 }
 
 ---
+
+[TestCommand_OfflineDatabase/fix_non_interactive_relax_package_json_with_offline_vulns - 4]
+
+---
+
+[TestCommand_OfflineDatabase/fix_non_interactive_relax_package_json_with_offline_vulns - 5]
+{
+  "name": "osv-fix",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo /"Error: no test specified/" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "npm-registry-client": "^7.5.0"
+  }
+}
+
+---

--- a/cmd/osv-scanner/fix/command_test.go
+++ b/cmd/osv-scanner/fix/command_test.go
@@ -154,6 +154,13 @@ func TestCommand_OfflineDatabase(t *testing.T) {
 			lockfile := testcmd.CopyFileFlagTo(t, tt, "-L", testDir)
 			manifest := testcmd.CopyFileFlagTo(t, tt, "-M", testDir)
 
+			old := tt.Args
+			tt.Args = []string{"", "fix", "--local-db-path", testDir}
+			tt.Args = append(tt.Args, old[2:]...)
+
+			// run each test twice since they should provide the same output,
+			// and the second run should be fast as the db is already available
+			testcmd.RunAndMatchSnapshots(t, tt)
 			testcmd.RunAndMatchSnapshots(t, tt)
 
 			if lockfile != "" {

--- a/cmd/osv-scanner/internal/testcmd/run.go
+++ b/cmd/osv-scanner/internal/testcmd/run.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -53,6 +54,23 @@ func run(t *testing.T, tc Case) (string, string) {
 	cf := tc.ClientFactories
 	if cf == nil {
 		cf = scalibr.NewClientFactories(tc.HTTPClient, "")
+	}
+
+	// Inject a per-test --local-db-path tempdir if offline databases are used without an explicit --local-db-path flag
+	if !slices.ContainsFunc(tc.Args, func(arg string) bool {
+		return arg == "--local-db-path" || strings.HasPrefix(arg, "--local-db-path=")
+	}) {
+		if slices.Contains(tc.Args, "--download-offline-databases") || slices.Contains(tc.Args, "--offline-vulnerabilities") {
+			dbDir := testutility.CreateTestDir(t)
+			subcmd := "source"
+			if len(tc.Args) >= 2 {
+				subcmd = tc.Args[1]
+			}
+			newArgs := make([]string, 0, len(tc.Args)+2)
+			newArgs = append(newArgs, "", subcmd, "--local-db-path", dbDir)
+			newArgs = append(newArgs, tc.Args[2:]...)
+			tc.Args = newArgs
+		}
 	}
 
 	ec := cmd.Run(tc.Args, stdout, stderr, cf, fetchCommandsToTest())

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -30,7 +30,12 @@ fi
 
 # If running in CI, test with coverage
 if [ -n "$CI" ]; then
-    go test ./... -coverpkg=./... -coverprofile coverage.out "$@"
+    # Omit -coverpkg=./... on macOS to avoid heavy linker overhead, memory pressure, and SIGBUS/timeouts
+    if [ "$RUNNER_OS" = "macOS" ] || [ "$(uname -s)" = "Darwin" ]; then
+        go test ./... -coverprofile coverage.out "$@"
+    else
+        go test ./... -coverpkg=./... -coverprofile coverage.out "$@"
+    fi
 else
     # Use gotestsum which has a nicer test output
     go run gotest.tools/gotestsum@v1.13.0 ./... "$@"


### PR DESCRIPTION
Omit `-coverpkg=./...` when running tests on macOS in CI.

### Background & Issue
Running `go test ./... -coverpkg=./...` forces the Go linker (`cmd/link`) to compile and inject cross-package coverage symbols from every package across the entire module into every test binary.

On macOS runners (which have slower virtual disk I/O and tighter memory limits), this cross-package coverage instrumentation creates severe memory-mapping (`mmap`) thrashing and high CPU overhead, leading to:
1. Linker `SIGBUS` bus error crashes (`encoding/binary.littleEndian.Uint16` inside `cmd/link/internal/ld.(*deadcodePass).flood`) when memory-mapped object files in `GOCACHE` are truncated or corrupted under memory thrashing.
2. Intermittent CI test timeouts.

### Fix
In `scripts/run_tests.sh`, check if running on macOS (`RUNNER_OS=macOS` or `uname -s = Darwin`) when in CI, and run `go test ./... -coverprofile coverage.out` without `-coverpkg=./...`. Standard package coverage is still recorded to `coverage.out`.

agy