### PR TITLE
test: add output tests covering the license summary

### DIFF
--- a/internal/output/__snapshots__/cyclonedx_test.snap
+++ b/internal/output/__snapshots__/cyclonedx_test.snap
@@ -137,80 +137,6 @@
 
 ---
 
-[TestPrintCycloneDXResults/CycloneDX14_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages,_some_license_violations#01 - 1]
-{
-  "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",
-  "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "version": 1,
-  "components": [
-    {
-      "bom-ref": "pkg:npm/mine1@1.2.3",
-      "type": "library",
-      "name": "mine1",
-      "version": "1.2.3",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT"
-          }
-        },
-        {
-          "license": {
-            "id": "Apache-2.0"
-          }
-        }
-      ],
-      "purl": "pkg:npm/mine1@1.2.3"
-    },
-    {
-      "bom-ref": "pkg:npm/mine1@1.3.5",
-      "type": "library",
-      "name": "mine1",
-      "version": "1.3.5",
-      "licenses": [
-        {
-          "license": {
-            "id": "Apache-2.0"
-          }
-        }
-      ],
-      "purl": "pkg:npm/mine1@1.3.5"
-    },
-    {
-      "bom-ref": "pkg:npm/mine2@3.2.5",
-      "type": "library",
-      "name": "mine2",
-      "version": "3.2.5",
-      "licenses": [
-        {
-          "license": {
-            "id": "UNKNOWN"
-          }
-        }
-      ],
-      "purl": "pkg:npm/mine2@3.2.5"
-    },
-    {
-      "bom-ref": "pkg:npm/mine3@0.4.1",
-      "type": "library",
-      "name": "mine3",
-      "version": "0.4.1",
-      "licenses": [
-        {
-          "license": {
-            "id": "Apache-2.0"
-          }
-        }
-      ],
-      "purl": "pkg:npm/mine3@0.4.1"
-    }
-  ],
-  "vulnerabilities": []
-}
-
----
-
 [TestPrintCycloneDXResults/CycloneDX14_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages_across_ecosystems,_some_license_violations - 1]
 {
   "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",
@@ -338,6 +264,80 @@
         {
           "license": {
             "id": "ISC"
+          }
+        }
+      ],
+      "purl": "pkg:npm/mine3@0.4.1"
+    }
+  ],
+  "vulnerabilities": []
+}
+
+---
+
+[TestPrintCycloneDXResults/CycloneDX14_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages_with_versions_and_commits,_some_license_violations - 1]
+{
+  "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.4",
+  "version": 1,
+  "components": [
+    {
+      "bom-ref": "pkg:npm/mine1@1.2.3",
+      "type": "library",
+      "name": "mine1",
+      "version": "1.2.3",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        },
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:npm/mine1@1.2.3"
+    },
+    {
+      "bom-ref": "pkg:npm/mine1@1.3.5",
+      "type": "library",
+      "name": "mine1",
+      "version": "1.3.5",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:npm/mine1@1.3.5"
+    },
+    {
+      "bom-ref": "pkg:npm/mine2@3.2.5",
+      "type": "library",
+      "name": "mine2",
+      "version": "3.2.5",
+      "licenses": [
+        {
+          "license": {
+            "id": "UNKNOWN"
+          }
+        }
+      ],
+      "purl": "pkg:npm/mine2@3.2.5"
+    },
+    {
+      "bom-ref": "pkg:npm/mine3@0.4.1",
+      "type": "library",
+      "name": "mine3",
+      "version": "0.4.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
           }
         }
       ],
@@ -2687,80 +2687,6 @@
 
 ---
 
-[TestPrintCycloneDXResults/CycloneDX15_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages,_some_license_violations#01 - 1]
-{
-  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
-  "bomFormat": "CycloneDX",
-  "specVersion": "1.5",
-  "version": 1,
-  "components": [
-    {
-      "bom-ref": "pkg:npm/mine1@1.2.3",
-      "type": "library",
-      "name": "mine1",
-      "version": "1.2.3",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT"
-          }
-        },
-        {
-          "license": {
-            "id": "Apache-2.0"
-          }
-        }
-      ],
-      "purl": "pkg:npm/mine1@1.2.3"
-    },
-    {
-      "bom-ref": "pkg:npm/mine1@1.3.5",
-      "type": "library",
-      "name": "mine1",
-      "version": "1.3.5",
-      "licenses": [
-        {
-          "license": {
-            "id": "Apache-2.0"
-          }
-        }
-      ],
-      "purl": "pkg:npm/mine1@1.3.5"
-    },
-    {
-      "bom-ref": "pkg:npm/mine2@3.2.5",
-      "type": "library",
-      "name": "mine2",
-      "version": "3.2.5",
-      "licenses": [
-        {
-          "license": {
-            "id": "UNKNOWN"
-          }
-        }
-      ],
-      "purl": "pkg:npm/mine2@3.2.5"
-    },
-    {
-      "bom-ref": "pkg:npm/mine3@0.4.1",
-      "type": "library",
-      "name": "mine3",
-      "version": "0.4.1",
-      "licenses": [
-        {
-          "license": {
-            "id": "Apache-2.0"
-          }
-        }
-      ],
-      "purl": "pkg:npm/mine3@0.4.1"
-    }
-  ],
-  "vulnerabilities": []
-}
-
----
-
 [TestPrintCycloneDXResults/CycloneDX15_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages_across_ecosystems,_some_license_violations - 1]
 {
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
@@ -2888,6 +2814,80 @@
         {
           "license": {
             "id": "ISC"
+          }
+        }
+      ],
+      "purl": "pkg:npm/mine3@0.4.1"
+    }
+  ],
+  "vulnerabilities": []
+}
+
+---
+
+[TestPrintCycloneDXResults/CycloneDX15_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages_with_versions_and_commits,_some_license_violations - 1]
+{
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "version": 1,
+  "components": [
+    {
+      "bom-ref": "pkg:npm/mine1@1.2.3",
+      "type": "library",
+      "name": "mine1",
+      "version": "1.2.3",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        },
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:npm/mine1@1.2.3"
+    },
+    {
+      "bom-ref": "pkg:npm/mine1@1.3.5",
+      "type": "library",
+      "name": "mine1",
+      "version": "1.3.5",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:npm/mine1@1.3.5"
+    },
+    {
+      "bom-ref": "pkg:npm/mine2@3.2.5",
+      "type": "library",
+      "name": "mine2",
+      "version": "3.2.5",
+      "licenses": [
+        {
+          "license": {
+            "id": "UNKNOWN"
+          }
+        }
+      ],
+      "purl": "pkg:npm/mine2@3.2.5"
+    },
+    {
+      "bom-ref": "pkg:npm/mine3@0.4.1",
+      "type": "library",
+      "name": "mine3",
+      "version": "0.4.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
           }
         }
       ],
@@ -5237,80 +5237,6 @@
 
 ---
 
-[TestPrintCycloneDXResults/CycloneDX16_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages,_some_license_violations#01 - 1]
-{
-  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
-  "bomFormat": "CycloneDX",
-  "specVersion": "1.6",
-  "version": 1,
-  "components": [
-    {
-      "bom-ref": "pkg:npm/mine1@1.2.3",
-      "type": "library",
-      "name": "mine1",
-      "version": "1.2.3",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT"
-          }
-        },
-        {
-          "license": {
-            "id": "Apache-2.0"
-          }
-        }
-      ],
-      "purl": "pkg:npm/mine1@1.2.3"
-    },
-    {
-      "bom-ref": "pkg:npm/mine1@1.3.5",
-      "type": "library",
-      "name": "mine1",
-      "version": "1.3.5",
-      "licenses": [
-        {
-          "license": {
-            "id": "Apache-2.0"
-          }
-        }
-      ],
-      "purl": "pkg:npm/mine1@1.3.5"
-    },
-    {
-      "bom-ref": "pkg:npm/mine2@3.2.5",
-      "type": "library",
-      "name": "mine2",
-      "version": "3.2.5",
-      "licenses": [
-        {
-          "license": {
-            "id": "UNKNOWN"
-          }
-        }
-      ],
-      "purl": "pkg:npm/mine2@3.2.5"
-    },
-    {
-      "bom-ref": "pkg:npm/mine3@0.4.1",
-      "type": "library",
-      "name": "mine3",
-      "version": "0.4.1",
-      "licenses": [
-        {
-          "license": {
-            "id": "Apache-2.0"
-          }
-        }
-      ],
-      "purl": "pkg:npm/mine3@0.4.1"
-    }
-  ],
-  "vulnerabilities": []
-}
-
----
-
 [TestPrintCycloneDXResults/CycloneDX16_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages_across_ecosystems,_some_license_violations - 1]
 {
   "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
@@ -5438,6 +5364,80 @@
         {
           "license": {
             "id": "ISC"
+          }
+        }
+      ],
+      "purl": "pkg:npm/mine3@0.4.1"
+    }
+  ],
+  "vulnerabilities": []
+}
+
+---
+
+[TestPrintCycloneDXResults/CycloneDX16_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages_with_versions_and_commits,_some_license_violations - 1]
+{
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "version": 1,
+  "components": [
+    {
+      "bom-ref": "pkg:npm/mine1@1.2.3",
+      "type": "library",
+      "name": "mine1",
+      "version": "1.2.3",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        },
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:npm/mine1@1.2.3"
+    },
+    {
+      "bom-ref": "pkg:npm/mine1@1.3.5",
+      "type": "library",
+      "name": "mine1",
+      "version": "1.3.5",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:npm/mine1@1.3.5"
+    },
+    {
+      "bom-ref": "pkg:npm/mine2@3.2.5",
+      "type": "library",
+      "name": "mine2",
+      "version": "3.2.5",
+      "licenses": [
+        {
+          "license": {
+            "id": "UNKNOWN"
+          }
+        }
+      ],
+      "purl": "pkg:npm/mine2@3.2.5"
+    },
+    {
+      "bom-ref": "pkg:npm/mine3@0.4.1",
+      "type": "library",
+      "name": "mine3",
+      "version": "0.4.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
           }
         }
       ],
@@ -7787,80 +7787,6 @@
 
 ---
 
-[TestPrintCycloneDXResults/CycloneDX17_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages,_some_license_violations#01 - 1]
-{
-  "$schema": "http://cyclonedx.org/schema/bom-1.7.schema.json",
-  "bomFormat": "CycloneDX",
-  "specVersion": "1.7",
-  "version": 1,
-  "components": [
-    {
-      "bom-ref": "pkg:npm/mine1@1.2.3",
-      "type": "library",
-      "name": "mine1",
-      "version": "1.2.3",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT"
-          }
-        },
-        {
-          "license": {
-            "id": "Apache-2.0"
-          }
-        }
-      ],
-      "purl": "pkg:npm/mine1@1.2.3"
-    },
-    {
-      "bom-ref": "pkg:npm/mine1@1.3.5",
-      "type": "library",
-      "name": "mine1",
-      "version": "1.3.5",
-      "licenses": [
-        {
-          "license": {
-            "id": "Apache-2.0"
-          }
-        }
-      ],
-      "purl": "pkg:npm/mine1@1.3.5"
-    },
-    {
-      "bom-ref": "pkg:npm/mine2@3.2.5",
-      "type": "library",
-      "name": "mine2",
-      "version": "3.2.5",
-      "licenses": [
-        {
-          "license": {
-            "id": "UNKNOWN"
-          }
-        }
-      ],
-      "purl": "pkg:npm/mine2@3.2.5"
-    },
-    {
-      "bom-ref": "pkg:npm/mine3@0.4.1",
-      "type": "library",
-      "name": "mine3",
-      "version": "0.4.1",
-      "licenses": [
-        {
-          "license": {
-            "id": "Apache-2.0"
-          }
-        }
-      ],
-      "purl": "pkg:npm/mine3@0.4.1"
-    }
-  ],
-  "vulnerabilities": []
-}
-
----
-
 [TestPrintCycloneDXResults/CycloneDX17_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages_across_ecosystems,_some_license_violations - 1]
 {
   "$schema": "http://cyclonedx.org/schema/bom-1.7.schema.json",
@@ -7988,6 +7914,80 @@
         {
           "license": {
             "id": "ISC"
+          }
+        }
+      ],
+      "purl": "pkg:npm/mine3@0.4.1"
+    }
+  ],
+  "vulnerabilities": []
+}
+
+---
+
+[TestPrintCycloneDXResults/CycloneDX17_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages_with_versions_and_commits,_some_license_violations - 1]
+{
+  "$schema": "http://cyclonedx.org/schema/bom-1.7.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.7",
+  "version": 1,
+  "components": [
+    {
+      "bom-ref": "pkg:npm/mine1@1.2.3",
+      "type": "library",
+      "name": "mine1",
+      "version": "1.2.3",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        },
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:npm/mine1@1.2.3"
+    },
+    {
+      "bom-ref": "pkg:npm/mine1@1.3.5",
+      "type": "library",
+      "name": "mine1",
+      "version": "1.3.5",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:npm/mine1@1.3.5"
+    },
+    {
+      "bom-ref": "pkg:npm/mine2@3.2.5",
+      "type": "library",
+      "name": "mine2",
+      "version": "3.2.5",
+      "licenses": [
+        {
+          "license": {
+            "id": "UNKNOWN"
+          }
+        }
+      ],
+      "purl": "pkg:npm/mine2@3.2.5"
+    },
+    {
+      "bom-ref": "pkg:npm/mine3@0.4.1",
+      "type": "library",
+      "name": "mine3",
+      "version": "0.4.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
           }
         }
       ],

--- a/internal/output/__snapshots__/githubannotation_test.snap
+++ b/internal/output/__snapshots__/githubannotation_test.snap
@@ -7,15 +7,15 @@
 
 ---
 
