### PR TITLE
feat(output): add a "Fix available" filter to the HTML report

### DIFF
--- a/internal/output/html/filter_template.gohtml
+++ b/internal/output/html/filter_template.gohtml
@@ -76,6 +76,10 @@
           <input type="checkbox" id="uncalled-type-checkbox" data-type-uncalled-count="{{ .VulnTypeSummary.Hidden }}">
           Uncalled/Unimportant ({{ .VulnTypeSummary.Hidden }})
         </label>
+        <label class="filter-option" for="fixable-type-checkbox">
+          <input type="checkbox" id="fixable-type-checkbox" data-fixable-count="{{ .VulnCount.FixableCount.Fixed }}">
+          Fix available ({{ .VulnCount.FixableCount.Fixed }})
+        </label>
       </div>
     </div>
   </div>

--- a/internal/output/html/filter_template.gohtml
+++ b/internal/output/html/filter_template.gohtml
@@ -76,8 +76,8 @@
           <input type="checkbox" id="uncalled-type-checkbox" data-type-uncalled-count="{{ .VulnTypeSummary.Hidden }}">
           Uncalled/Unimportant ({{ .VulnTypeSummary.Hidden }})
         </label>
-        <label class="filter-option" for="fixable-type-checkbox">
-          <input type="checkbox" id="fixable-type-checkbox" data-fixable-count="{{ .VulnCount.FixableCount.Fixed }}">
+        <label class="filter-option" for="fixable-checkbox">
+          <input type="checkbox" id="fixable-checkbox">
           Fix available ({{ .VulnCount.FixableCount.Fixed }})
         </label>
       </div>

--- a/internal/output/html/script.js
+++ b/internal/output/html/script.js
@@ -260,6 +260,7 @@ function applyFilters(selectedTypeFilterValue, selectedLayerFilterValue) {
   showAllVulns();
   applyTypeFilter(selectedTypeFilterValue);
   applyLayerFilter(selectedLayerFilterValue);
+  applyFixFilter();
   showAndHideParentSections();
 }
 
@@ -303,6 +304,21 @@ function applyLayerFilter(selectedLayerID) {
   });
 }
 
