### PR TITLE
fix: ensure `results` property is an array in json output when there are no lockfiles

### DIFF
--- a/cmd/osv-scanner/scan/image/__snapshots__/command_test.snap
+++ b/cmd/osv-scanner/scan/image/__snapshots__/command_test.snap
@@ -111,6 +111,27 @@ No issues found
 
 ---
 
+[TestCommand_Docker/real_empty_image_with_tag_and_allow_no_lockfiles_flag_json - 1]
+{
+  "results": [],
+  "experimental_config": {
+    "licenses": {
+      "summary": false,
+      "allowlist": null
+    }
+  }
+}
+
+---
+
+[TestCommand_Docker/real_empty_image_with_tag_and_allow_no_lockfiles_flag_json - 2]
+Checking if docker image ("hello-world:linux") exists locally...
+Saving docker image ("hello-world:linux") to temporary file...
+Scanning image "hello-world:linux"
+No package sources found
+
+---
+
 [TestCommand_ExplicitExtractors_WithDefaults/add_extractors - 1]
 Scanning local image tarball "testdata/test-alpine-sbom.tar"
 

--- a/cmd/osv-scanner/scan/image/command.go
+++ b/cmd/osv-scanner/scan/image/command.go
@@ -93,6 +93,12 @@ func action(_ context.Context, cmd *cli.Command, stdout, stderr io.Writer, clien
 	//nolint:contextcheck // passing the context in would be a breaking change
 	vulnResult, err = osvscanner.DoContainerScan(scannerAction)
 
+	// ensure that the results property is always an array
+	//goland:noinspection GoDfaErrorMayBeNotNil // false positive
+	if vulnResult.Results == nil {
+		vulnResult.Results = []models.PackageSource{}
+	}
+
 	if cmd.Bool("allow-no-lockfiles") && errors.Is(err, osvscanner.ErrNoPackagesFound) {
 		cmdlogger.Warnf("No package sources found")
 		err = nil

--- a/cmd/osv-scanner/scan/image/command_test.go
+++ b/cmd/osv-scanner/scan/image/command_test.go
@@ -184,6 +184,11 @@ func TestCommand_Docker(t *testing.T) {
 			Exit: 0,
 		},
 		{
+			Name: "real_empty_image_with_tag_and_allow_no_lockfiles_flag_json",
+			Args: []string{"", "image", "--format", "json", "--allow-no-lockfiles", "hello-world:linux"},
+			Exit: 0,
+		},
+		{
 			Name: "Real_Alpine_image",
 			Args: []string{"", "image", "alpine:3.18.9"},
 			Exit: 1,

--- a/cmd/osv-scanner/scan/source/__snapshots__/command_test.snap
+++ b/cmd/osv-scanner/scan/source/__snapshots__/command_test.snap
@@ -1394,6 +1394,25 @@ failed to resolve path: stat <rootdir>/testdata/locks-none-does-not-exist: no su
 
 ---
 
+[TestCommand/no_lockfiles_with_json_and_allow_flag_still_have_results_property - 1]
+{
+  "results": [],
+  "experimental_config": {
+    "licenses": {
+      "summary": false,
+      "allowlist": null
+    }
+  }
+}
+
+---
+
+[TestCommand/no_lockfiles_with_json_and_allow_flag_still_have_results_property - 2]
+Scanning dir ./testdata/locks-none
+No package sources found
+
+---
+
 [TestCommand/no_lockfiles_with_recursion_and_with_allow_flag_are_fine - 1]
 Scanning dir ./testdata/locks-none
 Scanned <rootdir>/testdata/locks-none/nested/composer.lock file and found 1 package

--- a/cmd/osv-scanner/scan/source/command.go
+++ b/cmd/osv-scanner/scan/source/command.go
@@ -147,6 +147,12 @@ func action(_ context.Context, cmd *cli.Command, stdout, stderr io.Writer, clien
 	//nolint:contextcheck // passing the context in would be a breaking change
 	vulnResult, err = osvscanner.DoScan(scannerAction)
 
+	// ensure that the results property is always an array
+	//goland:noinspection GoDfaErrorMayBeNotNil // false positive
+	if vulnResult.Results == nil {
+		vulnResult.Results = []models.PackageSource{}
+	}
+
 	if cmd.Bool("allow-no-lockfiles") && errors.Is(err, osvscanner.ErrNoPackagesFound) {
 		cmdlogger.Warnf("No package sources found")
 		err = nil

--- a/cmd/osv-scanner/scan/source/command_test.go
+++ b/cmd/osv-scanner/scan/source/command_test.go
@@ -135,6 +135,11 @@ func TestCommand(t *testing.T) {
 			Args: []string{"", "source", "--recursive", "--allow-no-lockfiles", "./testdata/locks-none"},
 			Exit: 0,
 		},
+		{
+			Name: "no_lockfiles_with_json_and_allow_flag_still_have_results_property",
+			Args: []string{"", "source", "--format", "json", "--allow-no-lockfiles", "./testdata/locks-none"},
+			Exit: 0,
+		},
 		// only the files in the given directories are checked by default (no recursion)
 		{
 			Name: "only_the_files_in_the_given_directories_are_checked_by_default_(no_recursion)",


### PR DESCRIPTION
I think this is fair given that using `--allow-no-lockfiles` implies you might not have any results, and so this means programmatic usage of the CLI does not require an "or" - instead it becomes safe to just always "loop" over the results.

I've applied this at the CLI level rather than the package level because we've got a few different returns there which we might (or might not) want to apply this, and this shouldn't impact those using the package directly because of Go slice semantics.

Happy to switch though to do doing this at the package level if folks think that'd be better