-[TestPrintGHAnnotationReport_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages,_some_license_violations#01 - 1]
-
----
-
 [TestPrintGHAnnotationReport_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages_across_ecosystems,_some_license_violations - 1]
 
 ---
 
 [TestPrintGHAnnotationReport_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages_and_groups,_some_license_violations - 1]
+
+---
+
+[TestPrintGHAnnotationReport_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages_with_versions_and_commits,_some_license_violations - 1]
 
 ---
 

--- a/internal/output/__snapshots__/machinejson_test.snap
+++ b/internal/output/__snapshots__/machinejson_test.snap
@@ -188,104 +188,6 @@
 
 ---
 
-[TestPrintJSONResults_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages,_some_license_violations#01 - 1]
-{
-  "results": [
-    {
-      "source": {
-        "path": "<rootdir>/path/to/my/first/lockfile",
-        "type": "lockfile"
-      },
-      "packages": [
-        {
-          "package": {
-            "name": "mine1",
-            "version": "1.2.3",
-            "ecosystem": "npm"
-          },
-          "licenses": [
-            "MIT",
-            "Apache-2.0"
-          ],
-          "license_violations": [
-            "MIT"
-          ]
-        }
-      ]
-    },
-    {
-      "source": {
-        "path": "<rootdir>/path/to/my/second/lockfile",
-        "type": "sbom"
-      },
-      "packages": [
-        {
-          "package": {
-            "name": "mine2",
-            "version": "3.2.5",
-            "ecosystem": "npm"
-          },
-          "licenses": [
-            "UNKNOWN"
-          ],
-          "license_violations": [
-            "UNKNOWN"
-          ]
-        },
-        {
-          "package": {
-            "name": "mine3",
-            "version": "0.4.1",
-            "ecosystem": "npm"
-          },
-          "licenses": [
-            "Apache-2.0"
-          ]
-        }
-      ]
-    },
-    {
-      "source": {
-        "path": "<rootdir>/path/to/my/third/lockfile",
-        "type": "unknown"
-      },
-      "packages": [
-        {
-          "package": {
-            "name": "mine1",
-            "version": "1.3.5",
-            "ecosystem": "npm"
-          },
-          "licenses": [
-            "Apache-2.0"
-          ]
-        },
-        {
-          "package": {
-            "name": "mine1",
-            "version": "1.2.3",
-            "ecosystem": "npm"
-          },
-          "licenses": [
-            "MIT"
-          ],
-          "license_violations": [
-            "MIT"
-          ]
-        }
-      ]
-    }
-  ],
-  "experimental_config": {
-    "licenses": {
-      "summary": false,
-      "allowlist": null
-    }
-  }
-}
-
----
-
 [TestPrintJSONResults_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages_across_ecosystems,_some_license_violations - 1]
 {
   "results": [
@@ -476,6 +378,106 @@
           "dependency_groups": [
             "build"
           ],
+          "licenses": [
+            "MIT"
+          ],
+          "license_violations": [
+            "MIT"
+          ]
+        }
+      ]
+    }
+  ],
+  "experimental_config": {
+    "licenses": {
+      "summary": false,
+      "allowlist": [
+        "ISC"
+      ]
+    }
+  }
+}
+
+---
+
+[TestPrintJSONResults_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages_with_versions_and_commits,_some_license_violations - 1]
+{
+  "results": [
+    {
+      "source": {
+        "path": "<rootdir>/path/to/my/first/lockfile",
+        "type": "lockfile"
+      },
+      "packages": [
+        {
+          "package": {
+            "name": "mine1",
+            "version": "1.2.3",
+            "ecosystem": "npm"
+          },
+          "licenses": [
+            "MIT",
+            "Apache-2.0"
+          ],
+          "license_violations": [
+            "MIT"
+          ]
+        }
+      ]
+    },
+    {
+      "source": {
+        "path": "<rootdir>/path/to/my/second/lockfile",
+        "type": "sbom"
+      },
+      "packages": [
+        {
+          "package": {
+            "name": "mine2",
+            "version": "3.2.5",
+            "ecosystem": "npm"
+          },
+          "licenses": [
+            "UNKNOWN"
+          ],
+          "license_violations": [
+            "UNKNOWN"
+          ]
+        },
+        {
+          "package": {
+            "name": "mine3",
+            "version": "0.4.1",
+            "ecosystem": "npm"
+          },
+          "licenses": [
+            "Apache-2.0"
+          ]
+        }
+      ]
+    },
+    {
+      "source": {
+        "path": "<rootdir>/path/to/my/third/lockfile",
+        "type": "unknown"
+      },
+      "packages": [
+        {
+          "package": {
+            "name": "mine1",
+            "version": "1.3.5",
+            "ecosystem": "npm"
+          },
+          "licenses": [
+            "Apache-2.0"
+          ]
+        },
+        {
+          "package": {
+            "name": "mine1",
+            "version": "1.2.3",
+            "ecosystem": "npm"
+          },
           "licenses": [
             "MIT"
           ],

--- a/internal/output/__snapshots__/markdowntable_test.snap
+++ b/internal/output/__snapshots__/markdowntable_test.snap
@@ -1,4 +1,412 @@
 
+[TestPrintMarkdownTableResults_WithLicenseSummary/multiple_sources_with_a_mixed_count_of_packages,_no_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+| License | No. of package versions |
+| --- | ---:|
+| ISC | 5 |
+
+---
+
+[TestPrintMarkdownTableResults_WithLicenseSummary/multiple_sources_with_a_mixed_count_of_packages,_some_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+| License | No. of package versions |
+| --- | ---:|
+| ISC | 2 |
+| MIT | 2 |
+| Apache-2.0 | 1 |
+
+---
+
+[TestPrintMarkdownTableResults_WithLicenseSummary/multiple_sources_with_a_mixed_count_of_packages_across_ecosystems,_some_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 3 ecosystems.
+0 vulnerabilities can be fixed.
+
+| License | No. of package versions |
+| --- | ---:|
+| ISC | 2 |
+| MIT | 2 |
+| Apache-2.0 | 1 |
+
+---
+
+[TestPrintMarkdownTableResults_WithLicenseSummary/multiple_sources_with_a_mixed_count_of_packages_and_groups,_some_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+| License | No. of package versions |
+| --- | ---:|
+| ISC | 2 |
+| MIT | 2 |
+| Apache-2.0 | 1 |
+
+---
+
+[TestPrintMarkdownTableResults_WithLicenseSummary/multiple_sources_with_a_mixed_count_of_packages_with_versions_and_commits,_some_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+| License | No. of package versions |
+| --- | ---:|
+| Apache-2.0 | 3 |
+| MIT | 2 |
+| UNKNOWN | 1 |
+
+---
+
+[TestPrintMarkdownTableResults_WithLicenseSummary/multiple_sources_with_no_packages - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+
+---
+
+[TestPrintMarkdownTableResults_WithLicenseSummary/no_sources - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 0 ecosystems.
+0 vulnerabilities can be fixed.
+
+
+---
+
+[TestPrintMarkdownTableResults_WithLicenseSummary/one_source_with_no_packages - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+
+---
+
+[TestPrintMarkdownTableResults_WithLicenseSummary/one_source_with_one_package,_no_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+| License | No. of package versions |
+| --- | ---:|
+| ISC | 1 |
+
+---
+
+[TestPrintMarkdownTableResults_WithLicenseSummary/one_source_with_one_package,_no_licenses - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+
+---
+
+[TestPrintMarkdownTableResults_WithLicenseSummary/one_source_with_one_package_and_an_unknown_license - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+| License | No. of package versions |
+| --- | ---:|
+| UNKNOWN | 1 |
+
+---
+
+[TestPrintMarkdownTableResults_WithLicenseSummary/one_source_with_one_package_and_multiple_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+| License | No. of package versions |
+| --- | ---:|
+| Apache-2.0 | 1 |
+| MIT | 1 |
+
+---
+
+[TestPrintMarkdownTableResults_WithLicenseSummary/one_source_with_one_package_and_one_license_violation - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+| License | No. of package versions |
+| --- | ---:|
+| MIT | 1 |
+
+---
+
+[TestPrintMarkdownTableResults_WithLicenseSummary/one_source_with_one_package_and_one_license_violation_(dev) - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+| License | No. of package versions |
+| --- | ---:|
+| MIT | 1 |
+
+---
+
+[TestPrintMarkdownTableResults_WithLicenseSummary/one_source_with_one_package_with_both_a_version_and_a_commit_and_one_license_violation - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+| License | No. of package versions |
+| --- | ---:|
+| MIT | 1 |
+
+---
+
+[TestPrintMarkdownTableResults_WithLicenseSummary/one_source_with_one_package_with_just_a_commit_and_one_license_violation - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+| License | No. of package versions |
+| --- | ---:|
+| MIT | 1 |
+
+---
+
+[TestPrintMarkdownTableResults_WithLicenseSummary/two_sources_with_packages,_one_license_violation - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+| License | No. of package versions |
+| --- | ---:|
+| ISC | 1 |
+| MIT | 1 |
+
+---
+
+[TestPrintMarkdownTableResults_WithLicenseSummaryAndViolations/multiple_sources_with_a_mixed_count_of_packages,_no_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+| License | No. of package versions |
+| --- | ---:|
+| ISC | 5 |
+
+---
+
+[TestPrintMarkdownTableResults_WithLicenseSummaryAndViolations/multiple_sources_with_a_mixed_count_of_packages,_some_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+| License | No. of package versions |
+| --- | ---:|
+| ISC | 2 |
+| MIT | 2 |
+| Apache-2.0 | 1 |
+| License Violation | Ecosystem | Package | Version | Source |
+| --- | --- | --- | --- | --- |
+| MIT | npm | mine1 | 1.2.3 | path/to/my/first/lockfile |
+| Apache-2.0 | npm | mine2 | 3.2.5 | path/to/my/second/lockfile |
+| MIT | npm | mine1 | 1.2.3 | path/to/my/third/lockfile |
+
+---
+
+[TestPrintMarkdownTableResults_WithLicenseSummaryAndViolations/multiple_sources_with_a_mixed_count_of_packages_across_ecosystems,_some_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 3 ecosystems.
+0 vulnerabilities can be fixed.
+
+| License | No. of package versions |
+| --- | ---:|
+| ISC | 2 |
+| MIT | 2 |
+| Apache-2.0 | 1 |
+| License Violation | Ecosystem | Package | Version | Source |
+| --- | --- | --- | --- | --- |
+| MIT | Packagist | author1/mine1 | 1.2.3 | path/to/my/first/lockfile |
+| Apache-2.0 | npm | mine2 | 3.2.5 | path/to/my/second/lockfile |
+| MIT | Packagist | author1/mine1 | 1.2.3 | path/to/my/third/lockfile |
+
+---
+
+[TestPrintMarkdownTableResults_WithLicenseSummaryAndViolations/multiple_sources_with_a_mixed_count_of_packages_and_groups,_some_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+| License | No. of package versions |
+| --- | ---:|
+| ISC | 2 |
+| MIT | 2 |
+| Apache-2.0 | 1 |
+| License Violation | Ecosystem | Package | Version | Source |
+| --- | --- | --- | --- | --- |
+| MIT | npm | mine1 | 1.2.3 | path/to/my/first/lockfile |
+| Apache-2.0 | npm | mine2 | 3.2.5 | path/to/my/second/lockfile |
+| MIT | npm | mine1 | 1.2.3 | path/to/my/third/lockfile |
+
+---
+
+[TestPrintMarkdownTableResults_WithLicenseSummaryAndViolations/multiple_sources_with_a_mixed_count_of_packages_with_versions_and_commits,_some_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+| License | No. of package versions |
+| --- | ---:|
+| Apache-2.0 | 3 |
+| MIT | 2 |
+| UNKNOWN | 1 |
+| License Violation | Ecosystem | Package | Version | Source |
+| --- | --- | --- | --- | --- |
+| MIT | npm | mine1 | 1.2.3 | path/to/my/first/lockfile |
+| UNKNOWN | npm | mine2 | 3.2.5 | path/to/my/second/lockfile |
+| MIT | npm | mine1 | 1.2.3 | path/to/my/third/lockfile |
+
+---
+
+[TestPrintMarkdownTableResults_WithLicenseSummaryAndViolations/multiple_sources_with_no_packages - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+
+---
+
+[TestPrintMarkdownTableResults_WithLicenseSummaryAndViolations/no_sources - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 0 ecosystems.
+0 vulnerabilities can be fixed.
+
+
+---
+
+[TestPrintMarkdownTableResults_WithLicenseSummaryAndViolations/one_source_with_no_packages - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+
+---
+
+[TestPrintMarkdownTableResults_WithLicenseSummaryAndViolations/one_source_with_one_package,_no_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+| License | No. of package versions |
+| --- | ---:|
+| ISC | 1 |
+
+---
+
+[TestPrintMarkdownTableResults_WithLicenseSummaryAndViolations/one_source_with_one_package,_no_licenses - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+
+---
+
+[TestPrintMarkdownTableResults_WithLicenseSummaryAndViolations/one_source_with_one_package_and_an_unknown_license - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+| License | No. of package versions |
+| --- | ---:|
+| UNKNOWN | 1 |
+
+---
+
+[TestPrintMarkdownTableResults_WithLicenseSummaryAndViolations/one_source_with_one_package_and_multiple_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+| License | No. of package versions |
+| --- | ---:|
+| Apache-2.0 | 1 |
+| MIT | 1 |
+| License Violation | Ecosystem | Package | Version | Source |
+| --- | --- | --- | --- | --- |
+| MIT, Apache-2.0 | npm | mine1 | 1.2.3 | path/to/my/first/lockfile |
+
+---
+
+[TestPrintMarkdownTableResults_WithLicenseSummaryAndViolations/one_source_with_one_package_and_one_license_violation - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+| License | No. of package versions |
+| --- | ---:|
+| MIT | 1 |
+| License Violation | Ecosystem | Package | Version | Source |
+| --- | --- | --- | --- | --- |
+| MIT | npm | mine1 | 1.2.3 | path/to/my/first/lockfile |
+
+---
+
+[TestPrintMarkdownTableResults_WithLicenseSummaryAndViolations/one_source_with_one_package_and_one_license_violation_(dev) - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+| License | No. of package versions |
+| --- | ---:|
+| MIT | 1 |
+| License Violation | Ecosystem | Package | Version | Source |
+| --- | --- | --- | --- | --- |
+| MIT | npm | mine1 | 1.2.3 | path/to/my/first/lockfile |
+
+---
+
+[TestPrintMarkdownTableResults_WithLicenseSummaryAndViolations/one_source_with_one_package_with_both_a_version_and_a_commit_and_one_license_violation - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+| License | No. of package versions |
+| --- | ---:|
+| MIT | 1 |
+| License Violation | Ecosystem | Package | Version | Source |
+| --- | --- | --- | --- | --- |
+| MIT | npm | mine1 | 1.2.3 | path/to/my/first/lockfile |
+
+---
+
+[TestPrintMarkdownTableResults_WithLicenseSummaryAndViolations/one_source_with_one_package_with_just_a_commit_and_one_license_violation - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+| License | No. of package versions |
+| --- | ---:|
+| MIT | 1 |
+| License Violation | Ecosystem | Package | Version | Source |
+| --- | --- | --- | --- | --- |
+| MIT | npm | mine1 |  | path/to/my/first/lockfile |
+
+---
+
+[TestPrintMarkdownTableResults_WithLicenseSummaryAndViolations/two_sources_with_packages,_one_license_violation - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+| License | No. of package versions |
+| --- | ---:|
+| ISC | 1 |
+| MIT | 1 |
+| License Violation | Ecosystem | Package | Version | Source |
+| --- | --- | --- | --- | --- |
+| MIT | npm | mine1 | 1.2.3 | path/to/my/first/lockfile |
+
+---
+
 [TestPrintMarkdownTableResults_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages,_no_license_violations - 1]
 
 Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
@@ -17,14 +425,6 @@ Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medi
 | MIT | npm | mine1 | 1.2.3 | path/to/my/first/lockfile |
 | Apache-2.0 | npm | mine2 | 3.2.5 | path/to/my/second/lockfile |
 | MIT | npm | mine1 | 1.2.3 | path/to/my/third/lockfile |
-
----
-
-[TestPrintMarkdownTableResults_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages,_some_license_violations#01 - 1]
-
-Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
-0 vulnerabilities can be fixed.
-
 
 ---
 
@@ -50,6 +450,19 @@ Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medi
 | --- | --- | --- | --- | --- |
 | MIT | npm | mine1 | 1.2.3 | path/to/my/first/lockfile |
 | Apache-2.0 | npm | mine2 | 3.2.5 | path/to/my/second/lockfile |
+| MIT | npm | mine1 | 1.2.3 | path/to/my/third/lockfile |
+
+---
+
+[TestPrintMarkdownTableResults_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages_with_versions_and_commits,_some_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+| License Violation | Ecosystem | Package | Version | Source |
+| --- | --- | --- | --- | --- |
+| MIT | npm | mine1 | 1.2.3 | path/to/my/first/lockfile |
+| UNKNOWN | npm | mine2 | 3.2.5 | path/to/my/second/lockfile |
 | MIT | npm | mine1 | 1.2.3 | path/to/my/third/lockfile |
 
 ---

--- a/internal/output/__snapshots__/output_result_test.snap
+++ b/internal/output/__snapshots__/output_result_test.snap
@@ -1,4 +1,9548 @@
 
+[TestPrintOutputResults_WithLicenseSummary/multiple_sources_with_a_mixed_count_of_packages,_no_license_violations - 1]
+{
+  "Ecosystems": [
+    {
+      "Name": "npm",
+      "Sources": [
+        {
+          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Type": "lockfile",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.2.3",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "ISC"
+              ],
+              "LicenseViolations": []
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 0
+        },
+        {
+          "Name": "sbom:<rootdir>/path/to/my/second/lockfile",
+          "Type": "sbom",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine2",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "3.2.5",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "ISC"
+              ],
+              "LicenseViolations": []
+            },
+            {
+              "Name": "mine3",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "0.4.1",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "ISC"
+              ],
+              "LicenseViolations": []
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 0
+        },
+        {
+          "Name": "unknown:<rootdir>/path/to/my/third/lockfile",
+          "Type": "unknown",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.2.3",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "ISC"
+              ],
+              "LicenseViolations": []
+            },
+            {
+              "Name": "mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.3.5",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "ISC"
+              ],
+              "LicenseViolations": []
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 0
+        }
+      ],
+      "IsOS": false
+    }
+  ],
+  "IsContainerScanning": false,
+  "ImageInfo": {
+    "OS": "",
+    "AllLayers": null,
+    "AllBaseImages": null
+  },
+  "LicenseSummary": {
+    "Summary": true,
+    "ShowViolations": false,
+    "LicenseCount": [
+      {
+        "name": "ISC",
+        "count": 5
+      }
+    ]
+  },
+  "VulnTypeSummary": {
+    "All": 0,
+    "OS": 0,
+    "Project": 0,
+    "Hidden": 0
+  },
+  "PackageTypeCount": {
+    "Regular": 0,
+    "Hidden": 0
+  },
+  "VulnCount": {
+    "AnalysisCount": {
+      "Regular": 0,
+      "Hidden": 0
+    },
+    "SeverityCount": {
+      "Critical": 0,
+      "High": 0,
+      "Medium": 0,
+      "Low": 0,
+      "Unknown": 0
+    },
+    "FixableCount": {
+      "Fixed": 0,
+      "UnFixed": 0
+    }
+  }
+}
+
+---
+
+[TestPrintOutputResults_WithLicenseSummary/multiple_sources_with_a_mixed_count_of_packages,_some_license_violations - 1]
+{
+  "Ecosystems": [
+    {
+      "Name": "npm",
+      "Sources": [
+        {
+          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Type": "lockfile",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.2.3",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "MIT"
+              ],
+              "LicenseViolations": [
+                "MIT"
+              ]
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 1
+        },
+        {
+          "Name": "sbom:<rootdir>/path/to/my/second/lockfile",
+          "Type": "sbom",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine2",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "3.2.5",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "Apache-2.0"
+              ],
+              "LicenseViolations": [
+                "Apache-2.0"
+              ]
+            },
+            {
+              "Name": "mine3",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "0.4.1",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "ISC"
+              ],
+              "LicenseViolations": []
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 1
+        },
+        {
+          "Name": "unknown:<rootdir>/path/to/my/third/lockfile",
+          "Type": "unknown",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.2.3",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "MIT"
+              ],
+              "LicenseViolations": [
+                "MIT"
+              ]
+            },
+            {
+              "Name": "mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.3.5",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "ISC"
+              ],
+              "LicenseViolations": []
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 1
+        }
+      ],
+      "IsOS": false
+    }
+  ],
+  "IsContainerScanning": false,
+  "ImageInfo": {
+    "OS": "",
+    "AllLayers": null,
+    "AllBaseImages": null
+  },
+  "LicenseSummary": {
+    "Summary": true,
+    "ShowViolations": false,
+    "LicenseCount": [
+      {
+        "name": "ISC",
+        "count": 2
+      },
+      {
+        "name": "MIT",
+        "count": 2
+      },
+      {
+        "name": "Apache-2.0",
+        "count": 1
+      }
+    ]
+  },
+  "VulnTypeSummary": {
+    "All": 0,
+    "OS": 0,
+    "Project": 0,
+    "Hidden": 0
+  },
+  "PackageTypeCount": {
+    "Regular": 0,
+    "Hidden": 0
+  },
+  "VulnCount": {
+    "AnalysisCount": {
+      "Regular": 0,
+      "Hidden": 0
+    },
+    "SeverityCount": {
+      "Critical": 0,
+      "High": 0,
+      "Medium": 0,
+      "Low": 0,
+      "Unknown": 0
+    },
+    "FixableCount": {
+      "Fixed": 0,
+      "UnFixed": 0
+    }
+  }
+}
+
+---
+
+[TestPrintOutputResults_WithLicenseSummary/multiple_sources_with_a_mixed_count_of_packages_across_ecosystems,_some_license_violations - 1]
+{
+  "Ecosystems": [
+    {
+      "Name": "NuGet",
+      "Sources": [
+        {
+          "Name": "unknown:<rootdir>/path/to/my/third/lockfile",
+          "Type": "unknown",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.3.5",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "ISC"
+              ],
+              "LicenseViolations": []
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 0
+        }
+      ],
+      "IsOS": false
+    },
+    {
+      "Name": "Packagist",
+      "Sources": [
+        {
+          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Type": "lockfile",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "author1/mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.2.3",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "MIT"
+              ],
+              "LicenseViolations": [
+                "MIT"
+              ]
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 1
+        },
+        {
+          "Name": "unknown:<rootdir>/path/to/my/third/lockfile",
+          "Type": "unknown",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "author1/mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.2.3",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "MIT"
+              ],
+              "LicenseViolations": [
+                "MIT"
+              ]
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 1
+        }
+      ],
+      "IsOS": false
+    },
+    {
+      "Name": "npm",
+      "Sources": [
+        {
+          "Name": "sbom:<rootdir>/path/to/my/second/lockfile",
+          "Type": "sbom",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine2",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "3.2.5",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "Apache-2.0"
+              ],
+              "LicenseViolations": [
+                "Apache-2.0"
+              ]
+            },
+            {
+              "Name": "mine3",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "0.4.1",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "ISC"
+              ],
+              "LicenseViolations": []
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 1
+        }
+      ],
+      "IsOS": false
+    }
+  ],
+  "IsContainerScanning": false,
+  "ImageInfo": {
+    "OS": "",
+    "AllLayers": null,
+    "AllBaseImages": null
+  },
+  "LicenseSummary": {
+    "Summary": true,
+    "ShowViolations": false,
+    "LicenseCount": [
+      {
+        "name": "ISC",
+        "count": 2
+      },
+      {
+        "name": "MIT",
+        "count": 2
+      },
+      {
+        "name": "Apache-2.0",
+        "count": 1
+      }
+    ]
+  },
+  "VulnTypeSummary": {
+    "All": 0,
+    "OS": 0,
+    "Project": 0,
+    "Hidden": 0
+  },
+  "PackageTypeCount": {
+    "Regular": 0,
+    "Hidden": 0
+  },
+  "VulnCount": {
+    "AnalysisCount": {
+      "Regular": 0,
+      "Hidden": 0
+    },
+    "SeverityCount": {
+      "Critical": 0,
+      "High": 0,
+      "Medium": 0,
+      "Low": 0,
+      "Unknown": 0
+    },
+    "FixableCount": {
+      "Fixed": 0,
+      "UnFixed": 0
+    }
+  }
+}
+
+---
+
+[TestPrintOutputResults_WithLicenseSummary/multiple_sources_with_a_mixed_count_of_packages_and_groups,_some_license_violations - 1]
+{
+  "Ecosystems": [
+    {
+      "Name": "npm",
+      "Sources": [
+        {
+          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Type": "lockfile",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.2.3",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "MIT"
+              ],
+              "LicenseViolations": [
+                "MIT"
+              ]
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 1
+        },
+        {
+          "Name": "sbom:<rootdir>/path/to/my/second/lockfile",
+          "Type": "sbom",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine2",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "3.2.5",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "Apache-2.0"
+              ],
+              "LicenseViolations": [
+                "Apache-2.0"
+              ]
+            },
+            {
+              "Name": "mine3",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "0.4.1",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "ISC"
+              ],
+              "LicenseViolations": []
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 1
+        },
+        {
+          "Name": "unknown:<rootdir>/path/to/my/third/lockfile",
+          "Type": "unknown",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.2.3",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "MIT"
+              ],
+              "LicenseViolations": [
+                "MIT"
+              ]
+            },
+            {
+              "Name": "mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.3.5",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "ISC"
+              ],
+              "LicenseViolations": []
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 1
+        }
+      ],
+      "IsOS": false
+    }
+  ],
+  "IsContainerScanning": false,
+  "ImageInfo": {
+    "OS": "",
+    "AllLayers": null,
+    "AllBaseImages": null
+  },
+  "LicenseSummary": {
+    "Summary": true,
+    "ShowViolations": false,
+    "LicenseCount": [
+      {
+        "name": "ISC",
+        "count": 2
+      },
+      {
+        "name": "MIT",
+        "count": 2
+      },
+      {
+        "name": "Apache-2.0",
+        "count": 1
+      }
+    ]
+  },
+  "VulnTypeSummary": {
+    "All": 0,
+    "OS": 0,
+    "Project": 0,
+    "Hidden": 0
+  },
+  "PackageTypeCount": {
+    "Regular": 0,
+    "Hidden": 0
+  },
+  "VulnCount": {
+    "AnalysisCount": {
+      "Regular": 0,
+      "Hidden": 0
+    },
+    "SeverityCount": {
+      "Critical": 0,
+      "High": 0,
+      "Medium": 0,
+      "Low": 0,
+      "Unknown": 0
+    },
+    "FixableCount": {
+      "Fixed": 0,
+      "UnFixed": 0
+    }
+  }
+}
+
+---
+
+[TestPrintOutputResults_WithLicenseSummary/multiple_sources_with_a_mixed_count_of_packages_with_versions_and_commits,_some_license_violations - 1]
+{
+  "Ecosystems": [
+    {
+      "Name": "npm",
+      "Sources": [
+        {
+          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Type": "lockfile",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.2.3",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "MIT",
+                "Apache-2.0"
+              ],
+              "LicenseViolations": [
+                "MIT"
+              ]
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 1
+        },
+        {
+          "Name": "sbom:<rootdir>/path/to/my/second/lockfile",
+          "Type": "sbom",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine2",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "3.2.5",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "UNKNOWN"
+              ],
+              "LicenseViolations": [
+                "UNKNOWN"
+              ]
+            },
+            {
+              "Name": "mine3",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "0.4.1",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "Apache-2.0"
+              ],
+              "LicenseViolations": []
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 1
+        },
+        {
+          "Name": "unknown:<rootdir>/path/to/my/third/lockfile",
+          "Type": "unknown",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.2.3",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "MIT"
+              ],
+              "LicenseViolations": [
+                "MIT"
+              ]
+            },
+            {
+              "Name": "mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.3.5",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "Apache-2.0"
+              ],
+              "LicenseViolations": []
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 1
+        }
+      ],
+      "IsOS": false
+    }
+  ],
+  "IsContainerScanning": false,
+  "ImageInfo": {
+    "OS": "",
+    "AllLayers": null,
+    "AllBaseImages": null
+  },
+  "LicenseSummary": {
+    "Summary": true,
+    "ShowViolations": false,
+    "LicenseCount": [
+      {
+        "name": "Apache-2.0",
+        "count": 3
+      },
+      {
+        "name": "MIT",
+        "count": 2
+      },
+      {
+        "name": "UNKNOWN",
+        "count": 1
+      }
+    ]
+  },
+  "VulnTypeSummary": {
+    "All": 0,
+    "OS": 0,
+    "Project": 0,
+    "Hidden": 0
+  },
+  "PackageTypeCount": {
+    "Regular": 0,
+    "Hidden": 0
+  },
+  "VulnCount": {
+    "AnalysisCount": {
+      "Regular": 0,
+      "Hidden": 0
+    },
+    "SeverityCount": {
+      "Critical": 0,
+      "High": 0,
+      "Medium": 0,
+      "Low": 0,
+      "Unknown": 0
+    },
+    "FixableCount": {
+      "Fixed": 0,
+      "UnFixed": 0
+    }
+  }
+}
+
+---
+
+[TestPrintOutputResults_WithLicenseSummary/multiple_sources_with_no_packages - 1]
+{
+  "Ecosystems": [
+    {
+      "Name": "",
+      "Sources": [
+        {
+          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Type": "lockfile",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 0
+        },
+        {
+          "Name": "sbom:<rootdir>/path/to/my/second/lockfile",
+          "Type": "sbom",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 0
+        },
+        {
+          "Name": "unknown:<rootdir>/path/to/my/third/lockfile",
+          "Type": "unknown",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 0
+        }
+      ],
+      "IsOS": false
+    }
+  ],
+  "IsContainerScanning": false,
+  "ImageInfo": {
+    "OS": "",
+    "AllLayers": null,
+    "AllBaseImages": null
+  },
+  "LicenseSummary": {
+    "Summary": true,
+    "ShowViolations": false,
+    "LicenseCount": []
+  },
+  "VulnTypeSummary": {
+    "All": 0,
+    "OS": 0,
+    "Project": 0,
+    "Hidden": 0
+  },
+  "PackageTypeCount": {
+    "Regular": 0,
+    "Hidden": 0
+  },
+  "VulnCount": {
+    "AnalysisCount": {
+      "Regular": 0,
+      "Hidden": 0
+    },
+    "SeverityCount": {
+      "Critical": 0,
+      "High": 0,
+      "Medium": 0,
+      "Low": 0,
+      "Unknown": 0
+    },
+    "FixableCount": {
+      "Fixed": 0,
+      "UnFixed": 0
+    }
+  }
+}
+
+---
+
+[TestPrintOutputResults_WithLicenseSummary/no_sources - 1]
+{
+  "Ecosystems": null,
+  "IsContainerScanning": false,
+  "ImageInfo": {
+    "OS": "",
+    "AllLayers": null,
+    "AllBaseImages": null
+  },
+  "LicenseSummary": {
+    "Summary": true,
+    "ShowViolations": false,
+    "LicenseCount": []
+  },
+  "VulnTypeSummary": {
+    "All": 0,
+    "OS": 0,
+    "Project": 0,
+    "Hidden": 0
+  },
+  "PackageTypeCount": {
+    "Regular": 0,
+    "Hidden": 0
+  },
+  "VulnCount": {
+    "AnalysisCount": {
+      "Regular": 0,
+      "Hidden": 0
+    },
+    "SeverityCount": {
+      "Critical": 0,
+      "High": 0,
+      "Medium": 0,
+      "Low": 0,
+      "Unknown": 0
+    },
+    "FixableCount": {
+      "Fixed": 0,
+      "UnFixed": 0
+    }
+  }
+}
+
+---
+
+[TestPrintOutputResults_WithLicenseSummary/one_source_with_no_packages - 1]
+{
+  "Ecosystems": [
+    {
+      "Name": "",
+      "Sources": [
+        {
+          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Type": "lockfile",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 0
+        }
+      ],
+      "IsOS": false
+    }
+  ],
+  "IsContainerScanning": false,
+  "ImageInfo": {
+    "OS": "",
+    "AllLayers": null,
+    "AllBaseImages": null
+  },
+  "LicenseSummary": {
+    "Summary": true,
+    "ShowViolations": false,
+    "LicenseCount": []
+  },
+  "VulnTypeSummary": {
+    "All": 0,
+    "OS": 0,
+    "Project": 0,
+    "Hidden": 0
+  },
+  "PackageTypeCount": {
+    "Regular": 0,
+    "Hidden": 0
+  },
+  "VulnCount": {
+    "AnalysisCount": {
+      "Regular": 0,
+      "Hidden": 0
+    },
+    "SeverityCount": {
+      "Critical": 0,
+      "High": 0,
+      "Medium": 0,
+      "Low": 0,
+      "Unknown": 0
+    },
+    "FixableCount": {
+      "Fixed": 0,
+      "UnFixed": 0
+    }
+  }
+}
+
+---
+
+[TestPrintOutputResults_WithLicenseSummary/one_source_with_one_package,_no_license_violations - 1]
+{
+  "Ecosystems": [
+    {
+      "Name": "npm",
+      "Sources": [
+        {
+          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Type": "lockfile",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.2.3",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "ISC"
+              ],
+              "LicenseViolations": []
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 0
+        }
+      ],
+      "IsOS": false
+    }
+  ],
+  "IsContainerScanning": false,
+  "ImageInfo": {
+    "OS": "",
+    "AllLayers": null,
+    "AllBaseImages": null
+  },
+  "LicenseSummary": {
+    "Summary": true,
+    "ShowViolations": false,
+    "LicenseCount": [
+      {
+        "name": "ISC",
+        "count": 1
+      }
+    ]
+  },
+  "VulnTypeSummary": {
+    "All": 0,
+    "OS": 0,
+    "Project": 0,
+    "Hidden": 0
+  },
+  "PackageTypeCount": {
+    "Regular": 0,
+    "Hidden": 0
+  },
+  "VulnCount": {
+    "AnalysisCount": {
+      "Regular": 0,
+      "Hidden": 0
+    },
+    "SeverityCount": {
+      "Critical": 0,
+      "High": 0,
+      "Medium": 0,
+      "Low": 0,
+      "Unknown": 0
+    },
+    "FixableCount": {
+      "Fixed": 0,
+      "UnFixed": 0
+    }
+  }
+}
+
+---
+
+[TestPrintOutputResults_WithLicenseSummary/one_source_with_one_package,_no_licenses - 1]
+{
+  "Ecosystems": [
+    {
+      "Name": "npm",
+      "Sources": [
+        {
+          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Type": "lockfile",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.2.3",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [],
+              "LicenseViolations": []
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 0
+        }
+      ],
+      "IsOS": false
+    }
+  ],
+  "IsContainerScanning": false,
+  "ImageInfo": {
+    "OS": "",
+    "AllLayers": null,
+    "AllBaseImages": null
+  },
+  "LicenseSummary": {
+    "Summary": true,
+    "ShowViolations": false,
+    "LicenseCount": []
+  },
+  "VulnTypeSummary": {
+    "All": 0,
+    "OS": 0,
+    "Project": 0,
+    "Hidden": 0
+  },
+  "PackageTypeCount": {
+    "Regular": 0,
+    "Hidden": 0
+  },
+  "VulnCount": {
+    "AnalysisCount": {
+      "Regular": 0,
+      "Hidden": 0
+    },
+    "SeverityCount": {
+      "Critical": 0,
+      "High": 0,
+      "Medium": 0,
+      "Low": 0,
+      "Unknown": 0
+    },
+    "FixableCount": {
+      "Fixed": 0,
+      "UnFixed": 0
+    }
+  }
+}
+
+---
+
+[TestPrintOutputResults_WithLicenseSummary/one_source_with_one_package_and_an_unknown_license - 1]
+{
+  "Ecosystems": [
+    {
+      "Name": "npm",
+      "Sources": [
+        {
+          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Type": "lockfile",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.2.3",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "UNKNOWN"
+              ],
+              "LicenseViolations": []
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 0
+        }
+      ],
+      "IsOS": false
+    }
+  ],
+  "IsContainerScanning": false,
+  "ImageInfo": {
+    "OS": "",
+    "AllLayers": null,
+    "AllBaseImages": null
+  },
+  "LicenseSummary": {
+    "Summary": true,
+    "ShowViolations": false,
+    "LicenseCount": [
+      {
+        "name": "UNKNOWN",
+        "count": 1
+      }
+    ]
+  },
+  "VulnTypeSummary": {
+    "All": 0,
+    "OS": 0,
+    "Project": 0,
+    "Hidden": 0
+  },
+  "PackageTypeCount": {
+    "Regular": 0,
+    "Hidden": 0
+  },
+  "VulnCount": {
+    "AnalysisCount": {
+      "Regular": 0,
+      "Hidden": 0
+    },
+    "SeverityCount": {
+      "Critical": 0,
+      "High": 0,
+      "Medium": 0,
+      "Low": 0,
+      "Unknown": 0
+    },
+    "FixableCount": {
+      "Fixed": 0,
+      "UnFixed": 0
+    }
+  }
+}
+
+---
+
+[TestPrintOutputResults_WithLicenseSummary/one_source_with_one_package_and_multiple_license_violations - 1]
+{
+  "Ecosystems": [
+    {
+      "Name": "npm",
+      "Sources": [
+        {
+          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Type": "lockfile",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.2.3",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "MIT",
+                "Apache-2.0"
+              ],
+              "LicenseViolations": [
+                "MIT",
+                "Apache-2.0"
+              ]
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 2
+        }
+      ],
+      "IsOS": false
+    }
+  ],
+  "IsContainerScanning": false,
+  "ImageInfo": {
+    "OS": "",
+    "AllLayers": null,
+    "AllBaseImages": null
+  },
+  "LicenseSummary": {
+    "Summary": true,
+    "ShowViolations": false,
+    "LicenseCount": [
+      {
+        "name": "Apache-2.0",
+        "count": 1
+      },
+      {
+        "name": "MIT",
+        "count": 1
+      }
+    ]
+  },
+  "VulnTypeSummary": {
+    "All": 0,
+    "OS": 0,
+    "Project": 0,
+    "Hidden": 0
+  },
+  "PackageTypeCount": {
+    "Regular": 0,
+    "Hidden": 0
+  },
+  "VulnCount": {
+    "AnalysisCount": {
+      "Regular": 0,
+      "Hidden": 0
+    },
+    "SeverityCount": {
+      "Critical": 0,
+      "High": 0,
+      "Medium": 0,
+      "Low": 0,
+      "Unknown": 0
+    },
+    "FixableCount": {
+      "Fixed": 0,
+      "UnFixed": 0
+    }
+  }
+}
+
+---
+
+[TestPrintOutputResults_WithLicenseSummary/one_source_with_one_package_and_one_license_violation - 1]
+{
+  "Ecosystems": [
+    {
+      "Name": "npm",
+      "Sources": [
+        {
+          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Type": "lockfile",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.2.3",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "MIT"
+              ],
+              "LicenseViolations": [
+                "MIT"
+              ]
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 1
+        }
+      ],
+      "IsOS": false
+    }
+  ],
+  "IsContainerScanning": false,
+  "ImageInfo": {
+    "OS": "",
+    "AllLayers": null,
+    "AllBaseImages": null
+  },
+  "LicenseSummary": {
+    "Summary": true,
+    "ShowViolations": false,
+    "LicenseCount": [
+      {
+        "name": "MIT",
+        "count": 1
+      }
+    ]
+  },
+  "VulnTypeSummary": {
+    "All": 0,
+    "OS": 0,
+    "Project": 0,
+    "Hidden": 0
+  },
+  "PackageTypeCount": {
+    "Regular": 0,
+    "Hidden": 0
+  },
+  "VulnCount": {
+    "AnalysisCount": {
+      "Regular": 0,
+      "Hidden": 0
+    },
+    "SeverityCount": {
+      "Critical": 0,
+      "High": 0,
+      "Medium": 0,
+      "Low": 0,
+      "Unknown": 0
+    },
+    "FixableCount": {
+      "Fixed": 0,
+      "UnFixed": 0
+    }
+  }
+}
+
+---
+
+[TestPrintOutputResults_WithLicenseSummary/one_source_with_one_package_and_one_license_violation_(dev) - 1]
+{
+  "Ecosystems": [
+    {
+      "Name": "npm",
+      "Sources": [
+        {
+          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Type": "lockfile",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.2.3",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "MIT"
+              ],
+              "LicenseViolations": [
+                "MIT"
+              ]
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 1
+        }
+      ],
+      "IsOS": false
+    }
+  ],
+  "IsContainerScanning": false,
+  "ImageInfo": {
+    "OS": "",
+    "AllLayers": null,
+    "AllBaseImages": null
+  },
+  "LicenseSummary": {
+    "Summary": true,
+    "ShowViolations": false,
+    "LicenseCount": [
+      {
+        "name": "MIT",
+        "count": 1
+      }
+    ]
+  },
+  "VulnTypeSummary": {
+    "All": 0,
+    "OS": 0,
+    "Project": 0,
+    "Hidden": 0
+  },
+  "PackageTypeCount": {
+    "Regular": 0,
+    "Hidden": 0
+  },
+  "VulnCount": {
+    "AnalysisCount": {
+      "Regular": 0,
+      "Hidden": 0
+    },
+    "SeverityCount": {
+      "Critical": 0,
+      "High": 0,
+      "Medium": 0,
+      "Low": 0,
+      "Unknown": 0
+    },
+    "FixableCount": {
+      "Fixed": 0,
+      "UnFixed": 0
+    }
+  }
+}
+
+---
+
+[TestPrintOutputResults_WithLicenseSummary/one_source_with_one_package_with_both_a_version_and_a_commit_and_one_license_violation - 1]
+{
+  "Ecosystems": [
+    {
+      "Name": "npm",
+      "Sources": [
+        {
+          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Type": "lockfile",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.2.3",
+              "Commit": "abc123",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "MIT"
+              ],
+              "LicenseViolations": [
+                "MIT"
+              ]
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 1
+        }
+      ],
+      "IsOS": false
+    }
+  ],
+  "IsContainerScanning": false,
+  "ImageInfo": {
+    "OS": "",
+    "AllLayers": null,
+    "AllBaseImages": null
+  },
+  "LicenseSummary": {
+    "Summary": true,
+    "ShowViolations": false,
+    "LicenseCount": [
+      {
+        "name": "MIT",
+        "count": 1
+      }
+    ]
+  },
+  "VulnTypeSummary": {
+    "All": 0,
+    "OS": 0,
+    "Project": 0,
+    "Hidden": 0
+  },
+  "PackageTypeCount": {
+    "Regular": 0,
+    "Hidden": 0
+  },
+  "VulnCount": {
+    "AnalysisCount": {
+      "Regular": 0,
+      "Hidden": 0
+    },
+    "SeverityCount": {
+      "Critical": 0,
+      "High": 0,
+      "Medium": 0,
+      "Low": 0,
+      "Unknown": 0
+    },
+    "FixableCount": {
+      "Fixed": 0,
+      "UnFixed": 0
+    }
+  }
+}
+
+---
+
+[TestPrintOutputResults_WithLicenseSummary/one_source_with_one_package_with_just_a_commit_and_one_license_violation - 1]
+{
+  "Ecosystems": [
+    {
+      "Name": "npm",
+      "Sources": [
+        {
+          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Type": "lockfile",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "",
+              "Commit": "abc123",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "MIT"
+              ],
+              "LicenseViolations": [
+                "MIT"
+              ]
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 1
+        }
+      ],
+      "IsOS": false
+    }
+  ],
+  "IsContainerScanning": false,
+  "ImageInfo": {
+    "OS": "",
+    "AllLayers": null,
+    "AllBaseImages": null
+  },
+  "LicenseSummary": {
+    "Summary": true,
+    "ShowViolations": false,
+    "LicenseCount": [
+      {
+        "name": "MIT",
+        "count": 1
+      }
+    ]
+  },
+  "VulnTypeSummary": {
+    "All": 0,
+    "OS": 0,
+    "Project": 0,
+    "Hidden": 0
+  },
+  "PackageTypeCount": {
+    "Regular": 0,
+    "Hidden": 0
+  },
+  "VulnCount": {
+    "AnalysisCount": {
+      "Regular": 0,
+      "Hidden": 0
+    },
+    "SeverityCount": {
+      "Critical": 0,
+      "High": 0,
+      "Medium": 0,
+      "Low": 0,
+      "Unknown": 0
+    },
+    "FixableCount": {
+      "Fixed": 0,
+      "UnFixed": 0
+    }
+  }
+}
+
+---
+
+[TestPrintOutputResults_WithLicenseSummary/two_sources_with_packages,_one_license_violation - 1]
+{
+  "Ecosystems": [
+    {
+      "Name": "npm",
+      "Sources": [
+        {
+          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Type": "lockfile",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.2.3",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "MIT"
+              ],
+              "LicenseViolations": [
+                "MIT"
+              ]
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 1
+        },
+        {
+          "Name": "sbom:<rootdir>/path/to/my/second/lockfile",
+          "Type": "sbom",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine2",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "5.9.0",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "ISC"
+              ],
+              "LicenseViolations": []
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 0
+        }
+      ],
+      "IsOS": false
+    }
+  ],
+  "IsContainerScanning": false,
+  "ImageInfo": {
+    "OS": "",
+    "AllLayers": null,
+    "AllBaseImages": null
+  },
+  "LicenseSummary": {
+    "Summary": true,
+    "ShowViolations": false,
+    "LicenseCount": [
+      {
+        "name": "ISC",
+        "count": 1
+      },
+      {
+        "name": "MIT",
+        "count": 1
+      }
+    ]
+  },
+  "VulnTypeSummary": {
+    "All": 0,
+    "OS": 0,
+    "Project": 0,
+    "Hidden": 0
+  },
+  "PackageTypeCount": {
+    "Regular": 0,
+    "Hidden": 0
+  },
+  "VulnCount": {
+    "AnalysisCount": {
+      "Regular": 0,
+      "Hidden": 0
+    },
+    "SeverityCount": {
+      "Critical": 0,
+      "High": 0,
+      "Medium": 0,
+      "Low": 0,
+      "Unknown": 0
+    },
+    "FixableCount": {
+      "Fixed": 0,
+      "UnFixed": 0
+    }
+  }
+}
+
+---
+
+[TestPrintOutputResults_WithLicenseSummaryAndViolations/multiple_sources_with_a_mixed_count_of_packages,_no_license_violations - 1]
+{
+  "Ecosystems": [
+    {
+      "Name": "npm",
+      "Sources": [
+        {
+          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Type": "lockfile",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.2.3",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "ISC"
+              ],
+              "LicenseViolations": []
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 0
+        },
+        {
+          "Name": "sbom:<rootdir>/path/to/my/second/lockfile",
+          "Type": "sbom",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine2",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "3.2.5",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "ISC"
+              ],
+              "LicenseViolations": []
+            },
+            {
+              "Name": "mine3",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "0.4.1",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "ISC"
+              ],
+              "LicenseViolations": []
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 0
+        },
+        {
+          "Name": "unknown:<rootdir>/path/to/my/third/lockfile",
+          "Type": "unknown",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.2.3",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "ISC"
+              ],
+              "LicenseViolations": []
+            },
+            {
+              "Name": "mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.3.5",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "ISC"
+              ],
+              "LicenseViolations": []
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 0
+        }
+      ],
+      "IsOS": false
+    }
+  ],
+  "IsContainerScanning": false,
+  "ImageInfo": {
+    "OS": "",
+    "AllLayers": null,
+    "AllBaseImages": null
+  },
+  "LicenseSummary": {
+    "Summary": true,
+    "ShowViolations": true,
+    "LicenseCount": [
+      {
+        "name": "ISC",
+        "count": 5
+      }
+    ]
+  },
+  "VulnTypeSummary": {
+    "All": 0,
+    "OS": 0,
+    "Project": 0,
+    "Hidden": 0
+  },
+  "PackageTypeCount": {
+    "Regular": 0,
+    "Hidden": 0
+  },
+  "VulnCount": {
+    "AnalysisCount": {
+      "Regular": 0,
+      "Hidden": 0
+    },
+    "SeverityCount": {
+      "Critical": 0,
+      "High": 0,
+      "Medium": 0,
+      "Low": 0,
+      "Unknown": 0
+    },
+    "FixableCount": {
+      "Fixed": 0,
+      "UnFixed": 0
+    }
+  }
+}
+
+---
+
+[TestPrintOutputResults_WithLicenseSummaryAndViolations/multiple_sources_with_a_mixed_count_of_packages,_some_license_violations - 1]
+{
+  "Ecosystems": [
+    {
+      "Name": "npm",
+      "Sources": [
+        {
+          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Type": "lockfile",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.2.3",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "MIT"
+              ],
+              "LicenseViolations": [
+                "MIT"
+              ]
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 1
+        },
+        {
+          "Name": "sbom:<rootdir>/path/to/my/second/lockfile",
+          "Type": "sbom",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine2",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "3.2.5",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "Apache-2.0"
+              ],
+              "LicenseViolations": [
+                "Apache-2.0"
+              ]
+            },
+            {
+              "Name": "mine3",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "0.4.1",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "ISC"
+              ],
+              "LicenseViolations": []
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 1
+        },
+        {
+          "Name": "unknown:<rootdir>/path/to/my/third/lockfile",
+          "Type": "unknown",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.2.3",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "MIT"
+              ],
+              "LicenseViolations": [
+                "MIT"
+              ]
+            },
+            {
+              "Name": "mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.3.5",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "ISC"
+              ],
+              "LicenseViolations": []
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 1
+        }
+      ],
+      "IsOS": false
+    }
+  ],
+  "IsContainerScanning": false,
+  "ImageInfo": {
+    "OS": "",
+    "AllLayers": null,
+    "AllBaseImages": null
+  },
+  "LicenseSummary": {
+    "Summary": true,
+    "ShowViolations": true,
+    "LicenseCount": [
+      {
+        "name": "ISC",
+        "count": 2
+      },
+      {
+        "name": "MIT",
+        "count": 2
+      },
+      {
+        "name": "Apache-2.0",
+        "count": 1
+      }
+    ]
+  },
+  "VulnTypeSummary": {
+    "All": 0,
+    "OS": 0,
+    "Project": 0,
+    "Hidden": 0
+  },
+  "PackageTypeCount": {
+    "Regular": 0,
+    "Hidden": 0
+  },
+  "VulnCount": {
+    "AnalysisCount": {
+      "Regular": 0,
+      "Hidden": 0
+    },
+    "SeverityCount": {
+      "Critical": 0,
+      "High": 0,
+      "Medium": 0,
+      "Low": 0,
+      "Unknown": 0
+    },
+    "FixableCount": {
+      "Fixed": 0,
+      "UnFixed": 0
+    }
+  }
+}
+
+---
+
+[TestPrintOutputResults_WithLicenseSummaryAndViolations/multiple_sources_with_a_mixed_count_of_packages_across_ecosystems,_some_license_violations - 1]
+{
+  "Ecosystems": [
+    {
+      "Name": "NuGet",
+      "Sources": [
+        {
+          "Name": "unknown:<rootdir>/path/to/my/third/lockfile",
+          "Type": "unknown",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.3.5",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "ISC"
+              ],
+              "LicenseViolations": []
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 0
+        }
+      ],
+      "IsOS": false
+    },
+    {
+      "Name": "Packagist",
+      "Sources": [
+        {
+          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Type": "lockfile",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "author1/mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.2.3",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "MIT"
+              ],
+              "LicenseViolations": [
+                "MIT"
+              ]
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 1
+        },
+        {
+          "Name": "unknown:<rootdir>/path/to/my/third/lockfile",
+          "Type": "unknown",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "author1/mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.2.3",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "MIT"
+              ],
+              "LicenseViolations": [
+                "MIT"
+              ]
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 1
+        }
+      ],
+      "IsOS": false
+    },
+    {
+      "Name": "npm",
+      "Sources": [
+        {
+          "Name": "sbom:<rootdir>/path/to/my/second/lockfile",
+          "Type": "sbom",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine2",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "3.2.5",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "Apache-2.0"
+              ],
+              "LicenseViolations": [
+                "Apache-2.0"
+              ]
+            },
+            {
+              "Name": "mine3",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "0.4.1",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "ISC"
+              ],
+              "LicenseViolations": []
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 1
+        }
+      ],
+      "IsOS": false
+    }
+  ],
+  "IsContainerScanning": false,
+  "ImageInfo": {
+    "OS": "",
+    "AllLayers": null,
+    "AllBaseImages": null
+  },
+  "LicenseSummary": {
+    "Summary": true,
+    "ShowViolations": true,
+    "LicenseCount": [
+      {
+        "name": "ISC",
+        "count": 2
+      },
+      {
+        "name": "MIT",
+        "count": 2
+      },
+      {
+        "name": "Apache-2.0",
+        "count": 1
+      }
+    ]
+  },
+  "VulnTypeSummary": {
+    "All": 0,
+    "OS": 0,
+    "Project": 0,
+    "Hidden": 0
+  },
+  "PackageTypeCount": {
+    "Regular": 0,
+    "Hidden": 0
+  },
+  "VulnCount": {
+    "AnalysisCount": {
+      "Regular": 0,
+      "Hidden": 0
+    },
+    "SeverityCount": {
+      "Critical": 0,
+      "High": 0,
+      "Medium": 0,
+      "Low": 0,
+      "Unknown": 0
+    },
+    "FixableCount": {
+      "Fixed": 0,
+      "UnFixed": 0
+    }
+  }
+}
+
+---
+
+[TestPrintOutputResults_WithLicenseSummaryAndViolations/multiple_sources_with_a_mixed_count_of_packages_and_groups,_some_license_violations - 1]
+{
+  "Ecosystems": [
+    {
+      "Name": "npm",
+      "Sources": [
+        {
+          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Type": "lockfile",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.2.3",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "MIT"
+              ],
+              "LicenseViolations": [
+                "MIT"
+              ]
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 1
+        },
+        {
+          "Name": "sbom:<rootdir>/path/to/my/second/lockfile",
+          "Type": "sbom",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine2",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "3.2.5",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "Apache-2.0"
+              ],
+              "LicenseViolations": [
+                "Apache-2.0"
+              ]
+            },
+            {
+              "Name": "mine3",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "0.4.1",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "ISC"
+              ],
+              "LicenseViolations": []
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 1
+        },
+        {
+          "Name": "unknown:<rootdir>/path/to/my/third/lockfile",
+          "Type": "unknown",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.2.3",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "MIT"
+              ],
+              "LicenseViolations": [
+                "MIT"
+              ]
+            },
+            {
+              "Name": "mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.3.5",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "ISC"
+              ],
+              "LicenseViolations": []
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 1
+        }
+      ],
+      "IsOS": false
+    }
+  ],
+  "IsContainerScanning": false,
+  "ImageInfo": {
+    "OS": "",
+    "AllLayers": null,
+    "AllBaseImages": null
+  },
+  "LicenseSummary": {
+    "Summary": true,
+    "ShowViolations": true,
+    "LicenseCount": [
+      {
+        "name": "ISC",
+        "count": 2
+      },
+      {
+        "name": "MIT",
+        "count": 2
+      },
+      {
+        "name": "Apache-2.0",
+        "count": 1
+      }
+    ]
+  },
+  "VulnTypeSummary": {
+    "All": 0,
+    "OS": 0,
+    "Project": 0,
+    "Hidden": 0
+  },
+  "PackageTypeCount": {
+    "Regular": 0,
+    "Hidden": 0
+  },
+  "VulnCount": {
+    "AnalysisCount": {
+      "Regular": 0,
+      "Hidden": 0
+    },
+    "SeverityCount": {
+      "Critical": 0,
+      "High": 0,
+      "Medium": 0,
+      "Low": 0,
+      "Unknown": 0
+    },
+    "FixableCount": {
+      "Fixed": 0,
+      "UnFixed": 0
+    }
+  }
+}
+
+---
+
+[TestPrintOutputResults_WithLicenseSummaryAndViolations/multiple_sources_with_a_mixed_count_of_packages_with_versions_and_commits,_some_license_violations - 1]
+{
+  "Ecosystems": [
+    {
+      "Name": "npm",
+      "Sources": [
+        {
+          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Type": "lockfile",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.2.3",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "MIT",
+                "Apache-2.0"
+              ],
+              "LicenseViolations": [
+                "MIT"
+              ]
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 1
+        },
+        {
+          "Name": "sbom:<rootdir>/path/to/my/second/lockfile",
+          "Type": "sbom",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine2",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "3.2.5",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "UNKNOWN"
+              ],
+              "LicenseViolations": [
+                "UNKNOWN"
+              ]
+            },
+            {
+              "Name": "mine3",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "0.4.1",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "Apache-2.0"
+              ],
+              "LicenseViolations": []
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 1
+        },
+        {
+          "Name": "unknown:<rootdir>/path/to/my/third/lockfile",
+          "Type": "unknown",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.2.3",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "MIT"
+              ],
+              "LicenseViolations": [
+                "MIT"
+              ]
+            },
+            {
+              "Name": "mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.3.5",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "Apache-2.0"
+              ],
+              "LicenseViolations": []
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 1
+        }
+      ],
+      "IsOS": false
+    }
+  ],
+  "IsContainerScanning": false,
+  "ImageInfo": {
+    "OS": "",
+    "AllLayers": null,
+    "AllBaseImages": null
+  },
+  "LicenseSummary": {
+    "Summary": true,
+    "ShowViolations": true,
+    "LicenseCount": [
+      {
+        "name": "Apache-2.0",
+        "count": 3
+      },
+      {
+        "name": "MIT",
+        "count": 2
+      },
+      {
+        "name": "UNKNOWN",
+        "count": 1
+      }
+    ]
+  },
+  "VulnTypeSummary": {
+    "All": 0,
+    "OS": 0,
+    "Project": 0,
+    "Hidden": 0
+  },
+  "PackageTypeCount": {
+    "Regular": 0,
+    "Hidden": 0
+  },
+  "VulnCount": {
+    "AnalysisCount": {
+      "Regular": 0,
+      "Hidden": 0
+    },
+    "SeverityCount": {
+      "Critical": 0,
+      "High": 0,
+      "Medium": 0,
+      "Low": 0,
+      "Unknown": 0
+    },
+    "FixableCount": {
+      "Fixed": 0,
+      "UnFixed": 0
+    }
+  }
+}
+
+---
+
+[TestPrintOutputResults_WithLicenseSummaryAndViolations/multiple_sources_with_no_packages - 1]
+{
+  "Ecosystems": [
+    {
+      "Name": "",
+      "Sources": [
+        {
+          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Type": "lockfile",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 0
+        },
+        {
+          "Name": "sbom:<rootdir>/path/to/my/second/lockfile",
+          "Type": "sbom",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 0
+        },
+        {
+          "Name": "unknown:<rootdir>/path/to/my/third/lockfile",
+          "Type": "unknown",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 0
+        }
+      ],
+      "IsOS": false
+    }
+  ],
+  "IsContainerScanning": false,
+  "ImageInfo": {
+    "OS": "",
+    "AllLayers": null,
+    "AllBaseImages": null
+  },
+  "LicenseSummary": {
+    "Summary": true,
+    "ShowViolations": true,
+    "LicenseCount": []
+  },
+  "VulnTypeSummary": {
+    "All": 0,
+    "OS": 0,
+    "Project": 0,
+    "Hidden": 0
+  },
+  "PackageTypeCount": {
+    "Regular": 0,
+    "Hidden": 0
+  },
+  "VulnCount": {
+    "AnalysisCount": {
+      "Regular": 0,
+      "Hidden": 0
+    },
+    "SeverityCount": {
+      "Critical": 0,
+      "High": 0,
+      "Medium": 0,
+      "Low": 0,
+      "Unknown": 0
+    },
+    "FixableCount": {
+      "Fixed": 0,
+      "UnFixed": 0
+    }
+  }
+}
+
+---
+
+[TestPrintOutputResults_WithLicenseSummaryAndViolations/no_sources - 1]
+{
+  "Ecosystems": null,
+  "IsContainerScanning": false,
+  "ImageInfo": {
+    "OS": "",
+    "AllLayers": null,
+    "AllBaseImages": null
+  },
+  "LicenseSummary": {
+    "Summary": true,
+    "ShowViolations": true,
+    "LicenseCount": []
+  },
+  "VulnTypeSummary": {
+    "All": 0,
+    "OS": 0,
+    "Project": 0,
+    "Hidden": 0
+  },
+  "PackageTypeCount": {
+    "Regular": 0,
+    "Hidden": 0
+  },
+  "VulnCount": {
+    "AnalysisCount": {
+      "Regular": 0,
+      "Hidden": 0
+    },
+    "SeverityCount": {
+      "Critical": 0,
+      "High": 0,
+      "Medium": 0,
+      "Low": 0,
+      "Unknown": 0
+    },
+    "FixableCount": {
+      "Fixed": 0,
+      "UnFixed": 0
+    }
+  }
+}
+
+---
+
+[TestPrintOutputResults_WithLicenseSummaryAndViolations/one_source_with_no_packages - 1]
+{
+  "Ecosystems": [
+    {
+      "Name": "",
+      "Sources": [
+        {
+          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Type": "lockfile",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 0
+        }
+      ],
+      "IsOS": false
+    }
+  ],
+  "IsContainerScanning": false,
+  "ImageInfo": {
+    "OS": "",
+    "AllLayers": null,
+    "AllBaseImages": null
+  },
+  "LicenseSummary": {
+    "Summary": true,
+    "ShowViolations": true,
+    "LicenseCount": []
+  },
+  "VulnTypeSummary": {
+    "All": 0,
+    "OS": 0,
+    "Project": 0,
+    "Hidden": 0
+  },
+  "PackageTypeCount": {
+    "Regular": 0,
+    "Hidden": 0
+  },
+  "VulnCount": {
+    "AnalysisCount": {
+      "Regular": 0,
+      "Hidden": 0
+    },
+    "SeverityCount": {
+      "Critical": 0,
+      "High": 0,
+      "Medium": 0,
+      "Low": 0,
+      "Unknown": 0
+    },
+    "FixableCount": {
+      "Fixed": 0,
+      "UnFixed": 0
+    }
+  }
+}
+
+---
+
+[TestPrintOutputResults_WithLicenseSummaryAndViolations/one_source_with_one_package,_no_license_violations - 1]
+{
+  "Ecosystems": [
+    {
+      "Name": "npm",
+      "Sources": [
+        {
+          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Type": "lockfile",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.2.3",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "ISC"
+              ],
+              "LicenseViolations": []
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 0
+        }
+      ],
+      "IsOS": false
+    }
+  ],
+  "IsContainerScanning": false,
+  "ImageInfo": {
+    "OS": "",
+    "AllLayers": null,
+    "AllBaseImages": null
+  },
+  "LicenseSummary": {
+    "Summary": true,
+    "ShowViolations": true,
+    "LicenseCount": [
+      {
+        "name": "ISC",
+        "count": 1
+      }
+    ]
+  },
+  "VulnTypeSummary": {
+    "All": 0,
+    "OS": 0,
+    "Project": 0,
+    "Hidden": 0
+  },
+  "PackageTypeCount": {
+    "Regular": 0,
+    "Hidden": 0
+  },
+  "VulnCount": {
+    "AnalysisCount": {
+      "Regular": 0,
+      "Hidden": 0
+    },
+    "SeverityCount": {
+      "Critical": 0,
+      "High": 0,
+      "Medium": 0,
+      "Low": 0,
+      "Unknown": 0
+    },
+    "FixableCount": {
+      "Fixed": 0,
+      "UnFixed": 0
+    }
+  }
+}
+
+---
+
+[TestPrintOutputResults_WithLicenseSummaryAndViolations/one_source_with_one_package,_no_licenses - 1]
+{
+  "Ecosystems": [
+    {
+      "Name": "npm",
+      "Sources": [
+        {
+          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Type": "lockfile",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.2.3",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [],
+              "LicenseViolations": []
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 0
+        }
+      ],
+      "IsOS": false
+    }
+  ],
+  "IsContainerScanning": false,
+  "ImageInfo": {
+    "OS": "",
+    "AllLayers": null,
+    "AllBaseImages": null
+  },
+  "LicenseSummary": {
+    "Summary": true,
+    "ShowViolations": true,
+    "LicenseCount": []
+  },
+  "VulnTypeSummary": {
+    "All": 0,
+    "OS": 0,
+    "Project": 0,
+    "Hidden": 0
+  },
+  "PackageTypeCount": {
+    "Regular": 0,
+    "Hidden": 0
+  },
+  "VulnCount": {
+    "AnalysisCount": {
+      "Regular": 0,
+      "Hidden": 0
+    },
+    "SeverityCount": {
+      "Critical": 0,
+      "High": 0,
+      "Medium": 0,
+      "Low": 0,
+      "Unknown": 0
+    },
+    "FixableCount": {
+      "Fixed": 0,
+      "UnFixed": 0
+    }
+  }
+}
+
+---
+
+[TestPrintOutputResults_WithLicenseSummaryAndViolations/one_source_with_one_package_and_an_unknown_license - 1]
+{
+  "Ecosystems": [
+    {
+      "Name": "npm",
+      "Sources": [
+        {
+          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Type": "lockfile",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.2.3",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "UNKNOWN"
+              ],
+              "LicenseViolations": []
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 0
+        }
+      ],
+      "IsOS": false
+    }
+  ],
+  "IsContainerScanning": false,
+  "ImageInfo": {
+    "OS": "",
+    "AllLayers": null,
+    "AllBaseImages": null
+  },
+  "LicenseSummary": {
+    "Summary": true,
+    "ShowViolations": true,
+    "LicenseCount": [
+      {
+        "name": "UNKNOWN",
+        "count": 1
+      }
+    ]
+  },
+  "VulnTypeSummary": {
+    "All": 0,
+    "OS": 0,
+    "Project": 0,
+    "Hidden": 0
+  },
+  "PackageTypeCount": {
+    "Regular": 0,
+    "Hidden": 0
+  },
+  "VulnCount": {
+    "AnalysisCount": {
+      "Regular": 0,
+      "Hidden": 0
+    },
+    "SeverityCount": {
+      "Critical": 0,
+      "High": 0,
+      "Medium": 0,
+      "Low": 0,
+      "Unknown": 0
+    },
+    "FixableCount": {
+      "Fixed": 0,
+      "UnFixed": 0
+    }
+  }
+}
+
+---
+
+[TestPrintOutputResults_WithLicenseSummaryAndViolations/one_source_with_one_package_and_multiple_license_violations - 1]
+{
+  "Ecosystems": [
+    {
+      "Name": "npm",
+      "Sources": [
+        {
+          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Type": "lockfile",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.2.3",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "MIT",
+                "Apache-2.0"
+              ],
+              "LicenseViolations": [
+                "MIT",
+                "Apache-2.0"
+              ]
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 2
+        }
+      ],
+      "IsOS": false
+    }
+  ],
+  "IsContainerScanning": false,
+  "ImageInfo": {
+    "OS": "",
+    "AllLayers": null,
+    "AllBaseImages": null
+  },
+  "LicenseSummary": {
+    "Summary": true,
+    "ShowViolations": true,
+    "LicenseCount": [
+      {
+        "name": "Apache-2.0",
+        "count": 1
+      },
+      {
+        "name": "MIT",
+        "count": 1
+      }
+    ]
+  },
+  "VulnTypeSummary": {
+    "All": 0,
+    "OS": 0,
+    "Project": 0,
+    "Hidden": 0
+  },
+  "PackageTypeCount": {
+    "Regular": 0,
+    "Hidden": 0
+  },
+  "VulnCount": {
+    "AnalysisCount": {
+      "Regular": 0,
+      "Hidden": 0
+    },
+    "SeverityCount": {
+      "Critical": 0,
+      "High": 0,
+      "Medium": 0,
+      "Low": 0,
+      "Unknown": 0
+    },
+    "FixableCount": {
+      "Fixed": 0,
+      "UnFixed": 0
+    }
+  }
+}
+
+---
+
+[TestPrintOutputResults_WithLicenseSummaryAndViolations/one_source_with_one_package_and_one_license_violation - 1]
+{
+  "Ecosystems": [
+    {
+      "Name": "npm",
+      "Sources": [
+        {
+          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Type": "lockfile",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.2.3",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "MIT"
+              ],
+              "LicenseViolations": [
+                "MIT"
+              ]
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 1
+        }
+      ],
+      "IsOS": false
+    }
+  ],
+  "IsContainerScanning": false,
+  "ImageInfo": {
+    "OS": "",
+    "AllLayers": null,
+    "AllBaseImages": null
+  },
+  "LicenseSummary": {
+    "Summary": true,
+    "ShowViolations": true,
+    "LicenseCount": [
+      {
+        "name": "MIT",
+        "count": 1
+      }
+    ]
+  },
+  "VulnTypeSummary": {
+    "All": 0,
+    "OS": 0,
+    "Project": 0,
+    "Hidden": 0
+  },
+  "PackageTypeCount": {
+    "Regular": 0,
+    "Hidden": 0
+  },
+  "VulnCount": {
+    "AnalysisCount": {
+      "Regular": 0,
+      "Hidden": 0
+    },
+    "SeverityCount": {
+      "Critical": 0,
+      "High": 0,
+      "Medium": 0,
+      "Low": 0,
+      "Unknown": 0
+    },
+    "FixableCount": {
+      "Fixed": 0,
+      "UnFixed": 0
+    }
+  }
+}
+
+---
+
+[TestPrintOutputResults_WithLicenseSummaryAndViolations/one_source_with_one_package_and_one_license_violation_(dev) - 1]
+{
+  "Ecosystems": [
+    {
+      "Name": "npm",
+      "Sources": [
+        {
+          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Type": "lockfile",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.2.3",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "MIT"
+              ],
+              "LicenseViolations": [
+                "MIT"
+              ]
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 1
+        }
+      ],
+      "IsOS": false
+    }
+  ],
+  "IsContainerScanning": false,
+  "ImageInfo": {
+    "OS": "",
+    "AllLayers": null,
+    "AllBaseImages": null
+  },
+  "LicenseSummary": {
+    "Summary": true,
+    "ShowViolations": true,
+    "LicenseCount": [
+      {
+        "name": "MIT",
+        "count": 1
+      }
+    ]
+  },
+  "VulnTypeSummary": {
+    "All": 0,
+    "OS": 0,
+    "Project": 0,
+    "Hidden": 0
+  },
+  "PackageTypeCount": {
+    "Regular": 0,
+    "Hidden": 0
+  },
+  "VulnCount": {
+    "AnalysisCount": {
+      "Regular": 0,
+      "Hidden": 0
+    },
+    "SeverityCount": {
+      "Critical": 0,
+      "High": 0,
+      "Medium": 0,
+      "Low": 0,
+      "Unknown": 0
+    },
+    "FixableCount": {
+      "Fixed": 0,
+      "UnFixed": 0
+    }
+  }
+}
+
+---
+
+[TestPrintOutputResults_WithLicenseSummaryAndViolations/one_source_with_one_package_with_both_a_version_and_a_commit_and_one_license_violation - 1]
+{
+  "Ecosystems": [
+    {
+      "Name": "npm",
+      "Sources": [
+        {
+          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Type": "lockfile",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.2.3",
+              "Commit": "abc123",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "MIT"
+              ],
+              "LicenseViolations": [
+                "MIT"
+              ]
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 1
+        }
+      ],
+      "IsOS": false
+    }
+  ],
+  "IsContainerScanning": false,
+  "ImageInfo": {
+    "OS": "",
+    "AllLayers": null,
+    "AllBaseImages": null
+  },
+  "LicenseSummary": {
+    "Summary": true,
+    "ShowViolations": true,
+    "LicenseCount": [
+      {
+        "name": "MIT",
+        "count": 1
+      }
+    ]
+  },
+  "VulnTypeSummary": {
+    "All": 0,
+    "OS": 0,
+    "Project": 0,
+    "Hidden": 0
+  },
+  "PackageTypeCount": {
+    "Regular": 0,
+    "Hidden": 0
+  },
+  "VulnCount": {
+    "AnalysisCount": {
+      "Regular": 0,
+      "Hidden": 0
+    },
+    "SeverityCount": {
+      "Critical": 0,
+      "High": 0,
+      "Medium": 0,
+      "Low": 0,
+      "Unknown": 0
+    },
+    "FixableCount": {
+      "Fixed": 0,
+      "UnFixed": 0
+    }
+  }
+}
+
+---
+
+[TestPrintOutputResults_WithLicenseSummaryAndViolations/one_source_with_one_package_with_just_a_commit_and_one_license_violation - 1]
+{
+  "Ecosystems": [
+    {
+      "Name": "npm",
+      "Sources": [
+        {
+          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Type": "lockfile",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "",
+              "Commit": "abc123",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "MIT"
+              ],
+              "LicenseViolations": [
+                "MIT"
+              ]
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 1
+        }
+      ],
+      "IsOS": false
+    }
+  ],
+  "IsContainerScanning": false,
+  "ImageInfo": {
+    "OS": "",
+    "AllLayers": null,
+    "AllBaseImages": null
+  },
+  "LicenseSummary": {
+    "Summary": true,
+    "ShowViolations": true,
+    "LicenseCount": [
+      {
+        "name": "MIT",
+        "count": 1
+      }
+    ]
+  },
+  "VulnTypeSummary": {
+    "All": 0,
+    "OS": 0,
+    "Project": 0,
+    "Hidden": 0
+  },
+  "PackageTypeCount": {
+    "Regular": 0,
+    "Hidden": 0
+  },
+  "VulnCount": {
+    "AnalysisCount": {
+      "Regular": 0,
+      "Hidden": 0
+    },
+    "SeverityCount": {
+      "Critical": 0,
+      "High": 0,
+      "Medium": 0,
+      "Low": 0,
+      "Unknown": 0
+    },
+    "FixableCount": {
+      "Fixed": 0,
+      "UnFixed": 0
+    }
+  }
+}
+
+---
+
+[TestPrintOutputResults_WithLicenseSummaryAndViolations/two_sources_with_packages,_one_license_violation - 1]
+{
+  "Ecosystems": [
+    {
+      "Name": "npm",
+      "Sources": [
+        {
+          "Name": "lockfile:<rootdir>/path/to/my/first/lockfile",
+          "Type": "lockfile",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine1",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "1.2.3",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "MIT"
+              ],
+              "LicenseViolations": [
+                "MIT"
+              ]
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 1
+        },
+        {
+          "Name": "sbom:<rootdir>/path/to/my/second/lockfile",
+          "Type": "sbom",
+          "PackageTypeCount": {
+            "Regular": 0,
+            "Hidden": 0
+          },
+          "Packages": [
+            {
+              "Name": "mine2",
+              "OSPackageNames": [
+                ""
+              ],
+              "InstalledVersion": "5.9.0",
+              "Commit": "",
+              "FixedVersion": "No fix available",
+              "RegularVulns": [],
+              "HiddenVulns": [],
+              "LayerDetail": {
+                "LayerIndex": 0,
+                "LayerInfo": {
+                  "Index": 0,
+                  "LayerMetadata": {
+                    "diff_id": "",
+                    "command": "",
+                    "is_empty": false,
+                    "base_image_index": 0
+                  },
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                },
+                "BaseImageInfo": {
+                  "Index": 0,
+                  "BaseImageInfo": null,
+                  "AllLayers": null,
+                  "Count": {
+                    "AnalysisCount": {
+                      "Regular": 0,
+                      "Hidden": 0
+                    },
+                    "SeverityCount": {
+                      "Critical": 0,
+                      "High": 0,
+                      "Medium": 0,
+                      "Low": 0,
+                      "Unknown": 0
+                    },
+                    "FixableCount": {
+                      "Fixed": 0,
+                      "UnFixed": 0
+                    }
+                  }
+                }
+              },
+              "VulnCount": {
+                "AnalysisCount": {
+                  "Regular": 0,
+                  "Hidden": 0
+                },
+                "SeverityCount": {
+                  "Critical": 0,
+                  "High": 0,
+                  "Medium": 0,
+                  "Low": 0,
+                  "Unknown": 0
+                },
+                "FixableCount": {
+                  "Fixed": 0,
+                  "UnFixed": 0
+                }
+              },
+              "Licenses": [
+                "ISC"
+              ],
+              "LicenseViolations": []
+            }
+          ],
+          "VulnCount": {
+            "AnalysisCount": {
+              "Regular": 0,
+              "Hidden": 0
+            },
+            "SeverityCount": {
+              "Critical": 0,
+              "High": 0,
+              "Medium": 0,
+              "Low": 0,
+              "Unknown": 0
+            },
+            "FixableCount": {
+              "Fixed": 0,
+              "UnFixed": 0
+            }
+          },
+          "LicenseViolationsCount": 0
+        }
+      ],
+      "IsOS": false
+    }
+  ],
+  "IsContainerScanning": false,
+  "ImageInfo": {
+    "OS": "",
+    "AllLayers": null,
+    "AllBaseImages": null
+  },
+  "LicenseSummary": {
+    "Summary": true,
+    "ShowViolations": true,
+    "LicenseCount": [
+      {
+        "name": "ISC",
+        "count": 1
+      },
+      {
+        "name": "MIT",
+        "count": 1
+      }
+    ]
+  },
+  "VulnTypeSummary": {
+    "All": 0,
+    "OS": 0,
+    "Project": 0,
+    "Hidden": 0
+  },
+  "PackageTypeCount": {
+    "Regular": 0,
+    "Hidden": 0
+  },
+  "VulnCount": {
+    "AnalysisCount": {
+      "Regular": 0,
+      "Hidden": 0
+    },
+    "SeverityCount": {
+      "Critical": 0,
+      "High": 0,
+      "Medium": 0,
+      "Low": 0,
+      "Unknown": 0
+    },
+    "FixableCount": {
+      "Fixed": 0,
+      "UnFixed": 0
+    }
+  }
+}
+
+---
+
 [TestPrintOutputResults_WithVulnerabilities/multiple_sources_with_a_mixed_count_of_grouped_packages,_and_multiple_vulnerabilities - 1]
 {
   "Ecosystems": [

--- a/internal/output/__snapshots__/sarif_test.snap
+++ b/internal/output/__snapshots__/sarif_test.snap
@@ -326,56 +326,6 @@
 }
 ---
 
-[TestPrintSARIFReport_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages,_some_license_violations#01 - 1]
-{
-  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
-  "properties": {},
-  "runs": [
-    {
-      "addresses": [],
-      "graphs": [],
-      "invocations": [],
-      "language": "en-US",
-      "logicalLocations": [],
-      "newlineSequences": [
-        "\r\n",
-        "\n"
-      ],
-      "policies": [],
-      "redactionTokens": [],
-      "results": [],
-      "runAggregates": [],
-      "taxonomies": [],
-      "threadFlowLocations": [],
-      "tool": {
-        "driver": {
-          "contents": [
-            "localizedData",
-            "nonLocalizedData"
-          ],
-          "informationUri": "https://github.com/google/osv-scanner",
-          "isComprehensive": false,
-          "language": "en-US",
-          "locations": [],
-          "name": "osv-scanner",
-          "notifications": [],
-          "rules": [],
-          "supportedTaxonomies": [],
-          "taxa": [],
-          "version": "2.5.1"
-        },
-        "extensions": []
-      },
-      "translations": [],
-      "versionControlProvenance": [],
-      "webRequests": [],
-      "webResponses": []
-    }
-  ],
-  "version": "2.1.0"
-}
----
-
 [TestPrintSARIFReport_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages_across_ecosystems,_some_license_violations - 1]
 {
   "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
@@ -427,6 +377,56 @@
 ---
 
 [TestPrintSARIFReport_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages_and_groups,_some_license_violations - 1]
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+  "properties": {},
+  "runs": [
+    {
+      "addresses": [],
+      "graphs": [],
+      "invocations": [],
+      "language": "en-US",
+      "logicalLocations": [],
+      "newlineSequences": [
+        "\r\n",
+        "\n"
+      ],
+      "policies": [],
+      "redactionTokens": [],
+      "results": [],
+      "runAggregates": [],
+      "taxonomies": [],
+      "threadFlowLocations": [],
+      "tool": {
+        "driver": {
+          "contents": [
+            "localizedData",
+            "nonLocalizedData"
+          ],
+          "informationUri": "https://github.com/google/osv-scanner",
+          "isComprehensive": false,
+          "language": "en-US",
+          "locations": [],
+          "name": "osv-scanner",
+          "notifications": [],
+          "rules": [],
+          "supportedTaxonomies": [],
+          "taxa": [],
+          "version": "2.5.1"
+        },
+        "extensions": []
+      },
+      "translations": [],
+      "versionControlProvenance": [],
+      "webRequests": [],
+      "webResponses": []
+    }
+  ],
+  "version": "2.1.0"
+}
+---
+
+[TestPrintSARIFReport_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages_with_versions_and_commits,_some_license_violations - 1]
 {
   "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
   "properties": {},

--- a/internal/output/__snapshots__/spdx_test.snap
+++ b/internal/output/__snapshots__/spdx_test.snap
@@ -467,240 +467,6 @@
 
 ---
 
-[TestPrintSPDXResults_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages,_some_license_violations#01 - 1]
-{
-  "spdxVersion": "SPDX-2.3",
-  "dataLicense": "CC0-1.0",
-  "SPDXID": "SPDXRef-DOCUMENT",
-  "name": "SCALIBR-generated SPDX",
-  "documentNamespace": "https://spdx.google/<uuid>",
-  "creationInfo": {
-    "creators": [
-      "Tool: SCALIBR"
-    ],
-    "created": "<timestamp>"
-  },
-  "packages": [
-    {
-      "name": "main",
-      "SPDXID": "SPDXRef-Package-main-<uuid>",
-      "versionInfo": "0",
-      "supplier": "NOASSERTION",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": false
-    },
-    {
-      "name": "mine1",
-      "SPDXID": "SPDXRef-Package-mine1-<uuid>",
-      "versionInfo": "1.2.3",
-      "supplier": "NOASSERTION",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": false,
-      "sourceInfo": "Identified by the javascript/packagelockjson extractor from <rootdir>/path/to/my/first/lockfile",
-      "licenseConcluded": "NOASSERTION",
-      "licenseDeclared": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/mine1@1.2.3"
-        }
-      ]
-    },
-    {
-      "name": "mine2",
-      "SPDXID": "SPDXRef-Package-mine2-<uuid>",
-      "versionInfo": "3.2.5",
-      "supplier": "NOASSERTION",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": false,
-      "sourceInfo": "Identified by the javascript/packagelockjson extractor from <rootdir>/path/to/my/second/lockfile",
-      "licenseConcluded": "NOASSERTION",
-      "licenseDeclared": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/mine2@3.2.5"
-        }
-      ]
-    },
-    {
-      "name": "mine3",
-      "SPDXID": "SPDXRef-Package-mine3-<uuid>",
-      "versionInfo": "0.4.1",
-      "supplier": "NOASSERTION",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": false,
-      "sourceInfo": "Identified by the javascript/packagelockjson extractor from <rootdir>/path/to/my/second/lockfile",
-      "licenseConcluded": "NOASSERTION",
-      "licenseDeclared": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/mine3@0.4.1"
-        }
-      ]
-    },
-    {
-      "name": "mine1",
-      "SPDXID": "SPDXRef-Package-mine1-<uuid>",
-      "versionInfo": "1.3.5",
-      "supplier": "NOASSERTION",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": false,
-      "sourceInfo": "Identified by the javascript/packagelockjson extractor from <rootdir>/path/to/my/third/lockfile",
-      "licenseConcluded": "NOASSERTION",
-      "licenseDeclared": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/mine1@1.3.5"
-        }
-      ]
-    },
-    {
-      "name": "mine1",
-      "SPDXID": "SPDXRef-Package-mine1-<uuid>",
-      "versionInfo": "1.2.3",
-      "supplier": "NOASSERTION",
-      "downloadLocation": "NOASSERTION",
-      "filesAnalyzed": false,
-      "sourceInfo": "Identified by the javascript/packagelockjson extractor from <rootdir>/path/to/my/third/lockfile",
-      "licenseConcluded": "NOASSERTION",
-      "licenseDeclared": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/mine1@1.2.3"
-        }
-      ]
-    }
-  ],
-  "files": [
-    {
-      "fileName": "<rootdir>/path/to/my/first/lockfile",
-      "SPDXID": "SPDXRef-File-<rootdir>-path-to-my-first-lockfile-<hash>",
-      "checksums": [
-        {
-          "algorithm": "SHA256",
-          "checksumValue": "<checksum>"
-        }
-      ],
-      "copyrightText": "NOASSERTION"
-    },
-    {
-      "fileName": "<rootdir>/path/to/my/second/lockfile",
-      "SPDXID": "SPDXRef-File-<rootdir>-path-to-my-second-lockfile-<hash>",
-      "checksums": [
-        {
-          "algorithm": "SHA256",
-          "checksumValue": "<checksum>"
-        }
-      ],
-      "copyrightText": "NOASSERTION"
-    },
-    {
-      "fileName": "<rootdir>/path/to/my/third/lockfile",
-      "SPDXID": "SPDXRef-File-<rootdir>-path-to-my-third-lockfile-<hash>",
-      "checksums": [
-        {
-          "algorithm": "SHA256",
-          "checksumValue": "<checksum>"
-        }
-      ],
-      "copyrightText": "NOASSERTION"
-    }
-  ],
-  "relationships": [
-    {
-      "spdxElementId": "SPDXRef-DOCUMENT",
-      "relatedSpdxElement": "SPDXRef-Package-main-<uuid>",
-      "relationshipType": "DESCRIBES"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-main-<uuid>",
-      "relatedSpdxElement": "SPDXRef-Package-mine1-<uuid>",
-      "relationshipType": "CONTAINS"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-mine1-<uuid>",
-      "relatedSpdxElement": "NOASSERTION",
-      "relationshipType": "CONTAINS"
-    },
-    {
-      "spdxElementId": "SPDXRef-File-<rootdir>-path-to-my-first-lockfile-<hash>",
-      "relatedSpdxElement": "SPDXRef-Package-mine1-<uuid>",
-      "relationshipType": "DEPENDENCY_MANIFEST_OF"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-main-<uuid>",
-      "relatedSpdxElement": "SPDXRef-Package-mine2-<uuid>",
-      "relationshipType": "CONTAINS"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-mine2-<uuid>",
-      "relatedSpdxElement": "NOASSERTION",
-      "relationshipType": "CONTAINS"
-    },
-    {
-      "spdxElementId": "SPDXRef-File-<rootdir>-path-to-my-second-lockfile-<hash>",
-      "relatedSpdxElement": "SPDXRef-Package-mine2-<uuid>",
-      "relationshipType": "DEPENDENCY_MANIFEST_OF"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-main-<uuid>",
-      "relatedSpdxElement": "SPDXRef-Package-mine3-<uuid>",
-      "relationshipType": "CONTAINS"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-mine3-<uuid>",
-      "relatedSpdxElement": "NOASSERTION",
-      "relationshipType": "CONTAINS"
-    },
-    {
-      "spdxElementId": "SPDXRef-File-<rootdir>-path-to-my-second-lockfile-<hash>",
-      "relatedSpdxElement": "SPDXRef-Package-mine3-<uuid>",
-      "relationshipType": "DEPENDENCY_MANIFEST_OF"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-main-<uuid>",
-      "relatedSpdxElement": "SPDXRef-Package-mine1-<uuid>",
-      "relationshipType": "CONTAINS"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-mine1-<uuid>",
-      "relatedSpdxElement": "NOASSERTION",
-      "relationshipType": "CONTAINS"
-    },
-    {
-      "spdxElementId": "SPDXRef-File-<rootdir>-path-to-my-third-lockfile-<hash>",
-      "relatedSpdxElement": "SPDXRef-Package-mine1-<uuid>",
-      "relationshipType": "DEPENDENCY_MANIFEST_OF"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-main-<uuid>",
-      "relatedSpdxElement": "SPDXRef-Package-mine1-<uuid>",
-      "relationshipType": "CONTAINS"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-mine1-<uuid>",
-      "relatedSpdxElement": "NOASSERTION",
-      "relationshipType": "CONTAINS"
-    },
-    {
-      "spdxElementId": "SPDXRef-File-<rootdir>-path-to-my-third-lockfile-<hash>",
-      "relatedSpdxElement": "SPDXRef-Package-mine1-<uuid>",
-      "relationshipType": "DEPENDENCY_MANIFEST_OF"
-    }
-  ]
-}
-
----
-
 [TestPrintSPDXResults_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages_across_ecosystems,_some_license_violations - 1]
 {
   "spdxVersion": "SPDX-2.3",
@@ -936,6 +702,240 @@
 ---
 
 [TestPrintSPDXResults_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages_and_groups,_some_license_violations - 1]
+{
+  "spdxVersion": "SPDX-2.3",
+  "dataLicense": "CC0-1.0",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "SCALIBR-generated SPDX",
+  "documentNamespace": "https://spdx.google/<uuid>",
+  "creationInfo": {
+    "creators": [
+      "Tool: SCALIBR"
+    ],
+    "created": "<timestamp>"
+  },
+  "packages": [
+    {
+      "name": "main",
+      "SPDXID": "SPDXRef-Package-main-<uuid>",
+      "versionInfo": "0",
+      "supplier": "NOASSERTION",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false
+    },
+    {
+      "name": "mine1",
+      "SPDXID": "SPDXRef-Package-mine1-<uuid>",
+      "versionInfo": "1.2.3",
+      "supplier": "NOASSERTION",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "sourceInfo": "Identified by the javascript/packagelockjson extractor from <rootdir>/path/to/my/first/lockfile",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/mine1@1.2.3"
+        }
+      ]
+    },
+    {
+      "name": "mine2",
+      "SPDXID": "SPDXRef-Package-mine2-<uuid>",
+      "versionInfo": "3.2.5",
+      "supplier": "NOASSERTION",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "sourceInfo": "Identified by the javascript/packagelockjson extractor from <rootdir>/path/to/my/second/lockfile",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/mine2@3.2.5"
+        }
+      ]
+    },
+    {
+      "name": "mine3",
+      "SPDXID": "SPDXRef-Package-mine3-<uuid>",
+      "versionInfo": "0.4.1",
+      "supplier": "NOASSERTION",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "sourceInfo": "Identified by the javascript/packagelockjson extractor from <rootdir>/path/to/my/second/lockfile",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/mine3@0.4.1"
+        }
+      ]
+    },
+    {
+      "name": "mine1",
+      "SPDXID": "SPDXRef-Package-mine1-<uuid>",
+      "versionInfo": "1.3.5",
+      "supplier": "NOASSERTION",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "sourceInfo": "Identified by the javascript/packagelockjson extractor from <rootdir>/path/to/my/third/lockfile",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/mine1@1.3.5"
+        }
+      ]
+    },
+    {
+      "name": "mine1",
+      "SPDXID": "SPDXRef-Package-mine1-<uuid>",
+      "versionInfo": "1.2.3",
+      "supplier": "NOASSERTION",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "sourceInfo": "Identified by the javascript/packagelockjson extractor from <rootdir>/path/to/my/third/lockfile",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/mine1@1.2.3"
+        }
+      ]
+    }
+  ],
+  "files": [
+    {
+      "fileName": "<rootdir>/path/to/my/first/lockfile",
+      "SPDXID": "SPDXRef-File-<rootdir>-path-to-my-first-lockfile-<hash>",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "<checksum>"
+        }
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "<rootdir>/path/to/my/second/lockfile",
+      "SPDXID": "SPDXRef-File-<rootdir>-path-to-my-second-lockfile-<hash>",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "<checksum>"
+        }
+      ],
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "<rootdir>/path/to/my/third/lockfile",
+      "SPDXID": "SPDXRef-File-<rootdir>-path-to-my-third-lockfile-<hash>",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "<checksum>"
+        }
+      ],
+      "copyrightText": "NOASSERTION"
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relatedSpdxElement": "SPDXRef-Package-main-<uuid>",
+      "relationshipType": "DESCRIBES"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-main-<uuid>",
+      "relatedSpdxElement": "SPDXRef-Package-mine1-<uuid>",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-mine1-<uuid>",
+      "relatedSpdxElement": "NOASSERTION",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-File-<rootdir>-path-to-my-first-lockfile-<hash>",
+      "relatedSpdxElement": "SPDXRef-Package-mine1-<uuid>",
+      "relationshipType": "DEPENDENCY_MANIFEST_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-main-<uuid>",
+      "relatedSpdxElement": "SPDXRef-Package-mine2-<uuid>",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-mine2-<uuid>",
+      "relatedSpdxElement": "NOASSERTION",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-File-<rootdir>-path-to-my-second-lockfile-<hash>",
+      "relatedSpdxElement": "SPDXRef-Package-mine2-<uuid>",
+      "relationshipType": "DEPENDENCY_MANIFEST_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-main-<uuid>",
+      "relatedSpdxElement": "SPDXRef-Package-mine3-<uuid>",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-mine3-<uuid>",
+      "relatedSpdxElement": "NOASSERTION",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-File-<rootdir>-path-to-my-second-lockfile-<hash>",
+      "relatedSpdxElement": "SPDXRef-Package-mine3-<uuid>",
+      "relationshipType": "DEPENDENCY_MANIFEST_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-main-<uuid>",
+      "relatedSpdxElement": "SPDXRef-Package-mine1-<uuid>",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-mine1-<uuid>",
+      "relatedSpdxElement": "NOASSERTION",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-File-<rootdir>-path-to-my-third-lockfile-<hash>",
+      "relatedSpdxElement": "SPDXRef-Package-mine1-<uuid>",
+      "relationshipType": "DEPENDENCY_MANIFEST_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-main-<uuid>",
+      "relatedSpdxElement": "SPDXRef-Package-mine1-<uuid>",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-mine1-<uuid>",
+      "relatedSpdxElement": "NOASSERTION",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-File-<rootdir>-path-to-my-third-lockfile-<hash>",
+      "relatedSpdxElement": "SPDXRef-Package-mine1-<uuid>",
+      "relationshipType": "DEPENDENCY_MANIFEST_OF"
+    }
+  ]
+}
+
+---
+
+[TestPrintSPDXResults_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages_with_versions_and_commits,_some_license_violations - 1]
 {
   "spdxVersion": "SPDX-2.3",
   "dataLicense": "CC0-1.0",

--- a/internal/output/__snapshots__/table_test.snap
+++ b/internal/output/__snapshots__/table_test.snap
@@ -1,4 +1,484 @@
 
+[TestPrintTableResults_LongTerminalWidth_WithLicenseSummary/multiple_sources_with_a_mixed_count_of_packages,_no_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭─────────┬─────────────────────────╮
+│ LICENSE │ NO. OF PACKAGE VERSIONS │
+├─────────┼─────────────────────────┤
+│ ISC     │                       5 │
+╰─────────┴─────────────────────────╯
+
+---
+
+[TestPrintTableResults_LongTerminalWidth_WithLicenseSummary/multiple_sources_with_a_mixed_count_of_packages,_some_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭────────────┬─────────────────────────╮
+│ LICENSE    │ NO. OF PACKAGE VERSIONS │
+├────────────┼─────────────────────────┤
+│ ISC        │                       2 │
+│ MIT        │                       2 │
+│ Apache-2.0 │                       1 │
+╰────────────┴─────────────────────────╯
+
+---
+
+[TestPrintTableResults_LongTerminalWidth_WithLicenseSummary/multiple_sources_with_a_mixed_count_of_packages_across_ecosystems,_some_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 3 ecosystems.
+0 vulnerabilities can be fixed.
+
+╭────────────┬─────────────────────────╮
+│ LICENSE    │ NO. OF PACKAGE VERSIONS │
+├────────────┼─────────────────────────┤
+│ ISC        │                       2 │
+│ MIT        │                       2 │
+│ Apache-2.0 │                       1 │
+╰────────────┴─────────────────────────╯
+
+---
+
+[TestPrintTableResults_LongTerminalWidth_WithLicenseSummary/multiple_sources_with_a_mixed_count_of_packages_and_groups,_some_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭────────────┬─────────────────────────╮
+│ LICENSE    │ NO. OF PACKAGE VERSIONS │
+├────────────┼─────────────────────────┤
+│ ISC        │                       2 │
+│ MIT        │                       2 │
+│ Apache-2.0 │                       1 │
+╰────────────┴─────────────────────────╯
+
+---
+
+[TestPrintTableResults_LongTerminalWidth_WithLicenseSummary/multiple_sources_with_a_mixed_count_of_packages_with_versions_and_commits,_some_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭────────────┬─────────────────────────╮
+│ LICENSE    │ NO. OF PACKAGE VERSIONS │
+├────────────┼─────────────────────────┤
+│ Apache-2.0 │                       3 │
+│ MIT        │                       2 │
+│ UNKNOWN    │                       1 │
+╰────────────┴─────────────────────────╯
+
+---
+
+[TestPrintTableResults_LongTerminalWidth_WithLicenseSummary/multiple_sources_with_no_packages - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+
+---
+
+[TestPrintTableResults_LongTerminalWidth_WithLicenseSummary/no_sources - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 0 ecosystems.
+0 vulnerabilities can be fixed.
+
+
+---
+
+[TestPrintTableResults_LongTerminalWidth_WithLicenseSummary/one_source_with_no_packages - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+
+---
+
+[TestPrintTableResults_LongTerminalWidth_WithLicenseSummary/one_source_with_one_package,_no_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭─────────┬─────────────────────────╮
+│ LICENSE │ NO. OF PACKAGE VERSIONS │
+├─────────┼─────────────────────────┤
+│ ISC     │                       1 │
+╰─────────┴─────────────────────────╯
+
+---
+
+[TestPrintTableResults_LongTerminalWidth_WithLicenseSummary/one_source_with_one_package,_no_licenses - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+
+---
+
+[TestPrintTableResults_LongTerminalWidth_WithLicenseSummary/one_source_with_one_package_and_an_unknown_license - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭─────────┬─────────────────────────╮
+│ LICENSE │ NO. OF PACKAGE VERSIONS │
+├─────────┼─────────────────────────┤
+│ UNKNOWN │                       1 │
+╰─────────┴─────────────────────────╯
+
+---
+
+[TestPrintTableResults_LongTerminalWidth_WithLicenseSummary/one_source_with_one_package_and_multiple_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭────────────┬─────────────────────────╮
+│ LICENSE    │ NO. OF PACKAGE VERSIONS │
+├────────────┼─────────────────────────┤
+│ Apache-2.0 │                       1 │
+│ MIT        │                       1 │
+╰────────────┴─────────────────────────╯
+
+---
+
+[TestPrintTableResults_LongTerminalWidth_WithLicenseSummary/one_source_with_one_package_and_one_license_violation - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭─────────┬─────────────────────────╮
+│ LICENSE │ NO. OF PACKAGE VERSIONS │
+├─────────┼─────────────────────────┤
+│ MIT     │                       1 │
+╰─────────┴─────────────────────────╯
+
+---
+
+[TestPrintTableResults_LongTerminalWidth_WithLicenseSummary/one_source_with_one_package_and_one_license_violation_(dev) - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭─────────┬─────────────────────────╮
+│ LICENSE │ NO. OF PACKAGE VERSIONS │
+├─────────┼─────────────────────────┤
+│ MIT     │                       1 │
+╰─────────┴─────────────────────────╯
+
+---
+
+[TestPrintTableResults_LongTerminalWidth_WithLicenseSummary/one_source_with_one_package_with_both_a_version_and_a_commit_and_one_license_violation - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭─────────┬─────────────────────────╮
+│ LICENSE │ NO. OF PACKAGE VERSIONS │
+├─────────┼─────────────────────────┤
+│ MIT     │                       1 │
+╰─────────┴─────────────────────────╯
+
+---
+
+[TestPrintTableResults_LongTerminalWidth_WithLicenseSummary/one_source_with_one_package_with_just_a_commit_and_one_license_violation - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭─────────┬─────────────────────────╮
+│ LICENSE │ NO. OF PACKAGE VERSIONS │
+├─────────┼─────────────────────────┤
+│ MIT     │                       1 │
+╰─────────┴─────────────────────────╯
+
+---
+
+[TestPrintTableResults_LongTerminalWidth_WithLicenseSummary/two_sources_with_packages,_one_license_violation - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭─────────┬─────────────────────────╮
+│ LICENSE │ NO. OF PACKAGE VERSIONS │
+├─────────┼─────────────────────────┤
+│ ISC     │                       1 │
+│ MIT     │                       1 │
+╰─────────┴─────────────────────────╯
+
+---
+
+[TestPrintTableResults_LongTerminalWidth_WithLicenseSummaryAndViolations/multiple_sources_with_a_mixed_count_of_packages,_no_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭─────────┬─────────────────────────╮
+│ LICENSE │ NO. OF PACKAGE VERSIONS │
+├─────────┼─────────────────────────┤
+│ ISC     │                       5 │
+╰─────────┴─────────────────────────╯
+
+---
+
+[TestPrintTableResults_LongTerminalWidth_WithLicenseSummaryAndViolations/multiple_sources_with_a_mixed_count_of_packages,_some_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭────────────┬─────────────────────────╮
+│ LICENSE    │ NO. OF PACKAGE VERSIONS │
+├────────────┼─────────────────────────┤
+│ ISC        │                       2 │
+│ MIT        │                       2 │
+│ Apache-2.0 │                       1 │
+╰────────────┴─────────────────────────╯
+╭───────────────────┬───────────┬─────────┬─────────┬────────────────────────────╮
+│ LICENSE VIOLATION │ ECOSYSTEM │ PACKAGE │ VERSION │ SOURCE                     │
+├───────────────────┼───────────┼─────────┼─────────┼────────────────────────────┤
+│ MIT               │ npm       │ mine1   │ 1.2.3   │ path/to/my/first/lockfile  │
+│ Apache-2.0        │ npm       │ mine2   │ 3.2.5   │ path/to/my/second/lockfile │
+│ MIT               │ npm       │ mine1   │ 1.2.3   │ path/to/my/third/lockfile  │
+╰───────────────────┴───────────┴─────────┴─────────┴────────────────────────────╯
+
+---
+
+[TestPrintTableResults_LongTerminalWidth_WithLicenseSummaryAndViolations/multiple_sources_with_a_mixed_count_of_packages_across_ecosystems,_some_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 3 ecosystems.
+0 vulnerabilities can be fixed.
+
+╭────────────┬─────────────────────────╮
+│ LICENSE    │ NO. OF PACKAGE VERSIONS │
+├────────────┼─────────────────────────┤
+│ ISC        │                       2 │
+│ MIT        │                       2 │
+│ Apache-2.0 │                       1 │
+╰────────────┴─────────────────────────╯
+╭───────────────────┬───────────┬───────────────┬─────────┬────────────────────────────╮
+│ LICENSE VIOLATION │ ECOSYSTEM │ PACKAGE       │ VERSION │ SOURCE                     │
+├───────────────────┼───────────┼───────────────┼─────────┼────────────────────────────┤
+│ MIT               │ Packagist │ author1/mine1 │ 1.2.3   │ path/to/my/first/lockfile  │
+│ Apache-2.0        │ npm       │ mine2         │ 3.2.5   │ path/to/my/second/lockfile │
+│ MIT               │ Packagist │ author1/mine1 │ 1.2.3   │ path/to/my/third/lockfile  │
+╰───────────────────┴───────────┴───────────────┴─────────┴────────────────────────────╯
+
+---
+
+[TestPrintTableResults_LongTerminalWidth_WithLicenseSummaryAndViolations/multiple_sources_with_a_mixed_count_of_packages_and_groups,_some_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭────────────┬─────────────────────────╮
+│ LICENSE    │ NO. OF PACKAGE VERSIONS │
+├────────────┼─────────────────────────┤
+│ ISC        │                       2 │
+│ MIT        │                       2 │
+│ Apache-2.0 │                       1 │
+╰────────────┴─────────────────────────╯
+╭───────────────────┬───────────┬─────────┬─────────┬────────────────────────────╮
+│ LICENSE VIOLATION │ ECOSYSTEM │ PACKAGE │ VERSION │ SOURCE                     │
+├───────────────────┼───────────┼─────────┼─────────┼────────────────────────────┤
+│ MIT               │ npm       │ mine1   │ 1.2.3   │ path/to/my/first/lockfile  │
+│ Apache-2.0        │ npm       │ mine2   │ 3.2.5   │ path/to/my/second/lockfile │
+│ MIT               │ npm       │ mine1   │ 1.2.3   │ path/to/my/third/lockfile  │
+╰───────────────────┴───────────┴─────────┴─────────┴────────────────────────────╯
+
+---
+
+[TestPrintTableResults_LongTerminalWidth_WithLicenseSummaryAndViolations/multiple_sources_with_a_mixed_count_of_packages_with_versions_and_commits,_some_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭────────────┬─────────────────────────╮
+│ LICENSE    │ NO. OF PACKAGE VERSIONS │
+├────────────┼─────────────────────────┤
+│ Apache-2.0 │                       3 │
+│ MIT        │                       2 │
+│ UNKNOWN    │                       1 │
+╰────────────┴─────────────────────────╯
+╭───────────────────┬───────────┬─────────┬─────────┬────────────────────────────╮
+│ LICENSE VIOLATION │ ECOSYSTEM │ PACKAGE │ VERSION │ SOURCE                     │
+├───────────────────┼───────────┼─────────┼─────────┼────────────────────────────┤
+│ MIT               │ npm       │ mine1   │ 1.2.3   │ path/to/my/first/lockfile  │
+│ UNKNOWN           │ npm       │ mine2   │ 3.2.5   │ path/to/my/second/lockfile │
+│ MIT               │ npm       │ mine1   │ 1.2.3   │ path/to/my/third/lockfile  │
+╰───────────────────┴───────────┴─────────┴─────────┴────────────────────────────╯
+
+---
+
+[TestPrintTableResults_LongTerminalWidth_WithLicenseSummaryAndViolations/multiple_sources_with_no_packages - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+
+---
+
+[TestPrintTableResults_LongTerminalWidth_WithLicenseSummaryAndViolations/no_sources - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 0 ecosystems.
+0 vulnerabilities can be fixed.
+
+
+---
+
+[TestPrintTableResults_LongTerminalWidth_WithLicenseSummaryAndViolations/one_source_with_no_packages - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+
+---
+
+[TestPrintTableResults_LongTerminalWidth_WithLicenseSummaryAndViolations/one_source_with_one_package,_no_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭─────────┬─────────────────────────╮
+│ LICENSE │ NO. OF PACKAGE VERSIONS │
+├─────────┼─────────────────────────┤
+│ ISC     │                       1 │
+╰─────────┴─────────────────────────╯
+
+---
+
+[TestPrintTableResults_LongTerminalWidth_WithLicenseSummaryAndViolations/one_source_with_one_package,_no_licenses - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+
+---
+
+[TestPrintTableResults_LongTerminalWidth_WithLicenseSummaryAndViolations/one_source_with_one_package_and_an_unknown_license - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭─────────┬─────────────────────────╮
+│ LICENSE │ NO. OF PACKAGE VERSIONS │
+├─────────┼─────────────────────────┤
+│ UNKNOWN │                       1 │
+╰─────────┴─────────────────────────╯
+
+---
+
+[TestPrintTableResults_LongTerminalWidth_WithLicenseSummaryAndViolations/one_source_with_one_package_and_multiple_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭────────────┬─────────────────────────╮
+│ LICENSE    │ NO. OF PACKAGE VERSIONS │
+├────────────┼─────────────────────────┤
+│ Apache-2.0 │                       1 │
+│ MIT        │                       1 │
+╰────────────┴─────────────────────────╯
+╭───────────────────┬───────────┬─────────┬─────────┬───────────────────────────╮
+│ LICENSE VIOLATION │ ECOSYSTEM │ PACKAGE │ VERSION │ SOURCE                    │
+├───────────────────┼───────────┼─────────┼─────────┼───────────────────────────┤
+│ MIT, Apache-2.0   │ npm       │ mine1   │ 1.2.3   │ path/to/my/first/lockfile │
+╰───────────────────┴───────────┴─────────┴─────────┴───────────────────────────╯
+
+---
+
+[TestPrintTableResults_LongTerminalWidth_WithLicenseSummaryAndViolations/one_source_with_one_package_and_one_license_violation - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭─────────┬─────────────────────────╮
+│ LICENSE │ NO. OF PACKAGE VERSIONS │
+├─────────┼─────────────────────────┤
+│ MIT     │                       1 │
+╰─────────┴─────────────────────────╯
+╭───────────────────┬───────────┬─────────┬─────────┬───────────────────────────╮
+│ LICENSE VIOLATION │ ECOSYSTEM │ PACKAGE │ VERSION │ SOURCE                    │
+├───────────────────┼───────────┼─────────┼─────────┼───────────────────────────┤
+│ MIT               │ npm       │ mine1   │ 1.2.3   │ path/to/my/first/lockfile │
+╰───────────────────┴───────────┴─────────┴─────────┴───────────────────────────╯
+
+---
+
+[TestPrintTableResults_LongTerminalWidth_WithLicenseSummaryAndViolations/one_source_with_one_package_and_one_license_violation_(dev) - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭─────────┬─────────────────────────╮
+│ LICENSE │ NO. OF PACKAGE VERSIONS │
+├─────────┼─────────────────────────┤
+│ MIT     │                       1 │
+╰─────────┴─────────────────────────╯
+╭───────────────────┬───────────┬─────────┬─────────┬───────────────────────────╮
+│ LICENSE VIOLATION │ ECOSYSTEM │ PACKAGE │ VERSION │ SOURCE                    │
+├───────────────────┼───────────┼─────────┼─────────┼───────────────────────────┤
+│ MIT               │ npm       │ mine1   │ 1.2.3   │ path/to/my/first/lockfile │
+╰───────────────────┴───────────┴─────────┴─────────┴───────────────────────────╯
+
+---
+
+[TestPrintTableResults_LongTerminalWidth_WithLicenseSummaryAndViolations/one_source_with_one_package_with_both_a_version_and_a_commit_and_one_license_violation - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭─────────┬─────────────────────────╮
+│ LICENSE │ NO. OF PACKAGE VERSIONS │
+├─────────┼─────────────────────────┤
+│ MIT     │                       1 │
+╰─────────┴─────────────────────────╯
+╭───────────────────┬───────────┬─────────┬─────────┬───────────────────────────╮
+│ LICENSE VIOLATION │ ECOSYSTEM │ PACKAGE │ VERSION │ SOURCE                    │
+├───────────────────┼───────────┼─────────┼─────────┼───────────────────────────┤
+│ MIT               │ npm       │ mine1   │ 1.2.3   │ path/to/my/first/lockfile │
+╰───────────────────┴───────────┴─────────┴─────────┴───────────────────────────╯
+
+---
+
+[TestPrintTableResults_LongTerminalWidth_WithLicenseSummaryAndViolations/one_source_with_one_package_with_just_a_commit_and_one_license_violation - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭─────────┬─────────────────────────╮
+│ LICENSE │ NO. OF PACKAGE VERSIONS │
+├─────────┼─────────────────────────┤
+│ MIT     │                       1 │
+╰─────────┴─────────────────────────╯
+╭───────────────────┬───────────┬─────────┬─────────┬───────────────────────────╮
+│ LICENSE VIOLATION │ ECOSYSTEM │ PACKAGE │ VERSION │ SOURCE                    │
+├───────────────────┼───────────┼─────────┼─────────┼───────────────────────────┤
+│ MIT               │ npm       │ mine1   │         │ path/to/my/first/lockfile │
+╰───────────────────┴───────────┴─────────┴─────────┴───────────────────────────╯
+
+---
+
+[TestPrintTableResults_LongTerminalWidth_WithLicenseSummaryAndViolations/two_sources_with_packages,_one_license_violation - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭─────────┬─────────────────────────╮
+│ LICENSE │ NO. OF PACKAGE VERSIONS │
+├─────────┼─────────────────────────┤
+│ ISC     │                       1 │
+│ MIT     │                       1 │
+╰─────────┴─────────────────────────╯
+╭───────────────────┬───────────┬─────────┬─────────┬───────────────────────────╮
+│ LICENSE VIOLATION │ ECOSYSTEM │ PACKAGE │ VERSION │ SOURCE                    │
+├───────────────────┼───────────┼─────────┼─────────┼───────────────────────────┤
+│ MIT               │ npm       │ mine1   │ 1.2.3   │ path/to/my/first/lockfile │
+╰───────────────────┴───────────┴─────────┴─────────┴───────────────────────────╯
+
+---
+
 [TestPrintTableResults_LongTerminalWidth_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages,_no_license_violations - 1]
 
 Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
@@ -19,14 +499,6 @@ Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medi
 │ Apache-2.0        │ npm       │ mine2   │ 3.2.5   │ path/to/my/second/lockfile │
 │ MIT               │ npm       │ mine1   │ 1.2.3   │ path/to/my/third/lockfile  │
 ╰───────────────────┴───────────┴─────────┴─────────┴────────────────────────────╯
-
----
-
-[TestPrintTableResults_LongTerminalWidth_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages,_some_license_violations#01 - 1]
-
-Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
-0 vulnerabilities can be fixed.
-
 
 ---
 
@@ -55,6 +527,21 @@ Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medi
 ├───────────────────┼───────────┼─────────┼─────────┼────────────────────────────┤
 │ MIT               │ npm       │ mine1   │ 1.2.3   │ path/to/my/first/lockfile  │
 │ Apache-2.0        │ npm       │ mine2   │ 3.2.5   │ path/to/my/second/lockfile │
+│ MIT               │ npm       │ mine1   │ 1.2.3   │ path/to/my/third/lockfile  │
+╰───────────────────┴───────────┴─────────┴─────────┴────────────────────────────╯
+
+---
+
+[TestPrintTableResults_LongTerminalWidth_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages_with_versions_and_commits,_some_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭───────────────────┬───────────┬─────────┬─────────┬────────────────────────────╮
+│ LICENSE VIOLATION │ ECOSYSTEM │ PACKAGE │ VERSION │ SOURCE                     │
+├───────────────────┼───────────┼─────────┼─────────┼────────────────────────────┤
+│ MIT               │ npm       │ mine1   │ 1.2.3   │ path/to/my/first/lockfile  │
+│ UNKNOWN           │ npm       │ mine2   │ 3.2.5   │ path/to/my/second/lockfile │
 │ MIT               │ npm       │ mine1   │ 1.2.3   │ path/to/my/third/lockfile  │
 ╰───────────────────┴───────────┴─────────┴─────────┴────────────────────────────╯
 
@@ -720,6 +1207,486 @@ Total 2 packages affected by 2 known vulnerabilities (0 Critical, 0 High, 0 Medi
 
 ---
 
+[TestPrintTableResults_NoTerminalWidth_WithLicenseSummary/multiple_sources_with_a_mixed_count_of_packages,_no_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
++---------+-------------------------+
+| LICENSE | NO. OF PACKAGE VERSIONS |
++---------+-------------------------+
+| ISC     |                       5 |
++---------+-------------------------+
+
+---
+
+[TestPrintTableResults_NoTerminalWidth_WithLicenseSummary/multiple_sources_with_a_mixed_count_of_packages,_some_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
++------------+-------------------------+
+| LICENSE    | NO. OF PACKAGE VERSIONS |
++------------+-------------------------+
+| ISC        |                       2 |
+| MIT        |                       2 |
+| Apache-2.0 |                       1 |
++------------+-------------------------+
+
+---
+
+[TestPrintTableResults_NoTerminalWidth_WithLicenseSummary/multiple_sources_with_a_mixed_count_of_packages_across_ecosystems,_some_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 3 ecosystems.
+0 vulnerabilities can be fixed.
+
++------------+-------------------------+
+| LICENSE    | NO. OF PACKAGE VERSIONS |
++------------+-------------------------+
+| ISC        |                       2 |
+| MIT        |                       2 |
+| Apache-2.0 |                       1 |
++------------+-------------------------+
+
+---
+
+[TestPrintTableResults_NoTerminalWidth_WithLicenseSummary/multiple_sources_with_a_mixed_count_of_packages_and_groups,_some_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
++------------+-------------------------+
+| LICENSE    | NO. OF PACKAGE VERSIONS |
++------------+-------------------------+
+| ISC        |                       2 |
+| MIT        |                       2 |
+| Apache-2.0 |                       1 |
++------------+-------------------------+
+
+---
+
+[TestPrintTableResults_NoTerminalWidth_WithLicenseSummary/multiple_sources_with_a_mixed_count_of_packages_with_versions_and_commits,_some_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
++------------+-------------------------+
+| LICENSE    | NO. OF PACKAGE VERSIONS |
++------------+-------------------------+
+| Apache-2.0 |                       3 |
+| MIT        |                       2 |
+| UNKNOWN    |                       1 |
++------------+-------------------------+
+
+---
+
+[TestPrintTableResults_NoTerminalWidth_WithLicenseSummary/multiple_sources_with_no_packages - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+
+---
+
+[TestPrintTableResults_NoTerminalWidth_WithLicenseSummary/no_sources - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 0 ecosystems.
+0 vulnerabilities can be fixed.
+
+
+---
+
+[TestPrintTableResults_NoTerminalWidth_WithLicenseSummary/one_source_with_no_packages - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+
+---
+
+[TestPrintTableResults_NoTerminalWidth_WithLicenseSummary/one_source_with_one_package,_no_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
++---------+-------------------------+
+| LICENSE | NO. OF PACKAGE VERSIONS |
++---------+-------------------------+
+| ISC     |                       1 |
++---------+-------------------------+
+
+---
+
+[TestPrintTableResults_NoTerminalWidth_WithLicenseSummary/one_source_with_one_package,_no_licenses - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+
+---
+
+[TestPrintTableResults_NoTerminalWidth_WithLicenseSummary/one_source_with_one_package_and_an_unknown_license - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
++---------+-------------------------+
+| LICENSE | NO. OF PACKAGE VERSIONS |
++---------+-------------------------+
+| UNKNOWN |                       1 |
++---------+-------------------------+
+
+---
+
+[TestPrintTableResults_NoTerminalWidth_WithLicenseSummary/one_source_with_one_package_and_multiple_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
++------------+-------------------------+
+| LICENSE    | NO. OF PACKAGE VERSIONS |
++------------+-------------------------+
+| Apache-2.0 |                       1 |
+| MIT        |                       1 |
++------------+-------------------------+
+
+---
+
+[TestPrintTableResults_NoTerminalWidth_WithLicenseSummary/one_source_with_one_package_and_one_license_violation - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
++---------+-------------------------+
+| LICENSE | NO. OF PACKAGE VERSIONS |
++---------+-------------------------+
+| MIT     |                       1 |
++---------+-------------------------+
+
+---
+
+[TestPrintTableResults_NoTerminalWidth_WithLicenseSummary/one_source_with_one_package_and_one_license_violation_(dev) - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
++---------+-------------------------+
+| LICENSE | NO. OF PACKAGE VERSIONS |
++---------+-------------------------+
+| MIT     |                       1 |
++---------+-------------------------+
+
+---
+
+[TestPrintTableResults_NoTerminalWidth_WithLicenseSummary/one_source_with_one_package_with_both_a_version_and_a_commit_and_one_license_violation - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
++---------+-------------------------+
+| LICENSE | NO. OF PACKAGE VERSIONS |
++---------+-------------------------+
+| MIT     |                       1 |
++---------+-------------------------+
+
+---
+
+[TestPrintTableResults_NoTerminalWidth_WithLicenseSummary/one_source_with_one_package_with_just_a_commit_and_one_license_violation - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
++---------+-------------------------+
+| LICENSE | NO. OF PACKAGE VERSIONS |
++---------+-------------------------+
+| MIT     |                       1 |
++---------+-------------------------+
+
+---
+
+[TestPrintTableResults_NoTerminalWidth_WithLicenseSummary/two_sources_with_packages,_one_license_violation - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
++---------+-------------------------+
+| LICENSE | NO. OF PACKAGE VERSIONS |
++---------+-------------------------+
+| ISC     |                       1 |
+| MIT     |                       1 |
++---------+-------------------------+
+
+---
+
+[TestPrintTableResults_NoTerminalWidth_WithLicenseSummaryAndViolations/multiple_sources_with_a_mixed_count_of_packages,_no_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
++---------+-------------------------+
+| LICENSE | NO. OF PACKAGE VERSIONS |
++---------+-------------------------+
+| ISC     |                       5 |
++---------+-------------------------+
+
+---
+
+[TestPrintTableResults_NoTerminalWidth_WithLicenseSummaryAndViolations/multiple_sources_with_a_mixed_count_of_packages,_some_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
++------------+-------------------------+
+| LICENSE    | NO. OF PACKAGE VERSIONS |
++------------+-------------------------+
+| ISC        |                       2 |
+| MIT        |                       2 |
+| Apache-2.0 |                       1 |
++------------+-------------------------+
++-------------------+-----------+---------+---------+----------------------------+
+| LICENSE VIOLATION | ECOSYSTEM | PACKAGE | VERSION | SOURCE                     |
++-------------------+-----------+---------+---------+----------------------------+
+| MIT               | npm       | mine1   | 1.2.3   | path/to/my/first/lockfile  |
+| Apache-2.0        | npm       | mine2   | 3.2.5   | path/to/my/second/lockfile |
+| MIT               | npm       | mine1   | 1.2.3   | path/to/my/third/lockfile  |
++-------------------+-----------+---------+---------+----------------------------+
+
+---
+
+[TestPrintTableResults_NoTerminalWidth_WithLicenseSummaryAndViolations/multiple_sources_with_a_mixed_count_of_packages_across_ecosystems,_some_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 3 ecosystems.
+0 vulnerabilities can be fixed.
+
++------------+-------------------------+
+| LICENSE    | NO. OF PACKAGE VERSIONS |
++------------+-------------------------+
+| ISC        |                       2 |
+| MIT        |                       2 |
+| Apache-2.0 |                       1 |
++------------+-------------------------+
++-------------------+-----------+---------------+---------+----------------------------+
+| LICENSE VIOLATION | ECOSYSTEM | PACKAGE       | VERSION | SOURCE                     |
++-------------------+-----------+---------------+---------+----------------------------+
+| MIT               | Packagist | author1/mine1 | 1.2.3   | path/to/my/first/lockfile  |
+| Apache-2.0        | npm       | mine2         | 3.2.5   | path/to/my/second/lockfile |
+| MIT               | Packagist | author1/mine1 | 1.2.3   | path/to/my/third/lockfile  |
++-------------------+-----------+---------------+---------+----------------------------+
+
+---
+
+[TestPrintTableResults_NoTerminalWidth_WithLicenseSummaryAndViolations/multiple_sources_with_a_mixed_count_of_packages_and_groups,_some_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
++------------+-------------------------+
+| LICENSE    | NO. OF PACKAGE VERSIONS |
++------------+-------------------------+
+| ISC        |                       2 |
+| MIT        |                       2 |
+| Apache-2.0 |                       1 |
++------------+-------------------------+
++-------------------+-----------+---------+---------+----------------------------+
+| LICENSE VIOLATION | ECOSYSTEM | PACKAGE | VERSION | SOURCE                     |
++-------------------+-----------+---------+---------+----------------------------+
+| MIT               | npm       | mine1   | 1.2.3   | path/to/my/first/lockfile  |
+| Apache-2.0        | npm       | mine2   | 3.2.5   | path/to/my/second/lockfile |
+| MIT               | npm       | mine1   | 1.2.3   | path/to/my/third/lockfile  |
++-------------------+-----------+---------+---------+----------------------------+
+
+---
+
+[TestPrintTableResults_NoTerminalWidth_WithLicenseSummaryAndViolations/multiple_sources_with_a_mixed_count_of_packages_with_versions_and_commits,_some_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
++------------+-------------------------+
+| LICENSE    | NO. OF PACKAGE VERSIONS |
++------------+-------------------------+
+| Apache-2.0 |                       3 |
+| MIT        |                       2 |
+| UNKNOWN    |                       1 |
++------------+-------------------------+
++-------------------+-----------+---------+---------+----------------------------+
+| LICENSE VIOLATION | ECOSYSTEM | PACKAGE | VERSION | SOURCE                     |
++-------------------+-----------+---------+---------+----------------------------+
+| MIT               | npm       | mine1   | 1.2.3   | path/to/my/first/lockfile  |
+| UNKNOWN           | npm       | mine2   | 3.2.5   | path/to/my/second/lockfile |
+| MIT               | npm       | mine1   | 1.2.3   | path/to/my/third/lockfile  |
++-------------------+-----------+---------+---------+----------------------------+
+
+---
+
+[TestPrintTableResults_NoTerminalWidth_WithLicenseSummaryAndViolations/multiple_sources_with_no_packages - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+
+---
+
+[TestPrintTableResults_NoTerminalWidth_WithLicenseSummaryAndViolations/no_sources - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 0 ecosystems.
+0 vulnerabilities can be fixed.
+
+
+---
+
+[TestPrintTableResults_NoTerminalWidth_WithLicenseSummaryAndViolations/one_source_with_no_packages - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+
+---
+
+[TestPrintTableResults_NoTerminalWidth_WithLicenseSummaryAndViolations/one_source_with_one_package,_no_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
++---------+-------------------------+
+| LICENSE | NO. OF PACKAGE VERSIONS |
++---------+-------------------------+
+| ISC     |                       1 |
++---------+-------------------------+
+
+---
+
+[TestPrintTableResults_NoTerminalWidth_WithLicenseSummaryAndViolations/one_source_with_one_package,_no_licenses - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+
+---
+
+[TestPrintTableResults_NoTerminalWidth_WithLicenseSummaryAndViolations/one_source_with_one_package_and_an_unknown_license - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
++---------+-------------------------+
+| LICENSE | NO. OF PACKAGE VERSIONS |
++---------+-------------------------+
+| UNKNOWN |                       1 |
++---------+-------------------------+
+
+---
+
+[TestPrintTableResults_NoTerminalWidth_WithLicenseSummaryAndViolations/one_source_with_one_package_and_multiple_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
++------------+-------------------------+
+| LICENSE    | NO. OF PACKAGE VERSIONS |
++------------+-------------------------+
+| Apache-2.0 |                       1 |
+| MIT        |                       1 |
++------------+-------------------------+
++-------------------+-----------+---------+---------+---------------------------+
+| LICENSE VIOLATION | ECOSYSTEM | PACKAGE | VERSION | SOURCE                    |
++-------------------+-----------+---------+---------+---------------------------+
+| MIT, Apache-2.0   | npm       | mine1   | 1.2.3   | path/to/my/first/lockfile |
++-------------------+-----------+---------+---------+---------------------------+
+
+---
+
+[TestPrintTableResults_NoTerminalWidth_WithLicenseSummaryAndViolations/one_source_with_one_package_and_one_license_violation - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
++---------+-------------------------+
+| LICENSE | NO. OF PACKAGE VERSIONS |
++---------+-------------------------+
+| MIT     |                       1 |
++---------+-------------------------+
++-------------------+-----------+---------+---------+---------------------------+
+| LICENSE VIOLATION | ECOSYSTEM | PACKAGE | VERSION | SOURCE                    |
++-------------------+-----------+---------+---------+---------------------------+
+| MIT               | npm       | mine1   | 1.2.3   | path/to/my/first/lockfile |
++-------------------+-----------+---------+---------+---------------------------+
+
+---
+
+[TestPrintTableResults_NoTerminalWidth_WithLicenseSummaryAndViolations/one_source_with_one_package_and_one_license_violation_(dev) - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
++---------+-------------------------+
+| LICENSE | NO. OF PACKAGE VERSIONS |
++---------+-------------------------+
+| MIT     |                       1 |
++---------+-------------------------+
++-------------------+-----------+---------+---------+---------------------------+
+| LICENSE VIOLATION | ECOSYSTEM | PACKAGE | VERSION | SOURCE                    |
++-------------------+-----------+---------+---------+---------------------------+
+| MIT               | npm       | mine1   | 1.2.3   | path/to/my/first/lockfile |
++-------------------+-----------+---------+---------+---------------------------+
+
+---
+
+[TestPrintTableResults_NoTerminalWidth_WithLicenseSummaryAndViolations/one_source_with_one_package_with_both_a_version_and_a_commit_and_one_license_violation - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
++---------+-------------------------+
+| LICENSE | NO. OF PACKAGE VERSIONS |
++---------+-------------------------+
+| MIT     |                       1 |
++---------+-------------------------+
++-------------------+-----------+---------+---------+---------------------------+
+| LICENSE VIOLATION | ECOSYSTEM | PACKAGE | VERSION | SOURCE                    |
++-------------------+-----------+---------+---------+---------------------------+
+| MIT               | npm       | mine1   | 1.2.3   | path/to/my/first/lockfile |
++-------------------+-----------+---------+---------+---------------------------+
+
+---
+
+[TestPrintTableResults_NoTerminalWidth_WithLicenseSummaryAndViolations/one_source_with_one_package_with_just_a_commit_and_one_license_violation - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
++---------+-------------------------+
+| LICENSE | NO. OF PACKAGE VERSIONS |
++---------+-------------------------+
+| MIT     |                       1 |
++---------+-------------------------+
++-------------------+-----------+---------+---------+---------------------------+
+| LICENSE VIOLATION | ECOSYSTEM | PACKAGE | VERSION | SOURCE                    |
++-------------------+-----------+---------+---------+---------------------------+
+| MIT               | npm       | mine1   |         | path/to/my/first/lockfile |
++-------------------+-----------+---------+---------+---------------------------+
+
+---
+
+[TestPrintTableResults_NoTerminalWidth_WithLicenseSummaryAndViolations/two_sources_with_packages,_one_license_violation - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
++---------+-------------------------+
+| LICENSE | NO. OF PACKAGE VERSIONS |
++---------+-------------------------+
+| ISC     |                       1 |
+| MIT     |                       1 |
++---------+-------------------------+
++-------------------+-----------+---------+---------+---------------------------+
+| LICENSE VIOLATION | ECOSYSTEM | PACKAGE | VERSION | SOURCE                    |
++-------------------+-----------+---------+---------+---------------------------+
+| MIT               | npm       | mine1   | 1.2.3   | path/to/my/first/lockfile |
++-------------------+-----------+---------+---------+---------------------------+
+
+---
+
 [TestPrintTableResults_NoTerminalWidth_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages,_no_license_violations - 1]
 
 Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
@@ -740,14 +1707,6 @@ Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medi
 | Apache-2.0        | npm       | mine2   | 3.2.5   | path/to/my/second/lockfile |
 | MIT               | npm       | mine1   | 1.2.3   | path/to/my/third/lockfile  |
 +-------------------+-----------+---------+---------+----------------------------+
-
----
-
-[TestPrintTableResults_NoTerminalWidth_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages,_some_license_violations#01 - 1]
-
-Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
-0 vulnerabilities can be fixed.
-
 
 ---
 
@@ -776,6 +1735,21 @@ Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medi
 +-------------------+-----------+---------+---------+----------------------------+
 | MIT               | npm       | mine1   | 1.2.3   | path/to/my/first/lockfile  |
 | Apache-2.0        | npm       | mine2   | 3.2.5   | path/to/my/second/lockfile |
+| MIT               | npm       | mine1   | 1.2.3   | path/to/my/third/lockfile  |
++-------------------+-----------+---------+---------+----------------------------+
+
+---
+
+[TestPrintTableResults_NoTerminalWidth_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages_with_versions_and_commits,_some_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
++-------------------+-----------+---------+---------+----------------------------+
+| LICENSE VIOLATION | ECOSYSTEM | PACKAGE | VERSION | SOURCE                     |
++-------------------+-----------+---------+---------+----------------------------+
+| MIT               | npm       | mine1   | 1.2.3   | path/to/my/first/lockfile  |
+| UNKNOWN           | npm       | mine2   | 3.2.5   | path/to/my/second/lockfile |
 | MIT               | npm       | mine1   | 1.2.3   | path/to/my/third/lockfile  |
 +-------------------+-----------+---------+---------+----------------------------+
 
@@ -1441,6 +2415,486 @@ Total 2 packages affected by 2 known vulnerabilities (0 Critical, 0 High, 0 Medi
 
 ---
 
+[TestPrintTableResults_StandardTerminalWidth_WithLicenseSummary/multiple_sources_with_a_mixed_count_of_packages,_no_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭─────────┬─────────────────────────╮
+│ LICENSE │ NO. OF PACKAGE VERSIONS │
+├─────────┼─────────────────────────┤
+│ ISC     │                       5 │
+╰─────────┴─────────────────────────╯
+
+---
+
+[TestPrintTableResults_StandardTerminalWidth_WithLicenseSummary/multiple_sources_with_a_mixed_count_of_packages,_some_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭────────────┬─────────────────────────╮
+│ LICENSE    │ NO. OF PACKAGE VERSIONS │
+├────────────┼─────────────────────────┤
+│ ISC        │                       2 │
+│ MIT        │                       2 │
+│ Apache-2.0 │                       1 │
+╰────────────┴─────────────────────────╯
+
+---
+
+[TestPrintTableResults_StandardTerminalWidth_WithLicenseSummary/multiple_sources_with_a_mixed_count_of_packages_across_ecosystems,_some_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 3 ecosystems.
+0 vulnerabilities can be fixed.
+
+╭────────────┬─────────────────────────╮
+│ LICENSE    │ NO. OF PACKAGE VERSIONS │
+├────────────┼─────────────────────────┤
+│ ISC        │                       2 │
+│ MIT        │                       2 │
+│ Apache-2.0 │                       1 │
+╰────────────┴─────────────────────────╯
+
+---
+
+[TestPrintTableResults_StandardTerminalWidth_WithLicenseSummary/multiple_sources_with_a_mixed_count_of_packages_and_groups,_some_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭────────────┬─────────────────────────╮
+│ LICENSE    │ NO. OF PACKAGE VERSIONS │
+├────────────┼─────────────────────────┤
+│ ISC        │                       2 │
+│ MIT        │                       2 │
+│ Apache-2.0 │                       1 │
+╰────────────┴─────────────────────────╯
+
+---
+
+[TestPrintTableResults_StandardTerminalWidth_WithLicenseSummary/multiple_sources_with_a_mixed_count_of_packages_with_versions_and_commits,_some_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭────────────┬─────────────────────────╮
+│ LICENSE    │ NO. OF PACKAGE VERSIONS │
+├────────────┼─────────────────────────┤
+│ Apache-2.0 │                       3 │
+│ MIT        │                       2 │
+│ UNKNOWN    │                       1 │
+╰────────────┴─────────────────────────╯
+
+---
+
+[TestPrintTableResults_StandardTerminalWidth_WithLicenseSummary/multiple_sources_with_no_packages - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+
+---
+
+[TestPrintTableResults_StandardTerminalWidth_WithLicenseSummary/no_sources - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 0 ecosystems.
+0 vulnerabilities can be fixed.
+
+
+---
+
+[TestPrintTableResults_StandardTerminalWidth_WithLicenseSummary/one_source_with_no_packages - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+
+---
+
+[TestPrintTableResults_StandardTerminalWidth_WithLicenseSummary/one_source_with_one_package,_no_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭─────────┬─────────────────────────╮
+│ LICENSE │ NO. OF PACKAGE VERSIONS │
+├─────────┼─────────────────────────┤
+│ ISC     │                       1 │
+╰─────────┴─────────────────────────╯
+
+---
+
+[TestPrintTableResults_StandardTerminalWidth_WithLicenseSummary/one_source_with_one_package,_no_licenses - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+
+---
+
+[TestPrintTableResults_StandardTerminalWidth_WithLicenseSummary/one_source_with_one_package_and_an_unknown_license - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭─────────┬─────────────────────────╮
+│ LICENSE │ NO. OF PACKAGE VERSIONS │
+├─────────┼─────────────────────────┤
+│ UNKNOWN │                       1 │
+╰─────────┴─────────────────────────╯
+
+---
+
+[TestPrintTableResults_StandardTerminalWidth_WithLicenseSummary/one_source_with_one_package_and_multiple_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭────────────┬─────────────────────────╮
+│ LICENSE    │ NO. OF PACKAGE VERSIONS │
+├────────────┼─────────────────────────┤
+│ Apache-2.0 │                       1 │
+│ MIT        │                       1 │
+╰────────────┴─────────────────────────╯
+
+---
+
+[TestPrintTableResults_StandardTerminalWidth_WithLicenseSummary/one_source_with_one_package_and_one_license_violation - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭─────────┬─────────────────────────╮
+│ LICENSE │ NO. OF PACKAGE VERSIONS │
+├─────────┼─────────────────────────┤
+│ MIT     │                       1 │
+╰─────────┴─────────────────────────╯
+
+---
+
+[TestPrintTableResults_StandardTerminalWidth_WithLicenseSummary/one_source_with_one_package_and_one_license_violation_(dev) - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭─────────┬─────────────────────────╮
+│ LICENSE │ NO. OF PACKAGE VERSIONS │
+├─────────┼─────────────────────────┤
+│ MIT     │                       1 │
+╰─────────┴─────────────────────────╯
+
+---
+
+[TestPrintTableResults_StandardTerminalWidth_WithLicenseSummary/one_source_with_one_package_with_both_a_version_and_a_commit_and_one_license_violation - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭─────────┬─────────────────────────╮
+│ LICENSE │ NO. OF PACKAGE VERSIONS │
+├─────────┼─────────────────────────┤
+│ MIT     │                       1 │
+╰─────────┴─────────────────────────╯
+
+---
+
+[TestPrintTableResults_StandardTerminalWidth_WithLicenseSummary/one_source_with_one_package_with_just_a_commit_and_one_license_violation - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭─────────┬─────────────────────────╮
+│ LICENSE │ NO. OF PACKAGE VERSIONS │
+├─────────┼─────────────────────────┤
+│ MIT     │                       1 │
+╰─────────┴─────────────────────────╯
+
+---
+
+[TestPrintTableResults_StandardTerminalWidth_WithLicenseSummary/two_sources_with_packages,_one_license_violation - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭─────────┬─────────────────────────╮
+│ LICENSE │ NO. OF PACKAGE VERSIONS │
+├─────────┼─────────────────────────┤
+│ ISC     │                       1 │
+│ MIT     │                       1 │
+╰─────────┴─────────────────────────╯
+
+---
+
+[TestPrintTableResults_StandardTerminalWidth_WithLicenseSummaryAndViolations/multiple_sources_with_a_mixed_count_of_packages,_no_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭─────────┬─────────────────────────╮
+│ LICENSE │ NO. OF PACKAGE VERSIONS │
+├─────────┼─────────────────────────┤
+│ ISC     │                       5 │
+╰─────────┴─────────────────────────╯
+
+---
+
+[TestPrintTableResults_StandardTerminalWidth_WithLicenseSummaryAndViolations/multiple_sources_with_a_mixed_count_of_packages,_some_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭────────────┬─────────────────────────╮
+│ LICENSE    │ NO. OF PACKAGE VERSIONS │
+├────────────┼─────────────────────────┤
+│ ISC        │                       2 │
+│ MIT        │                       2 │
+│ Apache-2.0 │                       1 │
+╰────────────┴─────────────────────────╯
+╭───────────────────┬───────────┬─────────┬─────────┬───────────────────────── ≈
+│ LICENSE VIOLATION │ ECOSYSTEM │ PACKAGE │ VERSION │ SOURCE                   ≈
+├───────────────────┼───────────┼─────────┼─────────┼───────────────────────── ≈
+│ MIT               │ npm       │ mine1   │ 1.2.3   │ path/to/my/first/lockfil ≈
+│ Apache-2.0        │ npm       │ mine2   │ 3.2.5   │ path/to/my/second/lockfi ≈
+│ MIT               │ npm       │ mine1   │ 1.2.3   │ path/to/my/third/lockfil ≈
+╰───────────────────┴───────────┴─────────┴─────────┴───────────────────────── ≈
+
+---
+
+[TestPrintTableResults_StandardTerminalWidth_WithLicenseSummaryAndViolations/multiple_sources_with_a_mixed_count_of_packages_across_ecosystems,_some_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 3 ecosystems.
+0 vulnerabilities can be fixed.
+
+╭────────────┬─────────────────────────╮
+│ LICENSE    │ NO. OF PACKAGE VERSIONS │
+├────────────┼─────────────────────────┤
+│ ISC        │                       2 │
+│ MIT        │                       2 │
+│ Apache-2.0 │                       1 │
+╰────────────┴─────────────────────────╯
+╭───────────────────┬───────────┬───────────────┬─────────┬─────────────────── ≈
+│ LICENSE VIOLATION │ ECOSYSTEM │ PACKAGE       │ VERSION │ SOURCE             ≈
+├───────────────────┼───────────┼───────────────┼─────────┼─────────────────── ≈
+│ MIT               │ Packagist │ author1/mine1 │ 1.2.3   │ path/to/my/first/l ≈
+│ Apache-2.0        │ npm       │ mine2         │ 3.2.5   │ path/to/my/second/ ≈
+│ MIT               │ Packagist │ author1/mine1 │ 1.2.3   │ path/to/my/third/l ≈
+╰───────────────────┴───────────┴───────────────┴─────────┴─────────────────── ≈
+
+---
+
+[TestPrintTableResults_StandardTerminalWidth_WithLicenseSummaryAndViolations/multiple_sources_with_a_mixed_count_of_packages_and_groups,_some_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭────────────┬─────────────────────────╮
+│ LICENSE    │ NO. OF PACKAGE VERSIONS │
+├────────────┼─────────────────────────┤
+│ ISC        │                       2 │
+│ MIT        │                       2 │
+│ Apache-2.0 │                       1 │
+╰────────────┴─────────────────────────╯
+╭───────────────────┬───────────┬─────────┬─────────┬───────────────────────── ≈
+│ LICENSE VIOLATION │ ECOSYSTEM │ PACKAGE │ VERSION │ SOURCE                   ≈
+├───────────────────┼───────────┼─────────┼─────────┼───────────────────────── ≈
+│ MIT               │ npm       │ mine1   │ 1.2.3   │ path/to/my/first/lockfil ≈
+│ Apache-2.0        │ npm       │ mine2   │ 3.2.5   │ path/to/my/second/lockfi ≈
+│ MIT               │ npm       │ mine1   │ 1.2.3   │ path/to/my/third/lockfil ≈
+╰───────────────────┴───────────┴─────────┴─────────┴───────────────────────── ≈
+
+---
+
+[TestPrintTableResults_StandardTerminalWidth_WithLicenseSummaryAndViolations/multiple_sources_with_a_mixed_count_of_packages_with_versions_and_commits,_some_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭────────────┬─────────────────────────╮
+│ LICENSE    │ NO. OF PACKAGE VERSIONS │
+├────────────┼─────────────────────────┤
+│ Apache-2.0 │                       3 │
+│ MIT        │                       2 │
+│ UNKNOWN    │                       1 │
+╰────────────┴─────────────────────────╯
+╭───────────────────┬───────────┬─────────┬─────────┬───────────────────────── ≈
+│ LICENSE VIOLATION │ ECOSYSTEM │ PACKAGE │ VERSION │ SOURCE                   ≈
+├───────────────────┼───────────┼─────────┼─────────┼───────────────────────── ≈
+│ MIT               │ npm       │ mine1   │ 1.2.3   │ path/to/my/first/lockfil ≈
+│ UNKNOWN           │ npm       │ mine2   │ 3.2.5   │ path/to/my/second/lockfi ≈
+│ MIT               │ npm       │ mine1   │ 1.2.3   │ path/to/my/third/lockfil ≈
+╰───────────────────┴───────────┴─────────┴─────────┴───────────────────────── ≈
+
+---
+
+[TestPrintTableResults_StandardTerminalWidth_WithLicenseSummaryAndViolations/multiple_sources_with_no_packages - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+
+---
+
+[TestPrintTableResults_StandardTerminalWidth_WithLicenseSummaryAndViolations/no_sources - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 0 ecosystems.
+0 vulnerabilities can be fixed.
+
+
+---
+
+[TestPrintTableResults_StandardTerminalWidth_WithLicenseSummaryAndViolations/one_source_with_no_packages - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+
+---
+
+[TestPrintTableResults_StandardTerminalWidth_WithLicenseSummaryAndViolations/one_source_with_one_package,_no_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭─────────┬─────────────────────────╮
+│ LICENSE │ NO. OF PACKAGE VERSIONS │
+├─────────┼─────────────────────────┤
+│ ISC     │                       1 │
+╰─────────┴─────────────────────────╯
+
+---
+
+[TestPrintTableResults_StandardTerminalWidth_WithLicenseSummaryAndViolations/one_source_with_one_package,_no_licenses - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+
+---
+
+[TestPrintTableResults_StandardTerminalWidth_WithLicenseSummaryAndViolations/one_source_with_one_package_and_an_unknown_license - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭─────────┬─────────────────────────╮
+│ LICENSE │ NO. OF PACKAGE VERSIONS │
+├─────────┼─────────────────────────┤
+│ UNKNOWN │                       1 │
+╰─────────┴─────────────────────────╯
+
+---
+
+[TestPrintTableResults_StandardTerminalWidth_WithLicenseSummaryAndViolations/one_source_with_one_package_and_multiple_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭────────────┬─────────────────────────╮
+│ LICENSE    │ NO. OF PACKAGE VERSIONS │
+├────────────┼─────────────────────────┤
+│ Apache-2.0 │                       1 │
+│ MIT        │                       1 │
+╰────────────┴─────────────────────────╯
+╭───────────────────┬───────────┬─────────┬─────────┬───────────────────────── ≈
+│ LICENSE VIOLATION │ ECOSYSTEM │ PACKAGE │ VERSION │ SOURCE                   ≈
+├───────────────────┼───────────┼─────────┼─────────┼───────────────────────── ≈
+│ MIT, Apache-2.0   │ npm       │ mine1   │ 1.2.3   │ path/to/my/first/lockfil ≈
+╰───────────────────┴───────────┴─────────┴─────────┴───────────────────────── ≈
+
+---
+
+[TestPrintTableResults_StandardTerminalWidth_WithLicenseSummaryAndViolations/one_source_with_one_package_and_one_license_violation - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭─────────┬─────────────────────────╮
+│ LICENSE │ NO. OF PACKAGE VERSIONS │
+├─────────┼─────────────────────────┤
+│ MIT     │                       1 │
+╰─────────┴─────────────────────────╯
+╭───────────────────┬───────────┬─────────┬─────────┬───────────────────────── ≈
+│ LICENSE VIOLATION │ ECOSYSTEM │ PACKAGE │ VERSION │ SOURCE                   ≈
+├───────────────────┼───────────┼─────────┼─────────┼───────────────────────── ≈
+│ MIT               │ npm       │ mine1   │ 1.2.3   │ path/to/my/first/lockfil ≈
+╰───────────────────┴───────────┴─────────┴─────────┴───────────────────────── ≈
+
+---
+
+[TestPrintTableResults_StandardTerminalWidth_WithLicenseSummaryAndViolations/one_source_with_one_package_and_one_license_violation_(dev) - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭─────────┬─────────────────────────╮
+│ LICENSE │ NO. OF PACKAGE VERSIONS │
+├─────────┼─────────────────────────┤
+│ MIT     │                       1 │
+╰─────────┴─────────────────────────╯
+╭───────────────────┬───────────┬─────────┬─────────┬───────────────────────── ≈
+│ LICENSE VIOLATION │ ECOSYSTEM │ PACKAGE │ VERSION │ SOURCE                   ≈
+├───────────────────┼───────────┼─────────┼─────────┼───────────────────────── ≈
+│ MIT               │ npm       │ mine1   │ 1.2.3   │ path/to/my/first/lockfil ≈
+╰───────────────────┴───────────┴─────────┴─────────┴───────────────────────── ≈
+
+---
+
+[TestPrintTableResults_StandardTerminalWidth_WithLicenseSummaryAndViolations/one_source_with_one_package_with_both_a_version_and_a_commit_and_one_license_violation - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭─────────┬─────────────────────────╮
+│ LICENSE │ NO. OF PACKAGE VERSIONS │
+├─────────┼─────────────────────────┤
+│ MIT     │                       1 │
+╰─────────┴─────────────────────────╯
+╭───────────────────┬───────────┬─────────┬─────────┬───────────────────────── ≈
+│ LICENSE VIOLATION │ ECOSYSTEM │ PACKAGE │ VERSION │ SOURCE                   ≈
+├───────────────────┼───────────┼─────────┼─────────┼───────────────────────── ≈
+│ MIT               │ npm       │ mine1   │ 1.2.3   │ path/to/my/first/lockfil ≈
+╰───────────────────┴───────────┴─────────┴─────────┴───────────────────────── ≈
+
+---
+
+[TestPrintTableResults_StandardTerminalWidth_WithLicenseSummaryAndViolations/one_source_with_one_package_with_just_a_commit_and_one_license_violation - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭─────────┬─────────────────────────╮
+│ LICENSE │ NO. OF PACKAGE VERSIONS │
+├─────────┼─────────────────────────┤
+│ MIT     │                       1 │
+╰─────────┴─────────────────────────╯
+╭───────────────────┬───────────┬─────────┬─────────┬───────────────────────── ≈
+│ LICENSE VIOLATION │ ECOSYSTEM │ PACKAGE │ VERSION │ SOURCE                   ≈
+├───────────────────┼───────────┼─────────┼─────────┼───────────────────────── ≈
+│ MIT               │ npm       │ mine1   │         │ path/to/my/first/lockfil ≈
+╰───────────────────┴───────────┴─────────┴─────────┴───────────────────────── ≈
+
+---
+
+[TestPrintTableResults_StandardTerminalWidth_WithLicenseSummaryAndViolations/two_sources_with_packages,_one_license_violation - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭─────────┬─────────────────────────╮
+│ LICENSE │ NO. OF PACKAGE VERSIONS │
+├─────────┼─────────────────────────┤
+│ ISC     │                       1 │
+│ MIT     │                       1 │
+╰─────────┴─────────────────────────╯
+╭───────────────────┬───────────┬─────────┬─────────┬───────────────────────── ≈
+│ LICENSE VIOLATION │ ECOSYSTEM │ PACKAGE │ VERSION │ SOURCE                   ≈
+├───────────────────┼───────────┼─────────┼─────────┼───────────────────────── ≈
+│ MIT               │ npm       │ mine1   │ 1.2.3   │ path/to/my/first/lockfil ≈
+╰───────────────────┴───────────┴─────────┴─────────┴───────────────────────── ≈
+
+---
+
 [TestPrintTableResults_StandardTerminalWidth_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages,_no_license_violations - 1]
 
 Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
@@ -1461,14 +2915,6 @@ Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medi
 │ Apache-2.0        │ npm       │ mine2   │ 3.2.5   │ path/to/my/second/lockfi ≈
 │ MIT               │ npm       │ mine1   │ 1.2.3   │ path/to/my/third/lockfil ≈
 ╰───────────────────┴───────────┴─────────┴─────────┴───────────────────────── ≈
-
----
-
-[TestPrintTableResults_StandardTerminalWidth_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages,_some_license_violations#01 - 1]
-
-Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
-0 vulnerabilities can be fixed.
-
 
 ---
 
@@ -1497,6 +2943,21 @@ Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medi
 ├───────────────────┼───────────┼─────────┼─────────┼───────────────────────── ≈
 │ MIT               │ npm       │ mine1   │ 1.2.3   │ path/to/my/first/lockfil ≈
 │ Apache-2.0        │ npm       │ mine2   │ 3.2.5   │ path/to/my/second/lockfi ≈
+│ MIT               │ npm       │ mine1   │ 1.2.3   │ path/to/my/third/lockfil ≈
+╰───────────────────┴───────────┴─────────┴─────────┴───────────────────────── ≈
+
+---
+
+[TestPrintTableResults_StandardTerminalWidth_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages_with_versions_and_commits,_some_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+╭───────────────────┬───────────┬─────────┬─────────┬───────────────────────── ≈
+│ LICENSE VIOLATION │ ECOSYSTEM │ PACKAGE │ VERSION │ SOURCE                   ≈
+├───────────────────┼───────────┼─────────┼─────────┼───────────────────────── ≈
+│ MIT               │ npm       │ mine1   │ 1.2.3   │ path/to/my/first/lockfil ≈
+│ UNKNOWN           │ npm       │ mine2   │ 3.2.5   │ path/to/my/second/lockfi ≈
 │ MIT               │ npm       │ mine1   │ 1.2.3   │ path/to/my/third/lockfil ≈
 ╰───────────────────┴───────────┴─────────┴─────────┴───────────────────────── ≈
 

--- a/internal/output/__snapshots__/vertical_test.snap
+++ b/internal/output/__snapshots__/vertical_test.snap
@@ -1,4 +1,712 @@
 
+[TestPrintVerticalResults_WithLicenseSummary/multiple_sources_with_a_mixed_count_of_packages,_no_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+License summary:
+  ISC: 5
+
+npm
+
+lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+sbom:<rootdir>/path/to/my/second/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+unknown:<rootdir>/path/to/my/third/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+---
+
+[TestPrintVerticalResults_WithLicenseSummary/multiple_sources_with_a_mixed_count_of_packages,_some_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+License summary:
+  ISC: 2
+  MIT: 2
+  Apache-2.0: 1
+
+npm
+
+lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+sbom:<rootdir>/path/to/my/second/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+unknown:<rootdir>/path/to/my/third/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+---
+
+[TestPrintVerticalResults_WithLicenseSummary/multiple_sources_with_a_mixed_count_of_packages_across_ecosystems,_some_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 3 ecosystems.
+0 vulnerabilities can be fixed.
+
+License summary:
+  ISC: 2
+  MIT: 2
+  Apache-2.0: 1
+
+NuGet
+
+unknown:<rootdir>/path/to/my/third/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+Packagist
+
+lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+unknown:<rootdir>/path/to/my/third/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+npm
+
+sbom:<rootdir>/path/to/my/second/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+---
+
+[TestPrintVerticalResults_WithLicenseSummary/multiple_sources_with_a_mixed_count_of_packages_and_groups,_some_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+License summary:
+  ISC: 2
+  MIT: 2
+  Apache-2.0: 1
+
+npm
+
+lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+sbom:<rootdir>/path/to/my/second/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+unknown:<rootdir>/path/to/my/third/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+---
+
+[TestPrintVerticalResults_WithLicenseSummary/multiple_sources_with_a_mixed_count_of_packages_with_versions_and_commits,_some_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+License summary:
+  Apache-2.0: 3
+  MIT: 2
+  UNKNOWN: 1
+
+npm
+
+lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+sbom:<rootdir>/path/to/my/second/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+unknown:<rootdir>/path/to/my/third/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+---
+
+[TestPrintVerticalResults_WithLicenseSummary/multiple_sources_with_no_packages - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+License summary:
+
+
+
+lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+sbom:<rootdir>/path/to/my/second/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+unknown:<rootdir>/path/to/my/third/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+---
+
+[TestPrintVerticalResults_WithLicenseSummary/no_sources - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 0 ecosystems.
+0 vulnerabilities can be fixed.
+
+License summary:
+
+
+---
+
+[TestPrintVerticalResults_WithLicenseSummary/one_source_with_no_packages - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+License summary:
+
+
+
+lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+---
+
+[TestPrintVerticalResults_WithLicenseSummary/one_source_with_one_package,_no_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+License summary:
+  ISC: 1
+
+npm
+
+lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+---
+
+[TestPrintVerticalResults_WithLicenseSummary/one_source_with_one_package,_no_licenses - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+License summary:
+
+npm
+
+lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+---
+
+[TestPrintVerticalResults_WithLicenseSummary/one_source_with_one_package_and_an_unknown_license - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+License summary:
+  UNKNOWN: 1
+
+npm
+
+lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+---
+
+[TestPrintVerticalResults_WithLicenseSummary/one_source_with_one_package_and_multiple_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+License summary:
+  Apache-2.0: 1
+  MIT: 1
+
+npm
+
+lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+---
+
+[TestPrintVerticalResults_WithLicenseSummary/one_source_with_one_package_and_one_license_violation - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+License summary:
+  MIT: 1
+
+npm
+
+lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+---
+
+[TestPrintVerticalResults_WithLicenseSummary/one_source_with_one_package_and_one_license_violation_(dev) - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+License summary:
+  MIT: 1
+
+npm
+
+lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+---
+
+[TestPrintVerticalResults_WithLicenseSummary/one_source_with_one_package_with_both_a_version_and_a_commit_and_one_license_violation - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+License summary:
+  MIT: 1
+
+npm
+
+lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+---
+
+[TestPrintVerticalResults_WithLicenseSummary/one_source_with_one_package_with_just_a_commit_and_one_license_violation - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+License summary:
+  MIT: 1
+
+npm
+
+lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+---
+
+[TestPrintVerticalResults_WithLicenseSummary/two_sources_with_packages,_one_license_violation - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+License summary:
+  ISC: 1
+  MIT: 1
+
+npm
+
+lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+sbom:<rootdir>/path/to/my/second/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+---
+
+[TestPrintVerticalResults_WithLicenseSummaryAndViolations/multiple_sources_with_a_mixed_count_of_packages,_no_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+License summary:
+  ISC: 5
+
+npm
+
+lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+  no license violations found
+
+sbom:<rootdir>/path/to/my/second/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+  no license violations found
+
+unknown:<rootdir>/path/to/my/third/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+  no license violations found
+
+---
+
+[TestPrintVerticalResults_WithLicenseSummaryAndViolations/multiple_sources_with_a_mixed_count_of_packages,_some_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+License summary:
+  ISC: 2
+  MIT: 2
+  Apache-2.0: 1
+
+npm
+
+lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+  license violations found:
+    mine1@1.2.3 (MIT)
+
+  1 license violation found in lockfile:<rootdir>/path/to/my/first/lockfile
+
+sbom:<rootdir>/path/to/my/second/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+  license violations found:
+    mine2@3.2.5 (Apache-2.0)
+
+  1 license violation found in sbom:<rootdir>/path/to/my/second/lockfile
+
+unknown:<rootdir>/path/to/my/third/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+  license violations found:
+    mine1@1.2.3 (MIT)
+
+  1 license violation found in unknown:<rootdir>/path/to/my/third/lockfile
+
+---
+
+[TestPrintVerticalResults_WithLicenseSummaryAndViolations/multiple_sources_with_a_mixed_count_of_packages_across_ecosystems,_some_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 3 ecosystems.
+0 vulnerabilities can be fixed.
+
+License summary:
+  ISC: 2
+  MIT: 2
+  Apache-2.0: 1
+
+NuGet
+
+unknown:<rootdir>/path/to/my/third/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+  no license violations found
+
+Packagist
+
+lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+  license violations found:
+    author1/mine1@1.2.3 (MIT)
+
+  1 license violation found in lockfile:<rootdir>/path/to/my/first/lockfile
+
+unknown:<rootdir>/path/to/my/third/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+  license violations found:
+    author1/mine1@1.2.3 (MIT)
+
+  1 license violation found in unknown:<rootdir>/path/to/my/third/lockfile
+
+npm
+
+sbom:<rootdir>/path/to/my/second/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+  license violations found:
+    mine2@3.2.5 (Apache-2.0)
+
+  1 license violation found in sbom:<rootdir>/path/to/my/second/lockfile
+
+---
+
+[TestPrintVerticalResults_WithLicenseSummaryAndViolations/multiple_sources_with_a_mixed_count_of_packages_and_groups,_some_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+License summary:
+  ISC: 2
+  MIT: 2
+  Apache-2.0: 1
+
+npm
+
+lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+  license violations found:
+    mine1@1.2.3 (MIT)
+
+  1 license violation found in lockfile:<rootdir>/path/to/my/first/lockfile
+
+sbom:<rootdir>/path/to/my/second/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+  license violations found:
+    mine2@3.2.5 (Apache-2.0)
+
+  1 license violation found in sbom:<rootdir>/path/to/my/second/lockfile
+
+unknown:<rootdir>/path/to/my/third/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+  license violations found:
+    mine1@1.2.3 (MIT)
+
+  1 license violation found in unknown:<rootdir>/path/to/my/third/lockfile
+
+---
+
+[TestPrintVerticalResults_WithLicenseSummaryAndViolations/multiple_sources_with_a_mixed_count_of_packages_with_versions_and_commits,_some_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+License summary:
+  Apache-2.0: 3
+  MIT: 2
+  UNKNOWN: 1
+
+npm
+
+lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+  license violations found:
+    mine1@1.2.3 (MIT)
+
+  1 license violation found in lockfile:<rootdir>/path/to/my/first/lockfile
+
+sbom:<rootdir>/path/to/my/second/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+  license violations found:
+    mine2@3.2.5 (UNKNOWN)
+
+  1 license violation found in sbom:<rootdir>/path/to/my/second/lockfile
+
+unknown:<rootdir>/path/to/my/third/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+  license violations found:
+    mine1@1.2.3 (MIT)
+
+  1 license violation found in unknown:<rootdir>/path/to/my/third/lockfile
+
+---
+
+[TestPrintVerticalResults_WithLicenseSummaryAndViolations/multiple_sources_with_no_packages - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+License summary:
+
+
+
+lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+  no license violations found
+
+sbom:<rootdir>/path/to/my/second/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+  no license violations found
+
+unknown:<rootdir>/path/to/my/third/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+  no license violations found
+
+---
+
+[TestPrintVerticalResults_WithLicenseSummaryAndViolations/no_sources - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 0 ecosystems.
+0 vulnerabilities can be fixed.
+
+License summary:
+
+
+---
+
+[TestPrintVerticalResults_WithLicenseSummaryAndViolations/one_source_with_no_packages - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+License summary:
+
+
+
+lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+  no license violations found
+
+---
+
+[TestPrintVerticalResults_WithLicenseSummaryAndViolations/one_source_with_one_package,_no_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+License summary:
+  ISC: 1
+
+npm
+
+lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+  no license violations found
+
+---
+
+[TestPrintVerticalResults_WithLicenseSummaryAndViolations/one_source_with_one_package,_no_licenses - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+License summary:
+
+npm
+
+lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+  no license violations found
+
+---
+
+[TestPrintVerticalResults_WithLicenseSummaryAndViolations/one_source_with_one_package_and_an_unknown_license - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+License summary:
+  UNKNOWN: 1
+
+npm
+
+lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+  no license violations found
+
+---
+
+[TestPrintVerticalResults_WithLicenseSummaryAndViolations/one_source_with_one_package_and_multiple_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+License summary:
+  Apache-2.0: 1
+  MIT: 1
+
+npm
+
+lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+  license violations found:
+    mine1@1.2.3 (MIT, Apache-2.0)
+
+  2 license violations found in lockfile:<rootdir>/path/to/my/first/lockfile
+
+---
+
+[TestPrintVerticalResults_WithLicenseSummaryAndViolations/one_source_with_one_package_and_one_license_violation - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+License summary:
+  MIT: 1
+
+npm
+
+lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+  license violations found:
+    mine1@1.2.3 (MIT)
+
+  1 license violation found in lockfile:<rootdir>/path/to/my/first/lockfile
+
+---
+
+[TestPrintVerticalResults_WithLicenseSummaryAndViolations/one_source_with_one_package_and_one_license_violation_(dev) - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+License summary:
+  MIT: 1
+
+npm
+
+lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+  license violations found:
+    mine1@1.2.3 (MIT)
+
+  1 license violation found in lockfile:<rootdir>/path/to/my/first/lockfile
+
+---
+
+[TestPrintVerticalResults_WithLicenseSummaryAndViolations/one_source_with_one_package_with_both_a_version_and_a_commit_and_one_license_violation - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+License summary:
+  MIT: 1
+
+npm
+
+lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+  license violations found:
+    mine1@1.2.3 (MIT)
+
+  1 license violation found in lockfile:<rootdir>/path/to/my/first/lockfile
+
+---
+
+[TestPrintVerticalResults_WithLicenseSummaryAndViolations/one_source_with_one_package_with_just_a_commit_and_one_license_violation - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+License summary:
+  MIT: 1
+
+npm
+
+lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+  license violations found:
+    mine1@ (MIT)
+
+  1 license violation found in lockfile:<rootdir>/path/to/my/first/lockfile
+
+---
+
+[TestPrintVerticalResults_WithLicenseSummaryAndViolations/two_sources_with_packages,_one_license_violation - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+License summary:
+  ISC: 1
+  MIT: 1
+
+npm
+
+lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+  license violations found:
+    mine1@1.2.3 (MIT)
+
+  1 license violation found in lockfile:<rootdir>/path/to/my/first/lockfile
+
+sbom:<rootdir>/path/to/my/second/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+  no license violations found
+
+---
+
 [TestPrintVerticalResults_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages,_no_license_violations - 1]
 
 Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
@@ -50,24 +758,6 @@ unknown:<rootdir>/path/to/my/third/lockfile: found 0 packages with issues
     mine1@1.2.3 (MIT)
 
   1 license violation found in unknown:<rootdir>/path/to/my/third/lockfile
-
----
-
-[TestPrintVerticalResults_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages,_some_license_violations#01 - 1]
-
-Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
-0 vulnerabilities can be fixed.
-
-npm
-
-lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
-  no known vulnerabilities found
-
-sbom:<rootdir>/path/to/my/second/lockfile: found 0 packages with issues
-  no known vulnerabilities found
-
-unknown:<rootdir>/path/to/my/third/lockfile: found 0 packages with issues
-  no known vulnerabilities found
 
 ---
 
@@ -132,6 +822,39 @@ sbom:<rootdir>/path/to/my/second/lockfile: found 0 packages with issues
 
   license violations found:
     mine2@3.2.5 (Apache-2.0)
+
+  1 license violation found in sbom:<rootdir>/path/to/my/second/lockfile
+
+unknown:<rootdir>/path/to/my/third/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+  license violations found:
+    mine1@1.2.3 (MIT)
+
+  1 license violation found in unknown:<rootdir>/path/to/my/third/lockfile
+
+---
+
+[TestPrintVerticalResults_WithLicenseViolations/multiple_sources_with_a_mixed_count_of_packages_with_versions_and_commits,_some_license_violations - 1]
+
+Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
+0 vulnerabilities can be fixed.
+
+npm
+
+lockfile:<rootdir>/path/to/my/first/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+  license violations found:
+    mine1@1.2.3 (MIT)
+
+  1 license violation found in lockfile:<rootdir>/path/to/my/first/lockfile
+
+sbom:<rootdir>/path/to/my/second/lockfile: found 0 packages with issues
+  no known vulnerabilities found
+
+  license violations found:
+    mine2@3.2.5 (UNKNOWN)
 
   1 license violation found in sbom:<rootdir>/path/to/my/second/lockfile
 

--- a/internal/output/helpers_test.go
+++ b/internal/output/helpers_test.go
@@ -1,7 +1,10 @@
 package output_test
 
 import (
+	"maps"
 	"path/filepath"
+	"slices"
+	"sort"
 	"testing"
 
 	"github.com/google/osv-scalibr/extractor"
@@ -1390,10 +1393,68 @@ func testOutputWithVulnerabilities(t *testing.T, run outputTestRunner) {
 func testOutputWithLicenseViolations(t *testing.T, run outputTestRunner) {
 	t.Helper()
 
+	testOutputWithLicenseIssues(t, run, models.ExperimentalLicenseConfig{Summary: false, Allowlist: []models.License{"ISC"}})
+}
+
+func testOutputWithLicenseSummary(t *testing.T, run outputTestRunner) {
+	t.Helper()
+
+	testOutputWithLicenseIssues(t, run, models.ExperimentalLicenseConfig{Summary: true})
+}
+
+func testOutputWithLicenseSummaryAndViolations(t *testing.T, run outputTestRunner) {
+	t.Helper()
+
+	testOutputWithLicenseIssues(t, run, models.ExperimentalLicenseConfig{Summary: true, Allowlist: []models.License{"ISC"}})
+}
+
+// buildTestLicenseSummary counts and orders the licenses of every package in
+// the results, matching how the scanner populates the LicenseSummary field
+// when license summarizing is enabled.
+func buildTestLicenseSummary(vulnResult *models.VulnerabilityResults) []models.LicenseCount {
+	counts := make(map[models.License]int)
+
+	for _, source := range vulnResult.Results {
+		for _, pkg := range source.Packages {
+			for _, license := range pkg.Licenses {
+				counts[license]++
+			}
+		}
+	}
+
+	licenses := slices.Collect(maps.Keys(counts))
+
+	// Sort the license count in descending count order with the UNKNOWN
+	// license last, matching the order used by the scanner.
+	sort.Slice(licenses, func(i, j int) bool {
+		if licenses[i] == "UNKNOWN" {
+			return false
+		}
+		if licenses[j] == "UNKNOWN" {
+			return true
+		}
+		if counts[licenses[i]] == counts[licenses[j]] {
+			return licenses[i] < licenses[j]
+		}
+
+		return counts[licenses[i]] > counts[licenses[j]]
+	})
+
+	licenseSummary := make([]models.LicenseCount, len(licenses))
+	for i, license := range licenses {
+		licenseSummary[i] = models.LicenseCount{Name: license, Count: counts[license]}
+	}
+
+	return licenseSummary
+}
+
+func testOutputWithLicenseIssues(t *testing.T, run outputTestRunner, licenseConfig models.ExperimentalLicenseConfig) {
+	t.Helper()
+
 	cwd := filepath.ToSlash(testutility.GetCurrentWorkingDirectory(t))
 
 	experimentalAnalysisConfig := models.ExperimentalAnalysisConfig{
-		Licenses: models.ExperimentalLicenseConfig{Summary: false, Allowlist: []models.License{"ISC"}},
+		Licenses: licenseConfig,
 	}
 
 	tests := []outputTestCase{
@@ -1989,9 +2050,10 @@ func testOutputWithLicenseViolations(t *testing.T, run outputTestRunner) {
 			},
 		},
 		{
-			name: "multiple_sources_with_a_mixed_count_of_packages,_some_license_violations",
+			name: "multiple_sources_with_a_mixed_count_of_packages_with_versions_and_commits,_some_license_violations",
 			args: outputTestCaseArgs{
 				vulnResult: &models.VulnerabilityResults{
+					ExperimentalAnalysisConfig: experimentalAnalysisConfig,
 					Results: []models.PackageSource{
 						{
 							Source: models.SourceInfo{Path: cwd + "/path/to/my/first/lockfile", Type: models.SourceTypeProjectPackage},
@@ -2063,6 +2125,12 @@ func testOutputWithLicenseViolations(t *testing.T, run outputTestRunner) {
 			},
 		},
 	}
+	if licenseConfig.Summary {
+		for _, tt := range tests {
+			tt.args.vulnResult.LicenseSummary = buildTestLicenseSummary(tt.args.vulnResult)
+		}
+	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/output/markdowntable_test.go
+++ b/internal/output/markdowntable_test.go
@@ -46,3 +46,29 @@ func TestPrintMarkdownTableResults_WithMixedIssues(t *testing.T) {
 		testutility.NewSnapshot().MatchText(t, outputWriter.String())
 	})
 }
+
+func TestPrintMarkdownTableResults_WithLicenseSummary(t *testing.T) {
+	t.Parallel()
+
+	testOutputWithLicenseSummary(t, func(t *testing.T, args outputTestCaseArgs) {
+		t.Helper()
+
+		outputWriter := &bytes.Buffer{}
+		output.PrintMarkdownTableResults(args.vulnResult, outputWriter, false)
+
+		testutility.NewSnapshot().MatchText(t, outputWriter.String())
+	})
+}
+
+func TestPrintMarkdownTableResults_WithLicenseSummaryAndViolations(t *testing.T) {
+	t.Parallel()
+
+	testOutputWithLicenseSummaryAndViolations(t, func(t *testing.T, args outputTestCaseArgs) {
+		t.Helper()
+
+		outputWriter := &bytes.Buffer{}
+		output.PrintMarkdownTableResults(args.vulnResult, outputWriter, false)
+
+		testutility.NewSnapshot().MatchText(t, outputWriter.String())
+	})
+}

--- a/internal/output/output_result_test.go
+++ b/internal/output/output_result_test.go
@@ -24,3 +24,37 @@ func TestPrintOutputResults_WithVulnerabilities(t *testing.T) {
 		testutility.NewSnapshot().MatchText(t, outputWriter.String())
 	})
 }
+
+func TestPrintOutputResults_WithLicenseSummary(t *testing.T) {
+	t.Parallel()
+
+	testOutputWithLicenseSummary(t, func(t *testing.T, args outputTestCaseArgs) {
+		t.Helper()
+
+		outputWriter := &bytes.Buffer{}
+		err := output.PrintResults(args.vulnResult, outputWriter)
+
+		if err != nil {
+			t.Errorf("Error writing output: %s", err)
+		}
+
+		testutility.NewSnapshot().MatchText(t, outputWriter.String())
+	})
+}
+
+func TestPrintOutputResults_WithLicenseSummaryAndViolations(t *testing.T) {
+	t.Parallel()
+
+	testOutputWithLicenseSummaryAndViolations(t, func(t *testing.T, args outputTestCaseArgs) {
+		t.Helper()
+
+		outputWriter := &bytes.Buffer{}
+		err := output.PrintResults(args.vulnResult, outputWriter)
+
+		if err != nil {
+			t.Errorf("Error writing output: %s", err)
+		}
+
+		testutility.NewSnapshot().MatchText(t, outputWriter.String())
+	})
+}

--- a/internal/output/table_test.go
+++ b/internal/output/table_test.go
@@ -125,3 +125,81 @@ func TestPrintTableResults_NoTerminalWidth_WithMixedIssues(t *testing.T) {
 		testutility.NewSnapshot().MatchText(t, outputWriter.String())
 	})
 }
+
+func TestPrintTableResults_StandardTerminalWidth_WithLicenseSummary(t *testing.T) {
+	t.Parallel()
+
+	testOutputWithLicenseSummary(t, func(t *testing.T, args outputTestCaseArgs) {
+		t.Helper()
+
+		outputWriter := &bytes.Buffer{}
+		output.PrintTableResults(args.vulnResult, outputWriter, 80, false)
+
+		testutility.NewSnapshot().MatchText(t, text.StripEscape(outputWriter.String()))
+	})
+}
+
+func TestPrintTableResults_StandardTerminalWidth_WithLicenseSummaryAndViolations(t *testing.T) {
+	t.Parallel()
+
+	testOutputWithLicenseSummaryAndViolations(t, func(t *testing.T, args outputTestCaseArgs) {
+		t.Helper()
+
+		outputWriter := &bytes.Buffer{}
+		output.PrintTableResults(args.vulnResult, outputWriter, 80, false)
+
+		testutility.NewSnapshot().MatchText(t, text.StripEscape(outputWriter.String()))
+	})
+}
+
+func TestPrintTableResults_LongTerminalWidth_WithLicenseSummary(t *testing.T) {
+	t.Parallel()
+
+	testOutputWithLicenseSummary(t, func(t *testing.T, args outputTestCaseArgs) {
+		t.Helper()
+
+		outputWriter := &bytes.Buffer{}
+		output.PrintTableResults(args.vulnResult, outputWriter, 800, false)
+
+		testutility.NewSnapshot().MatchText(t, text.StripEscape(outputWriter.String()))
+	})
+}
+
+func TestPrintTableResults_LongTerminalWidth_WithLicenseSummaryAndViolations(t *testing.T) {
+	t.Parallel()
+
+	testOutputWithLicenseSummaryAndViolations(t, func(t *testing.T, args outputTestCaseArgs) {
+		t.Helper()
+
+		outputWriter := &bytes.Buffer{}
+		output.PrintTableResults(args.vulnResult, outputWriter, 800, false)
+
+		testutility.NewSnapshot().MatchText(t, text.StripEscape(outputWriter.String()))
+	})
+}
+
+func TestPrintTableResults_NoTerminalWidth_WithLicenseSummary(t *testing.T) {
+	t.Parallel()
+
+	testOutputWithLicenseSummary(t, func(t *testing.T, args outputTestCaseArgs) {
+		t.Helper()
+
+		outputWriter := &bytes.Buffer{}
+		output.PrintTableResults(args.vulnResult, outputWriter, -1, false)
+
+		testutility.NewSnapshot().MatchText(t, outputWriter.String())
+	})
+}
+
+func TestPrintTableResults_NoTerminalWidth_WithLicenseSummaryAndViolations(t *testing.T) {
+	t.Parallel()
+
+	testOutputWithLicenseSummaryAndViolations(t, func(t *testing.T, args outputTestCaseArgs) {
+		t.Helper()
+
+		outputWriter := &bytes.Buffer{}
+		output.PrintTableResults(args.vulnResult, outputWriter, -1, false)
+
+		testutility.NewSnapshot().MatchText(t, outputWriter.String())
+	})
+}

--- a/internal/output/vertical_test.go
+++ b/internal/output/vertical_test.go
@@ -161,3 +161,29 @@ func TestPrintVerticalResults_CRSanitization(t *testing.T) {
 		assertSanitized(t, buf.String())
 	})
 }
+
+func TestPrintVerticalResults_WithLicenseSummary(t *testing.T) {
+	t.Parallel()
+
+	testOutputWithLicenseSummary(t, func(t *testing.T, args outputTestCaseArgs) {
+		t.Helper()
+
+		outputWriter := &bytes.Buffer{}
+		output.PrintVerticalResults(args.vulnResult, outputWriter, false)
+
+		testutility.NewSnapshot().MatchText(t, text.StripEscape(outputWriter.String()))
+	})
+}
+
+func TestPrintVerticalResults_WithLicenseSummaryAndViolations(t *testing.T) {
+	t.Parallel()
+
+	testOutputWithLicenseSummaryAndViolations(t, func(t *testing.T, args outputTestCaseArgs) {
+		t.Helper()
+
+		outputWriter := &bytes.Buffer{}
+		output.PrintVerticalResults(args.vulnResult, outputWriter, false)
+
+		testutility.NewSnapshot().MatchText(t, text.StripEscape(outputWriter.String()))
+	})
+}


### PR DESCRIPTION
Resolves #1840

Adds test coverage for the license summary logic in the `output` package, which was previously untested.

As suggested in the issue, the existing license violation test cases are reused: `testOutputWithLicenseViolations` now delegates to a shared `testOutputWithLicenseIssues` function that takes the license config as a parameter. Two new helpers build on it:

- `testOutputWithLicenseSummary`: summary enabled with no allowlist, so `ShowViolations` is false
- `testOutputWithLicenseSummaryAndViolations`: summary enabled with an allowlist, so `ShowViolations` is true

When summarizing is enabled, each test case's `LicenseSummary` field is derived from its packages' licenses using the same counting and ordering as the scanner (descending count, UNKNOWN last).

New snapshot tests are added for the outputs where the license summary rendering lives: table (all three terminal widths), vertical, markdown table, and the `Result` struct built by `BuildResults` (via `PrintResults`), which covers the `ShowViolations` handling in `buildResult`.

This also fixes a small pre-existing slip the new tests surfaced: the license violation case list had two cases named "multiple_sources_with_a_mixed_count_of_packages,_some_license_violations", and the second one (the versions-and-commits variant, going by its data) was missing `ExperimentalAnalysisConfig`, so it silently rendered without any license config. It now has a distinct name and the config, and the corresponding snapshot keys are updated.