### PR TITLE
fix: return error when no image is provided in DoContainerScan

### DIFF
--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -114,6 +114,9 @@ var ErrVulnerabilitiesFound = errors.New("vulnerabilities found")
 // TODO(v2): Actually use this error
 var ErrAPIFailed = errors.New("API query failed")
 
+// ErrNoImageSpecified is returned when a container scan is requested without an image.
+var ErrNoImageSpecified = errors.New("no container image specified")
+
 // DoScan performs the osv scanner action, with optional reporter to output information
 func DoScan(actions ScannerActions) (models.VulnerabilityResults, error) {
 	// --- Sanity check flags ----
@@ -167,6 +170,10 @@ func DoScan(actions ScannerActions) (models.VulnerabilityResults, error) {
 }
 
 func DoContainerScan(actions ScannerActions) (models.VulnerabilityResults, error) {
+	if actions.Image == "" {
+		return models.VulnerabilityResults{}, ErrNoImageSpecified
+	}
+
 	scanResults := results.ScanResults{
 		ConfigManager: config.Manager{
 			DefaultConfig: config.Config{},
@@ -227,9 +234,11 @@ func DoContainerScan(actions ScannerActions) (models.VulnerabilityResults, error
 	}
 
 	defer func() {
-		err := img.CleanUp()
-		if err != nil {
-			cmdlogger.Errorf("Failed to clean up image: %s", err)
+		if img != nil {
+			err := img.CleanUp()
+			if err != nil {
+				cmdlogger.Errorf("Failed to clean up image: %s", err)
+			}
 		}
 	}()
 

--- a/pkg/osvscanner/osvscanner_test.go
+++ b/pkg/osvscanner/osvscanner_test.go
@@ -2,6 +2,7 @@ package osvscanner_test
 
 import (
 	"bytes"
+	"errors"
 	"log/slog"
 	"testing"
 
@@ -50,5 +51,36 @@ func TestDoScan_LogHandlerOverride(t *testing.T) {
 	// altOutput should contain data now instead.
 	if altOutput.Len() == 0 {
 		t.Errorf("altOutput.Len() = %d, want %d", altOutput.Len(), 0)
+	}
+}
+
+func TestDoContainerScan_EmptyImage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		actions osvscanner.ScannerActions
+	}{
+		{
+			name:    "empty actions",
+			actions: osvscanner.ScannerActions{},
+		},
+		{
+			name: "image archive with empty image",
+			actions: osvscanner.ScannerActions{
+				IsImageArchive: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := osvscanner.DoContainerScan(tt.actions)
+			if !errors.Is(err, osvscanner.ErrNoImageSpecified) {
+				t.Errorf("DoContainerScan() error = %v, want %v", err, osvscanner.ErrNoImageSpecified)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Overview

Fixes #3072

`osvscanner.DoContainerScan` panics with a nil pointer dereference when called with an empty `ScannerActions.Image`.

## Details

- Defined exported `ErrNoImageSpecified = errors.New("no container image specified")`.
- Added validation at the entry of `DoContainerScan` to return `ErrNoImageSpecified` when `actions.Image == ""`.
- Guarded `img.CleanUp()` in the deferred cleanup function with an `img != nil` check.

## Testing

- Added `TestDoContainerScan_EmptyImage` in `pkg/osvscanner/osvscanner_test.go` verifying that `DoContainerScan` returns `ErrNoImageSpecified` without panicking for empty actions.
- Ran test suite for `pkg/osvscanner` — all tests passed.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/).
- [x] I have read the [CONTRIBUTING guide](https://github.com/google/osv-scanner/blob/main/CONTRIBUTING.md), and understand when to open a pull request
- [x] I have made my commits and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
