### PR TITLE
fix: respect explicit false for license scanning

### DIFF
--- a/cmd/osv-scanner/internal/helper/flags.go
+++ b/cmd/osv-scanner/internal/helper/flags.go
@@ -23,6 +23,7 @@ var offlineFlags = map[string]string{
 // that should be considered allowed
 type allowedLicencesFlag struct {
 	allowlist []string
+	enabled   bool
 }
 
 func (g *allowedLicencesFlag) Get() any {
@@ -30,6 +31,7 @@ func (g *allowedLicencesFlag) Get() any {
 }
 
 func (g *allowedLicencesFlag) Set(value string) error {
+	g.enabled = value != "false"
 	if value == "" || value == "false" || value == "true" {
 		g.allowlist = nil
 	} else {

--- a/cmd/osv-scanner/internal/helper/getters.go
+++ b/cmd/osv-scanner/internal/helper/getters.go
@@ -10,11 +10,12 @@ import (
 )
 
 func GetScanLicensesAllowlist(cmd *cli.Command) ([]string, error) {
-	if !cmd.IsSet("licenses") {
+	licenses := cmd.Generic("licenses").(*allowedLicencesFlag)
+	if !licenses.enabled {
 		return []string{}, nil
 	}
 
-	allowlist := cmd.Generic("licenses").(*allowedLicencesFlag).allowlist
+	allowlist := licenses.allowlist
 
 	if len(allowlist) == 0 {
 		return []string{}, nil
@@ -33,6 +34,7 @@ func GetScanLicensesAllowlist(cmd *cli.Command) ([]string, error) {
 
 func GetCommonScannerActions(cmd *cli.Command, scanLicensesAllowlist []string) osvscanner.ScannerActions {
 	callAnalysisStates := CreateCallAnalysisStates(cmd.StringSlice("call-analysis"), cmd.StringSlice("no-call-analysis"))
+	licenses := cmd.Generic("licenses").(*allowedLicencesFlag)
 
 	return osvscanner.ScannerActions{
 		IncludeGitRoot:        cmd.Bool("include-git-root"),
@@ -43,7 +45,7 @@ func GetCommonScannerActions(cmd *cli.Command, scanLicensesAllowlist []string) o
 		DownloadDatabases:     cmd.Bool("download-offline-databases"),
 		LocalDBPath:           cmd.String("local-db-path"),
 		PluginNetworkDisabled: cmd.Bool("offline"),
-		ScanLicensesSummary:   cmd.IsSet("licenses"),
+		ScanLicensesSummary:   licenses.enabled,
 		ScanLicensesAllowlist: scanLicensesAllowlist,
 		CallAnalysisStates:    callAnalysisStates,
 	}

--- a/cmd/osv-scanner/internal/helper/getters_test.go
+++ b/cmd/osv-scanner/internal/helper/getters_test.go
@@ -2,10 +2,81 @@ package helper
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	"github.com/urfave/cli/v3"
 )
+
+func TestGetCommonScannerActions_Licenses(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		args          []string
+		wantSummary   bool
+		wantAllowlist []string
+	}{
+		{
+			name: "unset",
+			args: []string{"osv-scanner"},
+		},
+		{
+			name:        "implicit_true",
+			args:        []string{"osv-scanner", "--licenses"},
+			wantSummary: true,
+		},
+		{
+			name:        "explicit_true",
+			args:        []string{"osv-scanner", "--licenses=true"},
+			wantSummary: true,
+		},
+		{
+			name: "explicit_false",
+			args: []string{"osv-scanner", "--licenses=false"},
+		},
+		{
+			name:          "allowlist",
+			args:          []string{"osv-scanner", "--licenses=MIT,Apache-2.0"},
+			wantSummary:   true,
+			wantAllowlist: []string{"MIT", "Apache-2.0"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var gotSummary bool
+			var gotAllowlist []string
+
+			cmd := &cli.Command{
+				Flags: BuildCommonScanFlags(nil),
+				Action: func(_ context.Context, cmd *cli.Command) error {
+					var err error
+					gotAllowlist, err = GetScanLicensesAllowlist(cmd)
+					if err != nil {
+						return err
+					}
+					gotSummary = GetCommonScannerActions(cmd, gotAllowlist).ScanLicensesSummary
+
+					return nil
+				},
+			}
+
+			if err := cmd.Run(context.Background(), tt.args); err != nil {
+				t.Fatalf("cmd.Run() error = %v", err)
+			}
+
+			if gotSummary != tt.wantSummary {
+				t.Errorf("ScanLicensesSummary = %v, want %v", gotSummary, tt.wantSummary)
+			}
+			if !slices.Equal(gotAllowlist, tt.wantAllowlist) {
+				t.Errorf("ScanLicensesAllowlist = %v, want %v", gotAllowlist, tt.wantAllowlist)
+			}
+		})
+	}
+}
 
 func TestGetCommonScannerActions_OfflineFlags(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Overview

`--licenses=false` was treated as enabled because scanner actions used flag presence instead of the parsed Boolean value.

This change tracks the enabled state in the custom Boolean/list flag and uses it when configuring license scanning.

Fixes #3057

## Details

- Preserve whether the hybrid `--licenses` flag is enabled.
- Disable both license summaries and allowlist handling for explicit false.
- Cover unset, implicit true, explicit true, explicit false, and allowlist values.

## Testing

- `GOTOOLCHAIN=go1.27.0 go test -count=1 ./cmd/osv-scanner/internal/helper`
- `GOTOOLCHAIN=go1.27.0 make test`
- `GOTOOLCHAIN=go1.27.0 ./scripts/run_lints.sh`
- Re-ran the issue reproduction and confirmed it no longer fails with `cannot retrieve licenses locally`.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/).
- [x] I have read the [CONTRIBUTING guide](https://github.com/google/osv-scanner/blob/main/CONTRIBUTING.md), and understand when to open a pull request
- [x] I have run the linter using `./scripts/run_lints.sh`.
- [x] I have run the unit tests using `./scripts/run_tests.sh`.
- [x] I have made my commits and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
