### PR TITLE
grouper: keep all members of an alias group when groups merge

### DIFF
--- a/internal/grouper/grouper.go
+++ b/internal/grouper/grouper.go
@@ -31,13 +31,32 @@ func Group(vulns []IDAliases) []models.GroupInfo {
 		groups[i] = i
 	}
 
+	// find returns the representative of the group holding i, following and
+	// shortening the chain as it goes.
+	find := func(i int) int {
+		for groups[i] != i {
+			groups[i] = groups[groups[i]]
+			i = groups[i]
+		}
+
+		return i
+	}
+
 	// Do a pair-wise (n^2) comparison and merge all intersecting vulns.
 	for i := range vulns {
 		for j := i + 1; j < len(vulns); j++ {
 			if hasAliasIntersection(vulns[i], vulns[j]) {
 				// Merge the two groups. Use the smaller index as the representative ID.
-				groups[i] = min(groups[i], groups[j])
-				groups[j] = groups[i]
+				rootI, rootJ := find(i), find(j)
+				if rootI == rootJ {
+					continue
+				}
+
+				if rootI < rootJ {
+					groups[rootJ] = rootI
+				} else {
+					groups[rootI] = rootJ
+				}
 			}
 		}
 	}
@@ -45,7 +64,8 @@ func Group(vulns []IDAliases) []models.GroupInfo {
 	// Extract groups into the final result structure.
 	extractedGroups := map[int][]string{}
 	extractedAliases := map[int][]string{}
-	for i, gid := range groups {
+	for i := range groups {
+		gid := find(i)
 		extractedGroups[gid] = append(extractedGroups[gid], vulns[i].ID)
 		extractedAliases[gid] = append(extractedAliases[gid], vulns[i].Aliases...)
 	}

--- a/internal/grouper/grouper_test.go
+++ b/internal/grouper/grouper_test.go
@@ -152,3 +152,46 @@ func TestGroup(t *testing.T) {
 		}
 	}
 }
+
+func TestGroupIsAliasTransitive(t *testing.T) {
+	t.Parallel()
+
+	// GHSA-aaaa and GHSA-bbbb are linked through a CVE that is not part of the
+	// results, and GHSA-cccc links that pair back to CVE-2024-1111, so all four
+	// belong to the same group.
+	v1 := grouper.IDAliases{
+		ID:      "CVE-2024-1111",
+		Aliases: []string{"GHSA-cccc"},
+	}
+	v2 := grouper.IDAliases{
+		ID:      "GHSA-aaaa",
+		Aliases: []string{"CVE-2024-9999"},
+	}
+	v3 := grouper.IDAliases{
+		ID:      "GHSA-bbbb",
+		Aliases: []string{"CVE-2024-9999"},
+	}
+	v4 := grouper.IDAliases{
+		ID:      "GHSA-cccc",
+		Aliases: []string{"CVE-2024-1111", "GHSA-aaaa"},
+	}
+
+	want := []models.GroupInfo{
+		{
+			IDs:     []string{v1.ID, v2.ID, v3.ID, v4.ID},
+			Aliases: []string{v1.ID, "CVE-2024-9999", v2.ID, v3.ID, v4.ID},
+		},
+	}
+
+	// The result must not depend on the order the vulnerabilities were scanned in.
+	for _, vulns := range [][]grouper.IDAliases{
+		{v1, v2, v3, v4},
+		{v2, v3, v4, v1},
+		{v4, v3, v2, v1},
+	} {
+		grouped := grouper.Group(vulns)
+		if diff := cmp.Diff(want, grouped); diff != "" {
+			t.Errorf("GroupedVulns() returned an unexpected result (-want +got):\n%s", diff)
+		}
+	}
+}


### PR DESCRIPTION
Group() was splitting up vulnerabilities that are only linked through a chain of aliases, so the same set of findings could come back as different groups depending on the scan order.

The merge step only rewrote the group id of the vuln it was looking at, not the other members of the group being merged in, so those were left behind pointing at the old id. I swapped it for a regular union-find find() with path compression, so the whole group follows when two groups merge. The representative is still the lowest index, so results for everything already covered by TestGroup are unchanged.

A concrete case, using the order the vulnerabilities are actually handed to Group() (they come out of ConvertVulnerabilityToIDAliases sorted by MostUpstreamsOrder): CVE-2024-1111 aliases GHSA-cccc, GHSA-aaaa and GHSA-bbbb both alias CVE-2024-9999, and GHSA-cccc aliases both CVE-2024-1111 and GHSA-aaaa. All four are one group, but GHSA-bbbb comes back on its own. Reordering the same four into the group, and the group changes.

The regression test runs that set in a few different orders. I also compared the new Group() against a plain connected-components implementation over 20000 random alias graphs - they agree everywhere, while the old code disagrees within the first few.

This is reachable from every scan: pkg/osvscanner/vulnerability_result.go uses these groups for the output and for the per-group MaxSeverity, and internal/ci/vulnerability_result_diff.go uses them too. I scanned the existing fixtures and snapshots for two groups sharing an alias (the fingerprint of this bug) and found none, so nothing else should need updating.