### PR TITLE
feat: configure retry policy for scalibr gRPC client

### DIFF
--- a/internal/scalibr/client_factories.go
+++ b/internal/scalibr/client_factories.go
@@ -78,6 +78,19 @@ func (c *ClientFactories) GoogleHTTPClient(_ context.Context, _ ...string) (*htt
 	return nil, errors.New("unimplemented, this should not be used from osv-scanner")
 }
 
+const defaultGRPCServiceConfig = `{
+	"methodConfig": [{
+		"name": [{}],
+		"retryPolicy": {
+			"maxAttempts": 4,
+			"initialBackoff": "0.1s",
+			"maxBackoff": "1s",
+			"backoffMultiplier": 2.0,
+			"retryableStatusCodes": ["UNAVAILABLE", "RESOURCE_EXHAUSTED"]
+		}
+	}]
+}`
+
 // GRPCClientConn returns a cached gRPC client connection from a package-level connection cache.
 func (c *ClientFactories) GRPCClientConn(url string, dialOpts ...grpc.DialOption) (grpc.ClientConnInterface, error) {
 	c.mu.Lock()
@@ -97,6 +110,7 @@ func (c *ClientFactories) GRPCClientConn(url string, dialOpts ...grpc.DialOption
 
 	ourDialOpts := []grpc.DialOption{
 		grpc.WithTransportCredentials(creds),
+		grpc.WithDefaultServiceConfig(defaultGRPCServiceConfig),
 		// We might want keep alive params in the future, but it works for now.
 		// grpc.WithKeepaliveParams(keepalive.ClientParameters{
 		// 	Time:                20 * time.Second,

--- a/internal/scalibr/client_factories_test.go
+++ b/internal/scalibr/client_factories_test.go
@@ -1,0 +1,74 @@
+package scalibr
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestClientFactories_GRPCClientConn(t *testing.T) {
+	t.Parallel()
+
+	cf := NewClientFactories(nil, "test-agent/1.0")
+	defer func() {
+		if err := cf.Close(); err != nil {
+			t.Errorf("failed to close client factories: %v", err)
+		}
+	}()
+
+	conn, err := cf.GRPCClientConn("api.deps.dev:443")
+	if err != nil {
+		t.Fatalf("GRPCClientConn failed: %v", err)
+	}
+	if conn == nil {
+		t.Fatal("expected non-nil connection")
+	}
+
+	// Calling again should return the cached connection.
+	conn2, err := cf.GRPCClientConn("api.deps.dev:443")
+	if err != nil {
+		t.Fatalf("GRPCClientConn second call failed: %v", err)
+	}
+	if conn != conn2 {
+		t.Errorf("expected cached connection to be returned")
+	}
+}
+
+func TestClientFactories_HTTPClient_UserAgent(t *testing.T) {
+	t.Parallel()
+
+	var receivedUserAgent string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedUserAgent = r.Header.Get("User-Agent")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	cf := NewClientFactories(ts.Client(), "test-agent/1.0")
+	client := cf.HTTPClient()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, ts.URL, nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("HTTP GET failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if receivedUserAgent != "test-agent/1.0" {
+		t.Errorf("expected User-Agent %q, got %q", "test-agent/1.0", receivedUserAgent)
+	}
+}
+
+func TestClientFactories_GoogleHTTPClient(t *testing.T) {
+	t.Parallel()
+
+	cf := NewClientFactories(nil, "")
+	_, err := cf.GoogleHTTPClient(context.Background())
+	if err == nil {
+		t.Fatal("expected error from GoogleHTTPClient, got nil")
+	}
+}


### PR DESCRIPTION
## Overview

Configure a default gRPC service config with an exponential backoff retry policy for transient errors (`UNAVAILABLE` and `RESOURCE_EXHAUSTED`) on gRPC connections created by osv-scanner for SCALIBR plugins (e.g. deps.dev base image resolution, licenses, transitive dependency resolution).

## Details

In `internal/scalibr/client_factories.go`, configure `grpc.WithDefaultServiceConfig` in `ClientFactories.GRPCClientConn` using:

```json
{
  "methodConfig": [{
    "name": [{}],
    "retryPolicy": {
      "maxAttempts": 4,
      "initialBackoff": "0.1s",
      "maxBackoff": "1s",
      "backoffMultiplier": 2.0,
      "retryableStatusCodes": ["UNAVAILABLE", "RESOURCE_EXHAUSTED"]
    }
  }]
}
```

## Testing

- Added unit tests in `internal/scalibr/client_factories_test.go` verifying that `GRPCClientConn` initializes and caches the gRPC connection, and that `Close` cleans up.
- Verified that all unit tests pass (`go test ./internal/scalibr/...`).
- Ran `./scripts/run_lints.sh` (passed with 0 issues).

## Checklist

- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/).
- [x] I have read the [CONTRIBUTING guide](https://github.com/google/osv-scanner/blob/main/CONTRIBUTING.md), and understand when to open a pull request
- [x] I have run the linter using `./scripts/run_lints.sh`.
- [x] I have run the unit tests using `./scripts/run_tests.sh`.
- [x] I have made my commits and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

agy