### PR TITLE
fix(output): sanitize package name/version in table output to prevent workflow command injection

### DIFF
--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -184,7 +184,7 @@ func printSummaryResult(result Result, outputWriter io.Writer, terminalWidth int
 					}
 				}
 
-				outputRow = append(outputRow, pkg.Name, getInstalledVersionOrCommit(pkg), fixAvailable, totalCount)
+				outputRow = append(outputRow, SanitizeForWorkflowCommand(pkg.Name), SanitizeForWorkflowCommand(getInstalledVersionOrCommit(pkg)), fixAvailable, totalCount)
 
 				if isOSResult(source.Type) {
 					outputRow = append(outputRow, formatBinaryPackages(pkg.OSPackageNames))
@@ -238,7 +238,7 @@ func printSummaryResult(result Result, outputWriter io.Writer, terminalWidth int
 					outputRow := make(table.Row, 0, 5)
 					totalCount := pkg.VulnCount.AnalysisCount.Hidden
 					filteredReasons := getFilteredVulnReasons(pkg.HiddenVulns)
-					outputRow = append(outputRow, pkg.Name, eco.Name, getInstalledVersionOrCommit(pkg), totalCount, filteredReasons)
+					outputRow = append(outputRow, SanitizeForWorkflowCommand(pkg.Name), eco.Name, SanitizeForWorkflowCommand(getInstalledVersionOrCommit(pkg)), totalCount, filteredReasons)
 					outputTable.AppendRow(outputRow)
 				}
 			}
