### PR TITLE
fix(output): don't panic on an unparsable fixed version

### DIFF
--- a/internal/output/output_result.go
+++ b/internal/output/output_result.go
@@ -581,13 +581,22 @@ func getNextFixVersion(allAffected []*osvschema.Affected, installedVersion strin
 		}
 		for _, affectedRange := range affected.GetRanges() {
 			for _, affectedEvent := range affectedRange.GetEvents() {
-				order, _ := vp.CompareStr(affectedEvent.GetFixed())
+				order, err := vp.CompareStr(affectedEvent.GetFixed())
 				// Skip if it's not a fix version event or the installed version is greater than the fix version.
-				if affectedEvent.GetFixed() == "" || order > 0 {
+				// A fixed version this ecosystem's parser rejects is skipped too: it cannot be
+				// compared, so it cannot be offered as the next fix. Advisories are third-party
+				// data, and using MustParse here aborted the whole scan after matching had already
+				// succeeded — the same reason the installed version above degrades instead of panicking.
+				if affectedEvent.GetFixed() == "" || err != nil || order > 0 {
 					continue
 				}
 
-				order, _ = semantic.MustParse(affectedEvent.GetFixed(), ecosystemPrefix).CompareStr(minFixVersion)
+				fixedVersion, err := semantic.Parse(affectedEvent.GetFixed(), ecosystemPrefix)
+				if err != nil {
+					continue
+				}
+
+				order, _ = fixedVersion.CompareStr(minFixVersion)
 				// Find the minimum fix version
 				if minFixVersion == UnfixedDescription || order < 0 {
 					minFixVersion = affectedEvent.GetFixed()

--- a/internal/output/output_result_internal_test.go
+++ b/internal/output/output_result_internal_test.go
@@ -1,0 +1,70 @@
+package output
+
+import (
+	"testing"
+
+	"github.com/ossf/osv-schema/bindings/go/osvschema"
+)
+
+// A `fixed` value the ecosystem's parser rejects must not abort the scan. Advisory
+// data is third-party input, and result building runs after matching has already
+// succeeded, so a panic here loses an otherwise complete scan.
+func TestGetNextFixVersion_UnparsableFixedVersion(t *testing.T) {
+	t.Parallel()
+
+	affected := []*osvschema.Affected{
+		{
+			Package: &osvschema.Package{Ecosystem: "CRAN", Name: "mypkg"},
+			Versions: []string{"1.0.0"},
+			Ranges: []*osvschema.Range{
+				{
+					Type: osvschema.Range_ECOSYSTEM,
+					Events: []*osvschema.Event{
+						{Introduced: "0"},
+						{Fixed: "notaversion"},
+					},
+				},
+			},
+		},
+	}
+
+	hasFix, fixVersion := getNextFixVersion(affected, "1.0.0", "mypkg", "CRAN")
+
+	if hasFix {
+		t.Errorf("getNextFixVersion() reported a fix from an unparsable version, got %q", fixVersion)
+	}
+	if fixVersion != UnfixedDescription {
+		t.Errorf("getNextFixVersion() = %q, want %q", fixVersion, UnfixedDescription)
+	}
+}
+
+// An unparsable entry must not hide a valid fix that appears alongside it.
+func TestGetNextFixVersion_UnparsableAlongsideValid(t *testing.T) {
+	t.Parallel()
+
+	affected := []*osvschema.Affected{
+		{
+			Package: &osvschema.Package{Ecosystem: "CRAN", Name: "mypkg"},
+			Versions: []string{"1.0.0"},
+			Ranges: []*osvschema.Range{
+				{
+					Type: osvschema.Range_ECOSYSTEM,
+					Events: []*osvschema.Event{
+						{Introduced: "0"},
+						{Fixed: "notaversion"},
+						{Fixed: "2.0.0"},
+					},
+				},
+			},
+		},
+	}
+
+	hasFix, fixVersion := getNextFixVersion(affected, "1.0.0", "mypkg", "CRAN")
+
+	if !hasFix {
+		t.Fatal("getNextFixVersion() found no fix, want the valid one alongside the unparsable entry")
+	}
+	if fixVersion != "2.0.0" {
+		t.Errorf("getNextFixVersion() = %q, want %q", fixVersion, "2.0.0")
+	}
+}


### PR DESCRIPTION
Fixes #2936.

I asked to be assigned on the issue first per CONTRIBUTING, and I'm opening this so the change is concrete rather than described — happy for it to be closed if you'd rather not take it, or to adjust the approach.

## The bug

`getNextFixVersion` parses every range event's `fixed` value with `semantic.MustParse`, which panics when the ecosystem's parser rejects the value.

The guard above it does not prevent this:

```go
order, _ := vp.CompareStr(affectedEvent.GetFixed())
if affectedEvent.GetFixed() == "" || order > 0 {
    continue
}
order, _ = semantic.MustParse(affectedEvent.GetFixed(), ecosystemPrefix).CompareStr(minFixVersion)
```

`CompareStr` returns `(0, err)` for a version it cannot parse and the error is discarded, so `order` stays `0`, the `order > 0` skip does not fire, and execution reaches `MustParse`.

Advisories are third-party data, and result building runs *after* matching has already succeeded, so a single unparsable `fixed` value aborts an otherwise complete scan. Every output format goes through `BuildResults`, so table, JSON, SARIF and HTML are all affected.

## The change

Use `semantic.Parse` and skip the event when it fails: a version that cannot be compared cannot be offered as the next fix.

This mirrors what the same function already does one branch earlier — an unparsable *installed* version returns `N/A` rather than panicking — so the `fixed` value was the only place here that crashed instead of degrading. A valid fix listed alongside an unparsable one is still reported, which the second test covers.

It is also the same class the match path was hardened against in #2867 and #2837; neither touched the output path.

## Verification

- With this change reverted, the new test fails with the real crash: `panic: invalid version: 'notaversion' is not allowed`. With it applied, both new tests pass.
- The full `internal/output` package is green (`go test ./internal/output/`), and `go vet` is clean.

## Note on reproduction

As discussed on the issue, no currently published advisory triggers this — the reporter checked `fixed` values across the validating ecosystems and found none that fail on this path. I'd still suggest it is worth guarding: the input is third-party, the crash discards a completed scan, and the surrounding code already treats the neighbouring field defensively.