### PR TITLE
fix: Remove purl caching to avoid dropping SBOM packages without purls.

### DIFF
--- a/internal/imodels/imodels.go
+++ b/internal/imodels/imodels.go
@@ -6,9 +6,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"sync"
 
-	"github.com/google/osv-scalibr/converter"
 	"github.com/google/osv-scalibr/extractor"
 	archivemetadata "github.com/google/osv-scalibr/extractor/filesystem/language/java/archive/metadata"
 	apkmetadata "github.com/google/osv-scalibr/extractor/filesystem/os/apk/metadata"
@@ -20,7 +18,6 @@ import (
 	"github.com/google/osv-scanner/v2/internal/scalibrextract/language/osv/osvscannerjson"
 	"github.com/google/osv-scanner/v2/internal/scalibrextract/vcs/gitrepo"
 	"github.com/google/osv-scanner/v2/internal/scalibrplugin"
-	"github.com/google/osv-scanner/v2/internal/utility/purl"
 	"github.com/google/osv-scanner/v2/internal/utility/semverlike"
 
 	scalibrosv "github.com/google/osv-scalibr/extractor/filesystem/osv"
@@ -30,36 +27,6 @@ import (
 
 var gitExtractors = map[string]struct{}{
 	gitrepo.Name: {},
-}
-
-// todo: SBOM special case, to be removed after PURL to ESI conversion within each extractor is complete
-var cache = sync.Map{} // map[*extractor.Package]*models.PackageInfo
-
-func toCachedPackageInfo(pkg *extractor.Package) *models.PackageInfo {
-	if SourceType(pkg) != models.SourceTypeSBOM {
-		return nil
-	}
-
-	v, ok := cache.Load(pkg)
-
-	if !ok {
-		purlStruct := converter.ToPURL(pkg)
-
-		if purlStruct == nil {
-			return nil
-		}
-
-		purlCache, _ := purl.ToPackage(purlStruct.String())
-		cache.Store(pkg, &purlCache)
-
-		return &purlCache
-	}
-
-	if v == nil {
-		return nil
-	}
-
-	return v.(*models.PackageInfo)
 }
 
 // Name patches the SCALIBR package name to something used by OSV.
@@ -125,11 +92,6 @@ func Ecosystem(pkg *extractor.Package) osvecosystem.Parsed {
 }
 
 func Version(pkg *extractor.Package) string {
-	// TODO(v2): SBOM special case, to be removed after PURL to ESI conversion within each extractor is complete
-	if purlCache := toCachedPackageInfo(pkg); purlCache != nil {
-		return purlCache.Version
-	}
-
 	// Assume Go stdlib patch version as the latest version
 	//
 	// This is done because go1.20 and earlier do not support patch

--- a/internal/imodels/imodels_test.go
+++ b/internal/imodels/imodels_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/google/osv-scalibr/extractor"
 	dpkgmetadata "github.com/google/osv-scalibr/extractor/filesystem/os/dpkg/metadata"
 	rpmmetadata "github.com/google/osv-scalibr/extractor/filesystem/os/rpm/metadata"
+	cdxmetadata "github.com/google/osv-scalibr/extractor/filesystem/sbom/cdx/metadata"
+	spdxmetadata "github.com/google/osv-scalibr/extractor/filesystem/sbom/spdx/metadata"
 	"github.com/google/osv-scalibr/purl"
 	"github.com/google/osv-scanner/v2/internal/scalibrextract/language/osv/osvscannerjson"
 )
@@ -111,6 +113,57 @@ func Test_Version(t *testing.T) {
 			name: "dpkg_version_unchanged",
 			pkg:  &extractor.Package{Version: "2:1.0-1", PURLType: purl.TypeDebian, Metadata: &dpkgmetadata.Metadata{OSID: "ubuntu", OSVersionID: "22.04"}},
 			want: "2:1.0-1",
+		},
+		{
+			name: "sbom_cyclonedx_versionless_purl",
+			pkg: &extractor.Package{
+				Name:     "lodash",
+				Version:  "4.17.16",
+				PURLType: purl.TypeNPM,
+				Plugins:  []string{"sbom/cdx"},
+				Metadata: &cdxmetadata.Metadata{
+					PURL: &purl.PackageURL{
+						Type: purl.TypeNPM,
+						Name: "lodash",
+					},
+				},
+			},
+			want: "4.17.16",
+		},
+		{
+			name: "sbom_spdx_versionless_purl",
+			pkg: &extractor.Package{
+				Name:     "lodash",
+				Version:  "4.17.16",
+				PURLType: purl.TypeNPM,
+				Plugins:  []string{"sbom/spdx"},
+				Metadata: &spdxmetadata.Metadata{
+					PURL: &purl.PackageURL{
+						Type: purl.TypeNPM,
+						Name: "lodash",
+					},
+				},
+			},
+			want: "4.17.16",
+		},
+		{
+			name: "sbom_without_version",
+			pkg: &extractor.Package{
+				Name:     "lodash",
+				Version:  "",
+				PURLType: purl.TypeNPM,
+				Plugins:  []string{"sbom/cdx"},
+			},
+			want: "",
+		},
+		{
+			name: "go_stdlib_patch_version",
+			pkg: &extractor.Package{
+				Name:     "go",
+				Version:  "1.20",
+				PURLType: purl.TypeGolang,
+			},
+			want: "1.20.99",
 		},
 	}
 

--- a/internal/scalibrannotator/filter/filter_test.go
+++ b/internal/scalibrannotator/filter/filter_test.go
@@ -53,6 +53,12 @@ func TestAnnotator_Annotate(t *testing.T) {
 		Version:  "1.2.3",
 		PURLType: purl.TypeNPM,
 	}
+	pkgSBOMVersionlessPURL := &extractor.Package{
+		Name:     "lodash",
+		Version:  "4.17.16",
+		PURLType: purl.TypeNPM,
+		Plugins:  []string{"sbom/cdx"},
+	}
 
 	tests := []struct {
 		name                 string
@@ -117,6 +123,13 @@ func TestAnnotator_Annotate(t *testing.T) {
 			},
 			inputPackages: []*extractor.Package{pkgScannable, pkgIgnored},
 			wantPackages:  []*extractor.Package{pkgScannable},
+		},
+		{
+			name:            "sbom_with_version_and_versionless_purl_is_scannable",
+			isContainerScan: false,
+			showAllPackages: false,
+			inputPackages:   []*extractor.Package{pkgSBOMVersionlessPURL},
+			wantPackages:    []*extractor.Package{pkgSBOMVersionlessPURL},
 		},
 	}
 


### PR DESCRIPTION
Fixes #3007 .

In osv-scalibr we already do the matching correctly. This is only really a problem in osv-scanner's filtering code.