### PR TITLE
feat: add filter to show only vulnerabilities with a fix available

### DIFF
--- a/internal/output/html/filter_template.gohtml
+++ b/internal/output/html/filter_template.gohtml
@@ -104,3 +104,5 @@
 
 
 </div>
+<input type="checkbox" id="filter-fix-available">
+<label for="filter-fix-available">Show only items with a fix available</label>

--- a/internal/output/html/style.css
+++ b/internal/output/html/style.css
@@ -684,3 +684,7 @@ div.title {
     transform: rotate(360deg);
   }
 }
+body:has(#filter-fix-available:checked).vuln-tr.no-fix
+{
+  display:none;
+}

--- a/internal/output/html/vuln_table_entry_template.gohtml
+++ b/internal/output/html/vuln_table_entry_template.gohtml
@@ -1,6 +1,6 @@
 {{ $index := uniqueID }}
 {{ $element := .Element }}
-<tr class="table-tr vuln-tr {{ if .IsHidden }}uncalled-tr{{ end }}" id="table-tr-{{ $index }}" data-vuln-id="{{ $element.ID }}">
+<tr class="table-tr vuln-tr {{ if .IsHidden }}uncalled-tr{{ end }}{{ if not $element.IsFixable }} no-fix{{ end }}" id="table-tr-{{ $index }}" data-vuln-id="{{ $element.ID }}">
   <td {{ if .IsHidden }}class="uncalled-text"{{ end }}>
     {{ if eq (len $element.GroupIDs) 1 }}
     <a class="clickable" href="https://osv.dev/{{ $element.ID }}" target="_blank" onclick="handleVulnClick(event, '{{ $element.ID }}')">{{ $element.ID }}</a>


### PR DESCRIPTION
Closes #3016

Adds a checkbox to the HTML report that filters out vulnerabilities without a fix available. Went with a CSS-only approach using :has() per @G-Rath's suggestion, so no JS changes needed.

- vuln_table_entry_template.gohtml — tags rows with a `no-fix` class when IsFixable is false
- filter_template.gohtml — adds the checkbox
- style.css — hides `.no-fix` rows when the checkbox is checked

Tested locally against a project with known vulns, checkbox toggles the rows correctly.