### PR TITLE
Fix/gh annotations escaping

### DIFF
--- a/internal/output/__snapshots__/githubannotation_test.snap
+++ b/internal/output/__snapshots__/githubannotation_test.snap
@@ -196,7 +196,7 @@
 ---
 
 [TestPrintGHAnnotationReport_WithVulnerabilities/one_source_with_workflow_command_injection_attempt_in_path - 1]
-::error file=dir%0D::stop-commands::T%0D::error::INJECTED%0A::warning::pwn/lockfile::dir%0D::stop-commands::T%0D::error::INJECTED%0A::warning::pwn/lockfile%0A+---------+-----------------------+------+-----------------+---------------+%0A| PACKAGE | VULNERABILITY ID      | CVSS | CURRENT VERSION | FIXED VERSION |%0A+---------+-----------------------+------+-----------------+---------------+%0A| mine1   | https://osv.dev/OSV-1 |      | 1.2.3           |               |%0A+---------+-----------------------+------+-----------------+---------------+
+::error file=dir%0D%3A%3Astop-commands%3A%3AT%0D%3A%3Aerror%3A%3AINJECTED%0A%3A%3Awarning%3A%3Apwn/lockfile::dir%0D::stop-commands::T%0D::error::INJECTED%0A::warning::pwn/lockfile%0A+---------+-----------------------+------+-----------------+---------------+%0A| PACKAGE | VULNERABILITY ID      | CVSS | CURRENT VERSION | FIXED VERSION |%0A+---------+-----------------------+------+-----------------+---------------+%0A| mine1   | https://osv.dev/OSV-1 |      | 1.2.3           |               |%0A+---------+-----------------------+------+-----------------+---------------+
 ---
 
 [TestPrintGHAnnotationReport_WithVulnerabilities/two_sources_with_packages,_one_vulnerability - 1]

--- a/internal/output/githubannotation.go
+++ b/internal/output/githubannotation.go
@@ -56,6 +56,22 @@ func createDeprecationTable(source models.PackageSource) (table.Writer, bool) {
 	return deprecationTable, hasRow
 }
 
+func escapeGHCommandData(s string) string {
+	s = strings.ReplaceAll(s, "%", "%25")
+	s = strings.ReplaceAll(s, "\r", "%0D")
+	s = strings.ReplaceAll(s, "\n", "%0A")
+	return s
+}
+
+func escapeGHCommandProperty(s string) string {
+	s = strings.ReplaceAll(s, "%", "%25")
+	s = strings.ReplaceAll(s, "\r", "%0D")
+	s = strings.ReplaceAll(s, "\n", "%0A")
+	s = strings.ReplaceAll(s, ":", "%3A")
+	s = strings.ReplaceAll(s, ",", "%2C")
+	return s
+}
+
 // PrintGHAnnotationReport prints GitHub specific annotations to outputWriter
 func PrintGHAnnotationReport(vulnResult *models.VulnerabilityResults, outputWriter io.Writer) error {
 	flattened := vulnResult.Flatten()
@@ -79,33 +95,17 @@ func PrintGHAnnotationReport(vulnResult *models.VulnerabilityResults, outputWrit
 
 		artifactPath = filepath.ToSlash(artifactPath)
 
-		// Sanitize artifactPath to prevent GitHub Actions workflow command injection.
-		// \r and \n in the file= parameter can terminate the annotation early and inject
-		// arbitrary workflow commands (e.g. ::warning::, ::add-mask::) into the runner output.
-		artifactPath = strings.ReplaceAll(artifactPath, "\r", "%0D")
-		artifactPath = strings.ReplaceAll(artifactPath, "\n", "%0A")
-
 		remediationTable, hasVulnTable := createSourceRemediationTable(source, groupedFixedVersions)
 		if hasVulnTable {
 			renderedTable := remediationTable.Render()
-			// This is required as github action annotations must be on the same terminal line
-			// so we URL encode the new line character
-			renderedTable = strings.ReplaceAll(renderedTable, "\n", "%0A")
-			// Sanitize \r to prevent workflow command injection via carriage return in package names
-			renderedTable = strings.ReplaceAll(renderedTable, "\r", "%0D")
-
-			// Prepend the table with a new line to look nicer in the output
-			fmt.Fprintf(outputWriter, "::error file=%s::%s%s", artifactPath, artifactPath, "%0A"+renderedTable)
+			fmt.Fprintf(outputWriter, "::error file=%s::%s%s", escapeGHCommandProperty(artifactPath), escapeGHCommandData(artifactPath), "%0A"+escapeGHCommandData(renderedTable))
 		}
 
 		// Create and render package deprecation table
 		deprecationTable, hasDeprecationTable := createDeprecationTable(source)
 		if hasDeprecationTable {
 			renderedDeprecationTable := deprecationTable.Render()
-			renderedDeprecationTable = strings.ReplaceAll(renderedDeprecationTable, "\n", "%0A")
-			// Sanitize \r to prevent workflow command injection via carriage return in package names
-			renderedDeprecationTable = strings.ReplaceAll(renderedDeprecationTable, "\r", "%0D")
-			fmt.Fprintf(outputWriter, "::error file=%s::%s%s", artifactPath, artifactPath, "%0A"+renderedDeprecationTable)
+			fmt.Fprintf(outputWriter, "::error file=%s::%s%s", escapeGHCommandProperty(artifactPath), escapeGHCommandData(artifactPath), "%0A"+escapeGHCommandData(renderedDeprecationTable))
 		}
 	}
 

--- a/internal/output/githubannotation_test.go
+++ b/internal/output/githubannotation_test.go
@@ -114,3 +114,68 @@ func TestPrintGHAnnotationReport_CRSanitization(t *testing.T) {
 		t.Errorf("GH annotation output does not contain %%0D encoding for \\r character.\nOutput: %q", result)
 	}
 }
