### PR TITLE
fix(spdx): bound recursion depth when parsing license expressions

### DIFF
--- a/internal/spdx/satisfies.go
+++ b/internal/spdx/satisfies.go
@@ -55,8 +55,17 @@ func (n nodeLeaf) satisfiedBy(licenses []string) bool {
 
 var _ node = nodeLeaf{}
 
+// maxDepth bounds how deeply nested the parser will recurse into bracketed
+// sub-expressions. License expressions are supplied by scanned package
+// metadata, which is untrusted; without a limit a deeply nested expression
+// (e.g. many "(") recurses until the goroutine stack overflows, which is a
+// fatal error that recover cannot catch. Real SPDX expressions nest only a
+// handful of levels, so this ceiling is far above any legitimate input.
+const maxDepth = 1000
+
 type tokens struct {
 	tokens []string
+	depth  int
 }
 
 // peek returns the next token in the list of tokens, or otherwise an empty string
@@ -219,10 +228,16 @@ func parseExpression(tokens *tokens) (node, error) {
 	}
 
 	if next == "(" {
+		tokens.depth++
+		if tokens.depth > maxDepth {
+			return nil, fmt.Errorf("license expression nested too deeply (limit %d)", maxDepth)
+		}
+
 		expr, err := parseOr(tokens)
 		if err != nil {
 			return nil, err
 		}
+		tokens.depth--
 
 		if tokens.peek() != ")" {
 			return nil, errors.New("missing closing bracket")

--- a/internal/spdx/satisfies_test.go
+++ b/internal/spdx/satisfies_test.go
@@ -418,3 +418,28 @@ func TestSatisfies_Invalid(t *testing.T) {
 		})
 	}
 }
+
+func TestSatisfies_DeeplyNested(t *testing.T) {
+	t.Parallel()
+
+	// A license expression is untrusted input taken from scanned package
+	// metadata. Deeply nested brackets must be rejected with an error rather
+	// than recursing until the goroutine stack overflows, which is a fatal
+	// error that recover cannot catch. The input is built here rather than
+	// listed in the table above so the generated subtest name stays readable.
+	license := models.License(strings.Repeat("(", 2_000_000) + "MIT" + strings.Repeat(")", 2_000_000))
+
+	got, err := spdx.Satisfies(license, []string{"MIT"})
+
+	if got {
+		t.Errorf("Satisfies(deeply nested) = %v, want %v", got, false)
+	}
+
+	if err == nil {
+		t.Fatal("Satisfies(deeply nested) = nil error, want a nesting-limit error")
+	}
+
+	if !strings.Contains(err.Error(), "nested too deeply") {
+		t.Errorf("Satisfies(deeply nested) = %v, want a nesting-limit error", err)
+	}
+}


### PR DESCRIPTION
## Overview

Fixes #2993.

`spdx.Satisfies` parses SPDX license expressions with an unbounded recursive
descent. Because license strings come from the metadata of packages in the
scanned target, a crafted expression with deeply nested brackets recurses until
the goroutine stack overflows. That is a Go fatal error which `recover` cannot
catch, so the whole scan process aborts.

This is a single, self-contained change addressing the specific issue I filed
(#2993), which I intend to shepherd through review myself. It is distinct from
the empty-token index panic in #2968; the `next()` bounds check discussed there
does not bound recursion depth.

## Details

The recursion runs `parseOr -> parseAnd -> parseExpression`, and
`parseExpression` calls back into `parseOr` on every `(`, with no limit on
nesting depth. On this machine the crash threshold sits between 1,000,000
nested brackets (survives) and 1,500,000 (overflows), roughly a 3 MB license
string.

The fix threads a nesting-depth counter through the descent and returns an
ordinary parse error once it passes a generous ceiling:

- a `depth` field is added to the `tokens` struct, incremented when
  `parseExpression` recurses into a bracketed sub-expression, and
- when the depth exceeds `maxDepth` (1000), the parser returns a normal error
  rather than recursing further.

Real SPDX expressions nest only a few levels, so the ceiling rejects nothing
legitimate. An over-nested expression is now rejected the same way as any other
invalid input, instead of terminating the process. CWE-674 (Uncontrolled
Recursion).

## Testing

- Added `TestSatisfies_DeeplyNested` in `internal/spdx/satisfies_test.go`, which
  drives a deeply nested expression and asserts a parse error rather than a
  crash. It triggers a fatal stack overflow without this change and passes with
  it.
- Ran the full package suite: `go test ./internal/spdx/...` passes.
- `gofmt` and `go vet ./internal/spdx/` are clean.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/).
- [x] I have run the linter (`gofmt`, `go vet`) on the changed package.
- [x] I have run the unit tests for the changed package and all tests pass.
- [x] I have made my commits and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

If the maintainers would prefer to assign #2993 before review, I am happy to
wait; opening the pull request here to make the proposed fix concrete.
