### PR TITLE
feat(config): surface config suppressions and add --no-config-ignore

### DIFF
--- a/cmd/osv-scanner/internal/helper/flags.go
+++ b/cmd/osv-scanner/internal/helper/flags.go
@@ -57,6 +57,11 @@ func BuildCommonScanFlags(defaultExtractors []string) []cli.Flag {
 			Usage:     "set/override config file",
 			TakesFile: true,
 		},
+		&cli.BoolFlag{
+			Name:  "no-config-ignore",
+			Usage: "ignore IgnoredVulns and PackageOverrides ignore directives from osv-scanner.toml files discovered next to scanned manifests (a config passed with --config is unaffected)",
+			Value: false,
+		},
 		&cli.StringFlag{
 			Name:    "format",
 			Aliases: []string{"f"},

--- a/cmd/osv-scanner/internal/helper/getters.go
+++ b/cmd/osv-scanner/internal/helper/getters.go
@@ -37,6 +37,7 @@ func GetCommonScannerActions(cmd *cli.Command, scanLicensesAllowlist []string) o
 	return osvscanner.ScannerActions{
 		IncludeGitRoot:        cmd.Bool("include-git-root"),
 		ConfigOverridePath:    cmd.String("config"),
+		NoConfigIgnore:        cmd.Bool("no-config-ignore"),
 		ShowAllPackages:       cmd.Bool("all-packages"),
 		ShowAllVulns:          cmd.Bool("all-vulns"),
 		CompareOffline:        cmd.Bool("offline-vulnerabilities"),

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,6 +22,12 @@ To configure scanning, place an osv-scanner.toml file in the scanned file's dire
 
 To override `osv-scanner.toml` files, pass the `--config=/path/to/config.toml` flag with the path to the configuration you want to apply instead, this will apply `config.toml` to all files parsed, and ignore `osv-scanner.toml` in all directories.
 
+## A note on trust
+
+An auto-discovered `osv-scanner.toml` is read from the directory of each manifest that is scanned, including directories inside the scanned tree that you did not author yourself, such as a vendored dependency, a git submodule, an extracted archive, or a directory added by a pull request. Its `IgnoredVulns` and `PackageOverrides` `ignore` directives suppress findings for that directory. This means code you are scanning can carry a config that hides its own vulnerabilities from the result.
+
+Whenever a config suppresses a finding, osv-scanner logs it at warning level (the config path, each suppressed vulnerability, and a count), so a suppressed result is not silent even at reduced verbosity. To refuse suppression directives that come from auto-discovered configs entirely, pass `--no-config-ignore`; a config you supply yourself with `--config` is always honored. Use `--no-config-ignore` when scanning code you do not fully control, for example in CI on pull requests or over vendored third-party trees.
+
 ## Ignore vulnerabilities by ID
 
 To ignore a vulnerability, enter the ID under the `IgnoreVulns` key. Optionally, add an expiry date or reason.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -80,6 +80,39 @@ func (e PackageOverrideEntry) matches(pkg *extractor.Package) bool {
 	return true
 }
 
+// withoutVulnIgnores returns a copy of the config with every directive that
+// suppresses a vulnerability removed: the IgnoredVulns list and the ignore
+// flags on any PackageOverrides. License overrides and the remaining fields are
+// left intact. It is used for configs discovered inside the scanned tree when
+// in-tree ignores have been disabled, so a config planted in the scanned tree
+// cannot hide findings.
+func (c Config) withoutVulnIgnores() Config {
+	dropped := len(c.IgnoredVulns)
+
+	overrides := make([]PackageOverrideEntry, 0, len(c.PackageOverrides))
+	for _, o := range c.PackageOverrides {
+		if o.Ignore || o.Vulnerability.Ignore {
+			dropped++
+			o.Ignore = false
+			o.Vulnerability.Ignore = false
+		}
+		overrides = append(overrides, o)
+	}
+
+	c.IgnoredVulns = nil
+	c.PackageOverrides = overrides
+
+	if dropped > 0 {
+		cmdlogger.Warnf(
+			"Ignored %d vulnerability-suppressing directive/s from %s because in-tree config ignores are disabled",
+			dropped,
+			c.LoadPath,
+		)
+	}
+
+	return c
+}
+
 type Vulnerability struct {
 	Ignore bool `toml:"ignore"`
 }

--- a/internal/config/config_internal_test.go
+++ b/internal/config/config_internal_test.go
@@ -1359,3 +1359,55 @@ func TestConfig_ShouldOverridePackageLicense(t *testing.T) {
 		})
 	}
 }
