### PR TITLE
Fall back to SBOM component version when PURL lacks one

### DIFF
--- a/internal/imodels/imodels.go
+++ b/internal/imodels/imodels.go
@@ -126,7 +126,7 @@ func Ecosystem(pkg *extractor.Package) osvecosystem.Parsed {
 
 func Version(pkg *extractor.Package) string {
 	// TODO(v2): SBOM special case, to be removed after PURL to ESI conversion within each extractor is complete
-	if purlCache := toCachedPackageInfo(pkg); purlCache != nil {
+	if purlCache := toCachedPackageInfo(pkg); purlCache != nil && purlCache.Version != "" {
 		return purlCache.Version
 	}
 

--- a/internal/imodels/imodels_test.go
+++ b/internal/imodels/imodels_test.go
@@ -8,7 +8,22 @@ import (
 	rpmmetadata "github.com/google/osv-scalibr/extractor/filesystem/os/rpm/metadata"
 	"github.com/google/osv-scalibr/purl"
 	"github.com/google/osv-scanner/v2/internal/scalibrextract/language/osv/osvscannerjson"
+	"github.com/google/osv-scanner/v2/pkg/models"
 )
+
+func Test_Version_SBOMPURLWithoutVersionFallsBackToPackageVersion(t *testing.T) {
+	pkg := &extractor.Package{
+		Name:    "lodash",
+		Version: "4.17.16",
+		Plugins: []string{"sbom/cdx"},
+	}
+	cache.Store(pkg, &models.PackageInfo{})
+	t.Cleanup(func() { cache.Delete(pkg) })
+
+	if got := Version(pkg); got != "4.17.16" {
+		t.Errorf("Version() = %q, want %q", got, "4.17.16")
+	}
+}
 
 func Test_Name(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Use pkg.Version when a valid SBOM PURL omits its optional version and add a focused regression test.