+function applyFixFilter() {
+  const fixableCheckbox = document.getElementById("fixable-type-checkbox");
+
+  if (!fixableCheckbox || !fixableCheckbox.checked) {
+    return;
+  }
+
+  const vulnRows = document.querySelectorAll(".vuln-tr");
+  vulnRows.forEach(vuln => {
+    if (vuln.getAttribute("data-fixable") !== "true") {
+      vuln.classList.add("hide-block");
+    }
+  });
+}
+
 function updateTypeFilterText() {
   const typeSelected = document.getElementById("type-filter-selected");
   const selectedVulnCount = document.getElementById("selected-count");
@@ -313,6 +329,7 @@ function updateTypeFilterText() {
   const uncalledTypeCheckbox = document.getElementById(
     "uncalled-type-checkbox"
   );
+  const fixableTypeCheckbox = document.getElementById("fixable-type-checkbox");
 
   let selectedText = "";
   let selectedCount = 0;
@@ -335,6 +352,9 @@ function updateTypeFilterText() {
       "data-type-uncalled-count"
     );
     selectedCount += parseInt(uncalledTypeVulnCount, 10);
+  }
+  if (fixableTypeCheckbox && fixableTypeCheckbox.checked) {
+    selectedText += `${selectedText ? ", " : ""}Fix available`;
   }
 
   if (
@@ -363,6 +383,10 @@ function resetFilterText() {
   const uncalledTypeCheckBox = document.getElementById(
     "uncalled-type-checkbox"
   );
+  const fixableTypeCheckBox = document.getElementById("fixable-type-checkbox");
+  if (fixableTypeCheckBox) {
+    fixableTypeCheckBox.checked = false;
+  }
   if (allTypeCheckedBox) {
     typeSelected.textContent = "Default";
     selectedVulnCount.textContent = allTypeCheckedBox.getAttribute(
@@ -408,6 +432,10 @@ function resetTypeCheckbox() {
       osTypeCheckbox.checked = true;
     }
     uncalledTypeCheckbox.checked = false;
+  }
+  const fixableTypeCheckbox = document.getElementById("fixable-type-checkbox");
+  if (fixableTypeCheckbox) {
+    fixableTypeCheckbox.checked = false;
   }
 }
 

--- a/internal/output/html/script.js
+++ b/internal/output/html/script.js
@@ -261,11 +261,12 @@ function applyFilters(selectedTypeFilterValue, selectedLayerFilterValue) {
   applyTypeFilter(selectedTypeFilterValue);
   applyLayerFilter(selectedLayerFilterValue);
   applyFixFilter();
+  // Runs last so the summary can count the rows that survived every filter.
+  updateTypeFilterText();
   showAndHideParentSections();
 }
 
 function applyTypeFilter(selectedValue) {
-  updateTypeFilterText();
   const selectedAll = selectedValue.has("all");
   const selectedProject = selectedAll || selectedValue.has("project");
   const selectedOS = selectedAll || selectedValue.has("os");
@@ -305,7 +306,7 @@ function applyLayerFilter(selectedLayerID) {
 }
 
 function applyFixFilter() {
-  const fixableCheckbox = document.getElementById("fixable-type-checkbox");
+  const fixableCheckbox = document.getElementById("fixable-checkbox");
 
   if (!fixableCheckbox || !fixableCheckbox.checked) {
     return;
@@ -329,7 +330,7 @@ function updateTypeFilterText() {
   const uncalledTypeCheckbox = document.getElementById(
     "uncalled-type-checkbox"
   );
-  const fixableTypeCheckbox = document.getElementById("fixable-type-checkbox");
+  const fixableCheckbox = document.getElementById("fixable-checkbox");
 
   let selectedText = "";
   let selectedCount = 0;
@@ -353,10 +354,6 @@ function updateTypeFilterText() {
     );
     selectedCount += parseInt(uncalledTypeVulnCount, 10);
   }
-  if (fixableTypeCheckbox && fixableTypeCheckbox.checked) {
-    selectedText += `${selectedText ? ", " : ""}Fix available`;
-  }
-
   if (
     allTypeCheckbox &&
     allTypeCheckbox.checked &&
@@ -364,6 +361,14 @@ function updateTypeFilterText() {
     !uncalledTypeCheckbox.checked
   ) {
     selectedText = "Default";
+  }
+
+  // Appended after the "Default" shorthand so it is not overwritten by it.
+  if (fixableCheckbox && fixableCheckbox.checked) {
+    selectedText += `${selectedText ? ", " : ""}Fix available`;
+    selectedCount = document.querySelectorAll(
+      ".vuln-tr:not(.hide-block)"
+    ).length;
   }
 
   typeSelected.textContent = selectedText;
@@ -383,10 +388,11 @@ function resetFilterText() {
   const uncalledTypeCheckBox = document.getElementById(
     "uncalled-type-checkbox"
   );
-  const fixableTypeCheckBox = document.getElementById("fixable-type-checkbox");
-  if (fixableTypeCheckBox) {
-    fixableTypeCheckBox.checked = false;
+  const fixableCheckbox = document.getElementById("fixable-checkbox");
+  if (fixableCheckbox) {
+    fixableCheckbox.checked = false;
   }
+
   if (allTypeCheckedBox) {
     typeSelected.textContent = "Default";
     selectedVulnCount.textContent = allTypeCheckedBox.getAttribute(
@@ -433,9 +439,9 @@ function resetTypeCheckbox() {
     }
     uncalledTypeCheckbox.checked = false;
   }
-  const fixableTypeCheckbox = document.getElementById("fixable-type-checkbox");
-  if (fixableTypeCheckbox) {
-    fixableTypeCheckbox.checked = false;
+  const fixableCheckbox = document.getElementById("fixable-checkbox");
+  if (fixableCheckbox) {
+    fixableCheckbox.checked = false;
   }
 }
 

--- a/internal/output/html/vuln_table_entry_template.gohtml
+++ b/internal/output/html/vuln_table_entry_template.gohtml
@@ -1,6 +1,6 @@
 {{ $index := uniqueID }}
 {{ $element := .Element }}
-<tr class="table-tr vuln-tr {{ if .IsHidden }}uncalled-tr{{ end }}" id="table-tr-{{ $index }}" data-vuln-id="{{ $element.ID }}">
+<tr class="table-tr vuln-tr {{ if .IsHidden }}uncalled-tr{{ end }}" id="table-tr-{{ $index }}" data-vuln-id="{{ $element.ID }}" data-fixable="{{ $element.IsFixable }}">
   <td {{ if .IsHidden }}class="uncalled-text"{{ end }}>
     {{ if eq (len $element.GroupIDs) 1 }}
     <a class="clickable" href="https://osv.dev/{{ $element.ID }}" target="_blank" onclick="handleVulnClick(event, '{{ $element.ID }}')">{{ $element.ID }}</a>


### PR DESCRIPTION
## Overview

Fixes #3016

Adds a client-side "Fix available" filter to the HTML report, so users can show only vulnerabilities that have a fix available instead of scanning the fix column visually.

## Details

- `vuln_table_entry_template.gohtml` stamps `data-fixable="true|false"` on each vulnerability row, using the existing `VulnResult.IsFixable` field — no changes to result building are needed.
- A "Fix available (N)" checkbox joins the existing Filters panel, labelled with the already-computed `VulnCount.FixableCount.Fixed`. Like the other options in that panel, N counts regular vulnerabilities only.
- New `applyFixFilter()` in `script.js` runs inside `applyFilters()`, after the type and layer filters. It only ever adds `hide-block`, and `applyFilters()` starts from `showAllVulns()`, so it composes with the other filters regardless of order. Packages, sources and ecosystems left with no visible rows are collapsed by the existing `showAndHideParentSections()`, which is what makes the report scannable for the case in #3016.
- The checkbox sits inside `#type-filter-option-container`, so the existing `change` listener picks it up, and it participates in the existing reset paths (`resetFilterText()` / `resetTypeCheckbox()`) — typing in the search box clears it, exactly like the "Uncalled/Unimportant" toggle.
- `updateTypeFilterText()` now runs at the end of `applyFilters()` instead of at the start of `applyTypeFilter()` (its only caller). That lets the summary append "Fix available" *after* the "Default" shorthand has been applied rather than before it, and report the number of rows actually left visible. With the fix filter off, the summary text and count are computed exactly as they are today.

Filtering stays purely client-side, consistent with the existing type/layer filters; no new CLI flags or output schema changes.

## Testing

- Unit tests for `internal/output` (covering HTML rendering across ~30 result scenarios) pass locally via `./scripts/run_tests.sh`.
- `prettier --check` is clean for `script.js` (the `.gohtml` templates are covered by `.prettierignore`).
- Filter interactions were exercised against a DOM built from these templates, driving the real `script.js` with `change` / `click` / `keyup` events: the fix filter on its own, combined with the type filter, combined with the layer filter, with "Uncalled/Unimportant" enabled, on reports both with and without OS results, and through the search-box reset path. In each case the visible rows are exactly the fixable ones, the parent sections collapse correctly, and the summary count matches the number of rows shown.
- As a regression check, 13 interaction sequences that never touch the new checkbox produce DOM state identical to `main` — every row's classes, the shown/hidden state of every package, source and ecosystem container, and the filter summary text and count.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/).
- [x] I have read the [CONTRIBUTING guide](https://github.com/google/osv-scanner/blob/main/CONTRIBUTING.md), and understand when to open a pull request
- [x] I have run the linter using `./scripts/run_lints.sh`. _(No Go source changes — this PR touches only a Go HTML template, the report's JS, and the filter template. `./scripts/run_formatters.sh` covers `script.js` and is clean.)_
- [x] I have run the unit tests using `./scripts/run_tests.sh`.
- [x] I have made my commits and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
