### PR TITLE
fix: return error when container image is missing

### DIFF
--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -167,6 +167,10 @@ func DoScan(actions ScannerActions) (models.VulnerabilityResults, error) {
 }
 
 func DoContainerScan(actions ScannerActions) (models.VulnerabilityResults, error) {
+	if actions.Image == "" {
+		return models.VulnerabilityResults{}, errors.New("container image must be provided")
+	}
+
 	scanResults := results.ScanResults{
 		ConfigManager: config.Manager{
 			DefaultConfig: config.Config{},

--- a/pkg/osvscanner/osvscanner_test.go
+++ b/pkg/osvscanner/osvscanner_test.go
@@ -8,6 +8,19 @@ import (
 	"github.com/google/osv-scanner/v2/pkg/osvscanner"
 )
 
+func TestDoContainerScan_NoImage(t *testing.T) {
+	t.Parallel()
+
+	_, err := osvscanner.DoContainerScan(osvscanner.ScannerActions{})
+	if err == nil {
+		t.Fatal("DoContainerScan() error = nil, want an error")
+	}
+
+	if got, want := err.Error(), "container image must be provided"; got != want {
+		t.Errorf("DoContainerScan() error = %q, want %q", got, want)
+	}
+}
+
 // TestDoScan_LogHandlerOverride tests that the SetLogger override works correctly
 //
 //nolint:paralleltest // No parallel test since slog.SetDefault sets global behavior


### PR DESCRIPTION
## Overview

Return a descriptive error from `DoContainerScan` when `ScannerActions.Image` is empty, instead of passing a nil image to osv-scalibr and panicking.

Fixes #3072

## Details

- Validate the required image input before config, accessors, plugins, or cleanup handlers are initialized.
- Add a focused public API regression test covering zero-value `ScannerActions`.

## Testing

- `GOTOOLCHAIN=go1.27.0 go test -count=1 ./pkg/osvscanner`
- `GOTOOLCHAIN=go1.27.0 make test`
- `GOTOOLCHAIN=go1.27.0 ./scripts/run_lints.sh` (0 issues)

## Checklist

- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/).
- [x] I have read the [CONTRIBUTING guide](https://github.com/google/osv-scanner/blob/main/CONTRIBUTING.md), and understand when to open a pull request
- [x] I have run the linter using `./scripts/run_lints.sh`.
- [x] I have run the unit tests using `./scripts/run_tests.sh`.
- [x] I have made my commits and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.