### PR TITLE
docs: Add local pre-commit hook integration guide for developers

### DIFF
--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -287,3 +287,37 @@ jobs:
 ```
 
 </details>
+
+## Local Pre-Commit Hook Integration
+
+To catch vulnerable dependencies locally before committing and pushing to your repository, you can integrate `osv-scanner` directly into your local Git workflows using [`pre-commit`](https://pre-commit.com/):
+
+### Configuration
+
+Add the following to your `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+  - repo: local
+    hooks:
+      - id: osv-scanner
+        name: OSV-Scanner Vulnerability Check
+        entry: osv-scanner scan source -r .
+        language: system
+        pass_filenames: false
+        always_run: true
+```
+
+Alternatively, you can create a standard `.git/hooks/pre-commit` script:
+
+```bash
+#!/bin/sh
+# Check for known open-source vulnerabilities before committing
+echo "Running OSV-Scanner dependency check..."
+osv-scanner scan source -r .
+if [ $? -ne 0 ]; then
+  echo "❌ Commit rejected: Vulnerabilities found in project dependencies."
+  echo "Run 'osv-scanner fix' or upgrade affected packages."
+  exit 1
+fi
+```


### PR DESCRIPTION
### 📖 Description

Adds a dedicated **Local Pre-Commit Hook Integration** section to docs/github-action.md.

### 🛡️ What this Adds
- Provides ready-to-use .pre-commit-config.yaml configuration to execute osv-scanner scan source -r . locally before pushing code.
- Includes standard .git/hooks/pre-commit shell script example to prevent vulnerable dependencies from entering repositories.

**Author**: Nandhakumar Murugan (Google Student Ambassador • B.E. CS & Cyber Security @ KG KITE)