### PR TITLE
fix(spdx): guard against panic on empty license expressions

### DIFF
--- a/internal/spdx/satisfies.go
+++ b/internal/spdx/satisfies.go
@@ -89,6 +89,10 @@ var allowed = map[string][]string{
 
 // nextAndIsNextNextValid returns both the next token, and checks if the token after that one is valid
 func (ts *tokens) nextAndIsNextNextValid() (string, error) {
+	if len(ts.tokens) == 0 {
+		return "", errors.New("unexpected end of expression")
+	}
+
 	next := ts.next()
 
 	return next, ts.isNextValid(next)
@@ -251,6 +255,13 @@ func parseExpression(tokens *tokens) (node, error) {
 
 // Satisfies checks if the given license expression is satisfied by the allowed licenses
 func Satisfies(license models.License, allowlist []string) (bool, error) {
+	// An empty expression (e.g. a package license field that was never set)
+	// contains no tokens, meaning it cannot be satisfied by anything on the
+	// allowlist. Handle it explicitly so it never reaches the tokenizer.
+	if strings.TrimSpace(string(license)) == "" {
+		return false, nil
+	}
+
 	tokens := tokenise(license)
 	nod, err := parse(&tokens)
 

--- a/internal/spdx/satisfies_test.go
+++ b/internal/spdx/satisfies_test.go
@@ -79,6 +79,23 @@ func TestSatisfies(t *testing.T) {
 				{"Apache-2.0"},
 			},
 		},
+		// empty expression licenses contain no tokens and can never satisfy an
+		// allowlist, but must not panic (regression for #2968)
+		{
+			license: "",
+			fail: [][]string{
+				{"MIT"},
+				{"MIT", "Apache-2.0"},
+				{},
+			},
+		},
+		{
+			license: "   ",
+			fail: [][]string{
+				{"MIT"},
+				{},
+			},
+		},
 		// AND expressions
 		{
 			license: "MIT AND Apache-2.0",

--- a/internal/spdx/satisfies_test.go
+++ b/internal/spdx/satisfies_test.go
@@ -80,7 +80,7 @@ func TestSatisfies(t *testing.T) {
 			},
 		},
 		// empty expression licenses contain no tokens and can never satisfy an
-		// allowlist, but must not panic (regression for #2968)
+		// allowlist.
 		{
 			license: "",
 			fail: [][]string{

--- a/pkg/osvscanner/vulnerability_result_internal_test.go
+++ b/pkg/osvscanner/vulnerability_result_internal_test.go
@@ -1,6 +1,7 @@
 package osvscanner
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/google/osv-scalibr/extractor"
@@ -10,6 +11,7 @@ import (
 	"github.com/google/osv-scanner/v2/internal/config"
 	"github.com/google/osv-scanner/v2/internal/imodels/results"
 	"github.com/google/osv-scanner/v2/internal/testutility"
+	"github.com/google/osv-scanner/v2/pkg/models"
 	"github.com/ossf/osv-schema/bindings/go/osvschema"
 )
 
@@ -173,5 +175,48 @@ func Test_assembleResult(t *testing.T) {
 			got := buildVulnerabilityResults(tt.args.actions, tt.args.scanResults)
 			testutility.NewSnapshot().MatchJSON(t, got)
 		})
+	}
+}
+
+// TestBuildVulnerabilityResultsWithEmptyLicense ensures a package with an empty
+// license field does not panic when a license allowlist is configured, and is
+// instead recorded as a license violation (regression for #2968).
+func TestBuildVulnerabilityResultsWithEmptyLicense(t *testing.T) {
+	t.Parallel()
+
+	scanResults := &results.ScanResults{
+		Inventory: inventory.Inventory{
+			Packages: []*extractor.Package{
+				{
+					Name:     "no-license-pkg",
+					PURLType: purl.TypeNPM,
+					Plugins:  []string{packagelockjson.Name},
+					Version:  "1.0.0",
+					Location: extractor.LocationFromPath("dir/package-lock.json"),
+					Licenses: []string{""},
+					ScanRoot: "root/",
+				},
+			},
+		},
+		ConfigManager: config.Manager{},
+	}
+
+	got := buildVulnerabilityResults(ScannerActions{
+		ShowAllPackages:       true,
+		ScanLicensesAllowlist: []string{"MIT"},
+		CallAnalysisStates:    map[string]bool{},
+	}, scanResults)
+
+	if len(got.Results) != 1 {
+		t.Fatalf("expected 1 package source, got %d", len(got.Results))
+	}
+
+	packages := got.Results[0].Packages
+	if len(packages) != 1 {
+		t.Fatalf("expected 1 package, got %d", len(packages))
+	}
+
+	if violations := packages[0].LicenseViolations; !slices.Equal(violations, []models.License{""}) {
+		t.Errorf("expected the empty license to be reported as a violation, got %v", violations)
 	}
 }

--- a/pkg/osvscanner/vulnerability_result_internal_test.go
+++ b/pkg/osvscanner/vulnerability_result_internal_test.go
@@ -180,7 +180,7 @@ func Test_assembleResult(t *testing.T) {
 
 // TestBuildVulnerabilityResultsWithEmptyLicense ensures a package with an empty
 // license field does not panic when a license allowlist is configured, and is
-// instead recorded as a license violation (regression for #2968).
+// instead recorded as a license violation.
 func TestBuildVulnerabilityResultsWithEmptyLicense(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Overview

Fixes #2968

`osv-scanner scan --licenses <allowlist>` panics with `index out of range` when any scanned package has an empty license field. An empty license string reaches `spdx.Satisfies("", allowlist)`: the tokenizer produces zero tokens, and `tokens.next()` dereferences `ts.tokens[0]` without a bounds check, terminating the whole scan.

## Details

Two changes in `internal/spdx/satisfies.go`:

1. `nextAndIsNextNextValid` now returns an error when the token stream is exhausted instead of calling `next()` on an empty list, so an empty expression can never reach the index-out-of-range dereference. This is the root-cause guard (`peek()` already protected itself; `next()` did not).
2. `Satisfies` handles empty/whitespace-only expressions explicitly, returning `false, nil` so an empty license is treated as "not satisfied by the allowlist" and recorded as a violation (via `pkg/osvscanner/vulnerability_result.go`) rather than aborting the scan.

Regression tests:

- `internal/spdx/satisfies_test.go`: empty (`""`) and whitespace-only (`"   "`) license expressions added to `TestSatisfies`, asserting they evaluate to not-satisfied without an error (these panicked at HEAD).
- `pkg/osvscanner/vulnerability_result_internal_test.go`: `TestBuildVulnerabilityResultsWithEmptyLicense` drives a package with `Licenses: []string{""}` through `buildVulnerabilityResults` with a `MIT` allowlist and asserts the empty license is reported as a violation and the scan completes.

## Testing

- Reproduced the panic at HEAD with `go test ./internal/spdx -run TestSatisfies` before the fix.
- `go test ./internal/spdx/... ./pkg/osvscanner/...` passes after the fix (including the new regression tests).
- `go vet ./internal/spdx/... ./pkg/osvscanner/...` reports no issues.
- `go build ./...` succeeds.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/).
- [x] I have read the [CONTRIBUTING guide](https://github.com/google/osv-scanner/blob/main/CONTRIBUTING.md), and understand when to open a pull request
- [ ] I have run the linter using `./scripts/run_lints.sh`.
- [x] I have run the unit tests using `./scripts/run_tests.sh`.
- [x] I have made my commits and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