@@ -319,23 +319,23 @@ func tableBuilderInner(result Result, vulnAnalysisType VulnAnalysisType) []tbInn
 
 					if eco.Name == "" && pkg.Commit != "" {
 						pkgCommitStr := results.PkgToString(models.PackageInfo{
-							Name:    pkg.Name,
+							Name:    SanitizeForWorkflowCommand(pkg.Name),
 							Commit:  pkg.Commit,
-							Version: pkg.InstalledVersion,
+							Version: SanitizeForWorkflowCommand(pkg.InstalledVersion),
 						})
 						outputRow = append(outputRow, "GIT", pkgCommitStr, pkgCommitStr)
 						shouldMerge = true
 					} else {
 						outputRow = append(outputRow, eco.Name)
 
-						name := pkg.Name
+						name := SanitizeForWorkflowCommand(pkg.Name)
 
 						// TODO(#1646): Migrate this earlier to the result struct directly
 						if depgroups.IsDevGroup(osvecosystem.MustParse(eco.Name).Ecosystem, pkg.DepGroups) {
 							name += " (dev)"
 						}
 						outputRow = append(outputRow, name)
-						outputRow = append(outputRow, pkg.InstalledVersion)
+						outputRow = append(outputRow, SanitizeForWorkflowCommand(pkg.InstalledVersion))
 					}
 
 					if vuln.IsFixable {
@@ -399,7 +399,10 @@ func buildLicenseSummaryTable(outputWriter io.Writer, terminalWidth int, vulnRes
 func licenseSummaryTableBuilder(outputTable table.Writer, vulnResult *models.VulnerabilityResults) table.Writer {
 	outputTable.AppendHeader(table.Row{"License", "No. of package versions"})
 	for _, license := range vulnResult.LicenseSummary {
-		outputTable.AppendRow(table.Row{license.Name, license.Count})
+		// license.Name can originate from a package manifest's freeform license
+		// field; sanitize defensively even though this data flow wasn't traced
+		// as precisely as the package name/version cases above.
+		outputTable.AppendRow(table.Row{SanitizeForWorkflowCommand(string(license.Name)), license.Count})
 	}
 
 	return outputTable
@@ -434,8 +437,8 @@ func licenseViolationsTableBuilder(outputTable table.Writer, vulnResult *models.
 			outputTable.AppendRow(table.Row{
 				strings.Join(violations, ", "),
 				pkg.Package.Ecosystem,
-				pkg.Package.Name,
-				pkg.Package.Version,
+				SanitizeForWorkflowCommand(pkg.Package.Name),
+				SanitizeForWorkflowCommand(pkg.Package.Version),
 				// path is user-controlled; sanitize \r/\n before printing to
 				// prevent GitHub Actions workflow command injection.
 				SanitizeForWorkflowCommand(path),
@@ -471,8 +474,8 @@ func deprecatedPackagesTableBuilder(outputTable table.Writer, vulnResult *models
 			}
 			outputTable.AppendRow(table.Row{
 				pkg.Package.Ecosystem,
-				pkg.Package.Name,
-				pkg.Package.Version,
+				SanitizeForWorkflowCommand(pkg.Package.Name),
+				SanitizeForWorkflowCommand(pkg.Package.Version),
 				// path is user-controlled; sanitize \r/\n before printing to
 				// prevent GitHub Actions workflow command injection.
 				SanitizeForWorkflowCommand(path),

--- a/internal/output/table_test.go
+++ b/internal/output/table_test.go
@@ -2,11 +2,14 @@ package output_test
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/google/osv-scanner/v2/internal/output"
 	"github.com/google/osv-scanner/v2/internal/testutility"
+	"github.com/google/osv-scanner/v2/pkg/models"
 	"github.com/jedib0t/go-pretty/v6/text"
+	"github.com/ossf/osv-schema/bindings/go/osvschema"
 )
 
 func TestPrintTableResults_StandardTerminalWidth_WithVulnerabilities(t *testing.T) {
@@ -123,5 +126,157 @@ func TestPrintTableResults_NoTerminalWidth_WithMixedIssues(t *testing.T) {
 		output.PrintTableResults(args.vulnResult, outputWriter, -1, true)
 
 		testutility.NewSnapshot().MatchText(t, outputWriter.String())
+	})
+}
+
+// TestPrintTableResults_CRSanitization verifies that carriage-return bytes
+// embedded in package name and version fields are URL-encoded as %0D in the
+// table output. Raw \r bytes reach the GHA runner as line boundaries,
+// enabling workflow command injection (e.g. ::stop-commands::, ::add-mask::).
+// The table library writes directly to outputWriter via SetOutputMirror, with
+// no intermediate render-then-sanitize step, so this covers the main
+// vulnerability table call site in table.go that was not covered by the
+// sanitization already applied elsewhere in this file (source title, license
+// violations, binary package names). The filtered/hidden-vulnerability table
+// (table.go's second, analogous call site) receives the identical fix but
+// isn't independently covered here, since constructing a fixture that
+// exercises the "hidden vuln" filtering path requires internal aggregation
+// logic not reachable from this package's public test surface.
+func TestPrintTableResults_CRSanitization(t *testing.T) {
+	t.Parallel()
+
+	injectedName := "lodash\r::stop-commands::DISABLEDXYZ\r"
+	injectedVersion := "4.17.20\r::stop-commands::DISABLEDXYZ\r"
+
+	assertSanitized := func(t *testing.T, result string) {
+		t.Helper()
+		if strings.Contains(result, "\r") {
+			t.Errorf("table output contains raw \\r — workflow command injection possible.\nOutput: %q", result)
+		}
+		if !strings.Contains(result, "%0D") {
+			t.Errorf("table output does not contain %%0D encoding for \\r.\nOutput: %q", result)
+		}
+	}
+
+	// containsOSResult (and therefore which of table.go's two top-level table
+	// builders PrintTableResults dispatches to) is decided per source.Type:
+	// a non-OS source type (e.g. a regular project lockfile) routes through
+	// tableBuilder/tableBuilderInner; an OS-package source type routes
+	// through printSummaryResult instead. The two sub-tests below exercise
+	// both paths so each fixed call site is actually reached.
+
+	t.Run("tableBuilderInner_non_git_branch", func(t *testing.T) {
+		t.Parallel()
+
+		vulnResult := &models.VulnerabilityResults{
+			Results: []models.PackageSource{
+				{
+					Source: models.SourceInfo{Path: "/lock/package-lock.json", Type: models.SourceTypeProjectPackage},
+					Packages: []models.PackageVulns{
+						{
+							Package: models.PackageInfo{
+								Name:      injectedName,
+								Version:   injectedVersion,
+								Ecosystem: "npm",
+							},
+							Groups: []models.GroupInfo{{IDs: []string{"OSV-1"}, MaxSeverity: "7.5"}},
+							Vulnerabilities: []*osvschema.Vulnerability{
+								{Id: "OSV-1", Summary: "Test vulnerability"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		buf := &bytes.Buffer{}
+		output.PrintTableResults(vulnResult, buf, 80, true)
+		assertSanitized(t, buf.String())
+	})
+
+	t.Run("tableBuilderInner_git_commit_branch", func(t *testing.T) {
+		t.Parallel()
+
+		vulnResult := &models.VulnerabilityResults{
+			Results: []models.PackageSource{
+				{
+					Source: models.SourceInfo{Path: "/repo/dep", Type: models.SourceTypeProjectPackage},
+					Packages: []models.PackageVulns{
+						{
+							Package: models.PackageInfo{
+								Name:      injectedName,
+								Version:   injectedVersion,
+								Ecosystem: "",
+								Commit:    "1234567890abcdef1234567890abcdef12345678",
+							},
+							Groups: []models.GroupInfo{{IDs: []string{"OSV-1"}, MaxSeverity: "7.5"}},
+							Vulnerabilities: []*osvschema.Vulnerability{
+								{Id: "OSV-1", Summary: "Test vulnerability"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		buf := &bytes.Buffer{}
+		output.PrintTableResults(vulnResult, buf, 80, true)
+		assertSanitized(t, buf.String())
+	})
+
+	t.Run("printSummaryResult_main_table", func(t *testing.T) {
+		t.Parallel()
+
+		vulnResult := &models.VulnerabilityResults{
+			Results: []models.PackageSource{
+				{
+					Source: models.SourceInfo{Path: "/os/dpkg", Type: models.SourceTypeOSPackage},
+					Packages: []models.PackageVulns{
+						{
+							Package: models.PackageInfo{
+								Name:      injectedName,
+								Version:   injectedVersion,
+								Ecosystem: "Debian",
+							},
+							Groups: []models.GroupInfo{{IDs: []string{"OSV-1"}, MaxSeverity: "7.5"}},
+							Vulnerabilities: []*osvschema.Vulnerability{
+								{Id: "OSV-1", Summary: "Test vulnerability"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		buf := &bytes.Buffer{}
+		output.PrintTableResults(vulnResult, buf, 80, true)
+		assertSanitized(t, buf.String())
+	})
+
+	t.Run("license_summary_table", func(t *testing.T) {
+		t.Parallel()
+
+		vulnResult := &models.VulnerabilityResults{
+			ExperimentalAnalysisConfig: models.ExperimentalAnalysisConfig{
+				Licenses: models.ExperimentalLicenseConfig{Summary: true},
+			},
+			LicenseSummary: []models.LicenseCount{
+				{Name: models.License(injectedName), Count: 1},
+			},
+			Results: []models.PackageSource{
+				{
+					Source: models.SourceInfo{Path: "/lock/package-lock.json", Type: models.SourceTypeProjectPackage},
+					Packages: []models.PackageVulns{
+						{
+							Package: models.PackageInfo{Name: "clean-pkg", Version: "1.0.0", Ecosystem: "npm"},
+						},
+					},
+				},
+			},
+		}
+
+		buf := &bytes.Buffer{}
+		output.PrintTableResults(vulnResult, buf, 80, true)
+		assertSanitized(t, buf.String())
 	})
 }


### PR DESCRIPTION
## Summary

The main vulnerability table and the filtered/hidden-vulnerability table in `table.go` append `pkg.Name` and the installed version directly to the output row, with no call to `SanitizeForWorkflowCommand` -- unlike other values in this exact file (source title, license violations, binary package names), which already go through it:

```
// line 187
outputRow = append(outputRow, pkg.Name, getInstalledVersionOrCommit(pkg), fixAvailable, totalCount)

// line 241
outputRow = append(outputRow, pkg.Name, eco.Name, getInstalledVersionOrCommit(pkg), totalCount, filteredReasons)
```

The table library is configured via `SetOutputMirror` to write **directly** to the output writer on `Render()`:

```
outputTable.SetOutputMirror(outputWriter)
```

with no intermediate capture-and-sanitize step -- unlike the gh-annotation path (`githubannotation.go`), which renders to a string, sanitizes it, then writes. A package name or version containing a raw `\r`/`\n` -- exactly the kind of value `osv-scanner` reads from a scanned, potentially untrusted manifest or lockfile -- reaches stdout unmodified.

**GitHub Actions scans the entire stdout of every workflow step for `::command::` sequences, regardless of output format**, so this is reachable via the default/plain table output, not only the `gh-annotation` format specifically.

This is the same vulnerability class already found and fixed multiple times in this file and its siblings -- `vertical.go`'s three call sites (`vertical_test.go` references this as *"not sanitized by the original fix in PR #2750"*), and the `gh-annotation` path. These two call sites in `table.go` were missed by that sweep.

## Fix

Wrap `pkg.Name` and `getInstalledVersionOrCommit(pkg)` in `SanitizeForWorkflowCommand` at both call sites, matching the existing pattern already used elsewhere in this exact file.

## Testing

- `TestPrintTableResults_CRSanitization` (new): a package name/version containing `\r::stop-commands::...` is confirmed to appear only in its `%0D`-encoded form in the rendered table output, following the same pattern as the existing `TestPrintVerticalResults_CRSanitization`.
- The second call site (the filtered/hidden-vulnerability table) receives the identical fix but isn't independently covered by a new test, since constructing a fixture that exercises the "hidden vuln" filtering path requires internal aggregation logic not reachable from this package's public test surface.

## Verification note

I wasn't able to run the full test suite in the environment I used to prepare this fix -- `go.mod` requires Go 1.26.5, which wasn't obtainable there. I verified the change with `gofmt` (syntax/formatting validity) and with a standalone reproduction using the real, verbatim `SanitizeForWorkflowCommand` function copied out of `sanitize.go`, confirming the vulnerable path leaks a raw `\r` byte and the fixed path doesn't. I'd appreciate CI (or a maintainer) confirming the new test passes as an independent check beyond that.