+
+// TestPrintGHAnnotationReport_Escaping verifies that characters like %, \r, \n, :, and ,
+// are correctly escaped in command properties and command data according to GitHub Actions docs.
+func TestPrintGHAnnotationReport_Escaping(t *testing.T) {
+	t.Parallel()
+
+	vulnResult := &models.VulnerabilityResults{
+		Results: []models.PackageSource{
+			{
+				Source: models.SourceInfo{
+					Path: "file,with:colon%and\r\nnewlines.json",
+					Type: "lockfile",
+				},
+				Packages: []models.PackageVulns{
+					{
+						Package: models.PackageInfo{
+							Name:      "pkg,with:colon%and\r\nnewlines",
+							Version:   "1.0.0",
+							Ecosystem: "npm",
+						},
+						Groups: []models.GroupInfo{
+							{
+								IDs:         []string{"GHSA-1234"},
+								MaxSeverity: "7.2",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	outputWriter := &bytes.Buffer{}
+	err := output.PrintGHAnnotationReport(vulnResult, outputWriter)
+	if err != nil {
+		t.Errorf("Error writing GH annotation output: %s", err)
+	}
+
+	result := outputWriter.String()
+
+	// Verify property escaping in the file= attribute
+	// file,with:colon%and\r\nnewlines.json -> file%2Cwith%3Acolon%25and%0D%0Anewlines.json
+	expectedProperty := "file%2Cwith%3Acolon%25and%0D%0Anewlines.json"
+	if !strings.Contains(result, "file="+expectedProperty+"::") {
+		t.Errorf("GH annotation output property not escaped properly.\nExpected property: %s\nOutput: %q", expectedProperty, result)
+	}
+
+	// Verify data escaping for % character in the message content
+	// The % should be escaped to %25
+	if !strings.Contains(result, "%25") {
+		t.Errorf("GH annotation output data does not contain %%25 encoding for %% character.\nOutput: %q", result)
+	}
+
+	// Verify data escaping for \r\n in the message content
+	// The \r\n should be escaped to %0D%0A
+	if !strings.Contains(result, "%0D%0A") {
+		t.Errorf("GH annotation output data does not contain %%0D%%0A encoding for \\r\\n character.\nOutput: %q", result)
+	}
+
+	// Verify that raw %, \r, \n are not present in the file property
+	if strings.Contains(result, "file=file,with:colon%and") {
+		t.Errorf("GH annotation output property contains unescaped special characters.\nOutput: %q", result)
+	}
+}
+


### PR DESCRIPTION
Implements the fix proposed in #2889 by hardening GitHub Actions workflow command escaping.

Changes
Added escapeGHCommandData() to escape %, \r, and \n in workflow command data.
Added escapeGHCommandProperty() to escape %, \r, \n, :, and , in workflow command properties.
Updated PrintGHAnnotationReport() to use the dedicated escaping helpers for both file= properties and annotation message data.
Replaced the previous inline escaping logic with the new helper functions.
Added TestPrintGHAnnotationReport_Escaping to verify correct escaping of special characters in both command properties and data.
Updated the relevant snapshot test to reflect the new escaping behavior.
Validation
✅ Existing tests pass.
✅ New regression test passes.
✅ Linting passes.
✅ Changes are minimal and focused solely on issue #2889.