+
+func TestConfig_withoutVulnIgnores(t *testing.T) {
+	t.Parallel()
+
+	pkg := &extractor.Package{
+		Name:     "lib1",
+		Version:  "1.0.0",
+		PURLType: purl.TypeGolang,
+	}
+
+	config := Config{
+		LoadPath: "/some/scanned/subdir/osv-scanner.toml",
+		IgnoredVulns: []*IgnoreEntry{
+			{ID: "GO-2022-0968"},
+		},
+		PackageOverrides: []PackageOverrideEntry{
+			{
+				Name:          "lib1",
+				Ecosystem:     "Go",
+				Ignore:        true,
+				Vulnerability: Vulnerability{Ignore: true},
+				License:       License{Override: []string{"MIT"}},
+			},
+		},
+	}
+
+	stripped := config.withoutVulnIgnores()
+
+	// The vulnerability-suppressing directives are gone.
+	if ignore, _ := stripped.ShouldIgnore("GO-2022-0968"); ignore {
+		t.Error("withoutVulnIgnores() still ignores a vulnerability by ID")
+	}
+	if ignore, _ := stripped.ShouldIgnorePackage(pkg); ignore {
+		t.Error("withoutVulnIgnores() still ignores a package")
+	}
+	if stripped.ShouldIgnorePackageVulnerabilities(pkg) {
+		t.Error("withoutVulnIgnores() still ignores a package's vulnerabilities")
+	}
+
+	// The non-suppressing license override is preserved.
+	if ok, entry := stripped.ShouldOverridePackageLicense(pkg); !ok || !reflect.DeepEqual(entry.License.Override, []string{"MIT"}) {
+		t.Errorf("withoutVulnIgnores() dropped the license override: ok=%v entry=%+v", ok, entry)
+	}
+
+	// The original config is left untouched.
+	if ignore, _ := config.ShouldIgnore("GO-2022-0968"); !ignore {
+		t.Error("withoutVulnIgnores() mutated the original config's IgnoredVulns")
+	}
+	if ignore, _ := config.ShouldIgnorePackage(pkg); !ignore {
+		t.Error("withoutVulnIgnores() mutated the original config's PackageOverrides")
+	}
+}

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -19,6 +19,14 @@ type Manager struct {
 	DefaultConfig Config
 	// Cache to store loaded configs
 	ConfigMap map[string]Config
+	// DisableInTreeIgnores drops the vulnerability-suppressing directives
+	// (IgnoredVulns and PackageOverrides with an ignore flag) from configs that
+	// are auto-discovered next to the scanned manifests. It does not affect a
+	// config supplied explicitly with --config via OverrideConfig, which the
+	// user has chosen and therefore trusts. This lets a scan refuse suppression
+	// directives that live inside the scanned tree, where they may have been
+	// planted by code the person running the scan did not author.
+	DisableInTreeIgnores bool
 }
 
 // UseOverride updates the Manager to use the config at the given path in place
