### PR TITLE
fix(output): preserve UTF-8 when truncating text

### DIFF
--- a/internal/output/vertical.go
+++ b/internal/output/vertical.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/google/osv-scanner/v2/pkg/models"
 	"github.com/jedib0t/go-pretty/v6/text"
@@ -305,7 +306,12 @@ func truncate(str string, limit int) string {
 			// ideally we want to keep words whole when truncating,
 			// but if we can't find a space just truncate at the limit
 			if truncateAt == -1 {
-				truncateAt = limit
+				if limit <= 0 {
+					truncateAt = 0
+				} else {
+					_, size := utf8.DecodeRuneInString(str[i:])
+					truncateAt = i + size
+				}
 			}
 
 			return str[:truncateAt] + "..."

--- a/internal/output/vertical_internal_test.go
+++ b/internal/output/vertical_internal_test.go
@@ -1,0 +1,63 @@
+package output
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestTruncate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		limit int
+		want  string
+	}{
+		{
+			name:  "multibyte without whitespace",
+			input: strings.Repeat("\u754c", 100),
+			limit: 80,
+			want:  strings.Repeat("\u754c", 80) + "...",
+		},
+		{
+			name:  "multibyte with whitespace boundary",
+			input: strings.Repeat("\u754c", 30) + " " + strings.Repeat("\u8a9e", 60),
+			limit: 80,
+			want:  strings.Repeat("\u754c", 30) + "...",
+		},
+		{
+			name:  "ASCII without whitespace",
+			input: strings.Repeat("a", 100),
+			limit: 80,
+			want:  strings.Repeat("a", 80) + "...",
+		},
+		{
+			name:  "short string unchanged",
+			input: "short text",
+			limit: 80,
+			want:  "short text",
+		},
+		{
+			name:  "zero limit preserves existing behavior",
+			input: "text",
+			limit: 0,
+			want:  "...",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := truncate(tt.input, tt.limit)
+			if got != tt.want {
+				t.Fatalf("truncate() = %q, want %q", got, tt.want)
+			}
+			if !utf8.ValidString(got) {
+				t.Fatalf("truncate() returned invalid UTF-8: %q", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Overview

Preserve valid UTF-8 when vertical output truncates long multibyte text without a whitespace boundary.

`truncate` counts characters by rune, but its no-whitespace fallback used that rune count directly as a byte slice index. For multibyte text, that could split a UTF-8 sequence.

Fixes #3056

## Details

Use the byte offset of the current rune and its decoded width to truncate after the complete limit-th rune.

The existing behavior of preferring an earlier whitespace boundary is unchanged. Existing ASCII, short-string, and zero-limit behavior is also covered by the regression tests.

## Testing

- focused multibyte truncation tests with and without a whitespace boundary
- regression test verified against the previous implementation, which produced partial UTF-8
- ASCII, short-string, and zero-limit preservation cases
- `GOTOOLCHAIN=go1.27.0 go test ./internal/output -run '^TestTruncate$' -count=1`
- `GOTOOLCHAIN=go1.27.0 go test ./internal/output -count=1`
- `GOTOOLCHAIN=go1.27.0 ./scripts/run_lints.sh`
- `GOTOOLCHAIN=go1.27.0 make test` — 2026 passed, 17 expected skips

AI-assisted contribution; I am responsible for maintainer follow-up and any requested changes.

## Checklist

- [ ] I have signed the Contributor License Agreement
- [x] I have read the CONTRIBUTING guide and understand when to open a pull request
- [x] I have run the linter
- [x] I have run the unit tests
- [x] My commits and PR title follow Conventional Commits
