### PR TITLE
fix: add gRPC transport keepalive parameters to prevent macOS test timeouts

### DIFF
--- a/internal/scalibr/client_factories.go
+++ b/internal/scalibr/client_factories.go
@@ -8,10 +8,12 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/google/osv-scalibr/plugin/config"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/keepalive"
 )
 
 type grpcClientConnCloser interface {
@@ -95,7 +97,14 @@ func (c *ClientFactories) GRPCClientConn(url string, dialOpts ...grpc.DialOption
 	}
 	creds := credentials.NewClientTLSFromCert(certPool, "")
 
-	ourDialOpts := []grpc.DialOption{grpc.WithTransportCredentials(creds)}
+	ourDialOpts := []grpc.DialOption{
+		grpc.WithTransportCredentials(creds),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time:                10 * time.Second,
+			Timeout:             5 * time.Second,
+			PermitWithoutStream: true,
+		}),
+	}
 	if c.defaultUserAgent != "" {
 		ourDialOpts = append(ourDialOpts, grpc.WithUserAgent(c.defaultUserAgent))
 	}


### PR DESCRIPTION
### Background & Issue
osv-scanner's `fix` command initializes a gRPC client connection to `api.deps.dev:443` for dependency resolution

On macOS CI apparently streams without transport keepalives can stall, especially using the native network stack.

Trying this to see if it helps.

---

Long term this will be fixed by the grpc VCRs anyway.

### Fix
In `internal/scalibr/client_factories.go`, configure gRPC keepalive client parameters on `GRPCClientConn`:
```go
ourDialOpts := []grpc.DialOption{
	grpc.WithTransportCredentials(creds),
	grpc.WithKeepaliveParams(keepalive.ClientParameters{
		Time:                10 * time.Second,
		Timeout:             5 * time.Second,
		PermitWithoutStream: true,
	}),
}
```

With these parameters, gRPC will transmit HTTP/2 PING frames every 10 seconds to detect dead TCP connections and fail/reconnect within 15 seconds.

agy