@@ -54,7 +62,13 @@ func (m *Manager) Get(targetPath string) Config {
 
 	config, configErr := tryLoadConfig(configPath)
 	if configErr == nil {
-		cmdlogger.Infof("Loaded filter from: %s", config.LoadPath)
+		if m.DisableInTreeIgnores {
+			config = config.withoutVulnIgnores()
+		}
+		// A discovered config can suppress findings, so surface it at warn level
+		// rather than burying it at info where a reduced-verbosity run would drop
+		// it while the exit code still reflected the suppressed result.
+		cmdlogger.Warnf("Loaded filter from: %s", config.LoadPath)
 	} else {
 		// anything other than the config file not existing is most likely due to an invalid config file
 		if !errors.Is(configErr, os.ErrNotExist) {

--- a/internal/scalibrannotator/filter/filter.go
+++ b/internal/scalibrannotator/filter/filter.go
@@ -148,9 +148,11 @@ func (a *Annotator) Annotate(_ context.Context, _ *annotator.ScanInput, results 
 		cmdlogger.Warnf("%s", warn)
 	}
 
+	// These are packages suppressed by config (ShouldIgnorePackage), so they
+	// hide findings and must stay visible at reduced verbosity.
 	slices.Sort(infos)
 	for _, info := range infos {
-		cmdlogger.Infof("%s", info)
+		cmdlogger.Warnf("%s", info)
 	}
 
 	if unscannableCount > 0 {
@@ -160,7 +162,7 @@ func (a *Annotator) Annotate(_ context.Context, _ *annotator.ScanInput, results 
 		cmdlogger.Infof("Filtered %d non container relevant package/s from the scan.", nonContainerRelevantCount)
 	}
 	if ignoredCount > 0 {
-		cmdlogger.Infof("Filtered %d ignored package/s from the scan.", ignoredCount)
+		cmdlogger.Warnf("Filtered %d ignored package/s from the scan.", ignoredCount)
 	}
 
 	slices.SortFunc(packageResults, scalibr.CmpPackages)

--- a/pkg/osvscanner/filter.go
+++ b/pkg/osvscanner/filter.go
@@ -54,13 +54,15 @@ func filterPackageVulns(pkgVulns models.PackageVulns, configToUse config.Config)
 				}
 
 				// NB: This only prints the first reason encountered in all the aliases.
+				// Warn rather than info: this hides a known vulnerability from the
+				// result, so it must stay visible at reduced verbosity.
 				switch len(group.Aliases) {
 				case 1:
-					cmdlogger.Infof("%s has been filtered out because: %s", ignoreLine.ID, reason)
+					cmdlogger.Warnf("%s has been filtered out because: %s", ignoreLine.ID, reason)
 				case 2:
-					cmdlogger.Infof("%s and 1 alias have been filtered out because: %s", ignoreLine.ID, reason)
+					cmdlogger.Warnf("%s and 1 alias have been filtered out because: %s", ignoreLine.ID, reason)
 				default:
-					cmdlogger.Infof("%s and %d aliases have been filtered out because: %s", ignoreLine.ID, len(group.Aliases)-1, reason)
+					cmdlogger.Warnf("%s and %d aliases have been filtered out because: %s", ignoreLine.ID, len(group.Aliases)-1, reason)
 				}
 
 				ignoreLine.MarkAsUsed()

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -48,6 +48,10 @@ type ScannerActions struct {
 	Image              string
 	IsImageArchive     bool
 	ConfigOverridePath string
+	// NoConfigIgnore drops vulnerability-suppressing directives from
+	// osv-scanner.toml files discovered next to the scanned manifests. A config
+	// passed explicitly with --config is unaffected.
+	NoConfigIgnore     bool
 	CallAnalysisStates map[string]bool
 	ShowAllPackages    bool
 	ShowAllVulns       bool
@@ -130,8 +134,9 @@ func DoScan(actions ScannerActions) (models.VulnerabilityResults, error) {
 
 	scanResults := results.ScanResults{
 		ConfigManager: config.Manager{
-			DefaultConfig: config.Config{},
-			ConfigMap:     make(map[string]config.Config),
+			DefaultConfig:        config.Config{},
+			ConfigMap:            make(map[string]config.Config),
+			DisableInTreeIgnores: actions.NoConfigIgnore,
 		},
 	}
 
@@ -169,8 +174,9 @@ func DoScan(actions ScannerActions) (models.VulnerabilityResults, error) {
 func DoContainerScan(actions ScannerActions) (models.VulnerabilityResults, error) {
 	scanResults := results.ScanResults{
 		ConfigManager: config.Manager{
-			DefaultConfig: config.Config{},
-			ConfigMap:     make(map[string]config.Config),
+			DefaultConfig:        config.Config{},
+			ConfigMap:            make(map[string]config.Config),
+			DisableInTreeIgnores: actions.NoConfigIgnore,
 		},
 	}
 
@@ -291,7 +297,10 @@ func finalizeScanResult(scanResult results.ScanResults, actions ScannerActions) 
 
 	filtered := filterResults(&vulnerabilityResults, &scanResult.ConfigManager, actions.ShowAllPackages)
 	if filtered > 0 {
-		cmdlogger.Infof(
+		// Warn rather than info: this count is how many known vulnerabilities the
+		// config removed from the result, so it must survive a reduced-verbosity
+		// run where the exit code alone would otherwise read as clean.
+		cmdlogger.Warnf(
 			"Filtered %d %s from output",
 			filtered,
 			output.Form(filtered, "vulnerability", "vulnerabilities"),


### PR DESCRIPTION
`Manager.Get` loads an `osv-scanner.toml` from the directory of each scanned manifest and applies its `IgnoredVulns` and `PackageOverrides` `ignore` directives to that directory's results. During a recursive scan this reaches directories the person running the scan did not author: a vendored dependency, a git submodule, an extracted archive, or a folder added by a pull request. A config placed in such a directory suppresses findings for it, so scanned code can carry a config that hides its own vulnerabilities. A single `[[PackageOverrides]]` with `nameIsRegex = true`, `name = ".*"`, `ignore = true` blanks the whole subtree without naming a vulnerability.

The suppression was only logged at info level, so under `--verbosity warn` (or a JSON/SARIF run) the scan printed "No issues found" and exited 0 with no trace, even though known-vulnerable packages had been dropped.

This raises every config-driven suppression to warning level, in both the vulnerability filter and the package annotator: the loaded config path, each suppressed vulnerability or package, and the filtered count. A suppressed result is now visible at the verbosity most CI runs use.

It also adds `--no-config-ignore`, which drops the vulnerability-suppressing directives (`IgnoredVulns` and the `ignore` flags on `PackageOverrides`) from auto-discovered configs while leaving license overrides in place. A config supplied explicitly with `--config` is trusted and unaffected. This gives a scan over code you do not fully control, such as CI on pull requests or vendored third-party trees, a way to refuse in-tree suppression outright. The docs gain a short trust note describing both.

`go test ./internal/config/... ./internal/scalibrannotator/... ./pkg/osvscanner/...` passes, including a new `config` test for the strict-mode helper. The log changes preserve message text, so existing stdout snapshots are unaffected at the default info verbosity.
