### PR TITLE
fix: Readd support for OSV_SCANNER_LOCAL_DB_CACHE_DIRECTORY

### DIFF
--- a/cmd/osv-scanner/fix/command.go
+++ b/cmd/osv-scanner/fix/command.go
@@ -199,9 +199,10 @@ func Command(stdout, _ io.Writer, clientFactories config.ClientFactories) *cli.C
 				Usage: "downloads vulnerability databases for offline comparison",
 			},
 			&cli.StringFlag{
-				Name:   "local-db-path",
-				Usage:  "sets the path that local databases should be stored",
-				Hidden: true,
+				Name:    "local-db-path",
+				Usage:   "sets the path that local databases should be stored",
+				Sources: cli.EnvVars("OSV_SCANNER_LOCAL_DB_CACHE_DIRECTORY"),
+				Hidden:  true,
 			},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {

--- a/cmd/osv-scanner/internal/helper/flags.go
+++ b/cmd/osv-scanner/internal/helper/flags.go
@@ -157,9 +157,10 @@ func BuildCommonScanFlags(defaultExtractors []string) []cli.Flag {
 			Usage: "downloads vulnerability databases for offline comparison",
 		},
 		&cli.StringFlag{
-			Name:   "local-db-path",
-			Usage:  "sets the path that local databases should be stored",
-			Hidden: true,
+			Name:    "local-db-path",
+			Usage:   "sets the path that local databases should be stored",
+			Sources: cli.EnvVars("OSV_SCANNER_LOCAL_DB_CACHE_DIRECTORY"),
+			Hidden:  true,
 		},
 		&cli.StringSliceFlag{
 			Name:  "call-analysis",


### PR DESCRIPTION
Partially fixes #2983

The migration to use osv-scalibr end-to-end replaced the `OSV_SCANNER_LOCAL_DB_CACHE_DIRECTORY` environment variable with `OSV_SCALIBR_LOCAL_DB_CACHE_DIRECTORY`.

Because the `SCANNER` env var was never provided to scalibr, the localmatcher defaulted back to the `~/.cache/osv-scalibr/` directory.

This PR binds the original environment variable to `local-db-path`, ensuring it is correctly passed to osv-scalibr.